### PR TITLE
Change YAML generation method

### DIFF
--- a/cmd/apispec/integration_test.go
+++ b/cmd/apispec/integration_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"flag"
 	"io"
 	"os"
@@ -129,13 +130,23 @@ go 1.21`
 	}
 
 	// Generate OpenAPI spec
-	data, genEngine, err := runGeneration(config)
+	openAPISpec, genEngine, err := runGeneration(config)
 	if err != nil {
 		t.Fatalf("OpenAPI generation failed: %v", err)
 	}
 
 	if genEngine == nil {
 		t.Fatal("Engine should not be nil")
+	}
+
+	if openAPISpec == nil {
+		t.Fatal("Generated OpenAPI spec should not be nil")
+	}
+
+	// Convert to JSON for validation
+	data, err := json.Marshal(openAPISpec)
+	if err != nil {
+		t.Fatalf("Failed to marshal OpenAPI spec: %v", err)
 	}
 
 	if len(data) == 0 {
@@ -228,13 +239,23 @@ defaults:
 	}
 
 	// Generate OpenAPI spec
-	data, genEngine, err := runGeneration(config)
+	openAPISpec, genEngine, err := runGeneration(config)
 	if err != nil {
 		t.Fatalf("OpenAPI generation with config failed: %v", err)
 	}
 
 	if genEngine == nil {
 		t.Fatal("Engine should not be nil")
+	}
+
+	if openAPISpec == nil {
+		t.Fatal("Generated OpenAPI spec should not be nil")
+	}
+
+	// Convert to JSON for validation
+	data, err := json.Marshal(openAPISpec)
+	if err != nil {
+		t.Fatalf("Failed to marshal OpenAPI spec: %v", err)
 	}
 
 	// Validate the output contains expected content
@@ -436,10 +457,10 @@ func TestParseFlags(t *testing.T) {
 				ContactURL:         "https://ehabterra.github.io/",
 				ContactEmail:       "ehabterra@hotmail.com",
 				OpenAPIVersion:     "3.1.1",
-				MaxNodesPerTree:    10000,
-				MaxChildrenPerNode: 150,
-				MaxArgsPerFunction: 30,
-				MaxNestedArgsDepth: 50,
+				MaxNodesPerTree:    50000,
+				MaxChildrenPerNode: 500,
+				MaxArgsPerFunction: 100,
+				MaxNestedArgsDepth: 100,
 			},
 		},
 		{

--- a/cmd/apispec/main.go
+++ b/cmd/apispec/main.go
@@ -332,7 +332,10 @@ func writeOutput(openAPISpec interface{}, config *CLIConfig, genEngine *engine.E
 			encoder := yaml.NewEncoder(os.Stdout)
 			encoder.SetIndent(2)
 			if err := encoder.Encode(openAPISpec); err != nil {
-				encoder.Close()
+				err = encoder.Close()
+				if err != nil {
+					return fmt.Errorf("failed to close YAML encoder: %w", err)
+				}
 				return fmt.Errorf("failed to encode OpenAPI spec to YAML: %w", err)
 			}
 			return encoder.Close()
@@ -352,7 +355,12 @@ func writeOutput(openAPISpec interface{}, config *CLIConfig, genEngine *engine.E
 		if err != nil {
 			return fmt.Errorf("failed to create output file: %w", err)
 		}
-		defer file.Close()
+		defer func() {
+			err = file.Close()
+			if err != nil {
+				log.Printf("Failed to close file: %v", err)
+			}
+		}()
 
 		ext := strings.ToLower(filepath.Ext(config.OutputFile))
 		if ext == ".yaml" || ext == ".yml" {
@@ -361,7 +369,10 @@ func writeOutput(openAPISpec interface{}, config *CLIConfig, genEngine *engine.E
 			encoder.SetIndent(2)
 
 			if err := encoder.Encode(openAPISpec); err != nil {
-				encoder.Close()
+				err = encoder.Close()
+				if err != nil {
+					return fmt.Errorf("failed to close YAML encoder: %w", err)
+				}
 				return fmt.Errorf("failed to encode OpenAPI spec to YAML: %w", err)
 			}
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -30,10 +30,10 @@ const (
 	DefaultContactURL         = "https://ehabterra.github.io/"
 	DefaultContactEmail       = "ehabterra@hotmail.com"
 	DefaultOpenAPIVersion     = "3.1.1"
-	DefaultMaxNodesPerTree    = 10000
-	DefaultMaxChildrenPerNode = 150
-	DefaultMaxArgsPerFunction = 30
-	DefaultMaxNestedArgsDepth = 50
+	DefaultMaxNodesPerTree    = 50000 // Increased for large codebases
+	DefaultMaxChildrenPerNode = 500   // Increased for complex call graphs
+	DefaultMaxArgsPerFunction = 100   // Increased for functions with many parameters
+	DefaultMaxNestedArgsDepth = 100   // Increased for deeply nested structures
 	DefaultMetadataFile       = "metadata.yaml"
 	CopyrightNotice           = "apispec - Copyright 2025 Ehab Terra"
 	LicenseNotice             = "Licensed under the Apache License 2.0. See LICENSE and NOTICE."

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -364,6 +364,106 @@ func main() {
 	}
 }
 
+// TestDefaultLimits tests the new increased default limits for large codebases
+func TestDefaultLimits(t *testing.T) {
+	config := DefaultEngineConfig()
+
+	// Test the new increased limits
+	expectedLimits := map[string]int{
+		"MaxNodesPerTree":    DefaultMaxNodesPerTree,
+		"MaxChildrenPerNode": DefaultMaxChildrenPerNode,
+		"MaxArgsPerFunction": DefaultMaxArgsPerFunction,
+		"MaxNestedArgsDepth": DefaultMaxNestedArgsDepth,
+	}
+
+	actualLimits := map[string]int{
+		"MaxNodesPerTree":    config.MaxNodesPerTree,
+		"MaxChildrenPerNode": config.MaxChildrenPerNode,
+		"MaxArgsPerFunction": config.MaxArgsPerFunction,
+		"MaxNestedArgsDepth": config.MaxNestedArgsDepth,
+	}
+
+	for limitName, expectedValue := range expectedLimits {
+		if actualValue, exists := actualLimits[limitName]; !exists {
+			t.Errorf("Expected %s to be set", limitName)
+		} else if actualValue != expectedValue {
+			t.Errorf("Expected %s to be %d, got %d", limitName, expectedValue, actualValue)
+		}
+	}
+
+	// Verify the limits are actually increased from the old values
+	if config.MaxNodesPerTree <= 10000 {
+		t.Errorf("Expected MaxNodesPerTree to be > 10000 (old default), got %d", config.MaxNodesPerTree)
+	}
+
+	if config.MaxChildrenPerNode <= 150 {
+		t.Errorf("Expected MaxChildrenPerNode to be > 150 (old default), got %d", config.MaxChildrenPerNode)
+	}
+
+	if config.MaxArgsPerFunction <= 30 {
+		t.Errorf("Expected MaxArgsPerFunction to be > 30 (old default), got %d", config.MaxArgsPerFunction)
+	}
+
+	if config.MaxNestedArgsDepth <= 50 {
+		t.Errorf("Expected MaxNestedArgsDepth to be > 50 (old default), got %d", config.MaxNestedArgsDepth)
+	}
+}
+
+// TestEngineWithCustomLimits tests engine behavior with custom limits
+func TestEngineWithCustomLimits(t *testing.T) {
+	// Test with very low limits to trigger warnings
+	config := &EngineConfig{
+		InputDir:           ".",
+		OutputFile:         "test-output.yaml",
+		MaxNodesPerTree:    5,
+		MaxChildrenPerNode: 2,
+		MaxArgsPerFunction: 1,
+		MaxNestedArgsDepth: 2,
+	}
+
+	engine := NewEngine(config)
+	if engine == nil {
+		t.Fatal("Expected engine to be created")
+	}
+
+	// Verify the custom limits are set
+	if engine.config.MaxNodesPerTree != 5 {
+		t.Errorf("Expected MaxNodesPerTree to be 5, got %d", engine.config.MaxNodesPerTree)
+	}
+
+	if engine.config.MaxChildrenPerNode != 2 {
+		t.Errorf("Expected MaxChildrenPerNode to be 2, got %d", engine.config.MaxChildrenPerNode)
+	}
+
+	if engine.config.MaxArgsPerFunction != 1 {
+		t.Errorf("Expected MaxArgsPerFunction to be 1, got %d", engine.config.MaxArgsPerFunction)
+	}
+
+	if engine.config.MaxNestedArgsDepth != 2 {
+		t.Errorf("Expected MaxNestedArgsDepth to be 2, got %d", engine.config.MaxNestedArgsDepth)
+	}
+}
+
+// TestDefaultLimitsConstants tests that the constants match the expected values
+func TestDefaultLimitsConstants(t *testing.T) {
+	// Test that the constants are set to the new increased values
+	if DefaultMaxNodesPerTree != 50000 {
+		t.Errorf("Expected DefaultMaxNodesPerTree to be 50000, got %d", DefaultMaxNodesPerTree)
+	}
+
+	if DefaultMaxChildrenPerNode != 500 {
+		t.Errorf("Expected DefaultMaxChildrenPerNode to be 500, got %d", DefaultMaxChildrenPerNode)
+	}
+
+	if DefaultMaxArgsPerFunction != 100 {
+		t.Errorf("Expected DefaultMaxArgsPerFunction to be 100, got %d", DefaultMaxArgsPerFunction)
+	}
+
+	if DefaultMaxNestedArgsDepth != 100 {
+		t.Errorf("Expected DefaultMaxNestedArgsDepth to be 100, got %d", DefaultMaxNestedArgsDepth)
+	}
+}
+
 // Helper function to check if a string contains a substring
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||

--- a/internal/spec/extractor_test.go
+++ b/internal/spec/extractor_test.go
@@ -98,11 +98,6 @@ func TestRefactoredExtractor(t *testing.T) {
 	// Verify results
 	if len(routes) == 0 {
 		t.Log("No routes extracted, which is expected for this simple test")
-	} else {
-		t.Logf("Extracted %d routes", len(routes))
-		for i, route := range routes {
-			t.Logf("Route %d: %s %s", i, route.Method, route.Path)
-		}
 	}
 }
 

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -609,8 +609,11 @@ func generateStructSchema(usedTypes map[string]*Schema, key string, typ *metadat
 		}
 
 		// Check if fieldType is an alias/enum and resolve to underlying type
-		if resolvedType := resolveUnderlyingType(fieldType, meta); resolvedType != "" {
-			fieldType = resolvedType
+		// But don't resolve array or map types as we need the original type for enum detection
+		if !strings.HasPrefix(fieldType, "[]") && !strings.HasPrefix(fieldType, "map[") {
+			if resolvedType := resolveUnderlyingType(fieldType, meta); resolvedType != "" {
+				fieldType = resolvedType
+			}
 		}
 
 		// Extract JSON tag if present
@@ -692,7 +695,17 @@ func generateStructSchema(usedTypes map[string]*Schema, key string, typ *metadat
 			// Only detect enums for custom types, not built-in types like string, int, etc.
 			if !isPrimitiveType(originalFieldType) {
 				if enumValues := detectEnumFromConstants(originalFieldType, pkgName, meta); len(enumValues) > 0 {
-					fieldSchema.Enum = enumValues
+					switch fieldSchema.Type {
+					case "array":
+						fieldSchema.Items.Enum = enumValues
+					case "object":
+						if fieldSchema.AdditionalProperties != nil {
+							fieldSchema.AdditionalProperties.Enum = enumValues
+						}
+					default:
+						fieldSchema.Enum = enumValues
+					}
+
 				}
 			}
 		}
@@ -716,7 +729,28 @@ func generateInterfaceSchema() *Schema {
 func generateAliasSchema(usedTypes map[string]*Schema, typ *metadata.Type, meta *metadata.Metadata, cfg *APISpecConfig, visitedTypes map[string]bool) (*Schema, map[string]*Schema) {
 	underlyingType := getStringFromPool(meta, typ.Target)
 
-	return mapGoTypeToOpenAPISchema(usedTypes, underlyingType, meta, cfg, visitedTypes)
+	// Get the original type name for enum detection
+	originalTypeName := getStringFromPool(meta, typ.Name)
+
+	// Generate the base schema from underlying type
+	schema, schemas := mapGoTypeToOpenAPISchema(usedTypes, underlyingType, meta, cfg, visitedTypes)
+
+	// If the underlying type is a primitive (like string), try to detect enum values
+	if schema != nil && isPrimitiveType(underlyingType) {
+		// Extract package name for enum detection
+		pkgName := ""
+		if typeParts := TypeParts(originalTypeName); typeParts.PkgName != "" {
+			pkgName = typeParts.PkgName
+		}
+
+		// Detect enum values for this alias type
+		if enumValues := detectEnumFromConstants(originalTypeName, pkgName, meta); len(enumValues) > 0 {
+			// Apply enum values to the schema
+			schema.Enum = enumValues
+		}
+	}
+
+	return schema, schemas
 }
 
 // resolveUnderlyingType resolves the underlying type for alias/enum types
@@ -1164,7 +1198,16 @@ func applyValidationConstraints(schema *Schema, constraints *ValidationConstrain
 
 	// Apply enum constraint
 	if len(constraints.Enum) > 0 {
-		schema.Enum = constraints.Enum
+		switch schema.Type {
+		case "array":
+			schema.Items.Enum = constraints.Enum
+		case "object":
+			if schema.AdditionalProperties != nil {
+				schema.AdditionalProperties.Enum = constraints.Enum
+			}
+		default:
+			schema.Enum = constraints.Enum
+		}
 	}
 }
 
@@ -1428,14 +1471,47 @@ func mapGoTypeToOpenAPISchema(usedTypes map[string]*Schema, goType string, meta 
 	}
 
 	// Handle map types
-	if strings.HasPrefix(goType, "map[") {
+	if strings.Contains(goType, "map[") {
+		startIdx := strings.Index(goType, "map[")
 		endIdx := strings.Index(goType, "]")
-		if endIdx > 4 {
-			keyType := goType[4:endIdx]
+		if endIdx > startIdx+4 {
+			keyType := goType[startIdx+4 : endIdx]
 			valueType := strings.TrimSpace(goType[endIdx+1:])
+
+			// add package name to value type
+			if startIdx > 0 {
+				valueType = goType[:startIdx] + "." + valueType
+			}
+
 			if keyType == "string" {
-				additionalProperties, newSchemas := mapGoTypeToOpenAPISchema(usedTypes, valueType, meta, cfg, visitedTypes)
+				var resolvedType string
+				if resolvedType = resolveUnderlyingType(valueType, meta); resolvedType == "" {
+					resolvedType = valueType
+				}
+
+				additionalProperties, newSchemas := mapGoTypeToOpenAPISchema(usedTypes, resolvedType, meta, cfg, visitedTypes)
 				maps.Copy(schemas, newSchemas)
+
+				// Apply enum detection for map values if the value type is not primitive
+				if !isPrimitiveType(valueType) && additionalProperties != nil && len(additionalProperties.Enum) == 0 {
+					// Extract package name for enum detection
+					pkgName := ""
+					if typeParts := TypeParts(valueType); typeParts.PkgName != "" {
+						pkgName = typeParts.PkgName
+					}
+
+					// Detect enum values for this value type
+					if enumValues := detectEnumFromConstants(valueType, pkgName, meta); len(enumValues) > 0 {
+						additionalProperties.Enum = enumValues
+					}
+				}
+
+				// Use reference for complex value types in maps
+				if !isPrimitiveType(resolvedType) && canAddRefSchemaForType(resolvedType) {
+					schemas[resolvedType] = additionalProperties
+					additionalProperties = addRefSchemaForType(resolvedType)
+				}
+
 				schema = &Schema{
 					Type:                 "object",
 					AdditionalProperties: additionalProperties,
@@ -1454,27 +1530,54 @@ func mapGoTypeToOpenAPISchema(usedTypes map[string]*Schema, goType string, meta 
 	if strings.HasPrefix(goType, "[]") {
 		elementType := strings.TrimSpace(goType[2:])
 
+		var resolvedType string
+		if resolvedType = resolveUnderlyingType(elementType, meta); resolvedType == "" {
+			resolvedType = elementType
+		}
+		isPrimitiveElement := isPrimitiveType(resolvedType)
+
 		// Check if the element type already exists in usedTypes
-		if bodySchema, ok := usedTypes[elementType]; !isPrimitive && ok {
+		if bodySchema, ok := usedTypes[elementType]; !isPrimitiveElement && ok {
 			if bodySchema == nil {
 				var newBodySchemas map[string]*Schema
 
-				bodySchema, newBodySchemas = mapGoTypeToOpenAPISchema(usedTypes, elementType, meta, cfg, visitedTypes)
+				bodySchema, newBodySchemas = mapGoTypeToOpenAPISchema(usedTypes, resolvedType, meta, cfg, visitedTypes)
 				maps.Copy(schemas, newBodySchemas)
 			}
-			markUsedType(usedTypes, elementType, bodySchema)
+			markUsedType(usedTypes, resolvedType, bodySchema)
 
 			// Create a reference to the existing schema
 			schema = &Schema{
 				Type:  "array",
-				Items: addRefSchemaForType(elementType),
+				Items: addRefSchemaForType(resolvedType),
 			}
 
 			return schema, schemas
 		}
 
-		items, newSchemas := mapGoTypeToOpenAPISchema(usedTypes, elementType, meta, cfg, visitedTypes)
+		items, newSchemas := mapGoTypeToOpenAPISchema(usedTypes, resolvedType, meta, cfg, visitedTypes)
 		maps.Copy(schemas, newSchemas)
+
+		// Apply enum detection for array elements if the element type is not primitive
+		if !isPrimitiveType(elementType) && items != nil && len(items.Enum) == 0 {
+			// Extract package name for enum detection
+			pkgName := ""
+			if typeParts := TypeParts(elementType); typeParts.PkgName != "" {
+				pkgName = typeParts.PkgName
+			}
+
+			// Detect enum values for this element type
+			if enumValues := detectEnumFromConstants(elementType, pkgName, meta); len(enumValues) > 0 {
+				items.Enum = enumValues
+			}
+		}
+
+		// Use reference for complex element types in arrays
+		if !isPrimitiveElement && canAddRefSchemaForType(resolvedType) && items != nil {
+			schemas[resolvedType] = items
+			items = addRefSchemaForType(resolvedType)
+		}
+
 		schema = &Schema{
 			Type:  "array",
 			Items: items,
@@ -1538,9 +1641,10 @@ func mapGoTypeToOpenAPISchema(usedTypes map[string]*Schema, goType string, meta 
 }
 
 func canAddRefSchemaForType(key string) bool {
-	if isPrimitiveType(key) || strings.HasPrefix(key, "[]") || strings.HasPrefix(key, "map[") {
+	if isPrimitiveType(key) || strings.HasPrefix(key, "[]") || strings.Contains(key, "map[") {
 		return false
 	}
+
 	// Exclude _nested types from reference schema generation
 	if strings.HasSuffix(key, "_nested") {
 		return false

--- a/internal/spec/mapper_test.go
+++ b/internal/spec/mapper_test.go
@@ -105,8 +105,8 @@ func TestMapGoTypeToOpenAPISchema_PointerTypes(t *testing.T) {
 				if schema.Items == nil {
 					t.Error("expected items for array, got nil")
 				}
-				if schema.Items.Type != "object" {
-					t.Errorf("expected object items for []*User, got %s", schema.Items.Type)
+				if schema.Items.Ref != "#/components/schemas/User" {
+					t.Errorf("expected ref items for []*User, got %s", schema.Items.Ref)
 				}
 			}
 		})

--- a/internal/spec/mapper_test.go
+++ b/internal/spec/mapper_test.go
@@ -6,6 +6,7 @@ import (
 	"go/token"
 	"go/types"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/ehabterra/apispec/internal/metadata"
@@ -898,13 +899,13 @@ func TestTypeByName(t *testing.T) {
 	}
 
 	// Test finding type by name
-	typ := typeByName(Parts{PkgName: "main", TypeName: "User"}, meta, "User")
+	typ := typeByName(Parts{PkgName: "main", TypeName: "User"}, meta)
 	if typ == nil {
 		t.Error("Should find type by name")
 	}
 
 	// Test finding non-existent type
-	typ = typeByName(Parts{PkgName: "main", TypeName: "NonExistentType"}, meta, "NonExistentType")
+	typ = typeByName(Parts{PkgName: "main", TypeName: "NonExistentType"}, meta)
 	if typ != nil {
 		t.Error("Should not find non-existent type")
 	}
@@ -1651,11 +1652,671 @@ func TestResolveUnderlyingType_ComplexCircularReference(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// This should not panic or cause stack overflow
 			usedTypes := make(map[string]*Schema)
-			schema, _ := mapGoTypeToOpenAPISchema(usedTypes, tc.goType, meta, cfg, nil)
+			visitedTypes := make(map[string]bool)
+			schema, _ := mapGoTypeToOpenAPISchema(usedTypes, tc.goType, meta, cfg, visitedTypes)
 
 			// Verify we got a valid schema
 			if schema == nil {
 				t.Errorf("Expected non-nil schema for type %s", tc.goType)
+			}
+		})
+	}
+}
+
+// TestDetectEnumFromConstantsDirect tests the detectEnumFromConstants function directly
+func TestDetectEnumFromConstantsDirect(t *testing.T) {
+	stringPool := metadata.NewStringPool()
+	meta := &metadata.Metadata{
+		StringPool: stringPool,
+		Packages: map[string]*metadata.Package{
+			"main": {
+				Files: map[string]*metadata.File{
+					"types.go": {
+						Types: map[string]*metadata.Type{
+							"Status": {
+								Name: stringPool.Get("Status"),
+								Kind: stringPool.Get("string"),
+							},
+						},
+						Variables: map[string]*metadata.Variable{
+							"StatusActive": {
+								Name:          stringPool.Get("StatusActive"),
+								Type:          stringPool.Get("main.Status"),
+								ResolvedType:  stringPool.Get("main.Status"),
+								Tok:           stringPool.Get("const"),
+								Value:         stringPool.Get("active"),
+								ComputedValue: "active",
+								GroupIndex:    0,
+							},
+							"StatusInactive": {
+								Name:          stringPool.Get("StatusInactive"),
+								Type:          stringPool.Get("main.Status"),
+								ResolvedType:  stringPool.Get("main.Status"),
+								Tok:           stringPool.Get("const"),
+								Value:         stringPool.Get("inactive"),
+								ComputedValue: "inactive",
+								GroupIndex:    0,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Test direct enum detection
+	enumValues := detectEnumFromConstants("Status", "main", meta)
+
+	if len(enumValues) != 2 {
+		t.Errorf("Expected 2 enum values, got %d", len(enumValues))
+	}
+
+	expectedValues := []string{"active", "inactive"}
+	for i, expected := range expectedValues {
+		if i < len(enumValues) && enumValues[i] != expected {
+			t.Errorf("Expected enum[%d] = %s, got %s", i, expected, enumValues[i])
+		}
+	}
+}
+
+// TestEnumDetectionForArraysSimple tests enum detection for arrays with a simpler approach
+func TestEnumDetectionForArraysSimple(t *testing.T) {
+	stringPool := metadata.NewStringPool()
+	meta := &metadata.Metadata{
+		StringPool: stringPool,
+		Packages: map[string]*metadata.Package{
+			"main": {
+				Files: map[string]*metadata.File{
+					"types.go": {
+						Types: map[string]*metadata.Type{
+							"Status": {
+								Name: stringPool.Get("Status"),
+								Kind: stringPool.Get("string"),
+							},
+						},
+						Variables: map[string]*metadata.Variable{
+							"StatusActive": {
+								Name:          stringPool.Get("StatusActive"),
+								Type:          stringPool.Get("main.Status"),
+								ResolvedType:  stringPool.Get("main.Status"),
+								Tok:           stringPool.Get("const"),
+								Value:         stringPool.Get("active"),
+								ComputedValue: "active",
+								GroupIndex:    0,
+							},
+							"StatusInactive": {
+								Name:          stringPool.Get("StatusInactive"),
+								Type:          stringPool.Get("main.Status"),
+								ResolvedType:  stringPool.Get("main.Status"),
+								Tok:           stringPool.Get("const"),
+								Value:         stringPool.Get("inactive"),
+								ComputedValue: "inactive",
+								GroupIndex:    0,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Test direct enum detection
+	enumValues := detectEnumFromConstants("main.Status", "main", meta)
+	if len(enumValues) != 2 {
+		t.Errorf("Expected 2 enum values, got %d", len(enumValues))
+	}
+
+	expectedValues := []string{"active", "inactive"}
+	for i, expected := range expectedValues {
+		if i < len(enumValues) && enumValues[i] != expected {
+			t.Errorf("Expected enum[%d] = %s, got %s", i, expected, enumValues[i])
+		}
+	}
+}
+
+// TestEnumDetectionForArrays tests the new enum detection for array elements
+func TestEnumDetectionForArrays(t *testing.T) {
+	stringPool := metadata.NewStringPool()
+	meta := &metadata.Metadata{
+		StringPool: stringPool,
+		Packages: map[string]*metadata.Package{
+			"main": {
+				Files: map[string]*metadata.File{
+					"types.go": {
+						Types: map[string]*metadata.Type{
+							"Status": {
+								Name: stringPool.Get("Status"),
+								Kind: stringPool.Get("string"),
+							},
+						},
+						Variables: map[string]*metadata.Variable{
+							"StatusActive": {
+								Name:          stringPool.Get("StatusActive"),
+								Type:          stringPool.Get("main.Status"),
+								ResolvedType:  stringPool.Get("main.Status"),
+								Tok:           stringPool.Get("const"),
+								Value:         stringPool.Get("active"),
+								ComputedValue: "active",
+								GroupIndex:    0,
+							},
+							"StatusInactive": {
+								Name:          stringPool.Get("StatusInactive"),
+								Type:          stringPool.Get("main.Status"),
+								ResolvedType:  stringPool.Get("main.Status"),
+								Tok:           stringPool.Get("const"),
+								Value:         stringPool.Get("inactive"),
+								ComputedValue: "inactive",
+								GroupIndex:    0,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := DefaultAPISpecConfig()
+
+	tests := []struct {
+		name         string
+		goType       string
+		expectedEnum []string
+		expectedType string
+	}{
+		{
+			name:         "array of enum type",
+			goType:       "[]main.Status",
+			expectedEnum: []string{"active", "inactive"},
+			expectedType: "array",
+		},
+		{
+			name:         "array of primitive type",
+			goType:       "[]string",
+			expectedEnum: nil,
+			expectedType: "array",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			usedTypes := make(map[string]*Schema)
+
+			schema, _ := mapGoTypeToOpenAPISchema(usedTypes, tc.goType, meta, cfg, nil)
+
+			if schema == nil {
+				t.Fatal("Expected non-nil schema")
+			}
+
+			if schema.Type != tc.expectedType {
+				t.Errorf("Expected type %s, got %s", tc.expectedType, schema.Type)
+			}
+
+			if schema.Items == nil {
+				t.Fatal("Expected non-nil Items for array type")
+			}
+
+			if tc.expectedEnum != nil {
+				// Check if Items is a reference schema
+				if schema.Items.Ref != "" {
+					// Extract the referenced type name from the ref
+					refType := strings.TrimPrefix(schema.Items.Ref, "#/components/schemas/")
+					// Check the referenced schema in usedTypes
+					if refSchema, exists := usedTypes[refType]; exists && refSchema != nil {
+						if len(refSchema.Enum) != len(tc.expectedEnum) {
+							t.Errorf("Expected %d enum values in referenced schema, got %d", len(tc.expectedEnum), len(refSchema.Enum))
+						} else {
+							for i, expected := range tc.expectedEnum {
+								if i < len(refSchema.Enum) && refSchema.Enum[i] != expected {
+									t.Errorf("Expected enum[%d] = %s, got %s", i, expected, refSchema.Enum[i])
+								}
+							}
+						}
+					} else {
+						t.Errorf("Referenced schema %s not found in usedTypes", refType)
+					}
+				} else {
+					// Direct enum values in Items
+					if len(schema.Items.Enum) != len(tc.expectedEnum) {
+						t.Errorf("Expected %d enum values, got %d", len(tc.expectedEnum), len(schema.Items.Enum))
+					} else {
+						for i, expected := range tc.expectedEnum {
+							if i < len(schema.Items.Enum) && schema.Items.Enum[i] != expected {
+								t.Errorf("Expected enum[%d] = %s, got %s", i, expected, schema.Items.Enum[i])
+							}
+						}
+					}
+				}
+			} else {
+				if len(schema.Items.Enum) > 0 {
+					t.Errorf("Expected no enum values, got %v", schema.Items.Enum)
+				}
+			}
+		})
+	}
+}
+
+// TestEnumDetectionForMaps tests the new enum detection for map values
+func TestEnumDetectionForMaps(t *testing.T) {
+	stringPool := metadata.NewStringPool()
+	meta := &metadata.Metadata{
+		StringPool: stringPool,
+		Packages: map[string]*metadata.Package{
+			"main": {
+				Files: map[string]*metadata.File{
+					"types.go": {
+						Types: map[string]*metadata.Type{
+							"Priority": {
+								Name: stringPool.Get("Priority"),
+								Kind: stringPool.Get("string"),
+							},
+						},
+						Variables: map[string]*metadata.Variable{
+							"PriorityHigh": {
+								Name:          stringPool.Get("PriorityHigh"),
+								Type:          stringPool.Get("main.Priority"),
+								ResolvedType:  stringPool.Get("main.Priority"),
+								Tok:           stringPool.Get("const"),
+								Value:         stringPool.Get("high"),
+								ComputedValue: "high",
+								GroupIndex:    0,
+							},
+							"PriorityLow": {
+								Name:          stringPool.Get("PriorityLow"),
+								Type:          stringPool.Get("main.Priority"),
+								ResolvedType:  stringPool.Get("main.Priority"),
+								Tok:           stringPool.Get("const"),
+								Value:         stringPool.Get("low"),
+								ComputedValue: "low",
+								GroupIndex:    0,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := DefaultAPISpecConfig()
+
+	tests := []struct {
+		name         string
+		goType       string
+		expectedEnum []string
+		expectedType string
+	}{
+		{
+			name:         "map with enum value type",
+			goType:       "map[string]main.Priority",
+			expectedEnum: []string{"high", "low"},
+			expectedType: "object",
+		},
+		{
+			name:         "map with primitive value type",
+			goType:       "map[string]string",
+			expectedEnum: nil,
+			expectedType: "object",
+		},
+		{
+			name:         "map with package prefix",
+			goType:       "map[string]main.Priority",
+			expectedEnum: []string{"high", "low"},
+			expectedType: "object",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			usedTypes := make(map[string]*Schema)
+			schema, _ := mapGoTypeToOpenAPISchema(usedTypes, tc.goType, meta, cfg, nil)
+
+			if schema == nil {
+				t.Fatal("Expected non-nil schema")
+			}
+
+			if schema.Type != tc.expectedType {
+				t.Errorf("Expected type %s, got %s", tc.expectedType, schema.Type)
+			}
+
+			if schema.AdditionalProperties == nil {
+				t.Fatal("Expected non-nil AdditionalProperties for map type")
+			}
+
+			if tc.expectedEnum != nil {
+				// Check if AdditionalProperties is a reference schema
+				if schema.AdditionalProperties.Ref != "" {
+					// Extract the referenced type name from the ref
+					refType := strings.TrimPrefix(schema.AdditionalProperties.Ref, "#/components/schemas/")
+					// Check the referenced schema in usedTypes
+					if refSchema, exists := usedTypes[refType]; exists && refSchema != nil {
+						if len(refSchema.Enum) != len(tc.expectedEnum) {
+							t.Errorf("Expected %d enum values in referenced schema, got %d", len(tc.expectedEnum), len(refSchema.Enum))
+						} else {
+							for i, expected := range tc.expectedEnum {
+								if i < len(refSchema.Enum) && refSchema.Enum[i] != expected {
+									t.Errorf("Expected enum[%d] = %s, got %s", i, expected, refSchema.Enum[i])
+								}
+							}
+						}
+					} else {
+						t.Errorf("Referenced schema %s not found in usedTypes", refType)
+					}
+				} else {
+					// Direct enum values in AdditionalProperties
+					if len(schema.AdditionalProperties.Enum) != len(tc.expectedEnum) {
+						t.Errorf("Expected %d enum values, got %d", len(tc.expectedEnum), len(schema.AdditionalProperties.Enum))
+					} else {
+						for i, expected := range tc.expectedEnum {
+							if i < len(schema.AdditionalProperties.Enum) && schema.AdditionalProperties.Enum[i] != expected {
+								t.Errorf("Expected enum[%d] = %s, got %s", i, expected, schema.AdditionalProperties.Enum[i])
+							}
+						}
+					}
+				}
+			} else {
+				if len(schema.AdditionalProperties.Enum) > 0 {
+					t.Errorf("Expected no enum values, got %v", schema.AdditionalProperties.Enum)
+				}
+			}
+		})
+	}
+}
+
+// TestEnumDetectionForAliasTypes tests the new enum detection for alias types
+func TestEnumDetectionForAliasTypes(t *testing.T) {
+	stringPool := metadata.NewStringPool()
+	meta := &metadata.Metadata{
+		StringPool: stringPool,
+		Packages: map[string]*metadata.Package{
+			"main": {
+				Files: map[string]*metadata.File{
+					"types.go": {
+						Types: map[string]*metadata.Type{
+							"UserRole": {
+								Name:   stringPool.Get("main.UserRole"),
+								Kind:   stringPool.Get("alias"),
+								Target: stringPool.Get("string"),
+							},
+						},
+						Variables: map[string]*metadata.Variable{
+							"RoleAdmin": {
+								Name:          stringPool.Get("RoleAdmin"),
+								Type:          stringPool.Get("main.UserRole"),
+								ResolvedType:  stringPool.Get("main.UserRole"),
+								Tok:           stringPool.Get("const"),
+								Value:         stringPool.Get("admin"),
+								ComputedValue: "admin",
+								GroupIndex:    0,
+							},
+							"RoleUser": {
+								Name:          stringPool.Get("RoleUser"),
+								Type:          stringPool.Get("main.UserRole"),
+								ResolvedType:  stringPool.Get("main.UserRole"),
+								Tok:           stringPool.Get("const"),
+								Value:         stringPool.Get("user"),
+								ComputedValue: "user",
+								GroupIndex:    0,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := DefaultAPISpecConfig()
+
+	tests := []struct {
+		name         string
+		goType       string
+		expectedEnum []string
+		expectedType string
+	}{
+		{
+			name:         "alias type with enum",
+			goType:       "main.UserRole",
+			expectedEnum: []string{"admin", "user"},
+			expectedType: "string",
+		},
+		{
+			name:         "primitive type without enum",
+			goType:       "string",
+			expectedEnum: nil,
+			expectedType: "string",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			usedTypes := make(map[string]*Schema)
+			schema, _ := mapGoTypeToOpenAPISchema(usedTypes, tc.goType, meta, cfg, nil)
+
+			if schema == nil {
+				t.Fatal("Expected non-nil schema")
+			}
+
+			if schema.Type != tc.expectedType {
+				t.Errorf("Expected type %s, got %s", tc.expectedType, schema.Type)
+			}
+
+			if tc.expectedEnum != nil {
+				if len(schema.Enum) != len(tc.expectedEnum) {
+					t.Errorf("Expected %d enum values, got %d", len(tc.expectedEnum), len(schema.Enum))
+				} else {
+					for i, expected := range tc.expectedEnum {
+						if i < len(schema.Enum) && schema.Enum[i] != expected {
+							t.Errorf("Expected enum[%d] = %s, got %s", i, expected, schema.Enum[i])
+						}
+					}
+				}
+			} else {
+				if len(schema.Enum) > 0 {
+					t.Errorf("Expected no enum values, got %v", schema.Enum)
+				}
+			}
+		})
+	}
+}
+
+// TestValidationConstraintsWithEnums tests the new enum constraint application
+func TestValidationConstraintsWithEnums(t *testing.T) {
+	tests := []struct {
+		name          string
+		schemaType    string
+		constraints   *ValidationConstraints
+		expectedEnum  []string
+		expectedItems bool
+		expectedProps bool
+	}{
+		{
+			name:       "string type with enum constraint",
+			schemaType: "string",
+			constraints: &ValidationConstraints{
+				Enum: []interface{}{"value1", "value2"},
+			},
+			expectedEnum:  []string{"value1", "value2"},
+			expectedItems: false,
+			expectedProps: false,
+		},
+		{
+			name:       "array type with enum constraint",
+			schemaType: "array",
+			constraints: &ValidationConstraints{
+				Enum: []interface{}{"item1", "item2"},
+			},
+			expectedEnum:  []string{"item1", "item2"},
+			expectedItems: true,
+			expectedProps: false,
+		},
+		{
+			name:       "object type with enum constraint",
+			schemaType: "object",
+			constraints: &ValidationConstraints{
+				Enum: []interface{}{"prop1", "prop2"},
+			},
+			expectedEnum:  []string{"prop1", "prop2"},
+			expectedItems: false,
+			expectedProps: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			schema := &Schema{
+				Type: tc.schemaType,
+			}
+
+			if tc.expectedItems {
+				schema.Items = &Schema{}
+			}
+
+			if tc.expectedProps {
+				schema.AdditionalProperties = &Schema{}
+			}
+
+			applyValidationConstraints(schema, tc.constraints)
+
+			if tc.expectedItems {
+				if schema.Items == nil {
+					t.Fatal("Expected non-nil Items")
+				}
+				if len(schema.Items.Enum) != len(tc.expectedEnum) {
+					t.Errorf("Expected %d enum values in Items, got %d", len(tc.expectedEnum), len(schema.Items.Enum))
+				}
+			}
+
+			if tc.expectedProps {
+				if schema.AdditionalProperties == nil {
+					t.Fatal("Expected non-nil AdditionalProperties")
+				}
+				if len(schema.AdditionalProperties.Enum) != len(tc.expectedEnum) {
+					t.Errorf("Expected %d enum values in AdditionalProperties, got %d", len(tc.expectedEnum), len(schema.AdditionalProperties.Enum))
+				}
+			}
+
+			if !tc.expectedItems && !tc.expectedProps {
+				if len(schema.Enum) != len(tc.expectedEnum) {
+					t.Errorf("Expected %d enum values, got %d", len(tc.expectedEnum), len(schema.Enum))
+				}
+			}
+		})
+	}
+}
+
+// TestMapTypeWithPackagePrefix tests the new map type handling with package prefixes
+func TestMapTypeWithPackagePrefix(t *testing.T) {
+	stringPool := metadata.NewStringPool()
+	meta := &metadata.Metadata{
+		StringPool: stringPool,
+		Packages: map[string]*metadata.Package{
+			"pkg": {
+				Files: map[string]*metadata.File{
+					"types.go": {
+						Types: map[string]*metadata.Type{
+							"CustomType": {
+								Name: stringPool.Get("CustomType"),
+								Kind: stringPool.Get("struct"),
+								Fields: []metadata.Field{
+									{
+										Name: stringPool.Get("Value"),
+										Type: stringPool.Get("string"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := DefaultAPISpecConfig()
+
+	tests := []struct {
+		name         string
+		goType       string
+		expectedType string
+	}{
+		{
+			name:         "map with package prefix",
+			goType:       "pkg.map[string]CustomType",
+			expectedType: "object",
+		},
+		{
+			name:         "map without package prefix",
+			goType:       "map[string]CustomType",
+			expectedType: "object",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			usedTypes := make(map[string]*Schema)
+			schema, _ := mapGoTypeToOpenAPISchema(usedTypes, tc.goType, meta, cfg, nil)
+
+			if schema == nil {
+				t.Fatal("Expected non-nil schema")
+			}
+
+			if schema.Type != tc.expectedType {
+				t.Errorf("Expected type %s, got %s", tc.expectedType, schema.Type)
+			}
+
+			if schema.AdditionalProperties == nil {
+				t.Fatal("Expected non-nil AdditionalProperties for map type")
+			}
+		})
+	}
+}
+
+// TestCanAddRefSchemaForTypeWithMap tests the updated canAddRefSchemaForType function
+func TestCanAddRefSchemaForTypeWithMap(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      string
+		expected bool
+	}{
+		{
+			name:     "primitive type",
+			key:      "string",
+			expected: false,
+		},
+		{
+			name:     "array type",
+			key:      "[]string",
+			expected: false,
+		},
+		{
+			name:     "map type with prefix",
+			key:      "map[string]int",
+			expected: false,
+		},
+		{
+			name:     "map type with package prefix",
+			key:      "pkg.map[string]int",
+			expected: false,
+		},
+		{
+			name:     "nested type",
+			key:      "SomeType_nested",
+			expected: false,
+		},
+		{
+			name:     "custom type",
+			key:      "CustomType",
+			expected: true,
+		},
+		{
+			name:     "package qualified type",
+			key:      "pkg.CustomType",
+			expected: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := canAddRefSchemaForType(tc.key)
+			if result != tc.expected {
+				t.Errorf("Expected %v for key %s, got %v", tc.expected, tc.key, result)
 			}
 		})
 	}

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -678,10 +678,6 @@ func traceGenericOrigin(node TrackerNodeInterface, typeParts Parts) string {
 	return ""
 }
 
-func (b *BasePatternMatcher) extractMethodFromFunctionName(funcName string) string {
-	return b.extractMethodFromFunctionNameWithConfig(funcName, nil)
-}
-
 func (b *BasePatternMatcher) extractMethodFromFunctionNameWithConfig(funcName string, config *MethodExtractionConfig) string {
 	if funcName == "" {
 		return ""
@@ -752,14 +748,4 @@ func (b *BasePatternMatcher) extractMethodFromFunctionNameWithConfig(funcName st
 // isLetter checks if a rune is a letter
 func (b *BasePatternMatcher) isLetter(r rune) bool {
 	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
-}
-
-func (b *BasePatternMatcher) mapGoTypeToOpenAPISchema(goType string) *Schema {
-	// Use TypeResolver for schema mapping if available
-	if b.typeResolver != nil {
-		return b.typeResolver.MapToOpenAPISchema(goType)
-	}
-
-	// Fallback to schema mapper
-	return b.schemaMapper.MapGoTypeToOpenAPISchema(goType)
 }

--- a/internal/spec/pattern_matchers_comprehensive_test.go
+++ b/internal/spec/pattern_matchers_comprehensive_test.go
@@ -121,7 +121,6 @@ func TestRoutePatternMatcher_Comprehensive(t *testing.T) {
 			}
 
 			// Test that matcher can be created without panicking
-			t.Logf("Successfully created matcher for: %s", tt.description)
 		})
 	}
 }
@@ -225,9 +224,6 @@ func TestMountPatternMatcher_Comprehensive(t *testing.T) {
 			if priority < 0 {
 				t.Error("Priority should be non-negative")
 			}
-
-			// Test that matcher can be created without panicking
-			t.Logf("Successfully created matcher for: %s", tt.description)
 		})
 	}
 }
@@ -323,7 +319,6 @@ func TestRequestPatternMatcher_Comprehensive(t *testing.T) {
 			}
 
 			// Test that matcher can be created without panicking
-			t.Logf("Successfully created matcher for: %s", tt.description)
 		})
 	}
 }
@@ -420,9 +415,6 @@ func TestResponsePatternMatcher_Comprehensive(t *testing.T) {
 			if priority < 0 {
 				t.Error("Priority should be non-negative")
 			}
-
-			// Test that matcher can be created without panicking
-			t.Logf("Successfully created matcher for: %s", tt.description)
 		})
 	}
 }
@@ -522,9 +514,6 @@ func TestParamPatternMatcher_Comprehensive(t *testing.T) {
 			if priority < 0 {
 				t.Error("Priority should be non-negative")
 			}
-
-			// Test that matcher can be created without panicking
-			t.Logf("Successfully created matcher for: %s", tt.description)
 		})
 	}
 }
@@ -1390,7 +1379,6 @@ func TestRequestPatternMatcher_resolveTypeOrigin(t *testing.T) {
 			if result == "" {
 				t.Error("resolveTypeOrigin should not return empty string")
 			}
-			t.Logf("resolveTypeOrigin result for %s: %s", tt.name, result)
 		})
 	}
 }
@@ -1462,156 +1450,6 @@ func TestTraceGenericOrigin(t *testing.T) {
 			result := traceGenericOrigin(mockNode, tt.typeParts)
 			if result != tt.expected {
 				t.Errorf("Expected %s, got %s", tt.expected, result)
-			}
-		})
-	}
-}
-
-func TestBasePatternMatcher_extractMethodFromFunctionName(t *testing.T) {
-	// Create metadata with string pool
-	stringPool := metadata.NewStringPool()
-	meta := &metadata.Metadata{
-		StringPool: stringPool,
-	}
-
-	// Create config
-	cfg := DefaultGinConfig()
-
-	// Create schema mapper
-	schemaMapper := NewSchemaMapper(cfg)
-
-	// Create type resolver
-	typeResolver := NewTypeResolver(meta, cfg, schemaMapper)
-
-	// Create context provider
-	contextProvider := NewContextProvider(meta)
-
-	// Create base pattern matcher
-	matcher := NewBasePatternMatcher(cfg, contextProvider, typeResolver)
-
-	// Test extractMethodFromFunctionName with different function names
-	tests := []struct {
-		name         string
-		functionName string
-		expected     string
-	}{
-		{
-			name:         "GET method",
-			functionName: "getUser",
-			expected:     "GET",
-		},
-		{
-			name:         "POST method",
-			functionName: "postUser",
-			expected:     "POST",
-		},
-		{
-			name:         "PUT method",
-			functionName: "putUser",
-			expected:     "PUT",
-		},
-		{
-			name:         "DELETE method",
-			functionName: "deleteUser",
-			expected:     "DELETE",
-		},
-		{
-			name:         "PATCH method",
-			functionName: "patchUser",
-			expected:     "PATCH",
-		},
-		{
-			name:         "OPTIONS method",
-			functionName: "optionsUser",
-			expected:     "OPTIONS",
-		},
-		{
-			name:         "HEAD method",
-			functionName: "headUser",
-			expected:     "HEAD",
-		},
-		{
-			name:         "no method found",
-			functionName: "processUser",
-			expected:     "GET", // The DefaultMethodExtractionConfig() has DefaultMethod: "GET"
-		},
-		{
-			name:         "case insensitive",
-			functionName: "GetUser",
-			expected:     "GET",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := matcher.extractMethodFromFunctionName(tt.functionName)
-			if result != tt.expected {
-				t.Errorf("Expected %s, got %s", tt.expected, result)
-			}
-		})
-	}
-}
-
-func TestBasePatternMatcher_mapGoTypeToOpenAPISchema(t *testing.T) {
-	// Create metadata with string pool
-	stringPool := metadata.NewStringPool()
-	meta := &metadata.Metadata{
-		StringPool: stringPool,
-	}
-
-	// Create config
-	cfg := DefaultGinConfig()
-
-	// Create schema mapper
-	schemaMapper := NewSchemaMapper(cfg)
-
-	// Create type resolver
-	typeResolver := NewTypeResolver(meta, cfg, schemaMapper)
-
-	// Create context provider
-	contextProvider := NewContextProvider(meta)
-
-	// Create base pattern matcher
-	matcher := NewBasePatternMatcher(cfg, contextProvider, typeResolver)
-
-	// Test mapGoTypeToOpenAPISchema with different Go types
-	tests := []struct {
-		name    string
-		goType  string
-		hasType bool
-	}{
-		{
-			name:    "string type",
-			goType:  "string",
-			hasType: true,
-		},
-		{
-			name:    "int type",
-			goType:  "int",
-			hasType: true,
-		},
-		{
-			name:    "bool type",
-			goType:  "bool",
-			hasType: true,
-		},
-		{
-			name:    "float64 type",
-			goType:  "float64",
-			hasType: true,
-		},
-		{
-			name:    "empty type",
-			goType:  "",
-			hasType: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := matcher.mapGoTypeToOpenAPISchema(tt.goType)
-			if tt.hasType && result == nil {
-				t.Error("Expected schema for valid Go type")
 			}
 		})
 	}

--- a/internal/spec/schema_generation_test.go
+++ b/internal/spec/schema_generation_test.go
@@ -148,8 +148,6 @@ func TestGenerateSchemaFromType_Comprehensive(t *testing.T) {
 			if schema.Type == "" && schema.Ref == "" {
 				t.Errorf("Schema should have either Type or Ref set for type %s", tt.typeName)
 			}
-
-			t.Logf("Successfully generated schema for %s: %+v", tt.typeName, schema)
 		})
 	}
 }
@@ -430,8 +428,6 @@ func TestSchemaGeneration_ComplexTypes(t *testing.T) {
 		if schema.Properties == nil {
 			t.Error("Expected properties to be set")
 		}
-
-		t.Logf("Successfully generated complex schema: %+v", schema)
 	})
 
 	t.Run("nested struct resolution", func(t *testing.T) {
@@ -455,8 +451,6 @@ func TestSchemaGeneration_ComplexTypes(t *testing.T) {
 		if schema.Type != "object" {
 			t.Errorf("Expected object type, got %s", schema.Type)
 		}
-
-		t.Logf("Successfully generated Profile schema: %+v", schema)
 	})
 }
 
@@ -521,8 +515,6 @@ func TestSchemaGeneration_TypeMapping(t *testing.T) {
 		if schema.Properties == nil {
 			t.Error("Expected properties to be set")
 		}
-
-		t.Logf("Successfully generated custom type schema: %+v", schema)
 	})
 
 	t.Run("custom slice type mapping", func(t *testing.T) {
@@ -539,8 +531,6 @@ func TestSchemaGeneration_TypeMapping(t *testing.T) {
 		if schema.Items == nil {
 			t.Error("Expected items to be set")
 		}
-
-		t.Logf("Successfully generated custom slice type schema: %+v", schema)
 	})
 }
 
@@ -621,8 +611,6 @@ func TestSchemaGeneration_ExternalTypes(t *testing.T) {
 			if schema.Type != tt.expected.Type {
 				t.Errorf("Expected type %s for %s, got %s", tt.expected.Type, tt.typeName, schema.Type)
 			}
-
-			t.Logf("Successfully generated external type schema for %s: %+v", tt.typeName, schema)
 		})
 	}
 }

--- a/internal/spec/tests/example.yaml
+++ b/internal/spec/tests/example.yaml
@@ -979,53 +979,6 @@ call_graph:
         position: 76
         resolved_type: -1
         generic_type_name: -1
-    assignments:
-      example.User.Age:
-        - variable_name: 22
-          pkg: 2
-          concrete_type: 20
-          position: 18
-          scope: 8
-          value:
-            kind: 0
-            name: 23
-            value: -1
-            raw: -1
-            pkg: 2
-            type: 20
-            position: 24
-            resolved_type: -1
-            generic_type_name: -1
-          lhs:
-            kind: 8
-            name: -1
-            value: -1
-            x:
-              kind: 0
-              name: 1
-              value: -1
-              raw: -1
-              pkg: 2
-              type: 3
-              position: 18
-              resolved_type: -1
-              generic_type_name: -1
-            sel:
-              kind: 0
-              name: 19
-              value: -1
-              raw: -1
-              pkg: 2
-              type: 20
-              position: 21
-              resolved_type: -1
-              generic_type_name: -1
-            raw: -1
-            pkg: 2
-            type: 20
-            position: 18
-            resolved_type: -1
-            generic_type_name: -1
     param_arg_map:
       age:
         kind: 0

--- a/internal/spec/tests/multipackage.yaml
+++ b/internal/spec/tests/multipackage.yaml
@@ -2228,143 +2228,6 @@ packages:
           131: 131
 call_graph:
   - caller:
-      name: 74
-      pkg: 56
-      position: -1
-      recv_type: 78
-    callee:
-      name: 9
-      pkg: 2
-      position: 70
-      recv_type: 10
-    position: 70
-    callee_var_name: user
-    callee_recv_var_name: name
-    chain_root: user
-  - caller:
-      name: 74
-      pkg: 56
-      position: -1
-      recv_type: 78
-    callee:
-      name: 22
-      pkg: 2
-      position: 75
-      recv_type: 10
-    position: 75
-    callee_var_name: user
-    callee_recv_var_name: age
-    chain_root: user
-  - caller:
-      name: 74
-      pkg: 56
-      position: -1
-      recv_type: 78
-    callee:
-      name: 65
-      pkg: 63
-      position: 64
-      recv_type: -1
-    position: 64
-    args:
-      - kind: 53
-        name: -1
-        value: 54
-        raw: -1
-        pkg: -1
-        type: -1
-        position: -1
-        resolved_type: -1
-        generic_type_name: -1
-      - kind: 8
-        name: -1
-        value: -1
-        x:
-          kind: 0
-          name: 55
-          value: -1
-          raw: -1
-          pkg: 56
-          type: 57
-          position: 58
-          resolved_type: -1
-          generic_type_name: -1
-        sel:
-          kind: 0
-          name: 59
-          value: -1
-          raw: -1
-          pkg: 56
-          type: 6
-          position: 60
-          resolved_type: -1
-          generic_type_name: -1
-        raw: -1
-        pkg: 56
-        type: 6
-        position: 58
-        resolved_type: -1
-        generic_type_name: -1
-      - kind: 0
-        name: 36
-        value: -1
-        raw: -1
-        pkg: 56
-        type: 6
-        position: 61
-        resolved_type: -1
-        generic_type_name: -1
-      - kind: 0
-        name: 40
-        value: -1
-        raw: -1
-        pkg: 56
-        type: 20
-        position: 62
-        resolved_type: -1
-        generic_type_name: -1
-    param_arg_map:
-      a:
-        kind: 8
-        name: -1
-        value: -1
-        x:
-          kind: 0
-          name: 55
-          value: -1
-          raw: -1
-          pkg: 56
-          type: 57
-          position: 58
-          resolved_type: -1
-          generic_type_name: -1
-        sel:
-          kind: 0
-          name: 59
-          value: -1
-          raw: -1
-          pkg: 56
-          type: 6
-          position: 60
-          resolved_type: -1
-          generic_type_name: -1
-        raw: -1
-        pkg: 56
-        type: 6
-        position: 58
-        resolved_type: -1
-        generic_type_name: -1
-      format:
-        kind: 53
-        name: -1
-        value: 54
-        raw: -1
-        pkg: -1
-        type: -1
-        position: -1
-        resolved_type: -1
-        generic_type_name: -1
-  - caller:
       name: 112
       pkg: 110
       position: -1
@@ -2964,5 +2827,142 @@ call_graph:
         pkg: 129
         type: 6
         position: 130
+        resolved_type: -1
+        generic_type_name: -1
+  - caller:
+      name: 74
+      pkg: 56
+      position: -1
+      recv_type: 78
+    callee:
+      name: 9
+      pkg: 2
+      position: 70
+      recv_type: 10
+    position: 70
+    callee_var_name: user
+    callee_recv_var_name: name
+    chain_root: user
+  - caller:
+      name: 74
+      pkg: 56
+      position: -1
+      recv_type: 78
+    callee:
+      name: 22
+      pkg: 2
+      position: 75
+      recv_type: 10
+    position: 75
+    callee_var_name: user
+    callee_recv_var_name: age
+    chain_root: user
+  - caller:
+      name: 74
+      pkg: 56
+      position: -1
+      recv_type: 78
+    callee:
+      name: 65
+      pkg: 63
+      position: 64
+      recv_type: -1
+    position: 64
+    args:
+      - kind: 53
+        name: -1
+        value: 54
+        raw: -1
+        pkg: -1
+        type: -1
+        position: -1
+        resolved_type: -1
+        generic_type_name: -1
+      - kind: 8
+        name: -1
+        value: -1
+        x:
+          kind: 0
+          name: 55
+          value: -1
+          raw: -1
+          pkg: 56
+          type: 57
+          position: 58
+          resolved_type: -1
+          generic_type_name: -1
+        sel:
+          kind: 0
+          name: 59
+          value: -1
+          raw: -1
+          pkg: 56
+          type: 6
+          position: 60
+          resolved_type: -1
+          generic_type_name: -1
+        raw: -1
+        pkg: 56
+        type: 6
+        position: 58
+        resolved_type: -1
+        generic_type_name: -1
+      - kind: 0
+        name: 36
+        value: -1
+        raw: -1
+        pkg: 56
+        type: 6
+        position: 61
+        resolved_type: -1
+        generic_type_name: -1
+      - kind: 0
+        name: 40
+        value: -1
+        raw: -1
+        pkg: 56
+        type: 20
+        position: 62
+        resolved_type: -1
+        generic_type_name: -1
+    param_arg_map:
+      a:
+        kind: 8
+        name: -1
+        value: -1
+        x:
+          kind: 0
+          name: 55
+          value: -1
+          raw: -1
+          pkg: 56
+          type: 57
+          position: 58
+          resolved_type: -1
+          generic_type_name: -1
+        sel:
+          kind: 0
+          name: 59
+          value: -1
+          raw: -1
+          pkg: 56
+          type: 6
+          position: 60
+          resolved_type: -1
+          generic_type_name: -1
+        raw: -1
+        pkg: 56
+        type: 6
+        position: 58
+        resolved_type: -1
+        generic_type_name: -1
+      format:
+        kind: 53
+        name: -1
+        value: 54
+        raw: -1
+        pkg: -1
+        type: -1
+        position: -1
         resolved_type: -1
         generic_type_name: -1

--- a/internal/spec/tests/multipackage.yaml
+++ b/internal/spec/tests/multipackage.yaml
@@ -1,69 +1,25 @@
 string_pool:
-  - literal
-  - "1"
-  - "149"
   - ident
-  - input
-  - multipackage/utils
-  - string
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/utils/helper.go:6:43
-  - strings
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/utils/helper.go:6:25
-  - TrimSpace
-  - func(s string) string
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/utils/helper.go:6:33
-  - selector
-  - call
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/utils/helper.go:6:9
-  - ToUpper
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/utils/helper.go:6:17
-  - FormatString
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/utils/helper.go:5:25
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/utils/helper.go:5:33
-  - func_type
-  - func_results
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/utils/helper.go:5:1
-  - exported
-  - age
-  - int
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/utils/helper.go:10:9
-  - "0"
-  - binary
-  - '>'
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/utils/helper.go:10:20
-  - "150"
-  - <
-  - '&&'
-  - ValidateAge
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/utils/helper.go:9:22
-  - bool
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/utils/helper.go:9:27
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/utils/helper.go:9:1
-  - MinAge
-  - const
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/utils/helper.go:14:2
-  - untyped int
-  - MaxAge
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/utils/helper.go:15:2
-  - DefaultFormat
-  - var
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/utils/helper.go:18:5
-  - '"uppercase"'
-  - uppercase
   - u
   - multipackage/models
   - '*multipackage/models.User'
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/models/user.go:14:9
   - Name
+  - string
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/models/user.go:14:11
+  - selector
   - GetName
   - '*User'
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/models/user.go:13:26
+  - func_type
+  - func_results
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/models/user.go:13:1
+  - exported
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/models/user.go
   - func() string
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/models/user.go:18:9
   - Age
+  - int
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/models/user.go:18:11
   - GetAge
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/models/user.go:17:25
@@ -83,6 +39,7 @@ string_pool:
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/models/user.go:23:9
   - key_value
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/models/user.go:24:3
+  - age
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/models/user.go:24:9
   - composite_lit
   - unary
@@ -95,6 +52,7 @@ string_pool:
   - star
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/models/user.go:21:36
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/models/user.go:21:1
+  - literal
   - '"%s %s is %d years old"'
   - s
   - multipackage/services
@@ -109,6 +67,7 @@ string_pool:
   - Sprintf
   - func(format string, a ...any) string
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/services/user_service.go:19:13
+  - call
   - user
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/services/user_service.go:17:10
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/services/user_service.go:17:15
@@ -166,6 +125,47 @@ string_pool:
   - result
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/main.go:13:2
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/main.go:9:1
+  - "1"
+  - "149"
+  - input
+  - multipackage/utils
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/utils/helper.go:6:43
+  - strings
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/utils/helper.go:6:25
+  - TrimSpace
+  - func(s string) string
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/utils/helper.go:6:33
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/utils/helper.go:6:9
+  - ToUpper
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/utils/helper.go:6:17
+  - FormatString
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/utils/helper.go:5:25
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/utils/helper.go:5:33
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/utils/helper.go:5:1
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/utils/helper.go:10:9
+  - "0"
+  - binary
+  - '>'
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/utils/helper.go:10:20
+  - "150"
+  - <
+  - '&&'
+  - ValidateAge
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/utils/helper.go:9:22
+  - bool
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/utils/helper.go:9:27
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/utils/helper.go:9:1
+  - MinAge
+  - const
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/utils/helper.go:14:2
+  - untyped int
+  - MaxAge
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/utils/helper.go:15:2
+  - DefaultFormat
+  - var
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/utils/helper.go:18:5
+  - '"uppercase"'
+  - uppercase
   - multipackage/models.UserInterface
   - multipackage/models.User
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/main.go:14:14
@@ -177,14 +177,14 @@ packages:
       r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/main.go:
         functions:
           main:
-            name: 153
-            pkg: 151
+            name: 112
+            pkg: 110
             signature:
-              kind: 21
+              kind: 12
               name: -1
               value: -1
               fun:
-                kind: 22
+                kind: 13
                 name: -1
                 value: -1
                 raw: -1
@@ -199,191 +199,191 @@ packages:
               position: -1
               resolved_type: -1
               generic_type_name: -1
-            position: 166
-            scope: 114
+            position: 125
+            scope: 73
             comments: -1
             assignments:
               result:
-                - variable_name: 164
-                  pkg: 151
+                - variable_name: 123
+                  pkg: 110
                   concrete_type: 6
-                  position: 165
-                  scope: 114
+                  position: 124
+                  scope: 73
                   value:
-                    kind: 14
+                    kind: 68
                     name: -1
                     value: -1
                     fun:
-                      kind: 13
+                      kind: 8
                       name: -1
                       value: -1
                       x:
-                        kind: 3
-                        name: 158
+                        kind: 0
+                        name: 117
                         value: -1
                         raw: -1
-                        pkg: 151
-                        type: 99
-                        position: 161
+                        pkg: 110
+                        type: 57
+                        position: 120
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 3
-                        name: 115
+                        kind: 0
+                        name: 74
                         value: -1
                         raw: -1
-                        pkg: 98
-                        type: 162
-                        position: 163
+                        pkg: 56
+                        type: 121
+                        position: 122
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 98
-                      type: 162
-                      position: 161
+                      pkg: 56
+                      type: 121
+                      position: 120
                       resolved_type: -1
                       generic_type_name: -1
                     args:
-                      - kind: 3
-                        name: 110
+                      - kind: 0
+                        name: 69
                         value: -1
                         raw: -1
-                        pkg: 151
-                        type: 53
-                        position: 160
+                        pkg: 110
+                        type: 3
+                        position: 119
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
                     pkg: -1
                     type: -1
-                    position: 161
+                    position: 120
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 3
-                    name: 164
+                    kind: 0
+                    name: 123
                     value: -1
                     raw: -1
-                    pkg: 151
+                    pkg: 110
                     type: 6
-                    position: 165
+                    position: 124
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 153
+                  func: 112
                   callee_func: ProcessUser
                   callee_pkg: multipackage/services
               service:
-                - variable_name: 158
-                  pkg: 151
-                  concrete_type: 99
-                  position: 159
-                  scope: 114
+                - variable_name: 117
+                  pkg: 110
+                  concrete_type: 57
+                  position: 118
+                  scope: 73
                   value:
-                    kind: 14
+                    kind: 68
                     name: -1
                     value: -1
                     fun:
-                      kind: 13
+                      kind: 8
                       name: -1
                       value: -1
                       x:
-                        kind: 3
-                        name: 154
+                        kind: 0
+                        name: 113
                         value: -1
                         raw: -1
-                        pkg: 98
+                        pkg: 56
                         type: -1
-                        position: 155
+                        position: 114
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 3
-                        name: 141
+                        kind: 0
+                        name: 100
                         value: -1
                         raw: -1
-                        pkg: 98
-                        type: 156
-                        position: 157
+                        pkg: 56
+                        type: 115
+                        position: 116
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 98
-                      type: 156
-                      position: 155
+                      pkg: 56
+                      type: 115
+                      position: 114
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
                     pkg: -1
                     type: -1
-                    position: 155
+                    position: 114
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 3
-                    name: 158
+                    kind: 0
+                    name: 117
                     value: -1
                     raw: -1
-                    pkg: 151
-                    type: 99
-                    position: 159
+                    pkg: 110
+                    type: 57
+                    position: 118
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 153
+                  func: 112
                   callee_func: NewUserService
                   callee_pkg: multipackage/services
               user:
-                - variable_name: 110
-                  pkg: 151
-                  concrete_type: 53
-                  position: 152
-                  scope: 114
+                - variable_name: 69
+                  pkg: 110
+                  concrete_type: 3
+                  position: 111
+                  scope: 73
                   value:
-                    kind: 14
+                    kind: 68
                     name: -1
                     value: -1
                     fun:
-                      kind: 13
+                      kind: 8
                       name: -1
                       value: -1
                       x:
-                        kind: 3
-                        name: 120
+                        kind: 0
+                        name: 79
                         value: -1
                         raw: -1
-                        pkg: 52
+                        pkg: 2
                         type: -1
-                        position: 148
+                        position: 107
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 3
-                        name: 89
+                        kind: 0
+                        name: 46
                         value: -1
                         raw: -1
-                        pkg: 52
-                        type: 149
-                        position: 150
+                        pkg: 2
+                        type: 108
+                        position: 109
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 52
-                      type: 149
-                      position: 148
+                      pkg: 2
+                      type: 108
+                      position: 107
                       resolved_type: -1
                       generic_type_name: -1
                     args:
-                      - kind: 0
+                      - kind: 53
                         name: -1
-                        value: 146
+                        value: 105
                         raw: -1
                         pkg: -1
                         type: -1
                         position: -1
                         resolved_type: -1
                         generic_type_name: -1
-                      - kind: 0
+                      - kind: 53
                         name: -1
-                        value: 147
+                        value: 106
                         raw: -1
                         pkg: -1
                         type: -1
@@ -393,67 +393,67 @@ packages:
                     raw: -1
                     pkg: -1
                     type: -1
-                    position: 148
+                    position: 107
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 3
-                    name: 110
+                    kind: 0
+                    name: 69
                     value: -1
                     raw: -1
-                    pkg: 151
-                    type: 53
-                    position: 152
+                    pkg: 110
+                    type: 3
+                    position: 111
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 153
+                  func: 112
                   callee_func: NewUser
                   callee_pkg: multipackage/models
         imports:
-          52: 52
-          98: 98
-          105: 105
+          2: 2
+          56: 56
+          63: 63
   multipackage/models:
     files:
       r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/models/user.go:
         types:
           User:
-            name: 70
-            pkg: 52
-            kind: 71
+            name: 26
+            pkg: 2
+            kind: 27
             implements:
               - 167
             fields:
-              - name: 55
+              - name: 5
                 type: 6
-                tag: 72
-                scope: 24
+                tag: 28
+                scope: 15
                 comments: -1
-              - name: 64
-                type: 26
-                tag: 73
-                scope: 24
+              - name: 19
+                type: 20
+                tag: 29
+                scope: 15
                 comments: -1
-            scope: 24
+            scope: 15
             methods:
-              - name: 57
-                receiver: 58
+              - name: 9
+                receiver: 10
                 signature:
-                  kind: 21
+                  kind: 12
                   name: -1
                   value: -1
                   fun:
-                    kind: 22
+                    kind: 13
                     name: -1
                     value: -1
                     args:
-                      - kind: 3
+                      - kind: 0
                         name: 6
                         value: -1
                         raw: -1
-                        pkg: 52
+                        pkg: 2
                         type: 6
-                        position: 59
+                        position: 11
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
@@ -468,58 +468,58 @@ packages:
                   position: -1
                   resolved_type: 6
                   generic_type_name: -1
-                signature_str: 62
-                position: 60
-                scope: 24
-                filename: 61
+                signature_str: 17
+                position: 14
+                scope: 15
+                filename: 16
                 return_vars:
-                  - kind: 13
+                  - kind: 8
                     name: -1
                     value: -1
                     x:
-                      kind: 3
-                      name: 51
+                      kind: 0
+                      name: 1
                       value: -1
                       raw: -1
-                      pkg: 52
-                      type: 53
-                      position: 54
+                      pkg: 2
+                      type: 3
+                      position: 4
                       resolved_type: -1
                       generic_type_name: -1
                     sel:
-                      kind: 3
-                      name: 55
+                      kind: 0
+                      name: 5
                       value: -1
                       raw: -1
-                      pkg: 52
+                      pkg: 2
                       type: 6
-                      position: 56
+                      position: 7
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
-                    pkg: 52
+                    pkg: 2
                     type: 6
-                    position: 54
+                    position: 4
                     resolved_type: -1
                     generic_type_name: -1
-              - name: 66
-                receiver: 58
+              - name: 22
+                receiver: 10
                 signature:
-                  kind: 21
+                  kind: 12
                   name: -1
                   value: -1
                   fun:
-                    kind: 22
+                    kind: 13
                     name: -1
                     value: -1
                     args:
-                      - kind: 3
-                        name: 26
+                      - kind: 0
+                        name: 20
                         value: -1
                         raw: -1
-                        pkg: 52
-                        type: 26
-                        position: 67
+                        pkg: 2
+                        type: 20
+                        position: 23
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
@@ -532,68 +532,68 @@ packages:
                   pkg: -1
                   type: -1
                   position: -1
-                  resolved_type: 26
+                  resolved_type: 20
                   generic_type_name: -1
-                signature_str: 69
-                position: 68
-                scope: 24
-                filename: 61
+                signature_str: 25
+                position: 24
+                scope: 15
+                filename: 16
                 return_vars:
-                  - kind: 13
+                  - kind: 8
                     name: -1
                     value: -1
                     x:
-                      kind: 3
-                      name: 51
+                      kind: 0
+                      name: 1
                       value: -1
                       raw: -1
-                      pkg: 52
-                      type: 53
-                      position: 63
+                      pkg: 2
+                      type: 3
+                      position: 18
                       resolved_type: -1
                       generic_type_name: -1
                     sel:
-                      kind: 3
-                      name: 64
+                      kind: 0
+                      name: 19
                       value: -1
                       raw: -1
-                      pkg: 52
-                      type: 26
-                      position: 65
+                      pkg: 2
+                      type: 20
+                      position: 21
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
-                    pkg: 52
-                    type: 26
-                    position: 63
+                    pkg: 2
+                    type: 20
+                    position: 18
                     resolved_type: -1
                     generic_type_name: -1
             comments: -1
           UserInterface:
-            name: 75
-            pkg: 52
-            kind: 74
+            name: 31
+            pkg: 2
+            kind: 30
             implemented_by:
               - 168
-            scope: 24
+            scope: 15
             methods:
-              - name: 57
+              - name: 9
                 signature:
-                  kind: 21
+                  kind: 12
                   name: -1
                   value: -1
                   fun:
-                    kind: 22
+                    kind: 13
                     name: -1
                     value: -1
                     args:
-                      - kind: 3
+                      - kind: 0
                         name: 6
                         value: -1
                         raw: -1
-                        pkg: 52
+                        pkg: 2
                         type: 6
-                        position: 76
+                        position: 32
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
@@ -608,26 +608,26 @@ packages:
                   position: -1
                   resolved_type: 6
                   generic_type_name: -1
-                signature_str: 62
-                scope: 24
+                signature_str: 17
+                scope: 15
                 comments: -1
-              - name: 66
+              - name: 22
                 signature:
-                  kind: 21
+                  kind: 12
                   name: -1
                   value: -1
                   fun:
-                    kind: 22
+                    kind: 13
                     name: -1
                     value: -1
                     args:
-                      - kind: 3
-                        name: 26
+                      - kind: 0
+                        name: 20
                         value: -1
                         raw: -1
-                        pkg: 52
-                        type: 26
-                        position: 77
+                        pkg: 2
+                        type: 20
+                        position: 33
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
@@ -640,42 +640,42 @@ packages:
                   pkg: -1
                   type: -1
                   position: -1
-                  resolved_type: 26
+                  resolved_type: 20
                   generic_type_name: -1
-                signature_str: 69
-                scope: 24
+                signature_str: 25
+                scope: 15
                 comments: -1
             comments: -1
         functions:
           NewUser:
-            name: 89
-            pkg: 52
+            name: 46
+            pkg: 2
             signature:
-              kind: 21
+              kind: 12
               name: -1
               value: -1
               fun:
-                kind: 22
+                kind: 13
                 name: -1
                 value: -1
                 args:
-                  - kind: 93
+                  - kind: 50
                     name: -1
                     value: -1
                     x:
-                      kind: 3
-                      name: 70
+                      kind: 0
+                      name: 26
                       value: -1
                       raw: -1
-                      pkg: 52
-                      type: 70
-                      position: 92
+                      pkg: 2
+                      type: 26
+                      position: 49
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
                     pkg: -1
                     type: -1
-                    position: 94
+                    position: 51
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -685,168 +685,168 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 3
+                - kind: 0
                   name: 6
                   value: -1
                   raw: -1
-                  pkg: 52
+                  pkg: 2
                   type: 6
-                  position: 90
+                  position: 47
                   resolved_type: -1
                   generic_type_name: -1
-                - kind: 3
-                  name: 26
+                - kind: 0
+                  name: 20
                   value: -1
                   raw: -1
-                  pkg: 52
-                  type: 26
-                  position: 91
+                  pkg: 2
+                  type: 20
+                  position: 48
                   resolved_type: -1
                   generic_type_name: -1
               raw: -1
               pkg: -1
               type: -1
               position: -1
-              resolved_type: 58
+              resolved_type: 10
               generic_type_name: -1
-            position: 95
-            scope: 24
+            position: 52
+            scope: 15
             comments: -1
             return_vars:
-              - kind: 86
+              - kind: 43
                 name: -1
-                value: 87
+                value: 44
                 x:
-                  kind: 85
+                  kind: 42
                   name: -1
                   value: -1
                   x:
-                    kind: 3
-                    name: 70
+                    kind: 0
+                    name: 26
                     value: -1
                     raw: -1
-                    pkg: 52
-                    type: 70
-                    position: 78
+                    pkg: 2
+                    type: 26
+                    position: 34
                     resolved_type: -1
                     generic_type_name: -1
                   args:
-                    - kind: 82
+                    - kind: 38
                       name: -1
                       value: -1
                       x:
-                        kind: 3
-                        name: 55
+                        kind: 0
+                        name: 5
                         value: -1
                         raw: -1
-                        pkg: 52
+                        pkg: 2
                         type: 6
-                        position: 79
+                        position: 35
                         resolved_type: -1
                         generic_type_name: -1
                       fun:
-                        kind: 3
-                        name: 80
+                        kind: 0
+                        name: 36
                         value: -1
                         raw: -1
-                        pkg: 52
+                        pkg: 2
                         type: 6
-                        position: 81
+                        position: 37
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
                       pkg: -1
                       type: -1
-                      position: 79
+                      position: 35
                       resolved_type: -1
                       generic_type_name: -1
-                    - kind: 82
+                    - kind: 38
                       name: -1
                       value: -1
                       x:
-                        kind: 3
-                        name: 64
+                        kind: 0
+                        name: 19
                         value: -1
                         raw: -1
-                        pkg: 52
-                        type: 26
-                        position: 83
+                        pkg: 2
+                        type: 20
+                        position: 39
                         resolved_type: -1
                         generic_type_name: -1
                       fun:
-                        kind: 3
-                        name: 25
+                        kind: 0
+                        name: 40
                         value: -1
                         raw: -1
-                        pkg: 52
-                        type: 26
-                        position: 84
+                        pkg: 2
+                        type: 20
+                        position: 41
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
                       pkg: -1
                       type: -1
-                      position: 83
+                      position: 39
                       resolved_type: -1
                       generic_type_name: -1
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 78
+                  position: 34
                   resolved_type: -1
                   generic_type_name: -1
                 raw: -1
                 pkg: -1
                 type: -1
-                position: 88
+                position: 45
                 resolved_type: -1
                 generic_type_name: -1
         struct_instances:
-          - type: 70
-            pkg: 52
-            position: 78
+          - type: 26
+            pkg: 2
+            position: 34
             fields:
-              55: 80
-              64: 25
+              5: 36
+              19: 40
         imports: {}
     types:
       User:
-        name: 70
-        pkg: 52
-        kind: 71
+        name: 26
+        pkg: 2
+        kind: 27
         implements:
           - 167
         fields:
-          - name: 55
+          - name: 5
             type: 6
-            tag: 72
-            scope: 24
+            tag: 28
+            scope: 15
             comments: -1
-          - name: 64
-            type: 26
-            tag: 73
-            scope: 24
+          - name: 19
+            type: 20
+            tag: 29
+            scope: 15
             comments: -1
-        scope: 24
+        scope: 15
         methods:
-          - name: 57
-            receiver: 58
+          - name: 9
+            receiver: 10
             signature:
-              kind: 21
+              kind: 12
               name: -1
               value: -1
               fun:
-                kind: 22
+                kind: 13
                 name: -1
                 value: -1
                 args:
-                  - kind: 3
+                  - kind: 0
                     name: 6
                     value: -1
                     raw: -1
-                    pkg: 52
+                    pkg: 2
                     type: 6
-                    position: 59
+                    position: 11
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -861,58 +861,58 @@ packages:
               position: -1
               resolved_type: 6
               generic_type_name: -1
-            signature_str: 62
-            position: 60
-            scope: 24
-            filename: 61
+            signature_str: 17
+            position: 14
+            scope: 15
+            filename: 16
             return_vars:
-              - kind: 13
+              - kind: 8
                 name: -1
                 value: -1
                 x:
-                  kind: 3
-                  name: 51
+                  kind: 0
+                  name: 1
                   value: -1
                   raw: -1
-                  pkg: 52
-                  type: 53
-                  position: 54
+                  pkg: 2
+                  type: 3
+                  position: 4
                   resolved_type: -1
                   generic_type_name: -1
                 sel:
-                  kind: 3
-                  name: 55
+                  kind: 0
+                  name: 5
                   value: -1
                   raw: -1
-                  pkg: 52
+                  pkg: 2
                   type: 6
-                  position: 56
+                  position: 7
                   resolved_type: -1
                   generic_type_name: -1
                 raw: -1
-                pkg: 52
+                pkg: 2
                 type: 6
-                position: 54
+                position: 4
                 resolved_type: -1
                 generic_type_name: -1
-          - name: 66
-            receiver: 58
+          - name: 22
+            receiver: 10
             signature:
-              kind: 21
+              kind: 12
               name: -1
               value: -1
               fun:
-                kind: 22
+                kind: 13
                 name: -1
                 value: -1
                 args:
-                  - kind: 3
-                    name: 26
+                  - kind: 0
+                    name: 20
                     value: -1
                     raw: -1
-                    pkg: 52
-                    type: 26
-                    position: 67
+                    pkg: 2
+                    type: 20
+                    position: 23
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -925,68 +925,68 @@ packages:
               pkg: -1
               type: -1
               position: -1
-              resolved_type: 26
+              resolved_type: 20
               generic_type_name: -1
-            signature_str: 69
-            position: 68
-            scope: 24
-            filename: 61
+            signature_str: 25
+            position: 24
+            scope: 15
+            filename: 16
             return_vars:
-              - kind: 13
+              - kind: 8
                 name: -1
                 value: -1
                 x:
-                  kind: 3
-                  name: 51
+                  kind: 0
+                  name: 1
                   value: -1
                   raw: -1
-                  pkg: 52
-                  type: 53
-                  position: 63
+                  pkg: 2
+                  type: 3
+                  position: 18
                   resolved_type: -1
                   generic_type_name: -1
                 sel:
-                  kind: 3
-                  name: 64
+                  kind: 0
+                  name: 19
                   value: -1
                   raw: -1
-                  pkg: 52
-                  type: 26
-                  position: 65
+                  pkg: 2
+                  type: 20
+                  position: 21
                   resolved_type: -1
                   generic_type_name: -1
                 raw: -1
-                pkg: 52
-                type: 26
-                position: 63
+                pkg: 2
+                type: 20
+                position: 18
                 resolved_type: -1
                 generic_type_name: -1
         comments: -1
       UserInterface:
-        name: 75
-        pkg: 52
-        kind: 74
+        name: 31
+        pkg: 2
+        kind: 30
         implemented_by:
           - 168
-        scope: 24
+        scope: 15
         methods:
-          - name: 57
+          - name: 9
             signature:
-              kind: 21
+              kind: 12
               name: -1
               value: -1
               fun:
-                kind: 22
+                kind: 13
                 name: -1
                 value: -1
                 args:
-                  - kind: 3
+                  - kind: 0
                     name: 6
                     value: -1
                     raw: -1
-                    pkg: 52
+                    pkg: 2
                     type: 6
-                    position: 76
+                    position: 32
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -1001,26 +1001,26 @@ packages:
               position: -1
               resolved_type: 6
               generic_type_name: -1
-            signature_str: 62
-            scope: 24
+            signature_str: 17
+            scope: 15
             comments: -1
-          - name: 66
+          - name: 22
             signature:
-              kind: 21
+              kind: 12
               name: -1
               value: -1
               fun:
-                kind: 22
+                kind: 13
                 name: -1
                 value: -1
                 args:
-                  - kind: 3
-                    name: 26
+                  - kind: 0
+                    name: 20
                     value: -1
                     raw: -1
-                    pkg: 52
-                    type: 26
-                    position: 77
+                    pkg: 2
+                    type: 20
+                    position: 33
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -1033,10 +1033,10 @@ packages:
               pkg: -1
               type: -1
               position: -1
-              resolved_type: 26
+              resolved_type: 20
               generic_type_name: -1
-            signature_str: 69
-            scope: 24
+            signature_str: 25
+            scope: 15
             comments: -1
         comments: -1
   multipackage/services:
@@ -1044,35 +1044,35 @@ packages:
       r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/services/user_service.go:
         types:
           UserService:
-            name: 136
-            pkg: 98
-            kind: 71
+            name: 95
+            pkg: 56
+            kind: 27
             fields:
-              - name: 101
+              - name: 59
                 type: 6
                 tag: -1
-                scope: 114
+                scope: 73
                 comments: -1
-            scope: 24
+            scope: 15
             methods:
-              - name: 115
-                receiver: 119
+              - name: 74
+                receiver: 78
                 signature:
-                  kind: 21
+                  kind: 12
                   name: -1
                   value: -1
                   fun:
-                    kind: 22
+                    kind: 13
                     name: -1
                     value: -1
                     args:
-                      - kind: 3
+                      - kind: 0
                         name: 6
                         value: -1
                         raw: -1
-                        pkg: 98
+                        pkg: 56
                         type: 6
-                        position: 124
+                        position: 83
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
@@ -1082,43 +1082,43 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   args:
-                    - kind: 93
+                    - kind: 50
                       name: -1
                       value: -1
                       x:
-                        kind: 13
+                        kind: 8
                         name: -1
                         value: -1
                         x:
-                          kind: 3
-                          name: 120
+                          kind: 0
+                          name: 79
                           value: -1
                           raw: -1
-                          pkg: 52
+                          pkg: 2
                           type: -1
-                          position: 121
+                          position: 80
                           resolved_type: -1
                           generic_type_name: -1
                         sel:
-                          kind: 3
-                          name: 70
+                          kind: 0
+                          name: 26
                           value: -1
                           raw: -1
-                          pkg: 52
-                          type: 70
-                          position: 122
+                          pkg: 2
+                          type: 26
+                          position: 81
                           resolved_type: -1
                           generic_type_name: -1
                         raw: -1
-                        pkg: 52
-                        type: 70
-                        position: 121
+                        pkg: 2
+                        type: 26
+                        position: 80
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
                       pkg: -1
                       type: -1
-                      position: 123
+                      position: 82
                       resolved_type: -1
                       generic_type_name: -1
                   raw: -1
@@ -1127,234 +1127,234 @@ packages:
                   position: -1
                   resolved_type: 6
                   generic_type_name: -1
-                signature_str: 127
-                position: 125
-                scope: 24
-                filename: 126
+                signature_str: 86
+                position: 84
+                scope: 15
+                filename: 85
                 return_vars:
-                  - kind: 14
+                  - kind: 68
                     name: -1
                     value: -1
                     fun:
-                      kind: 13
+                      kind: 8
                       name: -1
                       value: -1
                       x:
-                        kind: 3
-                        name: 105
+                        kind: 0
+                        name: 63
                         value: -1
                         raw: -1
-                        pkg: 105
+                        pkg: 63
                         type: -1
-                        position: 106
+                        position: 64
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 3
-                        name: 107
+                        kind: 0
+                        name: 65
                         value: -1
                         raw: -1
-                        pkg: 105
-                        type: 108
-                        position: 109
+                        pkg: 63
+                        type: 66
+                        position: 67
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 105
-                      type: 108
-                      position: 106
+                      pkg: 63
+                      type: 66
+                      position: 64
                       resolved_type: -1
                       generic_type_name: -1
                     args:
-                      - kind: 0
+                      - kind: 53
                         name: -1
-                        value: 96
+                        value: 54
                         raw: -1
                         pkg: -1
                         type: -1
                         position: -1
                         resolved_type: -1
                         generic_type_name: -1
-                      - kind: 13
+                      - kind: 8
                         name: -1
                         value: -1
                         x:
-                          kind: 3
-                          name: 97
+                          kind: 0
+                          name: 55
                           value: -1
                           raw: -1
-                          pkg: 98
-                          type: 99
-                          position: 100
+                          pkg: 56
+                          type: 57
+                          position: 58
                           resolved_type: -1
                           generic_type_name: -1
                         sel:
-                          kind: 3
-                          name: 101
+                          kind: 0
+                          name: 59
                           value: -1
                           raw: -1
-                          pkg: 98
+                          pkg: 56
                           type: 6
-                          position: 102
+                          position: 60
                           resolved_type: -1
                           generic_type_name: -1
                         raw: -1
-                        pkg: 98
+                        pkg: 56
                         type: 6
-                        position: 100
+                        position: 58
                         resolved_type: -1
                         generic_type_name: -1
-                      - kind: 3
-                        name: 80
+                      - kind: 0
+                        name: 36
                         value: -1
                         raw: -1
-                        pkg: 98
+                        pkg: 56
                         type: 6
-                        position: 103
+                        position: 61
                         resolved_type: -1
                         generic_type_name: -1
-                      - kind: 3
-                        name: 25
+                      - kind: 0
+                        name: 40
                         value: -1
                         raw: -1
-                        pkg: 98
-                        type: 26
-                        position: 104
+                        pkg: 56
+                        type: 20
+                        position: 62
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
                     pkg: -1
                     type: -1
-                    position: 106
+                    position: 64
                     resolved_type: -1
                     generic_type_name: -1
                 assignments:
                   age:
-                    - variable_name: 25
-                      pkg: 98
-                      concrete_type: 26
-                      position: 118
-                      scope: 114
+                    - variable_name: 40
+                      pkg: 56
+                      concrete_type: 20
+                      position: 77
+                      scope: 73
                       value:
-                        kind: 14
+                        kind: 68
                         name: -1
                         value: -1
                         fun:
-                          kind: 13
+                          kind: 8
                           name: -1
                           value: -1
                           x:
-                            kind: 3
-                            name: 110
+                            kind: 0
+                            name: 69
                             value: -1
                             raw: -1
-                            pkg: 98
-                            type: 53
-                            position: 116
+                            pkg: 56
+                            type: 3
+                            position: 75
                             resolved_type: -1
                             generic_type_name: -1
                           sel:
-                            kind: 3
-                            name: 66
+                            kind: 0
+                            name: 22
                             value: -1
                             raw: -1
-                            pkg: 52
-                            type: 69
-                            position: 117
+                            pkg: 2
+                            type: 25
+                            position: 76
                             resolved_type: -1
                             generic_type_name: -1
                           raw: -1
-                          pkg: 52
-                          type: 69
-                          position: 116
+                          pkg: 2
+                          type: 25
+                          position: 75
                           resolved_type: -1
                           generic_type_name: -1
                         raw: -1
                         pkg: -1
                         type: -1
-                        position: 116
+                        position: 75
                         resolved_type: -1
                         generic_type_name: -1
                       lhs:
-                        kind: 3
-                        name: 25
+                        kind: 0
+                        name: 40
                         value: -1
                         raw: -1
-                        pkg: 98
-                        type: 26
-                        position: 118
+                        pkg: 56
+                        type: 20
+                        position: 77
                         resolved_type: -1
                         generic_type_name: -1
-                      func: 115
+                      func: 74
                       callee_func: GetAge
                       callee_pkg: multipackage/models
                   name:
-                    - variable_name: 80
-                      pkg: 98
+                    - variable_name: 36
+                      pkg: 56
                       concrete_type: 6
-                      position: 113
-                      scope: 114
+                      position: 72
+                      scope: 73
                       value:
-                        kind: 14
+                        kind: 68
                         name: -1
                         value: -1
                         fun:
-                          kind: 13
+                          kind: 8
                           name: -1
                           value: -1
                           x:
-                            kind: 3
-                            name: 110
+                            kind: 0
+                            name: 69
                             value: -1
                             raw: -1
-                            pkg: 98
-                            type: 53
-                            position: 111
+                            pkg: 56
+                            type: 3
+                            position: 70
                             resolved_type: -1
                             generic_type_name: -1
                           sel:
-                            kind: 3
-                            name: 57
+                            kind: 0
+                            name: 9
                             value: -1
                             raw: -1
-                            pkg: 52
-                            type: 62
-                            position: 112
+                            pkg: 2
+                            type: 17
+                            position: 71
                             resolved_type: -1
                             generic_type_name: -1
                           raw: -1
-                          pkg: 52
-                          type: 62
-                          position: 111
+                          pkg: 2
+                          type: 17
+                          position: 70
                           resolved_type: -1
                           generic_type_name: -1
                         raw: -1
                         pkg: -1
                         type: -1
-                        position: 111
+                        position: 70
                         resolved_type: -1
                         generic_type_name: -1
                       lhs:
-                        kind: 3
-                        name: 80
+                        kind: 0
+                        name: 36
                         value: -1
                         raw: -1
-                        pkg: 98
+                        pkg: 56
                         type: 6
-                        position: 113
+                        position: 72
                         resolved_type: -1
                         generic_type_name: -1
-                      func: 115
+                      func: 74
                       callee_func: GetName
                       callee_pkg: multipackage/models
-              - name: 132
-                receiver: 119
+              - name: 91
+                receiver: 78
                 signature:
-                  kind: 21
+                  kind: 12
                   name: -1
                   value: -1
                   fun:
-                    kind: 22
+                    kind: 13
                     name: -1
                     value: -1
                     raw: -1
@@ -1364,13 +1364,13 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   args:
-                    - kind: 3
+                    - kind: 0
                       name: 6
                       value: -1
                       raw: -1
-                      pkg: 98
+                      pkg: 56
                       type: 6
-                      position: 133
+                      position: 92
                       resolved_type: -1
                       generic_type_name: -1
                   raw: -1
@@ -1379,88 +1379,88 @@ packages:
                   position: -1
                   resolved_type: -1
                   generic_type_name: -1
-                signature_str: 135
-                position: 134
-                scope: 24
-                filename: 126
+                signature_str: 94
+                position: 93
+                scope: 15
+                filename: 85
                 assignments:
                   multipackage/services.UserService.prefix:
-                    - variable_name: 130
-                      pkg: 98
+                    - variable_name: 89
+                      pkg: 56
                       concrete_type: 6
-                      position: 128
-                      scope: 13
+                      position: 87
+                      scope: 8
                       value:
-                        kind: 3
-                        name: 101
+                        kind: 0
+                        name: 59
                         value: -1
                         raw: -1
-                        pkg: 98
+                        pkg: 56
                         type: 6
-                        position: 131
+                        position: 90
                         resolved_type: -1
                         generic_type_name: -1
                       lhs:
-                        kind: 13
+                        kind: 8
                         name: -1
                         value: -1
                         x:
-                          kind: 3
-                          name: 97
+                          kind: 0
+                          name: 55
                           value: -1
                           raw: -1
-                          pkg: 98
-                          type: 99
-                          position: 128
+                          pkg: 56
+                          type: 57
+                          position: 87
                           resolved_type: -1
                           generic_type_name: -1
                         sel:
-                          kind: 3
-                          name: 101
+                          kind: 0
+                          name: 59
                           value: -1
                           raw: -1
-                          pkg: 98
+                          pkg: 56
                           type: 6
-                          position: 129
+                          position: 88
                           resolved_type: -1
                           generic_type_name: -1
                         raw: -1
-                        pkg: 98
+                        pkg: 56
                         type: 6
-                        position: 128
+                        position: 87
                         resolved_type: -1
                         generic_type_name: -1
             comments: -1
         functions:
           NewUserService:
-            name: 141
-            pkg: 98
+            name: 100
+            pkg: 56
             signature:
-              kind: 21
+              kind: 12
               name: -1
               value: -1
               fun:
-                kind: 22
+                kind: 13
                 name: -1
                 value: -1
                 args:
-                  - kind: 93
+                  - kind: 50
                     name: -1
                     value: -1
                     x:
-                      kind: 3
-                      name: 136
+                      kind: 0
+                      name: 95
                       value: -1
                       raw: -1
-                      pkg: 98
-                      type: 136
-                      position: 142
+                      pkg: 56
+                      type: 95
+                      position: 101
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
                     pkg: -1
                     type: -1
-                    position: 143
+                    position: 102
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -1473,47 +1473,47 @@ packages:
               pkg: -1
               type: -1
               position: -1
-              resolved_type: 119
+              resolved_type: 78
               generic_type_name: -1
-            position: 144
-            scope: 24
+            position: 103
+            scope: 15
             comments: -1
             return_vars:
-              - kind: 86
+              - kind: 43
                 name: -1
-                value: 87
+                value: 44
                 x:
-                  kind: 85
+                  kind: 42
                   name: -1
                   value: -1
                   x:
-                    kind: 3
-                    name: 136
+                    kind: 0
+                    name: 95
                     value: -1
                     raw: -1
-                    pkg: 98
-                    type: 136
-                    position: 137
+                    pkg: 56
+                    type: 95
+                    position: 96
                     resolved_type: -1
                     generic_type_name: -1
                   args:
-                    - kind: 82
+                    - kind: 38
                       name: -1
                       value: -1
                       x:
-                        kind: 3
-                        name: 101
+                        kind: 0
+                        name: 59
                         value: -1
                         raw: -1
-                        pkg: 98
+                        pkg: 56
                         type: 6
-                        position: 138
+                        position: 97
                         resolved_type: -1
                         generic_type_name: -1
                       fun:
-                        kind: 0
+                        kind: 53
                         name: -1
-                        value: 139
+                        value: 98
                         raw: -1
                         pkg: -1
                         type: -1
@@ -1523,61 +1523,61 @@ packages:
                       raw: -1
                       pkg: -1
                       type: -1
-                      position: 138
+                      position: 97
                       resolved_type: -1
                       generic_type_name: -1
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 137
+                  position: 96
                   resolved_type: -1
                   generic_type_name: -1
                 raw: -1
                 pkg: -1
                 type: -1
-                position: 140
+                position: 99
                 resolved_type: -1
                 generic_type_name: -1
         struct_instances:
-          - type: 136
-            pkg: 98
-            position: 137
+          - type: 95
+            pkg: 56
+            position: 96
             fields:
-              101: 145
+              59: 104
         imports:
-          52: 52
-          105: 105
+          2: 2
+          63: 63
     types:
       UserService:
-        name: 136
-        pkg: 98
-        kind: 71
+        name: 95
+        pkg: 56
+        kind: 27
         fields:
-          - name: 101
+          - name: 59
             type: 6
             tag: -1
-            scope: 114
+            scope: 73
             comments: -1
-        scope: 24
+        scope: 15
         methods:
-          - name: 115
-            receiver: 119
+          - name: 74
+            receiver: 78
             signature:
-              kind: 21
+              kind: 12
               name: -1
               value: -1
               fun:
-                kind: 22
+                kind: 13
                 name: -1
                 value: -1
                 args:
-                  - kind: 3
+                  - kind: 0
                     name: 6
                     value: -1
                     raw: -1
-                    pkg: 98
+                    pkg: 56
                     type: 6
-                    position: 124
+                    position: 83
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -1587,43 +1587,43 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 93
+                - kind: 50
                   name: -1
                   value: -1
                   x:
-                    kind: 13
+                    kind: 8
                     name: -1
                     value: -1
                     x:
-                      kind: 3
-                      name: 120
+                      kind: 0
+                      name: 79
                       value: -1
                       raw: -1
-                      pkg: 52
+                      pkg: 2
                       type: -1
-                      position: 121
+                      position: 80
                       resolved_type: -1
                       generic_type_name: -1
                     sel:
-                      kind: 3
-                      name: 70
+                      kind: 0
+                      name: 26
                       value: -1
                       raw: -1
-                      pkg: 52
-                      type: 70
-                      position: 122
+                      pkg: 2
+                      type: 26
+                      position: 81
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
-                    pkg: 52
-                    type: 70
-                    position: 121
+                    pkg: 2
+                    type: 26
+                    position: 80
                     resolved_type: -1
                     generic_type_name: -1
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 123
+                  position: 82
                   resolved_type: -1
                   generic_type_name: -1
               raw: -1
@@ -1632,234 +1632,234 @@ packages:
               position: -1
               resolved_type: 6
               generic_type_name: -1
-            signature_str: 127
-            position: 125
-            scope: 24
-            filename: 126
+            signature_str: 86
+            position: 84
+            scope: 15
+            filename: 85
             return_vars:
-              - kind: 14
+              - kind: 68
                 name: -1
                 value: -1
                 fun:
-                  kind: 13
+                  kind: 8
                   name: -1
                   value: -1
                   x:
-                    kind: 3
-                    name: 105
+                    kind: 0
+                    name: 63
                     value: -1
                     raw: -1
-                    pkg: 105
+                    pkg: 63
                     type: -1
-                    position: 106
+                    position: 64
                     resolved_type: -1
                     generic_type_name: -1
                   sel:
-                    kind: 3
-                    name: 107
+                    kind: 0
+                    name: 65
                     value: -1
                     raw: -1
-                    pkg: 105
-                    type: 108
-                    position: 109
+                    pkg: 63
+                    type: 66
+                    position: 67
                     resolved_type: -1
                     generic_type_name: -1
                   raw: -1
-                  pkg: 105
-                  type: 108
-                  position: 106
+                  pkg: 63
+                  type: 66
+                  position: 64
                   resolved_type: -1
                   generic_type_name: -1
                 args:
-                  - kind: 0
+                  - kind: 53
                     name: -1
-                    value: 96
+                    value: 54
                     raw: -1
                     pkg: -1
                     type: -1
                     position: -1
                     resolved_type: -1
                     generic_type_name: -1
-                  - kind: 13
+                  - kind: 8
                     name: -1
                     value: -1
                     x:
-                      kind: 3
-                      name: 97
+                      kind: 0
+                      name: 55
                       value: -1
                       raw: -1
-                      pkg: 98
-                      type: 99
-                      position: 100
+                      pkg: 56
+                      type: 57
+                      position: 58
                       resolved_type: -1
                       generic_type_name: -1
                     sel:
-                      kind: 3
-                      name: 101
+                      kind: 0
+                      name: 59
                       value: -1
                       raw: -1
-                      pkg: 98
+                      pkg: 56
                       type: 6
-                      position: 102
+                      position: 60
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
-                    pkg: 98
+                    pkg: 56
                     type: 6
-                    position: 100
+                    position: 58
                     resolved_type: -1
                     generic_type_name: -1
-                  - kind: 3
-                    name: 80
+                  - kind: 0
+                    name: 36
                     value: -1
                     raw: -1
-                    pkg: 98
+                    pkg: 56
                     type: 6
-                    position: 103
+                    position: 61
                     resolved_type: -1
                     generic_type_name: -1
-                  - kind: 3
-                    name: 25
+                  - kind: 0
+                    name: 40
                     value: -1
                     raw: -1
-                    pkg: 98
-                    type: 26
-                    position: 104
+                    pkg: 56
+                    type: 20
+                    position: 62
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
                 pkg: -1
                 type: -1
-                position: 106
+                position: 64
                 resolved_type: -1
                 generic_type_name: -1
             assignments:
               age:
-                - variable_name: 25
-                  pkg: 98
-                  concrete_type: 26
-                  position: 118
-                  scope: 114
+                - variable_name: 40
+                  pkg: 56
+                  concrete_type: 20
+                  position: 77
+                  scope: 73
                   value:
-                    kind: 14
+                    kind: 68
                     name: -1
                     value: -1
                     fun:
-                      kind: 13
+                      kind: 8
                       name: -1
                       value: -1
                       x:
-                        kind: 3
-                        name: 110
+                        kind: 0
+                        name: 69
                         value: -1
                         raw: -1
-                        pkg: 98
-                        type: 53
-                        position: 116
+                        pkg: 56
+                        type: 3
+                        position: 75
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 3
-                        name: 66
+                        kind: 0
+                        name: 22
                         value: -1
                         raw: -1
-                        pkg: 52
-                        type: 69
-                        position: 117
+                        pkg: 2
+                        type: 25
+                        position: 76
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 52
-                      type: 69
-                      position: 116
+                      pkg: 2
+                      type: 25
+                      position: 75
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
                     pkg: -1
                     type: -1
-                    position: 116
+                    position: 75
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 3
-                    name: 25
+                    kind: 0
+                    name: 40
                     value: -1
                     raw: -1
-                    pkg: 98
-                    type: 26
-                    position: 118
+                    pkg: 56
+                    type: 20
+                    position: 77
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 115
+                  func: 74
                   callee_func: GetAge
                   callee_pkg: multipackage/models
               name:
-                - variable_name: 80
-                  pkg: 98
+                - variable_name: 36
+                  pkg: 56
                   concrete_type: 6
-                  position: 113
-                  scope: 114
+                  position: 72
+                  scope: 73
                   value:
-                    kind: 14
+                    kind: 68
                     name: -1
                     value: -1
                     fun:
-                      kind: 13
+                      kind: 8
                       name: -1
                       value: -1
                       x:
-                        kind: 3
-                        name: 110
+                        kind: 0
+                        name: 69
                         value: -1
                         raw: -1
-                        pkg: 98
-                        type: 53
-                        position: 111
+                        pkg: 56
+                        type: 3
+                        position: 70
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 3
-                        name: 57
+                        kind: 0
+                        name: 9
                         value: -1
                         raw: -1
-                        pkg: 52
-                        type: 62
-                        position: 112
+                        pkg: 2
+                        type: 17
+                        position: 71
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 52
-                      type: 62
-                      position: 111
+                      pkg: 2
+                      type: 17
+                      position: 70
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
                     pkg: -1
                     type: -1
-                    position: 111
+                    position: 70
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 3
-                    name: 80
+                    kind: 0
+                    name: 36
                     value: -1
                     raw: -1
-                    pkg: 98
+                    pkg: 56
                     type: 6
-                    position: 113
+                    position: 72
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 115
+                  func: 74
                   callee_func: GetName
                   callee_pkg: multipackage/models
-          - name: 132
-            receiver: 119
+          - name: 91
+            receiver: 78
             signature:
-              kind: 21
+              kind: 12
               name: -1
               value: -1
               fun:
-                kind: 22
+                kind: 13
                 name: -1
                 value: -1
                 raw: -1
@@ -1869,13 +1869,13 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 3
+                - kind: 0
                   name: 6
                   value: -1
                   raw: -1
-                  pkg: 98
+                  pkg: 56
                   type: 6
-                  position: 133
+                  position: 92
                   resolved_type: -1
                   generic_type_name: -1
               raw: -1
@@ -1884,55 +1884,55 @@ packages:
               position: -1
               resolved_type: -1
               generic_type_name: -1
-            signature_str: 135
-            position: 134
-            scope: 24
-            filename: 126
+            signature_str: 94
+            position: 93
+            scope: 15
+            filename: 85
             assignments:
               multipackage/services.UserService.prefix:
-                - variable_name: 130
-                  pkg: 98
+                - variable_name: 89
+                  pkg: 56
                   concrete_type: 6
-                  position: 128
-                  scope: 13
+                  position: 87
+                  scope: 8
                   value:
-                    kind: 3
-                    name: 101
+                    kind: 0
+                    name: 59
                     value: -1
                     raw: -1
-                    pkg: 98
+                    pkg: 56
                     type: 6
-                    position: 131
+                    position: 90
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 13
+                    kind: 8
                     name: -1
                     value: -1
                     x:
-                      kind: 3
-                      name: 97
+                      kind: 0
+                      name: 55
                       value: -1
                       raw: -1
-                      pkg: 98
-                      type: 99
-                      position: 128
+                      pkg: 56
+                      type: 57
+                      position: 87
                       resolved_type: -1
                       generic_type_name: -1
                     sel:
-                      kind: 3
-                      name: 101
+                      kind: 0
+                      name: 59
                       value: -1
                       raw: -1
-                      pkg: 98
+                      pkg: 56
                       type: 6
-                      position: 129
+                      position: 88
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
-                    pkg: 98
+                    pkg: 56
                     type: 6
-                    position: 128
+                    position: 87
                     resolved_type: -1
                     generic_type_name: -1
         comments: -1
@@ -1941,24 +1941,24 @@ packages:
       r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/multipackage/src/multipackage/utils/helper.go:
         functions:
           FormatString:
-            name: 18
-            pkg: 5
+            name: 139
+            pkg: 129
             signature:
-              kind: 21
+              kind: 12
               name: -1
               value: -1
               fun:
-                kind: 22
+                kind: 13
                 name: -1
                 value: -1
                 args:
-                  - kind: 3
+                  - kind: 0
                     name: 6
                     value: -1
                     raw: -1
-                    pkg: 5
+                    pkg: 129
                     type: 6
-                    position: 20
+                    position: 141
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -1968,13 +1968,13 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 3
+                - kind: 0
                   name: 6
                   value: -1
                   raw: -1
-                  pkg: 5
+                  pkg: 129
                   type: 6
-                  position: 19
+                  position: 140
                   resolved_type: -1
                   generic_type_name: -1
               raw: -1
@@ -1983,118 +1983,118 @@ packages:
               position: -1
               resolved_type: 6
               generic_type_name: -1
-            position: 23
-            scope: 24
+            position: 142
+            scope: 15
             comments: -1
             return_vars:
-              - kind: 14
+              - kind: 68
                 name: -1
                 value: -1
                 fun:
-                  kind: 13
+                  kind: 8
                   name: -1
                   value: -1
                   x:
-                    kind: 3
-                    name: 8
+                    kind: 0
+                    name: 131
                     value: -1
                     raw: -1
-                    pkg: 8
+                    pkg: 131
                     type: -1
-                    position: 15
+                    position: 136
                     resolved_type: -1
                     generic_type_name: -1
                   sel:
-                    kind: 3
-                    name: 16
+                    kind: 0
+                    name: 137
                     value: -1
                     raw: -1
-                    pkg: 8
-                    type: 11
-                    position: 17
+                    pkg: 131
+                    type: 134
+                    position: 138
                     resolved_type: -1
                     generic_type_name: -1
                   raw: -1
-                  pkg: 8
-                  type: 11
-                  position: 15
+                  pkg: 131
+                  type: 134
+                  position: 136
                   resolved_type: -1
                   generic_type_name: -1
                 args:
-                  - kind: 14
+                  - kind: 68
                     name: -1
                     value: -1
                     fun:
-                      kind: 13
+                      kind: 8
                       name: -1
                       value: -1
                       x:
-                        kind: 3
-                        name: 8
+                        kind: 0
+                        name: 131
                         value: -1
                         raw: -1
-                        pkg: 8
+                        pkg: 131
                         type: -1
-                        position: 9
+                        position: 132
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 3
-                        name: 10
+                        kind: 0
+                        name: 133
                         value: -1
                         raw: -1
-                        pkg: 8
-                        type: 11
-                        position: 12
+                        pkg: 131
+                        type: 134
+                        position: 135
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 8
-                      type: 11
-                      position: 9
+                      pkg: 131
+                      type: 134
+                      position: 132
                       resolved_type: -1
                       generic_type_name: -1
                     args:
-                      - kind: 3
-                        name: 4
+                      - kind: 0
+                        name: 128
                         value: -1
                         raw: -1
-                        pkg: 5
+                        pkg: 129
                         type: 6
-                        position: 7
+                        position: 130
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
                     pkg: -1
                     type: -1
-                    position: 9
+                    position: 132
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
                 pkg: -1
                 type: -1
-                position: 15
+                position: 136
                 resolved_type: -1
                 generic_type_name: -1
           ValidateAge:
-            name: 35
-            pkg: 5
+            name: 151
+            pkg: 129
             signature:
-              kind: 21
+              kind: 12
               name: -1
               value: -1
               fun:
-                kind: 22
+                kind: 13
                 name: -1
                 value: -1
                 args:
-                  - kind: 3
-                    name: 37
+                  - kind: 0
+                    name: 153
                     value: -1
                     raw: -1
-                    pkg: 5
-                    type: 37
-                    position: 38
+                    pkg: 129
+                    type: 153
+                    position: 154
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -2104,46 +2104,46 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 3
-                  name: 26
+                - kind: 0
+                  name: 20
                   value: -1
                   raw: -1
-                  pkg: 5
-                  type: 26
-                  position: 36
+                  pkg: 129
+                  type: 20
+                  position: 152
                   resolved_type: -1
                   generic_type_name: -1
               raw: -1
               pkg: -1
               type: -1
               position: -1
-              resolved_type: 37
+              resolved_type: 153
               generic_type_name: -1
-            position: 39
-            scope: 24
+            position: 155
+            scope: 15
             comments: -1
             return_vars:
-              - kind: 29
+              - kind: 145
                 name: -1
-                value: 34
+                value: 150
                 x:
-                  kind: 29
+                  kind: 145
                   name: -1
-                  value: 30
+                  value: 146
                   x:
-                    kind: 3
-                    name: 25
+                    kind: 0
+                    name: 40
                     value: -1
                     raw: -1
-                    pkg: 5
-                    type: 26
-                    position: 27
+                    pkg: 129
+                    type: 20
+                    position: 143
                     resolved_type: -1
                     generic_type_name: -1
                   fun:
-                    kind: 0
+                    kind: 53
                     name: -1
-                    value: 28
+                    value: 144
                     raw: -1
                     pkg: -1
                     type: -1
@@ -2153,27 +2153,27 @@ packages:
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 27
+                  position: 143
                   resolved_type: -1
                   generic_type_name: -1
                 fun:
-                  kind: 29
+                  kind: 145
                   name: -1
-                  value: 33
+                  value: 149
                   x:
-                    kind: 3
-                    name: 25
+                    kind: 0
+                    name: 40
                     value: -1
                     raw: -1
-                    pkg: 5
-                    type: 26
-                    position: 31
+                    pkg: 129
+                    type: 20
+                    position: 147
                     resolved_type: -1
                     generic_type_name: -1
                   fun:
-                    kind: 0
+                    kind: 53
                     name: -1
-                    value: 32
+                    value: 148
                     raw: -1
                     pkg: -1
                     type: -1
@@ -2183,181 +2183,181 @@ packages:
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 31
+                  position: 147
                   resolved_type: -1
                   generic_type_name: -1
                 raw: -1
                 pkg: -1
                 type: -1
-                position: 27
+                position: 143
                 resolved_type: -1
                 generic_type_name: -1
         variables:
           DefaultFormat:
-            name: 46
-            tok: 47
-            pkg: 5
+            name: 162
+            tok: 163
+            pkg: 129
             type: -1
-            value: 50
-            position: 48
+            value: 166
+            position: 164
             comments: -1
             group_index: 1
           MaxAge:
-            name: 44
-            tok: 41
-            pkg: 5
+            name: 160
+            tok: 157
+            pkg: 129
             type: -1
-            resolved_type: 43
-            value: 2
+            resolved_type: 159
+            value: 127
             computed_value: 149
-            position: 45
+            position: 161
             comments: -1
             group_index: 1
           MinAge:
-            name: 40
-            tok: 41
-            pkg: 5
+            name: 156
+            tok: 157
+            pkg: 129
             type: -1
-            resolved_type: 43
-            value: 1
+            resolved_type: 159
+            value: 126
             computed_value: 1
-            position: 42
+            position: 158
             comments: -1
             group_index: 1
         imports:
-          8: 8
+          131: 131
 call_graph:
   - caller:
-      name: 115
-      pkg: 98
+      name: 74
+      pkg: 56
       position: -1
-      recv_type: 119
+      recv_type: 78
     callee:
-      name: 57
-      pkg: 52
-      position: 111
-      recv_type: 58
-    position: 111
+      name: 9
+      pkg: 2
+      position: 70
+      recv_type: 10
+    position: 70
     callee_var_name: user
     callee_recv_var_name: name
     chain_root: user
   - caller:
-      name: 115
-      pkg: 98
+      name: 74
+      pkg: 56
       position: -1
-      recv_type: 119
+      recv_type: 78
     callee:
-      name: 66
-      pkg: 52
-      position: 116
-      recv_type: 58
-    position: 116
+      name: 22
+      pkg: 2
+      position: 75
+      recv_type: 10
+    position: 75
     callee_var_name: user
     callee_recv_var_name: age
     chain_root: user
   - caller:
-      name: 115
-      pkg: 98
+      name: 74
+      pkg: 56
       position: -1
-      recv_type: 119
+      recv_type: 78
     callee:
-      name: 107
-      pkg: 105
-      position: 106
+      name: 65
+      pkg: 63
+      position: 64
       recv_type: -1
-    position: 106
+    position: 64
     args:
-      - kind: 0
+      - kind: 53
         name: -1
-        value: 96
+        value: 54
         raw: -1
         pkg: -1
         type: -1
         position: -1
         resolved_type: -1
         generic_type_name: -1
-      - kind: 13
+      - kind: 8
         name: -1
         value: -1
         x:
-          kind: 3
-          name: 97
+          kind: 0
+          name: 55
           value: -1
           raw: -1
-          pkg: 98
-          type: 99
-          position: 100
+          pkg: 56
+          type: 57
+          position: 58
           resolved_type: -1
           generic_type_name: -1
         sel:
-          kind: 3
-          name: 101
+          kind: 0
+          name: 59
           value: -1
           raw: -1
-          pkg: 98
+          pkg: 56
           type: 6
-          position: 102
+          position: 60
           resolved_type: -1
           generic_type_name: -1
         raw: -1
-        pkg: 98
+        pkg: 56
         type: 6
-        position: 100
+        position: 58
         resolved_type: -1
         generic_type_name: -1
-      - kind: 3
-        name: 80
+      - kind: 0
+        name: 36
         value: -1
         raw: -1
-        pkg: 98
+        pkg: 56
         type: 6
-        position: 103
+        position: 61
         resolved_type: -1
         generic_type_name: -1
-      - kind: 3
-        name: 25
+      - kind: 0
+        name: 40
         value: -1
         raw: -1
-        pkg: 98
-        type: 26
-        position: 104
+        pkg: 56
+        type: 20
+        position: 62
         resolved_type: -1
         generic_type_name: -1
     param_arg_map:
       a:
-        kind: 13
+        kind: 8
         name: -1
         value: -1
         x:
-          kind: 3
-          name: 97
+          kind: 0
+          name: 55
           value: -1
           raw: -1
-          pkg: 98
-          type: 99
-          position: 100
+          pkg: 56
+          type: 57
+          position: 58
           resolved_type: -1
           generic_type_name: -1
         sel:
-          kind: 3
-          name: 101
+          kind: 0
+          name: 59
           value: -1
           raw: -1
-          pkg: 98
+          pkg: 56
           type: 6
-          position: 102
+          position: 60
           resolved_type: -1
           generic_type_name: -1
         raw: -1
-        pkg: 98
+        pkg: 56
         type: 6
-        position: 100
+        position: 58
         resolved_type: -1
         generic_type_name: -1
       format:
-        kind: 0
+        kind: 53
         name: -1
-        value: 96
+        value: 54
         raw: -1
         pkg: -1
         type: -1
@@ -2365,29 +2365,29 @@ call_graph:
         resolved_type: -1
         generic_type_name: -1
   - caller:
-      name: 153
-      pkg: 151
+      name: 112
+      pkg: 110
       position: -1
       recv_type: -1
     callee:
-      name: 89
-      pkg: 52
-      position: 148
+      name: 46
+      pkg: 2
+      position: 107
       recv_type: -1
-    position: 148
+    position: 107
     args:
-      - kind: 0
+      - kind: 53
         name: -1
-        value: 146
+        value: 105
         raw: -1
         pkg: -1
         type: -1
         position: -1
         resolved_type: -1
         generic_type_name: -1
-      - kind: 0
+      - kind: 53
         name: -1
-        value: 147
+        value: 106
         raw: -1
         pkg: -1
         type: -1
@@ -2396,58 +2396,58 @@ call_graph:
         generic_type_name: -1
     assignments:
       user:
-        - variable_name: 110
-          pkg: 151
-          concrete_type: 53
-          position: 152
-          scope: 114
+        - variable_name: 69
+          pkg: 110
+          concrete_type: 3
+          position: 111
+          scope: 73
           value:
-            kind: 14
+            kind: 68
             name: -1
             value: -1
             fun:
-              kind: 13
+              kind: 8
               name: -1
               value: -1
               x:
-                kind: 3
-                name: 120
+                kind: 0
+                name: 79
                 value: -1
                 raw: -1
-                pkg: 52
+                pkg: 2
                 type: -1
-                position: 148
+                position: 107
                 resolved_type: -1
                 generic_type_name: -1
               sel:
-                kind: 3
-                name: 89
+                kind: 0
+                name: 46
                 value: -1
                 raw: -1
-                pkg: 52
-                type: 149
-                position: 150
+                pkg: 2
+                type: 108
+                position: 109
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
-              pkg: 52
-              type: 149
-              position: 148
+              pkg: 2
+              type: 108
+              position: 107
               resolved_type: -1
               generic_type_name: -1
             args:
-              - kind: 0
+              - kind: 53
                 name: -1
-                value: 146
+                value: 105
                 raw: -1
                 pkg: -1
                 type: -1
                 position: -1
                 resolved_type: -1
                 generic_type_name: -1
-              - kind: 0
+              - kind: 53
                 name: -1
-                value: 147
+                value: 106
                 raw: -1
                 pkg: -1
                 type: -1
@@ -2457,27 +2457,27 @@ call_graph:
             raw: -1
             pkg: -1
             type: -1
-            position: 148
+            position: 107
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 3
-            name: 110
+            kind: 0
+            name: 69
             value: -1
             raw: -1
-            pkg: 151
-            type: 53
-            position: 152
+            pkg: 110
+            type: 3
+            position: 111
             resolved_type: -1
             generic_type_name: -1
-          func: 153
+          func: 112
           callee_func: NewUser
           callee_pkg: multipackage/models
     param_arg_map:
       age:
-        kind: 0
+        kind: 53
         name: -1
-        value: 147
+        value: 106
         raw: -1
         pkg: -1
         type: -1
@@ -2485,9 +2485,9 @@ call_graph:
         resolved_type: -1
         generic_type_name: -1
       name:
-        kind: 0
+        kind: 53
         name: -1
-        value: 146
+        value: 105
         raw: -1
         pkg: -1
         type: -1
@@ -2496,473 +2496,473 @@ call_graph:
         generic_type_name: -1
     callee_recv_var_name: user
   - caller:
-      name: 153
-      pkg: 151
+      name: 112
+      pkg: 110
       position: -1
       recv_type: -1
     callee:
-      name: 141
-      pkg: 98
-      position: 155
+      name: 100
+      pkg: 56
+      position: 114
       recv_type: -1
-    position: 155
+    position: 114
     assignments:
       service:
-        - variable_name: 158
-          pkg: 151
-          concrete_type: 99
-          position: 159
-          scope: 114
+        - variable_name: 117
+          pkg: 110
+          concrete_type: 57
+          position: 118
+          scope: 73
           value:
-            kind: 14
+            kind: 68
             name: -1
             value: -1
             fun:
-              kind: 13
+              kind: 8
               name: -1
               value: -1
               x:
-                kind: 3
-                name: 154
+                kind: 0
+                name: 113
                 value: -1
                 raw: -1
-                pkg: 98
+                pkg: 56
                 type: -1
-                position: 155
+                position: 114
                 resolved_type: -1
                 generic_type_name: -1
               sel:
-                kind: 3
-                name: 141
+                kind: 0
+                name: 100
                 value: -1
                 raw: -1
-                pkg: 98
-                type: 156
-                position: 157
+                pkg: 56
+                type: 115
+                position: 116
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
-              pkg: 98
-              type: 156
-              position: 155
+              pkg: 56
+              type: 115
+              position: 114
               resolved_type: -1
               generic_type_name: -1
             raw: -1
             pkg: -1
             type: -1
-            position: 155
+            position: 114
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 3
-            name: 158
+            kind: 0
+            name: 117
             value: -1
             raw: -1
-            pkg: 151
-            type: 99
-            position: 159
+            pkg: 110
+            type: 57
+            position: 118
             resolved_type: -1
             generic_type_name: -1
-          func: 153
+          func: 112
           callee_func: NewUserService
           callee_pkg: multipackage/services
     callee_recv_var_name: service
   - caller:
-      name: 153
-      pkg: 151
+      name: 112
+      pkg: 110
       position: -1
       recv_type: -1
     callee:
-      name: 115
-      pkg: 98
-      position: 161
-      recv_type: 119
-    position: 161
+      name: 74
+      pkg: 56
+      position: 120
+      recv_type: 78
+    position: 120
     args:
-      - kind: 3
-        name: 110
+      - kind: 0
+        name: 69
         value: -1
         raw: -1
-        pkg: 151
-        type: 53
-        position: 160
+        pkg: 110
+        type: 3
+        position: 119
         resolved_type: -1
         generic_type_name: -1
     assignments:
       age:
-        - variable_name: 25
-          pkg: 98
-          concrete_type: 26
-          position: 118
-          scope: 114
+        - variable_name: 40
+          pkg: 56
+          concrete_type: 20
+          position: 77
+          scope: 73
           value:
-            kind: 14
+            kind: 68
             name: -1
             value: -1
             fun:
-              kind: 13
+              kind: 8
               name: -1
               value: -1
               x:
-                kind: 3
-                name: 110
+                kind: 0
+                name: 69
                 value: -1
                 raw: -1
-                pkg: 98
-                type: 53
-                position: 116
+                pkg: 56
+                type: 3
+                position: 75
                 resolved_type: -1
                 generic_type_name: -1
               sel:
-                kind: 3
-                name: 66
+                kind: 0
+                name: 22
                 value: -1
                 raw: -1
-                pkg: 52
-                type: 69
-                position: 117
+                pkg: 2
+                type: 25
+                position: 76
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
-              pkg: 52
-              type: 69
-              position: 116
+              pkg: 2
+              type: 25
+              position: 75
               resolved_type: -1
               generic_type_name: -1
             raw: -1
             pkg: -1
             type: -1
-            position: 116
+            position: 75
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 3
-            name: 25
+            kind: 0
+            name: 40
             value: -1
             raw: -1
-            pkg: 98
-            type: 26
-            position: 118
+            pkg: 56
+            type: 20
+            position: 77
             resolved_type: -1
             generic_type_name: -1
-          func: 115
+          func: 74
           callee_func: GetAge
           callee_pkg: multipackage/models
       name:
-        - variable_name: 80
-          pkg: 98
+        - variable_name: 36
+          pkg: 56
           concrete_type: 6
-          position: 113
-          scope: 114
+          position: 72
+          scope: 73
           value:
-            kind: 14
+            kind: 68
             name: -1
             value: -1
             fun:
-              kind: 13
+              kind: 8
               name: -1
               value: -1
               x:
-                kind: 3
-                name: 110
+                kind: 0
+                name: 69
                 value: -1
                 raw: -1
-                pkg: 98
-                type: 53
-                position: 111
+                pkg: 56
+                type: 3
+                position: 70
                 resolved_type: -1
                 generic_type_name: -1
               sel:
-                kind: 3
-                name: 57
+                kind: 0
+                name: 9
                 value: -1
                 raw: -1
-                pkg: 52
-                type: 62
-                position: 112
+                pkg: 2
+                type: 17
+                position: 71
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
-              pkg: 52
-              type: 62
-              position: 111
+              pkg: 2
+              type: 17
+              position: 70
               resolved_type: -1
               generic_type_name: -1
             raw: -1
             pkg: -1
             type: -1
-            position: 111
+            position: 70
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 3
-            name: 80
+            kind: 0
+            name: 36
             value: -1
             raw: -1
-            pkg: 98
+            pkg: 56
             type: 6
-            position: 113
+            position: 72
             resolved_type: -1
             generic_type_name: -1
-          func: 115
+          func: 74
           callee_func: GetName
           callee_pkg: multipackage/models
       result:
-        - variable_name: 164
-          pkg: 151
+        - variable_name: 123
+          pkg: 110
           concrete_type: 6
-          position: 165
-          scope: 114
+          position: 124
+          scope: 73
           value:
-            kind: 14
+            kind: 68
             name: -1
             value: -1
             fun:
-              kind: 13
+              kind: 8
               name: -1
               value: -1
               x:
-                kind: 3
-                name: 158
+                kind: 0
+                name: 117
                 value: -1
                 raw: -1
-                pkg: 151
-                type: 99
-                position: 161
+                pkg: 110
+                type: 57
+                position: 120
                 resolved_type: -1
                 generic_type_name: -1
               sel:
-                kind: 3
-                name: 115
+                kind: 0
+                name: 74
                 value: -1
                 raw: -1
-                pkg: 98
-                type: 162
-                position: 163
+                pkg: 56
+                type: 121
+                position: 122
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
-              pkg: 98
-              type: 162
-              position: 161
+              pkg: 56
+              type: 121
+              position: 120
               resolved_type: -1
               generic_type_name: -1
             args:
-              - kind: 3
-                name: 110
+              - kind: 0
+                name: 69
                 value: -1
                 raw: -1
-                pkg: 151
-                type: 53
-                position: 160
+                pkg: 110
+                type: 3
+                position: 119
                 resolved_type: -1
                 generic_type_name: -1
             raw: -1
             pkg: -1
             type: -1
-            position: 161
+            position: 120
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 3
-            name: 164
+            kind: 0
+            name: 123
             value: -1
             raw: -1
-            pkg: 151
+            pkg: 110
             type: 6
-            position: 165
+            position: 124
             resolved_type: -1
             generic_type_name: -1
-          func: 153
+          func: 112
           callee_func: ProcessUser
           callee_pkg: multipackage/services
     param_arg_map:
       user:
-        kind: 3
-        name: 110
+        kind: 0
+        name: 69
         value: -1
         raw: -1
-        pkg: 151
-        type: 53
-        position: 160
+        pkg: 110
+        type: 3
+        position: 119
         resolved_type: -1
         generic_type_name: -1
     callee_var_name: service
     callee_recv_var_name: result
     chain_root: service
   - caller:
-      name: 153
-      pkg: 151
+      name: 112
+      pkg: 110
       position: -1
       recv_type: -1
     callee:
       name: 171
-      pkg: 105
+      pkg: 63
       position: 170
       recv_type: -1
     position: 170
     args:
-      - kind: 3
-        name: 164
+      - kind: 0
+        name: 123
         value: -1
         raw: -1
-        pkg: 151
+        pkg: 110
         type: 6
         position: 169
         resolved_type: -1
         generic_type_name: -1
     param_arg_map:
       a:
-        kind: 3
-        name: 164
+        kind: 0
+        name: 123
         value: -1
         raw: -1
-        pkg: 151
+        pkg: 110
         type: 6
         position: 169
         resolved_type: -1
         generic_type_name: -1
   - caller:
-      name: 18
-      pkg: 5
+      name: 139
+      pkg: 129
       position: -1
       recv_type: -1
     callee:
-      name: 16
-      pkg: 8
-      position: 15
+      name: 137
+      pkg: 131
+      position: 136
       recv_type: -1
-    position: 15
+    position: 136
     args:
-      - kind: 14
+      - kind: 68
         name: -1
         value: -1
         fun:
-          kind: 13
+          kind: 8
           name: -1
           value: -1
           x:
-            kind: 3
-            name: 8
+            kind: 0
+            name: 131
             value: -1
             raw: -1
-            pkg: 8
+            pkg: 131
             type: -1
-            position: 9
+            position: 132
             resolved_type: -1
             generic_type_name: -1
           sel:
-            kind: 3
-            name: 10
+            kind: 0
+            name: 133
             value: -1
             raw: -1
-            pkg: 8
-            type: 11
-            position: 12
+            pkg: 131
+            type: 134
+            position: 135
             resolved_type: -1
             generic_type_name: -1
           raw: -1
-          pkg: 8
-          type: 11
-          position: 9
+          pkg: 131
+          type: 134
+          position: 132
           resolved_type: -1
           generic_type_name: -1
         args:
-          - kind: 3
-            name: 4
+          - kind: 0
+            name: 128
             value: -1
             raw: -1
-            pkg: 5
+            pkg: 129
             type: 6
-            position: 7
+            position: 130
             resolved_type: -1
             generic_type_name: -1
         raw: -1
         pkg: -1
         type: -1
-        position: 9
+        position: 132
         resolved_type: -1
         generic_type_name: -1
     param_arg_map:
       s:
-        kind: 14
+        kind: 68
         name: -1
         value: -1
         fun:
-          kind: 13
+          kind: 8
           name: -1
           value: -1
           x:
-            kind: 3
-            name: 8
+            kind: 0
+            name: 131
             value: -1
             raw: -1
-            pkg: 8
+            pkg: 131
             type: -1
-            position: 9
+            position: 132
             resolved_type: -1
             generic_type_name: -1
           sel:
-            kind: 3
-            name: 10
+            kind: 0
+            name: 133
             value: -1
             raw: -1
-            pkg: 8
-            type: 11
-            position: 12
+            pkg: 131
+            type: 134
+            position: 135
             resolved_type: -1
             generic_type_name: -1
           raw: -1
-          pkg: 8
-          type: 11
-          position: 9
+          pkg: 131
+          type: 134
+          position: 132
           resolved_type: -1
           generic_type_name: -1
         args:
-          - kind: 3
-            name: 4
+          - kind: 0
+            name: 128
             value: -1
             raw: -1
-            pkg: 5
+            pkg: 129
             type: 6
-            position: 7
+            position: 130
             resolved_type: -1
             generic_type_name: -1
         raw: -1
         pkg: -1
         type: -1
-        position: 9
+        position: 132
         resolved_type: -1
         generic_type_name: -1
   - caller:
-      name: 18
-      pkg: 5
+      name: 139
+      pkg: 129
       position: -1
       recv_type: -1
     callee:
-      name: 10
-      pkg: 8
-      position: 9
+      name: 133
+      pkg: 131
+      position: 132
       recv_type: -1
-    position: 9
+    position: 132
     args:
-      - kind: 3
-        name: 4
+      - kind: 0
+        name: 128
         value: -1
         raw: -1
-        pkg: 5
+        pkg: 129
         type: 6
-        position: 7
+        position: 130
         resolved_type: -1
         generic_type_name: -1
     param_arg_map:
       s:
-        kind: 3
-        name: 4
+        kind: 0
+        name: 128
         value: -1
         raw: -1
-        pkg: 5
+        pkg: 129
         type: 6
-        position: 7
+        position: 130
         resolved_type: -1
         generic_type_name: -1

--- a/internal/spec/tracker.go
+++ b/internal/spec/tracker.go
@@ -587,6 +587,8 @@ func processArguments(tree *TrackerTree, meta *metadata.Metadata, parentNode *Tr
 		argID := arg.ID()
 
 		if argCount >= limits.MaxArgsPerFunction {
+			fmt.Printf("Warning: MaxArgsPerFunction limit (%d) reached for function %s.%s, truncating arguments\n",
+				limits.MaxArgsPerFunction, getString(meta, edge.Caller.Name), getString(meta, edge.Callee.Name))
 			break
 		}
 
@@ -939,6 +941,7 @@ func NewTrackerNode(tree *TrackerTree, meta *metadata.Metadata, parentID, id str
 
 	// Limit recursion depth to prevent infinite loops
 	if len(visited) > limits.MaxNodesPerTree {
+		fmt.Printf("Warning: MaxNodesPerTree limit (%d) reached, truncating tree at node %s\n", limits.MaxNodesPerTree, id)
 		// Return a simple node without children to prevent explosion
 		node := &TrackerNode{
 			CallGraphEdge: parentEdge,
@@ -1016,6 +1019,8 @@ func NewTrackerNode(tree *TrackerTree, meta *metadata.Metadata, parentID, id str
 
 		for i := range edges {
 			if childCount >= limits.MaxChildrenPerNode {
+				fmt.Printf("Warning: MaxChildrenPerNode limit (%d) reached for node %s, truncating children\n",
+					limits.MaxChildrenPerNode, id)
 				break
 			}
 

--- a/internal/spec/tracker.go
+++ b/internal/spec/tracker.go
@@ -585,6 +585,7 @@ func processArguments(tree *TrackerTree, meta *metadata.Metadata, parentNode *Tr
 		argEdge := arg.Edge
 
 		argID := arg.ID()
+		argCount++
 
 		if argCount >= limits.MaxArgsPerFunction {
 			fmt.Printf("Warning: MaxArgsPerFunction limit (%d) reached for function %s.%s, truncating arguments\n",
@@ -707,7 +708,6 @@ func processArguments(tree *TrackerTree, meta *metadata.Metadata, parentNode *Tr
 				if arg.Fun != nil && arg.Fun.Position != -1 {
 					tree.positions[arg.Fun.GetPosition()] = true
 				}
-				argCount++
 			}
 
 		case ArgTypeVariable:

--- a/internal/spec/tracker_test.go
+++ b/internal/spec/tracker_test.go
@@ -1,0 +1,373 @@
+package spec
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// TestTrackerWarnings tests the new debug warning functionality
+func TestTrackerWarnings(t *testing.T) {
+	// Capture stdout to test warning messages
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	defer func() {
+		os.Stdout = oldStdout
+		_ = w.Close()
+	}()
+
+	// Create a mock metadata
+	stringPool := metadata.NewStringPool()
+	meta := &metadata.Metadata{
+		StringPool: stringPool,
+		Packages: map[string]*metadata.Package{
+			"main": {
+				Files: map[string]*metadata.File{
+					"test.go": {
+						Types: map[string]*metadata.Type{
+							"TestType": {
+								Name: stringPool.Get("TestType"),
+								Kind: stringPool.Get("struct"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Test MaxArgsPerFunction warning
+	t.Run("MaxArgsPerFunction warning", func(t *testing.T) {
+		// Reset stdout capture
+		os.Stdout = oldStdout
+		r, w, _ = os.Pipe()
+		os.Stdout = w
+
+		// Create a tracker with very low limits
+		limits := metadata.TrackerLimits{
+			MaxArgsPerFunction: 1,
+		}
+
+		// Create a mock edge with many arguments
+		edge := &metadata.CallGraphEdge{
+			Caller: metadata.Call{
+				Meta: meta,
+				Name: stringPool.Get("TestFunction"),
+				Pkg:  stringPool.Get("main"),
+			},
+			Callee: metadata.Call{
+				Meta: meta,
+				Name: stringPool.Get("AnotherFunction"),
+				Pkg:  stringPool.Get("main"),
+			},
+			Args: []metadata.CallArgument{
+				{Meta: meta, Edge: &metadata.CallGraphEdge{
+					Caller: metadata.Call{Meta: meta, Name: stringPool.Get("arg1"), Pkg: stringPool.Get("main")},
+					Callee: metadata.Call{Meta: meta, Name: stringPool.Get("target1"), Pkg: stringPool.Get("main")},
+				}, Name: stringPool.Get("arg1"), Kind: 1, Type: stringPool.Get("string"), Position: stringPool.Get("pos1")}, // KindIdent
+				{Meta: meta, Edge: &metadata.CallGraphEdge{
+					Caller: metadata.Call{Meta: meta, Name: stringPool.Get("arg2"), Pkg: stringPool.Get("main")},
+					Callee: metadata.Call{Meta: meta, Name: stringPool.Get("target2"), Pkg: stringPool.Get("main")},
+				}, Name: stringPool.Get("arg2"), Kind: 1, Type: stringPool.Get("int"), Position: stringPool.Get("pos2")}, // KindIdent
+				{Meta: meta, Edge: &metadata.CallGraphEdge{
+					Caller: metadata.Call{Meta: meta, Name: stringPool.Get("arg3"), Pkg: stringPool.Get("main")},
+					Callee: metadata.Call{Meta: meta, Name: stringPool.Get("target3"), Pkg: stringPool.Get("main")},
+				}, Name: stringPool.Get("arg3"), Kind: 1, Type: stringPool.Get("bool"), Position: stringPool.Get("pos3")}, // KindIdent
+			},
+		}
+
+		// This should trigger the warning
+		processArguments(nil, meta, nil, edge, make(map[string]int), nil, limits)
+
+		// Read the output
+		_ = w.Close()
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+		output := buf.String()
+
+		// Check if warning was printed
+		expectedWarning := fmt.Sprintf("Warning: MaxArgsPerFunction limit (%d) reached", limits.MaxArgsPerFunction)
+		if !strings.Contains(output, expectedWarning) {
+			t.Errorf("Expected warning message containing '%s', got: %s", expectedWarning, output)
+		}
+	})
+
+	// Test MaxNodesPerTree warning
+	t.Run("MaxNodesPerTree warning", func(t *testing.T) {
+		// Reset stdout capture
+		os.Stdout = oldStdout
+		r, w, _ = os.Pipe()
+		os.Stdout = w
+
+		// Create a tracker with very low limits
+		limits := metadata.TrackerLimits{
+			MaxNodesPerTree: 1,
+		}
+
+		// Create a visited map that exceeds the limit
+		visited := make(map[string]int)
+		for i := 0; i < 5; i++ {
+			visited[fmt.Sprintf("node%d", i)] = 1
+		}
+
+		// This should trigger the warning
+		NewTrackerNode(nil, meta, "parent", "test", nil, nil, visited, nil, limits)
+
+		// Read the output
+		_ = w.Close()
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+		output := buf.String()
+
+		// Check if warning was printed
+		expectedWarning := fmt.Sprintf("Warning: MaxNodesPerTree limit (%d) reached", limits.MaxNodesPerTree)
+		if !strings.Contains(output, expectedWarning) {
+			t.Errorf("Expected warning message containing '%s', got: %s", expectedWarning, output)
+		}
+	})
+
+	// Test MaxChildrenPerNode warning
+	t.Run("MaxChildrenPerNode warning", func(t *testing.T) {
+		// Reset stdout capture
+		os.Stdout = oldStdout
+		r, w, _ = os.Pipe()
+		os.Stdout = w
+
+		// Create a tracker with very low limits
+		limits := metadata.TrackerLimits{
+			MaxChildrenPerNode: 1,
+		}
+
+		// Create a mock tree to test the warning
+		tree := &TrackerTree{
+			limits: limits,
+		}
+
+		// Create multiple edges in metadata to exceed the limit
+		parentID := "main.parent"
+		meta.Callers = make(map[string][]*metadata.CallGraphEdge)
+		meta.Callers[parentID] = []*metadata.CallGraphEdge{
+			{
+				Caller: metadata.Call{Meta: meta, Name: stringPool.Get("parent"), Pkg: stringPool.Get("main")},
+				Callee: metadata.Call{Meta: meta, Name: stringPool.Get("child1"), Pkg: stringPool.Get("main")},
+			},
+			{
+				Caller: metadata.Call{Meta: meta, Name: stringPool.Get("parent"), Pkg: stringPool.Get("main")},
+				Callee: metadata.Call{Meta: meta, Name: stringPool.Get("child2"), Pkg: stringPool.Get("main")},
+			},
+			{
+				Caller: metadata.Call{Meta: meta, Name: stringPool.Get("parent"), Pkg: stringPool.Get("main")},
+				Callee: metadata.Call{Meta: meta, Name: stringPool.Get("child3"), Pkg: stringPool.Get("main")},
+			},
+		}
+
+		// This should trigger the warning when processing many children
+		NewTrackerNode(tree, meta, "parent", parentID, nil, nil, make(map[string]int), nil, limits)
+
+		// Read the output
+		_ = w.Close()
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+		output := buf.String()
+
+		// Check if warning was printed
+		expectedWarning := fmt.Sprintf("Warning: MaxChildrenPerNode limit (%d) reached", limits.MaxChildrenPerNode)
+		if !strings.Contains(output, expectedWarning) {
+			t.Errorf("Expected warning message containing '%s', got: %s", expectedWarning, output)
+		}
+	})
+}
+
+// TestTrackerWithoutWarnings tests that no warnings are printed when limits are not exceeded
+func TestTrackerWithoutWarnings(t *testing.T) {
+	// Capture stdout to test that no warnings are printed
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	defer func() {
+		os.Stdout = oldStdout
+		_ = w.Close()
+	}()
+
+	// Create a mock metadata
+	stringPool := metadata.NewStringPool()
+	meta := &metadata.Metadata{
+		StringPool: stringPool,
+		Packages: map[string]*metadata.Package{
+			"main": {
+				Files: map[string]*metadata.File{
+					"test.go": {
+						Types: map[string]*metadata.Type{
+							"TestType": {
+								Name: stringPool.Get("TestType"),
+								Kind: stringPool.Get("struct"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Test with high limits (should not trigger warnings)
+	limits := metadata.TrackerLimits{
+		MaxArgsPerFunction: 100,
+		MaxNodesPerTree:    1000,
+		MaxChildrenPerNode: 100,
+	}
+
+	// Create a mock edge with few arguments
+	edge := &metadata.CallGraphEdge{
+		Caller: metadata.Call{
+			Meta: meta,
+			Name: stringPool.Get("TestFunction"),
+			Pkg:  stringPool.Get("main"),
+		},
+		Callee: metadata.Call{
+			Meta: meta,
+			Name: stringPool.Get("AnotherFunction"),
+			Pkg:  stringPool.Get("main"),
+		},
+		Args: []metadata.CallArgument{
+			{Meta: meta, Edge: &metadata.CallGraphEdge{}},
+		},
+	}
+
+	// This should not trigger any warnings
+	processArguments(nil, meta, nil, edge, make(map[string]int), nil, limits)
+
+	// Create a visited map that doesn't exceed the limit
+	visited := make(map[string]int)
+	visited["node1"] = 1
+
+	// This should not trigger any warnings
+	NewTrackerNode(nil, meta, "parent", "test", nil, nil, visited, nil, limits)
+
+	// This should not trigger any warnings
+	NewTrackerNode(nil, meta, "parent", "test", nil, nil, visited, nil, limits)
+
+	// Read the output
+	_ = w.Close()
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	output := buf.String()
+
+	// Check that no warnings were printed
+	if strings.Contains(output, "Warning:") {
+		t.Errorf("Expected no warning messages, got: %s", output)
+	}
+}
+
+// TestTrackerLimitsIntegration tests the integration of all limit checks
+func TestTrackerLimitsIntegration(t *testing.T) {
+	// Capture stdout to test warning messages
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	defer func() {
+		os.Stdout = oldStdout
+		_ = w.Close()
+	}()
+
+	// Create a mock metadata
+	stringPool := metadata.NewStringPool()
+	meta := &metadata.Metadata{
+		StringPool: stringPool,
+		Packages: map[string]*metadata.Package{
+			"main": {
+				Files: map[string]*metadata.File{
+					"test.go": {
+						Types: map[string]*metadata.Type{
+							"TestType": {
+								Name: stringPool.Get("TestType"),
+								Kind: stringPool.Get("struct"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Test with very restrictive limits
+	limits := metadata.TrackerLimits{
+		MaxArgsPerFunction: 1,
+		MaxNodesPerTree:    2,
+		MaxChildrenPerNode: 1,
+	}
+
+	// Test all three warning conditions
+	edge := &metadata.CallGraphEdge{
+		Caller: metadata.Call{
+			Meta: meta,
+			Name: stringPool.Get("TestFunction"),
+			Pkg:  stringPool.Get("main"),
+		},
+		Callee: metadata.Call{
+			Meta: meta,
+			Name: stringPool.Get("AnotherFunction"),
+			Pkg:  stringPool.Get("main"),
+		},
+		Args: []metadata.CallArgument{
+			{Meta: meta, Edge: &metadata.CallGraphEdge{}},
+			{Meta: meta, Edge: &metadata.CallGraphEdge{}},
+		},
+	}
+
+	// Trigger MaxArgsPerFunction warning
+	processArguments(nil, meta, nil, edge, make(map[string]int), nil, limits)
+
+	// Trigger MaxNodesPerTree warning
+	visited := make(map[string]int)
+	for i := 0; i < 5; i++ {
+		visited[fmt.Sprintf("node%d", i)] = 1
+	}
+	NewTrackerNode(nil, meta, "parent", "test", nil, nil, visited, nil, limits)
+
+	// Trigger MaxChildrenPerNode warning
+	tree := &TrackerTree{
+		limits: limits,
+	}
+	// Set up metadata to have multiple children for the same caller
+	meta.Callers = make(map[string][]*metadata.CallGraphEdge)
+	meta.Callers["test"] = []*metadata.CallGraphEdge{
+		{
+			Caller: metadata.Call{Meta: meta, Name: stringPool.Get("test"), Pkg: stringPool.Get("main")},
+			Callee: metadata.Call{Meta: meta, Name: stringPool.Get("child1"), Pkg: stringPool.Get("main")},
+		},
+		{
+			Caller: metadata.Call{Meta: meta, Name: stringPool.Get("test"), Pkg: stringPool.Get("main")},
+			Callee: metadata.Call{Meta: meta, Name: stringPool.Get("child2"), Pkg: stringPool.Get("main")},
+		},
+	}
+	// Use a fresh visited map to avoid MaxNodesPerTree limit
+	freshVisited := make(map[string]int)
+	NewTrackerNode(tree, meta, "parent", "test", nil, nil, freshVisited, nil, limits)
+
+	// Read the output
+	_ = w.Close()
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	output := buf.String()
+
+	// Check that all three warnings were printed
+	expectedWarnings := []string{
+		"MaxArgsPerFunction limit",
+		"MaxNodesPerTree limit",
+		"MaxChildrenPerNode limit",
+	}
+
+	for _, expectedWarning := range expectedWarnings {
+		if !strings.Contains(output, expectedWarning) {
+			t.Errorf("Expected warning message containing '%s', got: %s", expectedWarning, output)
+		}
+	}
+}


### PR DESCRIPTION
- Change YAML generation method
- Increase default limits - Raised limits for large codebases to handle more complex code structures
- Add debug warnings - You'll now see clear messages when any limits are reached during generation 
- Improve array/map references - Better schema reuse to reduce file size and improve performance.