### PR TITLE
Fan out conditional response status codes; document recent fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Coverage](https://img.shields.io/badge/coverage-49.0%25-red.svg)](https://github.com/ehabterra/apispec)
 [![Go Report Card](https://goreportcard.com/badge/github.com/ehabterra/apispec)](https://goreportcard.com/report/github.com/ehabterra/apispec)
-[![Go Version](https://img.shields.io/badge/go-1.24+-00ADD8?style=flat&logo=go)](https://go.dev/)
+[![Go Version](https://img.shields.io/badge/go-1.26+-00ADD8?style=flat&logo=go)](https://go.dev/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/ehabterra/apispec/blob/main/LICENSE)
 [![GitHub Actions](https://img.shields.io/github/actions/workflow/status/ehabterra/apispec/ci.yml?branch=main&label=CI&logo=github)](https://github.com/ehabterra/apispec/actions/workflows/ci.yml)
 [![Tests](https://img.shields.io/github/actions/workflow/status/ehabterra/apispec/test.yml?branch=main&label=Tests&logo=github)](https://github.com/ehabterra/apispec/actions/workflows/test.yml)
@@ -43,6 +43,9 @@ Click *the image above to watch the full demo on YouTube*
 - **Performance Profiling**: Built-in CPU, memory, block, mutex, and trace profiling for performance analysis.
 - **Configurable Limits**: Fine-tune analysis limits for large codebases with detailed warning messages.
 - **CGO Support**: Skip CGO packages during analysis to avoid build errors.
+- **Conditional Response Status Codes**: When an error/status variable is reassigned across `if`/`else` branches with distinct HTTP status codes, APISpec emits one response per status (sharing the body/schema). Closes [#39](https://github.com/ehabterra/apispec/issues/39).
+- **Request Body Source Disambiguation**: New `framework.requestContext` config (`typeRegexes` + `bodyAccessors`) lets generic decoders like `json.Decode` and `json.Unmarshal` be classified as request-body decoders only when the source argument can be traced back to a request-context body accessor (e.g. `r.Body`), eliminating false positives from unrelated decoding.
+- **Underlying Field Type Rendering**: Schema generation now resolves the underlying primitive type of struct fields whose declared type is an alias or named type, so aliased fields render with their concrete OpenAPI type.
 
 > **Note**: Generating call-graph diagrams and metadata files consumes additional resources and time.
 
@@ -82,7 +85,7 @@ APISpec focuses on practical coverage for real-world services. Current coverage 
 - [x] **External type introspection**: types from external packages are automatically resolved to their underlying primitives; complex external types can be defined via `externalTypes` in config.
 - [x] **Generics (functions)**: detects type parameters and maps concrete types at call sites.
 - [ ] **Generics (types)**: generic struct and type instantiation are partially supported.
-- [ ] **Inferred status codes**: status codes assigned via variables are not inferred.
+- [x] **Inferred status codes (branched)**: when a response call's status argument traces back to a local variable reassigned across `if`/`else` branches (each branch calling a constructor like `NewError(msg, http.StatusXxx)`), APISpec emits one response per distinct status code, sharing the body schema. Status codes assigned via a single variable still follow latest-wins resolution.
 - [x] **Interfaces**: captures interface types and methods; unresolved dynamic values are represented generically.
 - [x] **Chain calls**: efficiently processes method chaining and establishes parent-child relationships in the call graph.
 - [x] **Nested calls**: handles chained/method calls and nested expressions.
@@ -215,6 +218,7 @@ type User struct {
 #### How External Type Resolution Works
 
 - **External Types**: Types from packages like `github.com/google/uuid.UUID` are automatically resolved to their underlying primitive types (e.g., `string` with `format: "byte"`)
+- **Pointer External Types**: Pointers to external types (e.g., `*uuid.UUID`) are now resolved to the same primitive schema as their non-pointer counterparts.
 - **Internal Types**: Types from your own project (even in different packages) are preserved as-is for proper schema generation
 - **Standard Library**: Types like `time.Time` are handled appropriately based on configuration
 
@@ -883,6 +887,25 @@ typeMapping:
         type: string
 ```
 
+#### Request Body Source (Generic Decoder Disambiguation)
+
+Generic decoders like `json.Decode`, `json.Unmarshal`, and `render.DecodeJSON` are used both for request bodies *and* for unrelated decoding (config files, internal payloads). The `requestContext` block tells APISpec which receivers count as "request context" and which method names are body accessors. A decoder call is only classified as a request-body decoder when its source argument can be traced — through selectors, idents, assignments, and parameter boundaries — back to a body accessor on a request-context typed root.
+
+```yaml
+framework:
+  requestContext:
+    # Receivers (and pointer variants) that represent a request context.
+    typeRegexes:
+      - ^net/http\.\*Request$
+      - ^github\.com/gin-gonic/gin\.\*Context$
+    # Method/field names on those receivers that yield the request body.
+    bodyAccessors:
+      - ^Body$
+      - ^GetRawData$
+```
+
+When `requestContext` is omitted, APISpec falls back to its prior receiver-only matching behaviour, so existing configs keep working without modification.
+
 #### External Package Types
 
 ```yaml
@@ -918,7 +941,7 @@ externalTypes:
 
 ### Prerequisites
 
-- Go 1.24+ (Didn't test it on version before 1.24)
+- Go 1.26+
 - Understanding of AST (Abstract Syntax Tree)
 - Familiarity with OpenAPI 3.1 specification
 

--- a/internal/spec/conditional_status_test.go
+++ b/internal/spec/conditional_status_test.go
@@ -1,0 +1,181 @@
+package spec
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// TestExtractResponse_BranchedStatuses mirrors issue #39: an error variable
+// reassigned across if/else branches with different status codes should
+// produce one ResponseInfo per distinct status.
+//
+//	if errors.As(err, &a401) {
+//	    err = NewError(msg, http.StatusUnauthorized)   // 401
+//	} else if errors.As(err, &a404) {
+//	    err = NewError(msg, http.StatusNotFound)       // 404
+//	} else {
+//	    err = NewError(msg, http.StatusInternalServerError) // 500
+//	}
+//	RespondWithError(w, err)
+func TestExtractResponse_BranchedStatuses(t *testing.T) {
+	meta := &metadata.Metadata{
+		StringPool: metadata.NewStringPool(),
+		Packages: map[string]*metadata.Package{
+			"app": {Files: map[string]*metadata.File{}},
+		},
+	}
+
+	// Build three assignments, each a call to NewError(msg, http.StatusXxx).
+	assigns := make([]metadata.Assignment, 0, 3)
+	for _, status := range []string{
+		"StatusUnauthorized",
+		"StatusNotFound",
+		"StatusInternalServerError",
+	} {
+		statusArg := metadata.NewCallArgument(meta)
+		statusArg.SetKind(metadata.KindSelector)
+		// Render as "http.<Name>" so MapStatusCode's last-dot split picks
+		// up the constant name.
+		x := metadata.NewCallArgument(meta)
+		x.SetKind(metadata.KindIdent)
+		x.SetName("http")
+		sel := metadata.NewCallArgument(meta)
+		sel.SetKind(metadata.KindIdent)
+		sel.SetName(status)
+		statusArg.X = x
+		statusArg.Sel = sel
+
+		msgArg := metadata.NewCallArgument(meta)
+		msgArg.SetKind(metadata.KindIdent)
+		msgArg.SetName("msg")
+
+		rhs := metadata.NewCallArgument(meta)
+		rhs.SetKind(metadata.KindCall)
+		fun := metadata.NewCallArgument(meta)
+		fun.SetKind(metadata.KindIdent)
+		fun.SetName("NewError")
+		rhs.Fun = fun
+		rhs.Args = []*metadata.CallArgument{msgArg, statusArg}
+
+		assigns = append(assigns, metadata.Assignment{
+			Value: *rhs,
+		})
+	}
+
+	// Register the handler function with the branched err assignments.
+	handlerFn := &metadata.Function{
+		AssignmentMap: map[string][]metadata.Assignment{
+			"err": assigns,
+		},
+	}
+	meta.Packages["app"].Files["handlers.go"] = &metadata.File{
+		Functions: map[string]*metadata.Function{
+			"handler": handlerFn,
+		},
+	}
+
+	// Build the call to RespondWithError(w, err): arg0 = w, arg1 = err.
+	errArg := metadata.NewCallArgument(meta)
+	errArg.SetKind(metadata.KindIdent)
+	errArg.SetName("err")
+	wArg := metadata.NewCallArgument(meta)
+	wArg.SetKind(metadata.KindIdent)
+	wArg.SetName("w")
+
+	edge := &metadata.CallGraphEdge{
+		Caller: metadata.Call{
+			Name: meta.StringPool.Get("handler"),
+			Pkg:  meta.StringPool.Get("app"),
+		},
+		Callee: metadata.Call{
+			Name: meta.StringPool.Get("RespondWithError"),
+			Pkg:  meta.StringPool.Get("app"),
+		},
+		Args: []*metadata.CallArgument{wArg, errArg},
+	}
+	node := &TrackerNode{CallGraphEdge: edge}
+
+	cfg := &APISpecConfig{
+		Defaults: Defaults{ResponseContentType: "application/json"},
+	}
+	cp := NewContextProvider(meta)
+	matcher := &ResponsePatternMatcherImpl{
+		BasePatternMatcher: &BasePatternMatcher{
+			cfg:             cfg,
+			contextProvider: cp,
+			schemaMapper:    NewSchemaMapper(cfg),
+		},
+		pattern: ResponsePattern{
+			CallRegex:      "^RespondWithError$",
+			StatusFromArg:  true,
+			StatusArgIndex: 1,
+		},
+	}
+
+	results := matcher.ExtractResponse(node, &RouteInfo{
+		Response: map[string]*ResponseInfo{},
+	})
+
+	got := make([]int, 0, len(results))
+	for _, r := range results {
+		got = append(got, r.StatusCode)
+	}
+	sort.Ints(got)
+
+	want := []int{401, 404, 500}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d responses, got %d: %v", len(want), len(got), got)
+	}
+	for i, st := range want {
+		if got[i] != st {
+			t.Fatalf("expected statuses %v, got %v", want, got)
+		}
+	}
+}
+
+// TestExtractResponse_SingleAssignment_NoFanOut ensures the fan-out path
+// does not fire for variables with a single assignment, preserving
+// pre-#39 latest-wins behaviour byte-for-byte.
+func TestExtractResponse_SingleAssignment_NoFanOut(t *testing.T) {
+	meta := &metadata.Metadata{
+		StringPool: metadata.NewStringPool(),
+		Packages:   map[string]*metadata.Package{},
+	}
+	cfg := &APISpecConfig{
+		Defaults: Defaults{ResponseContentType: "application/json"},
+	}
+	cp := NewContextProvider(meta)
+
+	matcher := &ResponsePatternMatcherImpl{
+		BasePatternMatcher: &BasePatternMatcher{
+			cfg:             cfg,
+			contextProvider: cp,
+			schemaMapper:    NewSchemaMapper(cfg),
+		},
+		pattern: ResponsePattern{
+			StatusFromArg:  true,
+			StatusArgIndex: 0,
+			DefaultStatus: 200,
+		},
+	}
+
+	// Literal status arg: classic single-response flow.
+	statusLit := metadata.NewCallArgument(meta)
+	statusLit.SetKind(metadata.KindLiteral)
+	statusLit.SetValue("201")
+	edge := &metadata.CallGraphEdge{
+		Args: []*metadata.CallArgument{statusLit},
+	}
+
+	results := matcher.ExtractResponse(&TrackerNode{CallGraphEdge: edge}, &RouteInfo{
+		Response: map[string]*ResponseInfo{},
+	})
+	if len(results) != 1 {
+		t.Fatalf("expected exactly 1 response for literal status, got %d", len(results))
+	}
+	if results[0].StatusCode != 201 {
+		t.Fatalf("expected status 201, got %d", results[0].StatusCode)
+	}
+}

--- a/internal/spec/conditional_status_test.go
+++ b/internal/spec/conditional_status_test.go
@@ -157,7 +157,7 @@ func TestExtractResponse_SingleAssignment_NoFanOut(t *testing.T) {
 		pattern: ResponsePattern{
 			StatusFromArg:  true,
 			StatusArgIndex: 0,
-			DefaultStatus: 200,
+			DefaultStatus:  200,
 		},
 	}
 

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -365,9 +365,13 @@ func (e *Extractor) extractRouteChildren(routeNode TrackerNodeInterface, route *
 			route.Request = req
 		}
 
-		// Extract response
-		if resp := e.extractResponseFromNode(child, route, visitedEdges); resp != nil && (resp.BodyType != "" || resp.StatusCode != 0) {
-			route.Response[fmt.Sprintf("%d", resp.StatusCode)] = resp
+		// Extract responses (multiple if status fan-out applies — see
+		// ExtractResponse / issue #39). Each emitted ResponseInfo lands
+		// under its own status-keyed slot in route.Response.
+		for _, resp := range e.extractResponseFromNode(child, route, visitedEdges) {
+			if resp != nil && (resp.BodyType != "" || resp.StatusCode != 0) {
+				route.Response[fmt.Sprintf("%d", resp.StatusCode)] = resp
+			}
 		}
 
 		// Extract parameters
@@ -395,8 +399,10 @@ func (e *Extractor) extractRequestFromNode(node TrackerNodeInterface, route *Rou
 	return nil
 }
 
-// extractResponseFromNode extracts response information from a node
-func (e *Extractor) extractResponseFromNode(node TrackerNodeInterface, route *RouteInfo, visitedEdges map[string]bool) *ResponseInfo {
+// extractResponseFromNode extracts response information from a node.
+// Returns a slice because a single call site can yield multiple responses
+// when conditional status codes apply (see ExtractResponse / issue #39).
+func (e *Extractor) extractResponseFromNode(node TrackerNodeInterface, route *RouteInfo, visitedEdges map[string]bool) []*ResponseInfo {
 	// Ensure that each edge is visited only once
 	if node == nil || node.GetEdge() == nil {
 		return nil
@@ -416,11 +422,6 @@ func (e *Extractor) extractResponseFromNode(node TrackerNodeInterface, route *Ro
 			return matcher.ExtractResponse(node, route)
 		}
 	}
-	// // If no response matcher matches, return the default response info
-	// return &ResponseInfo{
-	// 	StatusCode:  e.cfg.Defaults.ResponseStatus,
-	// 	ContentType: e.cfg.Defaults.ResponseContentType,
-	// }
 	return nil
 }
 
@@ -566,8 +567,15 @@ func (r *ResponsePatternMatcherImpl) GetPriority() int {
 	return priority
 }
 
-// ExtractResponse extracts response information from a matched node
-func (r *ResponsePatternMatcherImpl) ExtractResponse(node TrackerNodeInterface, route *RouteInfo) *ResponseInfo {
+// ExtractResponse extracts response information from a matched node.
+//
+// Returns a slice to support conditional status codes (issue #39): when the
+// status arg is a local variable reassigned across branches with different
+// status codes, we emit one ResponseInfo per distinct status (all sharing
+// the same body/schema). For the typical "one status per call" case, the
+// slice has exactly one element — byte-identical to the previous
+// single-response behaviour.
+func (r *ResponsePatternMatcherImpl) ExtractResponse(node TrackerNodeInterface, route *RouteInfo) []*ResponseInfo {
 	var (
 		statusResolved bool
 	)
@@ -660,11 +668,87 @@ func (r *ResponsePatternMatcherImpl) ExtractResponse(node TrackerNodeInterface, 
 		respInfo.Schema = schema
 	}
 
+	// Conditional status codes (issue #39): if the status arg is a local
+	// variable with multiple branched assignments mapping to *distinct*
+	// status codes, emit one response per status, sharing the body/schema.
+	// This runs before the "no status, no body — return nil" guard so that
+	// patterns whose status arg is an opaque ident (e.g. RespondWithError(w,
+	// err)) still produce responses when the branches encode the codes.
+	if r.pattern.StatusFromArg && len(edge.Args) > r.pattern.StatusArgIndex {
+		if expanded := r.expandStatusesFromIdent(edge.Args[r.pattern.StatusArgIndex], edge); len(expanded) > 1 {
+			out := make([]*ResponseInfo, 0, len(expanded))
+			for _, st := range expanded {
+				out = append(out, &ResponseInfo{
+					StatusCode:  st,
+					ContentType: respInfo.ContentType,
+					BodyType:    respInfo.BodyType,
+					Schema:      respInfo.Schema,
+				})
+			}
+			return out
+		}
+	}
+
 	if !statusResolved && respInfo.BodyType == "" {
 		return nil
 	}
 
-	return respInfo
+	return []*ResponseInfo{respInfo}
+}
+
+// expandStatusesFromIdent walks the caller's function-level AssignmentMap
+// for the given ident and returns the distinct status codes implied by the
+// RHS calls of each assignment. For each assignment whose value is a call,
+// the first argument that parses as a known HTTP status (via
+// schemaMapper.MapStatusCode) is taken as that branch's status.
+//
+// Returns nil when:
+//   - the arg is not a KindIdent,
+//   - the caller function or its AssignmentMap can't be located, or
+//   - fewer than two assignments exist (single-branch flows are left
+//     untouched so existing latest-wins behaviour is preserved).
+func (r *ResponsePatternMatcherImpl) expandStatusesFromIdent(arg *metadata.CallArgument, edge *metadata.CallGraphEdge) []int {
+	if arg == nil || arg.GetKind() != metadata.KindIdent || edge == nil {
+		return nil
+	}
+	impl, ok := r.contextProvider.(*ContextProviderImpl)
+	if !ok || impl.meta == nil {
+		return nil
+	}
+	callerName := impl.GetString(edge.Caller.Name)
+	callerPkg := impl.GetString(edge.Caller.Pkg)
+	fn := findFunction(impl.meta, callerPkg, callerName)
+	if fn == nil {
+		return nil
+	}
+	assigns, ok := fn.AssignmentMap[arg.GetName()]
+	if !ok || len(assigns) < 2 {
+		return nil
+	}
+	seen := make(map[int]struct{}, len(assigns))
+	out := make([]int, 0, len(assigns))
+	for _, a := range assigns {
+		if a.Value.GetKind() != metadata.KindCall {
+			continue
+		}
+		for _, callArg := range a.Value.Args {
+			if callArg == nil {
+				continue
+			}
+			argStr := impl.GetArgumentInfo(callArg)
+			status, ok := r.schemaMapper.MapStatusCode(argStr)
+			if !ok {
+				continue
+			}
+			if _, dup := seen[status]; dup {
+				break
+			}
+			seen[status] = struct{}{}
+			out = append(out, status)
+			break // first matching arg wins per assignment
+		}
+	}
+	return out
 }
 
 // resolveTypeOrigin traces the origin of a type through assignments and type parameters

--- a/internal/spec/extractor_test.go
+++ b/internal/spec/extractor_test.go
@@ -303,8 +303,8 @@ func TestExtractResponse_WithLiteralValue(t *testing.T) {
 				},
 			}
 
-			// Extract response
-			result := matcher.ExtractResponse(node, &RouteInfo{
+			// Extract response (now returns []*ResponseInfo)
+			results := matcher.ExtractResponse(node, &RouteInfo{
 				Path:     "/test",
 				Method:   "POST",
 				Handler:  "testHandler",
@@ -335,10 +335,11 @@ func TestExtractResponse_WithLiteralValue(t *testing.T) {
 			})
 
 			// Verify that literal values are handled correctly
-			if result == nil {
-				t.Fatal("Expected non-nil result")
+			if len(results) == 0 {
+				t.Fatal("Expected non-empty result")
 				return
 			}
+			result := results[0]
 
 			// For literal values, we expect the appropriate type based on the value
 			if result.BodyType != tc.expectedType {
@@ -381,15 +382,16 @@ func TestResponsePattern_DefaultStatus(t *testing.T) {
 		},
 	}
 
-	result := matcher.ExtractResponse(&TrackerNode{
+	results := matcher.ExtractResponse(&TrackerNode{
 		CallGraphEdge: &metadata.CallGraphEdge{},
 	}, &RouteInfo{
 		Response: map[string]*ResponseInfo{},
 	})
 
-	if result == nil {
-		t.Fatal("expected response info when default status is configured")
+	if len(results) != 1 {
+		t.Fatalf("expected single response info when default status is configured, got %d", len(results))
 	}
+	result := results[0]
 
 	if result.StatusCode != http.StatusNotFound {
 		t.Fatalf("expected status %d, got %d", http.StatusNotFound, result.StatusCode)

--- a/internal/spec/interfaces.go
+++ b/internal/spec/interfaces.go
@@ -44,8 +44,12 @@ type RequestPatternMatcher interface {
 type ResponsePatternMatcher interface {
 	PatternMatcher
 
-	// ExtractResponse extracts response information from a matched node
-	ExtractResponse(node TrackerNodeInterface, route *RouteInfo) *ResponseInfo
+	// ExtractResponse extracts response information from a matched node.
+	// Returns one entry for the typical "one status per call" case, and
+	// multiple entries when the status arg traces back to a local variable
+	// with multiple branched assignments — e.g. an `err` reassigned in
+	// each branch of an if/else chain with a different status code.
+	ExtractResponse(node TrackerNodeInterface, route *RouteInfo) []*ResponseInfo
 }
 
 // ParamPatternMatcher matches parameter patterns


### PR DESCRIPTION
## Summary
- Fan out responses when a status arg traces back to a local variable reassigned across `if`/`else` branches with distinct status codes (e.g. `err = NewError(msg, http.StatusXxx)` per branch). Single-assignment flows keep latest-wins.
- `ResponsePatternMatcher.ExtractResponse` now returns `[]*ResponseInfo`; the typical one-status case returns a one-element slice.
- README updated for Go 1.26, the new fan-out behaviour, the `framework.requestContext` config, underlying-field rendering, and pointer-to-external-type (`*uuid.UUID`) resolution.

Closes #39.

## Test plan
- [x] `go test ./internal/spec/...` — new `conditional_status_test.go` covers the 401/404/500 branched case and the single-assignment no-fan-out guard
- [ ] Run on a real handler with branched `RespondWithError` and verify the generated spec lists each status

🤖 Generated with [Claude Code](https://claude.com/claude-code)