### PR TITLE
dynamic mount prefix

### DIFF
--- a/internal/spec/dynamic_path_params_test.go
+++ b/internal/spec/dynamic_path_params_test.go
@@ -1,0 +1,100 @@
+package spec
+
+import (
+	"testing"
+)
+
+// TestDynamicParamNameRoundTrip pins the PascalCase + "Param" mangling so
+// dynamicParamComponentName / refTargetName stay symmetric. ensureAllPathParams
+// relies on this symmetry to recognise that a $ref covers a placeholder.
+func TestDynamicParamNameRoundTrip(t *testing.T) {
+	cases := []string{"mountPoint", "prefix", "x", "userID"}
+	for _, name := range cases {
+		ref := dynamicParamRef(name)
+		got := refTargetName(ref)
+		if got != name {
+			t.Errorf("round-trip for %q: ref=%q decoded=%q", name, ref, got)
+		}
+	}
+}
+
+// TestAppendDynamicParamRefs_AddsAndDedupes ensures $ref entries are appended
+// only once even when the same placeholder shows up in multiple sources, and
+// that an inline param with the same name suppresses the $ref.
+func TestAppendDynamicParamRefs_AddsAndDedupes(t *testing.T) {
+	// Empty start: two dynamics produce two $refs.
+	out := appendDynamicParamRefs(nil, []string{"mountPoint", "mountPoint", "version"})
+	if len(out) != 2 {
+		t.Fatalf("expected 2 params, got %d", len(out))
+	}
+	if out[0].Ref != "#/components/parameters/MountPointParam" {
+		t.Errorf("first ref %q", out[0].Ref)
+	}
+	if out[1].Ref != "#/components/parameters/VersionParam" {
+		t.Errorf("second ref %q", out[1].Ref)
+	}
+
+	// An inline param with matching name suppresses the $ref.
+	existing := []Parameter{{Name: "mountPoint", In: "path", Required: true, Schema: &Schema{Type: "string"}}}
+	out = appendDynamicParamRefs(existing, []string{"mountPoint"})
+	if len(out) != 1 {
+		t.Fatalf("expected inline to suppress $ref, got %d params", len(out))
+	}
+	if out[0].Ref != "" {
+		t.Errorf("expected inline param preserved, got ref %q", out[0].Ref)
+	}
+}
+
+// TestEnsureAllPathParams_RecognisesRef checks that a $ref-only entry counts
+// as "covered" so ensureAllPathParams doesn't add a duplicate inline declaration
+// for the same {name} in the path. Without this, the spec would carry both a
+// $ref and an x-warning inline param for every dynamic placeholder.
+func TestEnsureAllPathParams_RecognisesRef(t *testing.T) {
+	params := []Parameter{{Ref: "#/components/parameters/MountPointParam"}}
+	got := ensureAllPathParams("/{mountPoint}/{id}", params)
+
+	// Expect: original $ref kept, plus one inline for {id}. No duplicate for mountPoint.
+	if len(got) != 2 {
+		t.Fatalf("expected 2 params (ref + id), got %d: %+v", len(got), got)
+	}
+	var sawRef, sawID bool
+	for _, p := range got {
+		if p.Ref == "#/components/parameters/MountPointParam" {
+			sawRef = true
+		}
+		if p.Name == "id" {
+			sawID = true
+		}
+	}
+	if !sawRef || !sawID {
+		t.Errorf("expected to see both $ref and inline id: %+v", got)
+	}
+}
+
+// TestAddDynamicPathParamComponents_RegistersOnce ensures each unique
+// placeholder appears exactly once in components.parameters, even when many
+// routes share the same name (the typical case: every operation under a
+// dynamic-mount prefix references the same placeholder).
+func TestAddDynamicPathParamComponents_RegistersOnce(t *testing.T) {
+	routes := []*RouteInfo{
+		{DynamicParams: []string{"mountPoint"}},
+		{DynamicParams: []string{"mountPoint"}},
+		{DynamicParams: []string{"mountPoint", "version"}},
+	}
+	var components Components
+	addDynamicPathParamComponents(&components, routes)
+
+	if components.Parameters == nil {
+		t.Fatal("expected components.Parameters populated")
+	}
+	if len(components.Parameters) != 2 {
+		t.Fatalf("expected 2 unique components, got %d", len(components.Parameters))
+	}
+	mp, ok := components.Parameters["MountPointParam"]
+	if !ok || mp.Name != "mountPoint" || mp.In != "path" || !mp.Required {
+		t.Errorf("MountPointParam missing or malformed: %+v", mp)
+	}
+	if _, ok := components.Parameters["VersionParam"]; !ok {
+		t.Errorf("VersionParam missing")
+	}
+}

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -67,6 +67,12 @@ type RouteInfo struct {
 
 	// Resolved router group prefix (if any)
 	GroupPrefix string
+
+	// DynamicParams names path placeholders synthesized from unresolvable
+	// call expressions (issue #34). The mapper uses these to emit one
+	// shared component parameter per name and $ref it from each operation
+	// instead of inlining a fresh declaration on every route.
+	DynamicParams []string
 }
 
 func NewRouteInfo() *RouteInfo {
@@ -172,24 +178,28 @@ func (e *Extractor) initializePatternMatchers() {
 func (e *Extractor) ExtractRoutes() []*RouteInfo {
 	routes := make([]*RouteInfo, 0)
 	for _, root := range e.tree.GetRoots() {
-		e.traverseForRoutes(root, "", nil, &routes)
+		e.traverseForRoutes(root, "", nil, nil, &routes)
 	}
 	return routes
 }
 
 // traverseForRoutes traverses the tree to find routes
-func (e *Extractor) traverseForRoutes(node TrackerNodeInterface, mountPath string, mountTags []string, routes *[]*RouteInfo) {
-	e.traverseForRoutesWithVisited(node, mountPath, mountTags, routes, make(map[string]bool))
+func (e *Extractor) traverseForRoutes(node TrackerNodeInterface, mountPath string, mountTags []string, mountDynParams []string, routes *[]*RouteInfo) {
+	e.traverseForRoutesWithVisited(node, mountPath, mountTags, mountDynParams, routes, make(map[string]bool))
 }
 
 // traverseForRoutesWithVisited traverses with visited tracking to prevent cycles
-func (e *Extractor) traverseForRoutesWithVisited(node TrackerNodeInterface, mountPath string, mountTags []string, routes *[]*RouteInfo, visited map[string]bool) {
+func (e *Extractor) traverseForRoutesWithVisited(node TrackerNodeInterface, mountPath string, mountTags []string, mountDynParams []string, routes *[]*RouteInfo, visited map[string]bool) {
 	if node == nil {
 		return
 	}
 
-	// Prevent infinite recursion
-	nodeKey := node.GetKey()
+	// Prevent infinite recursion. The key includes mountPath so the same
+	// sub-router can be mounted at multiple prefixes (each visit walks
+	// the sub-tree under a different mount). Cycles within a single mount
+	// context still short-circuit because mountPath only changes when a
+	// Mount call introduces a new prefix — see issue #34 follow-up.
+	nodeKey := node.GetKey() + "@" + mountPath
 	if visited[nodeKey] {
 		return
 	}
@@ -199,14 +209,14 @@ func (e *Extractor) traverseForRoutesWithVisited(node TrackerNodeInterface, moun
 
 	// Check for mount patterns first
 	if mountInfo, isMount := e.executeMountPattern(node); isMount {
-		e.handleMountNode(node, mountInfo, mountPath, mountTags, routes, visited)
+		e.handleMountNode(node, mountInfo, mountPath, mountTags, mountDynParams, routes, visited)
 	} else if isRoute := e.executeRoutePattern(node, routeInfo); isRoute {
 		// Check for route patterns
-		e.handleRouteNode(node, routeInfo, mountPath, mountTags, routes)
+		e.handleRouteNode(node, routeInfo, mountPath, mountTags, mountDynParams, routes)
 	} else {
 		// Continue traversing children
 		for _, child := range node.GetChildren() {
-			e.traverseForRoutesWithVisited(child, mountPath, mountTags, routes, visited)
+			e.traverseForRoutesWithVisited(child, mountPath, mountTags, mountDynParams, routes, visited)
 		}
 	}
 }
@@ -253,7 +263,7 @@ func (e *Extractor) executeRoutePattern(node TrackerNodeInterface, routeInfo *Ro
 }
 
 // handleMountNode handles a mount node
-func (e *Extractor) handleMountNode(node TrackerNodeInterface, mountInfo MountInfo, mountPath string, mountTags []string, routes *[]*RouteInfo, visited map[string]bool) {
+func (e *Extractor) handleMountNode(node TrackerNodeInterface, mountInfo MountInfo, mountPath string, mountTags []string, mountDynParams []string, routes *[]*RouteInfo, visited map[string]bool) {
 	// Update mount path if needed
 	if mountInfo.Path != "" {
 		if mountPath == "" || !strings.HasSuffix(mountPath, mountInfo.Path) {
@@ -261,9 +271,16 @@ func (e *Extractor) handleMountNode(node TrackerNodeInterface, mountInfo MountIn
 		}
 	}
 
+	// Carry dynamic placeholder names from this mount into nested routes
+	// so each child operation $refs the shared component parameter.
+	childDynParams := mountDynParams
+	if len(mountInfo.DynamicParams) > 0 {
+		childDynParams = appendUniqueStrings(mountDynParams, mountInfo.DynamicParams...)
+	}
+
 	// Handle router assignment if present
 	if mountInfo.Assignment != nil {
-		e.handleRouterAssignment(mountInfo, mountPath, mountTags, routes, visited)
+		e.handleRouterAssignment(mountInfo, mountPath, mountTags, childDynParams, routes, visited)
 	}
 
 	// Continue traversing children
@@ -274,12 +291,12 @@ func (e *Extractor) handleMountNode(node TrackerNodeInterface, mountInfo MountIn
 		} else {
 			newTags = mountTags
 		}
-		e.traverseForRoutesWithVisited(child, mountPath, newTags, routes, visited)
+		e.traverseForRoutesWithVisited(child, mountPath, newTags, childDynParams, routes, visited)
 	}
 }
 
 // handleRouteNode handles a route node
-func (e *Extractor) handleRouteNode(node TrackerNodeInterface, routeInfo *RouteInfo, mountPath string, mountTags []string, routes *[]*RouteInfo) {
+func (e *Extractor) handleRouteNode(node TrackerNodeInterface, routeInfo *RouteInfo, mountPath string, mountTags []string, mountDynParams []string, routes *[]*RouteInfo) {
 	// Prepend mount path if present
 	if mountPath != "" {
 		routeInfo.MountPath = joinPaths(mountPath, routeInfo.MountPath)
@@ -290,6 +307,11 @@ func (e *Extractor) handleRouteNode(node TrackerNodeInterface, routeInfo *RouteI
 		routeInfo.Tags = mountTags
 	}
 
+	// Merge inherited mount dynamic params with any produced by the route itself.
+	if len(mountDynParams) > 0 {
+		routeInfo.DynamicParams = appendUniqueStrings(mountDynParams, routeInfo.DynamicParams...)
+	}
+
 	// Extract route/request/response/params from children with visited edges tracking
 	visitedEdges := make(map[string]bool)
 	e.extractRouteChildren(node, routeInfo, mountTags, routes, visitedEdges)
@@ -298,10 +320,17 @@ func (e *Extractor) handleRouteNode(node TrackerNodeInterface, routeInfo *RouteI
 	e.overrideApplier.ApplyOverrides(routeInfo)
 
 	if routeInfo.IsValid() && routes != nil {
-		// Update existing route or add new one
+		// Update existing route or add new one. Dedup key is the
+		// effective OpenAPI identity (mount + path + method + handler)
+		// rather than just the handler name, so the same sub-router
+		// mounted at multiple prefixes yields one route per prefix
+		// instead of the last-mount-wins behaviour from before.
 		var found bool
 		for i := range *routes {
-			if (*routes)[i].Function == routeInfo.Function {
+			if (*routes)[i].Function == routeInfo.Function &&
+				(*routes)[i].MountPath == routeInfo.MountPath &&
+				(*routes)[i].Path == routeInfo.Path &&
+				(*routes)[i].Method == routeInfo.Method {
 				(*routes)[i] = routeInfo
 				found = true
 				break
@@ -314,7 +343,7 @@ func (e *Extractor) handleRouteNode(node TrackerNodeInterface, routeInfo *RouteI
 }
 
 // handleRouterAssignment handles router assignment for mounts
-func (e *Extractor) handleRouterAssignment(mountInfo MountInfo, mountPath string, mountTags []string, routes *[]*RouteInfo, visited map[string]bool) {
+func (e *Extractor) handleRouterAssignment(mountInfo MountInfo, mountPath string, mountTags []string, mountDynParams []string, routes *[]*RouteInfo, visited map[string]bool) {
 	// Find the target node for the assignment
 	targetNode := e.findTargetNode(mountInfo.Assignment)
 	if targetNode != nil {
@@ -325,9 +354,35 @@ func (e *Extractor) handleRouterAssignment(mountInfo MountInfo, mountPath string
 			} else {
 				newTags = mountTags
 			}
-			e.traverseForRoutesWithVisited(child, mountPath, newTags, routes, visited)
+			e.traverseForRoutesWithVisited(child, mountPath, newTags, mountDynParams, routes, visited)
 		}
 	}
+}
+
+// appendUniqueStrings returns base + extras with duplicates removed,
+// preserving first-seen order. Used to merge mount-inherited dynamic
+// placeholder names into a route without ballooning the slice.
+func appendUniqueStrings(base []string, extras ...string) []string {
+	if len(extras) == 0 {
+		return base
+	}
+	seen := make(map[string]struct{}, len(base)+len(extras))
+	out := make([]string, 0, len(base)+len(extras))
+	for _, s := range base {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	for _, s := range extras {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
 }
 
 // findTargetNode finds the target node for an assignment
@@ -357,7 +412,7 @@ func (e *Extractor) extractRouteChildren(routeNode TrackerNodeInterface, route *
 	for _, child := range routeNode.GetChildren() {
 		// Check for route patterns in children nodes
 		if isRoute := e.executeRoutePattern(child, route); isRoute {
-			e.handleRouteNode(child, route, "", mountTags, routes)
+			e.handleRouteNode(child, route, "", mountTags, route.DynamicParams, routes)
 		}
 
 		// Extract request

--- a/internal/spec/extractor_test.go
+++ b/internal/spec/extractor_test.go
@@ -432,7 +432,7 @@ func TestTraverseForRoutesWithVisited_CycleDetection(t *testing.T) {
 	visited := make(map[string]bool)
 
 	start := time.Now()
-	extractor.traverseForRoutesWithVisited(node1, "", []string{}, &routes, visited)
+	extractor.traverseForRoutesWithVisited(node1, "", []string{}, nil, &routes, visited)
 	duration := time.Since(start)
 
 	// Should complete quickly (cycle detection should work)
@@ -474,7 +474,7 @@ func TestTraverseForRoutesWithVisited_NoCycle(t *testing.T) {
 	routes := []*RouteInfo{}
 	visited := make(map[string]bool)
 
-	extractor.traverseForRoutesWithVisited(node1, "", []string{}, &routes, visited)
+	extractor.traverseForRoutesWithVisited(node1, "", []string{}, nil, &routes, visited)
 
 	// Check that visited map was populated
 	if len(visited) == 0 {

--- a/internal/spec/interfaces.go
+++ b/internal/spec/interfaces.go
@@ -96,6 +96,11 @@ type MountInfo struct {
 	RouterArg  *metadata.CallArgument
 	Assignment *metadata.CallArgument
 	Pattern    MountPattern
+
+	// DynamicParams names path placeholders synthesized from unresolvable
+	// call expressions (issue #34). Propagated to nested routes so each
+	// inheriting operation can $ref the corresponding component parameter.
+	DynamicParams []string
 }
 
 // PatternExecutor defines the interface for pattern execution

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -93,6 +93,12 @@ func MapMetadataToOpenAPI(tree TrackerTreeInterface, cfg *APISpecConfig, genCfg 
 	// Generate component schemas
 	components := generateComponentSchemas(tree.GetMetadata(), cfg, routes)
 
+	// Register shared component parameters for dynamic-path placeholders
+	// (issue #34). Each unique placeholder name across routes becomes one
+	// component, $ref'd from every operation that uses it — see
+	// buildPathsFromRoutes for the per-operation wiring.
+	addDynamicPathParamComponents(&components, routes)
+
 	// Use Info from config if present, else fallback to GeneratorConfig
 	var info Info
 	if cfg != nil && (cfg.Info.Title != "" || cfg.Info.Description != "" || cfg.Info.Version != "") {
@@ -174,6 +180,11 @@ func buildPathsFromRoutes(routes []*RouteInfo) map[string]PathItem {
 		} else {
 			operation.Parameters = nil
 		}
+		// Emit $refs for dynamic-path placeholders so each operation
+		// reuses the shared component parameter rather than inlining a
+		// fresh declaration. The matching {name} in the path is then
+		// considered "covered" by ensureAllPathParams below.
+		operation.Parameters = appendDynamicParamRefs(operation.Parameters, route.DynamicParams)
 		operation.Parameters = ensureAllPathParams(openAPIPath, operation.Parameters)
 
 		// Add responses
@@ -193,6 +204,13 @@ func ensureAllPathParams(openAPIPath string, params []Parameter) []Parameter {
 	for _, p := range params {
 		if p.In == "path" {
 			paramMap[p.Name] = true
+		}
+		// Treat a $ref parameter as covering its target name so we don't
+		// re-inline an auto-declared duplicate (issue #34).
+		if p.Ref != "" {
+			if name := refTargetName(p.Ref); name != "" {
+				paramMap[name] = true
+			}
 		}
 	}
 	// Find all {param} in the path
@@ -214,6 +232,96 @@ func ensureAllPathParams(openAPIPath string, params []Parameter) []Parameter {
 		}
 	}
 	return params
+}
+
+// appendDynamicParamRefs adds one $ref entry per dynamic placeholder name,
+// pointing at the shared component parameter. Duplicates (a name already
+// covered by an inline parameter or another $ref) are skipped.
+func appendDynamicParamRefs(params []Parameter, dynamic []string) []Parameter {
+	if len(dynamic) == 0 {
+		return params
+	}
+	covered := make(map[string]struct{}, len(params))
+	for _, p := range params {
+		if p.In == "path" && p.Name != "" {
+			covered[p.Name] = struct{}{}
+		}
+		if p.Ref != "" {
+			if name := refTargetName(p.Ref); name != "" {
+				covered[name] = struct{}{}
+			}
+		}
+	}
+	for _, name := range dynamic {
+		if _, ok := covered[name]; ok {
+			continue
+		}
+		covered[name] = struct{}{}
+		params = append(params, Parameter{Ref: dynamicParamRef(name)})
+	}
+	return params
+}
+
+// addDynamicPathParamComponents registers one component parameter per
+// unique dynamic placeholder name found across all routes. Once registered,
+// each operation references it via $ref (see appendDynamicParamRefs).
+func addDynamicPathParamComponents(components *Components, routes []*RouteInfo) {
+	if components == nil {
+		return
+	}
+	for _, route := range routes {
+		for _, name := range route.DynamicParams {
+			if components.Parameters == nil {
+				components.Parameters = map[string]*Parameter{}
+			}
+			key := dynamicParamComponentName(name)
+			if _, exists := components.Parameters[key]; exists {
+				continue
+			}
+			components.Parameters[key] = &Parameter{
+				Name:        name,
+				In:          "path",
+				Required:    true,
+				Description: "Auto-declared from an unresolved path expression (e.g. a function call evaluated at runtime). APISpec could not statically determine the path segment — see issue #34.",
+				Schema:      &Schema{Type: "string"},
+				Extensions: map[string]any{
+					"x-warning": "This parameter was synthesized from an unresolved path expression and may not represent a real per-request parameter.",
+				},
+			}
+		}
+	}
+}
+
+// dynamicParamComponentName returns the PascalCase + "Param" suffix used as
+// the key under components.parameters for a synthesized placeholder.
+func dynamicParamComponentName(name string) string {
+	if name == "" {
+		return "PathParam"
+	}
+	first := strings.ToUpper(name[:1])
+	return first + name[1:] + "Param"
+}
+
+// dynamicParamRef returns the $ref string pointing at the component
+// parameter for the given synthesized placeholder name.
+func dynamicParamRef(name string) string {
+	return "#/components/parameters/" + dynamicParamComponentName(name)
+}
+
+// refTargetName extracts the trailing segment of a #/components/parameters/<X>
+// ref and reverses the PascalCase + "Param" mangling so callers can match
+// against placeholder names found in a path.
+func refTargetName(ref string) string {
+	const prefix = "#/components/parameters/"
+	if !strings.HasPrefix(ref, prefix) {
+		return ""
+	}
+	key := strings.TrimPrefix(ref, prefix)
+	key = strings.TrimSuffix(key, "Param")
+	if key == "" {
+		return ""
+	}
+	return strings.ToLower(key[:1]) + key[1:]
 }
 
 // deduplicateParameters removes duplicate parameters by (name, in)

--- a/internal/spec/openapi.go
+++ b/internal/spec/openapi.go
@@ -79,8 +79,9 @@ type Operation struct {
 
 // Parameter represents an OpenAPI parameter
 type Parameter struct {
-	Name        string                 `yaml:"name" json:"name"`
-	In          string                 `yaml:"in" json:"in"`
+	Ref         string                 `yaml:"$ref,omitempty" json:"$ref,omitempty"`
+	Name        string                 `yaml:"name,omitempty" json:"name,omitempty"`
+	In          string                 `yaml:"in,omitempty" json:"in,omitempty"`
 	Description string                 `yaml:"description,omitempty" json:"description,omitempty"`
 	Required    bool                   `yaml:"required,omitempty" json:"required,omitempty"`
 	Schema      *Schema                `yaml:"schema,omitempty" json:"schema,omitempty"`

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -59,6 +59,37 @@ func NewBasePatternMatcher(cfg *APISpecConfig, contextProvider ContextProvider, 
 	}
 }
 
+// resolvePathArg renders a CallArgument as an OpenAPI path string.
+//
+// Literals and const idents resolve to their value via the context
+// provider. Function-call expressions (e.g. r.Mount(mountPoint(prefix,
+// "/api"), sub)) cannot be statically evaluated without interpreting
+// the Go body — see issue #34 — so they surface as a {placeholder}
+// named after the called function. The second return value, dynamicName,
+// is the placeholder name when one was synthesized (so the caller can
+// register a shared component parameter) and the empty string otherwise.
+//
+// All other kinds fall through to GetArgumentInfo for backwards
+// compatibility — handling KindIdent (non-const variable) and
+// KindBinary (`prefix + "/x"`) similarly is a possible follow-up but
+// is out of scope for the initial fix.
+func (b *BasePatternMatcher) resolvePathArg(arg *metadata.CallArgument) (path, dynamicName string) {
+	if arg == nil {
+		return "", ""
+	}
+	if arg.GetKind() == metadata.KindCall {
+		name := arg.GetName()
+		if name == "" && arg.Fun != nil {
+			name = arg.Fun.GetName()
+		}
+		if name == "" {
+			name = "path"
+		}
+		return "{" + name + "}", name
+	}
+	return b.contextProvider.GetArgumentInfo(arg), ""
+}
+
 // RoutePatternMatcherImpl implements RoutePatternMatcher
 type RoutePatternMatcherImpl struct {
 	*BasePatternMatcher
@@ -250,9 +281,13 @@ func (r *RoutePatternMatcherImpl) extractRouteDetails(node TrackerNodeInterface,
 	}
 
 	if r.pattern.PathFromArg && len(edge.Args) > r.pattern.PathArgIndex {
-		routeInfo.Path = r.contextProvider.GetArgumentInfo(edge.Args[r.pattern.PathArgIndex])
+		path, dynName := r.resolvePathArg(edge.Args[r.pattern.PathArgIndex])
+		routeInfo.Path = path
 		if routeInfo.Path == "" {
 			routeInfo.Path = "/"
+		}
+		if dynName != "" {
+			routeInfo.DynamicParams = append(routeInfo.DynamicParams, dynName)
 		}
 		found = true
 	}
@@ -440,7 +475,11 @@ func (m *MountPatternMatcherImpl) ExtractMount(node TrackerNodeInterface) MountI
 	edge := node.GetEdge()
 	// Extract path if available
 	if m.pattern.PathFromArg && len(edge.Args) > m.pattern.PathArgIndex {
-		mountInfo.Path = m.contextProvider.GetArgumentInfo(edge.Args[m.pattern.PathArgIndex])
+		path, dynName := m.resolvePathArg(edge.Args[m.pattern.PathArgIndex])
+		mountInfo.Path = path
+		if dynName != "" {
+			mountInfo.DynamicParams = append(mountInfo.DynamicParams, dynName)
+		}
 	}
 
 	// Extract router argument if available

--- a/internal/spec/tests/multipackage.yaml
+++ b/internal/spec/tests/multipackage.yaml
@@ -1,19 +1,67 @@
 string_pool:
+  - ident
+  - u
+  - multipackage/models
+  - '*multipackage/models.User'
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:14:9
+  - Name
+  - string
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:14:11
+  - selector
+  - GetName
+  - '*User'
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:13:26
+  - func_type
+  - func_results
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:13:1
+  - exported
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go
+  - func() string
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:18:9
+  - Age
+  - int
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:18:11
+  - GetAge
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:17:25
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:17:1
+  - func() int
+  - User
+  - struct
+  - json:"name"
+  - json:"age"
+  - interface
+  - UserInterface
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:9:12
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:10:11
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:22:10
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:23:3
+  - name
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:23:9
+  - key_value
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:24:3
+  - age
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:24:9
+  - composite_lit
+  - unary
+  - '&'
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:22:9
+  - NewUser
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:21:19
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:21:31
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:21:37
+  - star
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:21:36
+  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:21:1
+  - func(string, int) *User
   - literal
   - '"%s %s is %d years old"'
-  - ident
   - s
   - multipackage/services
   - '*multipackage/services.UserService'
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/services/user_service.go:19:46
   - prefix
-  - string
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/services/user_service.go:19:48
-  - selector
-  - name
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/services/user_service.go:19:56
-  - age
-  - int
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/services/user_service.go:19:62
   - fmt
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/services/user_service.go:19:9
@@ -22,32 +70,21 @@ string_pool:
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/services/user_service.go:19:13
   - call
   - models
-  - multipackage/models
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/services/user_service.go:16:41
-  - User
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/services/user_service.go:16:48
-  - star
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/services/user_service.go:16:40
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/services/user_service.go:16:54
-  - func_type
-  - func_results
   - user
-  - '*multipackage/models.User'
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/services/user_service.go:17:10
-  - GetName
-  - func() string
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/services/user_service.go:17:15
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/services/user_service.go:17:2
   - unexported
   - ProcessUser
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/services/user_service.go:18:9
-  - GetAge
-  - func() int
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/services/user_service.go:18:14
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/services/user_service.go:18:2
   - '*UserService'
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/services/user_service.go:16:1
-  - exported
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/services/user_service.go
   - func(*models.User) string
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/services/user_service.go:22:40
@@ -59,15 +96,9 @@ string_pool:
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/services/user_service.go:22:1
   - 'func(string) '
   - UserService
-  - struct
-  - interface
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/services/user_service.go:13:10
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/services/user_service.go:13:22
   - '"User:"'
-  - key_value
-  - composite_lit
-  - unary
-  - '&'
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/services/user_service.go:13:9
   - NewUserService
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/services/user_service.go:12:24
@@ -78,7 +109,6 @@ string_pool:
   - '"John"'
   - "25"
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/main.go:10:10
-  - NewUser
   - func(name string, age int) *multipackage/models.User
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/main.go:10:17
   - multipackage
@@ -141,36 +171,6 @@ string_pool:
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/utils/helper.go:18:5
   - '"uppercase"'
   - uppercase
-  - u
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:14:9
-  - Name
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:14:11
-  - '*User'
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:13:26
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:13:1
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:18:9
-  - Age
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:18:11
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:17:25
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:17:1
-  - json:"name"
-  - json:"age"
-  - UserInterface
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:9:12
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:10:11
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:22:10
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:23:3
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:23:9
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:24:3
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:24:9
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:22:9
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:21:19
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:21:31
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:21:37
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:21:36
-  - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:21:1
-  - func(string, int) *User
   - multipackage/models.UserInterface
   - multipackage/models.User
   - r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/main.go:14:14
@@ -183,14 +183,14 @@ packages:
       r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/main.go:
         functions:
           main:
-            name: 84
-            pkg: 82
+            name: 114
+            pkg: 112
             signature:
-              kind: 30
+              kind: 12
               name: -1
               value: -1
               fun:
-                kind: 31
+                kind: 13
                 name: -1
                 value: -1
                 raw: -1
@@ -205,202 +205,202 @@ packages:
               position: -1
               resolved_type: -1
               generic_type_name: -1
-            signature_str: 98
-            position: 97
-            scope: 39
+            signature_str: 128
+            position: 127
+            scope: 79
             comments: -1
             assignments:
               result:
-                - variable_name: 95
-                  pkg: 82
-                  concrete_type: 8
-                  position: 96
-                  scope: 39
+                - variable_name: 125
+                  pkg: 112
+                  concrete_type: 6
+                  position: 126
+                  scope: 79
                   value:
-                    kind: 21
+                    kind: 69
                     name: -1
                     value: -1
                     fun:
-                      kind: 10
+                      kind: 8
                       name: -1
                       value: -1
                       x:
-                        kind: 2
-                        name: 89
+                        kind: 0
+                        name: 119
                         value: -1
                         raw: -1
-                        pkg: 82
-                        type: 5
-                        position: 92
+                        pkg: 112
+                        type: 58
+                        position: 122
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 2
-                        name: 40
+                        kind: 0
+                        name: 80
                         value: -1
                         raw: -1
-                        pkg: 4
-                        type: 93
-                        position: 94
+                        pkg: 57
+                        type: 123
+                        position: 124
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 4
-                      type: 93
-                      position: 92
+                      pkg: 57
+                      type: 123
+                      position: 122
                       resolved_type: -1
                       generic_type_name: -1
                       receiver_type:
-                        kind: 2
-                        name: 59
+                        kind: 0
+                        name: 96
                         value: -1
                         raw: -1
-                        pkg: 4
-                        type: 59
+                        pkg: 57
+                        type: 96
                         position: -1
                         resolved_type: -1
                         generic_type_name: -1
                     args:
-                      - kind: 2
-                        name: 32
+                      - kind: 0
+                        name: 75
                         value: -1
                         raw: -1
-                        pkg: 82
-                        type: 33
-                        position: 91
+                        pkg: 112
+                        type: 3
+                        position: 121
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
                     pkg: -1
                     type: -1
-                    position: 92
+                    position: 122
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 2
-                    name: 95
+                    kind: 0
+                    name: 125
                     value: -1
                     raw: -1
-                    pkg: 82
-                    type: 8
-                    position: 96
+                    pkg: 112
+                    type: 6
+                    position: 126
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 84
+                  func: 114
                   callee_func: ProcessUser
                   callee_pkg: multipackage/services
               service:
-                - variable_name: 89
-                  pkg: 82
-                  concrete_type: 5
-                  position: 90
-                  scope: 39
+                - variable_name: 119
+                  pkg: 112
+                  concrete_type: 58
+                  position: 120
+                  scope: 79
                   value:
-                    kind: 21
+                    kind: 69
                     name: -1
                     value: -1
                     fun:
-                      kind: 10
+                      kind: 8
                       name: -1
                       value: -1
                       x:
-                        kind: 2
-                        name: 85
+                        kind: 0
+                        name: 115
                         value: -1
                         raw: -1
-                        pkg: 4
+                        pkg: 57
                         type: -1
-                        position: 86
+                        position: 116
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 2
-                        name: 70
+                        kind: 0
+                        name: 101
                         value: -1
                         raw: -1
-                        pkg: 4
-                        type: 87
-                        position: 88
+                        pkg: 57
+                        type: 117
+                        position: 118
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 4
-                      type: 87
-                      position: 86
+                      pkg: 57
+                      type: 117
+                      position: 116
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
                     pkg: -1
                     type: -1
-                    position: 86
+                    position: 116
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 2
-                    name: 89
+                    kind: 0
+                    name: 119
                     value: -1
                     raw: -1
-                    pkg: 82
-                    type: 5
-                    position: 90
+                    pkg: 112
+                    type: 58
+                    position: 120
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 84
+                  func: 114
                   callee_func: NewUserService
                   callee_pkg: multipackage/services
               user:
-                - variable_name: 32
-                  pkg: 82
-                  concrete_type: 33
-                  position: 83
-                  scope: 39
+                - variable_name: 75
+                  pkg: 112
+                  concrete_type: 3
+                  position: 113
+                  scope: 79
                   value:
-                    kind: 21
+                    kind: 69
                     name: -1
                     value: -1
                     fun:
-                      kind: 10
+                      kind: 8
                       name: -1
                       value: -1
                       x:
-                        kind: 2
-                        name: 22
+                        kind: 0
+                        name: 70
                         value: -1
                         raw: -1
-                        pkg: 23
+                        pkg: 2
                         type: -1
-                        position: 78
+                        position: 109
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 2
-                        name: 79
+                        kind: 0
+                        name: 46
                         value: -1
                         raw: -1
-                        pkg: 23
-                        type: 80
-                        position: 81
+                        pkg: 2
+                        type: 110
+                        position: 111
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 23
-                      type: 80
-                      position: 78
+                      pkg: 2
+                      type: 110
+                      position: 109
                       resolved_type: -1
                       generic_type_name: -1
                     args:
-                      - kind: 0
+                      - kind: 54
                         name: -1
-                        value: 76
+                        value: 107
                         raw: -1
                         pkg: -1
                         type: -1
                         position: -1
                         resolved_type: -1
                         generic_type_name: -1
-                      - kind: 0
+                      - kind: 54
                         name: -1
-                        value: 77
+                        value: 108
                         raw: -1
                         pkg: -1
                         type: -1
@@ -410,67 +410,67 @@ packages:
                     raw: -1
                     pkg: -1
                     type: -1
-                    position: 78
+                    position: 109
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 2
-                    name: 32
+                    kind: 0
+                    name: 75
                     value: -1
                     raw: -1
-                    pkg: 82
-                    type: 33
-                    position: 83
+                    pkg: 112
+                    type: 3
+                    position: 113
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 84
+                  func: 114
                   callee_func: NewUser
                   callee_pkg: multipackage/models
         imports:
-          4: 4
-          16: 16
-          23: 23
+          2: 2
+          57: 57
+          64: 64
   multipackage/models:
     files:
       r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/models/user.go:
         types:
           User:
-            name: 25
-            pkg: 23
-            kind: 60
+            name: 26
+            pkg: 2
+            kind: 27
             implements:
               - 172
             fields:
-              - name: 144
-                type: 8
-                tag: 155
-                scope: 48
+              - name: 5
+                type: 6
+                tag: 28
+                scope: 15
                 comments: -1
-              - name: 151
-                type: 14
-                tag: 156
-                scope: 48
+              - name: 19
+                type: 20
+                tag: 29
+                scope: 15
                 comments: -1
-            scope: 48
+            scope: 15
             methods:
-              - name: 35
-                receiver: 146
+              - name: 9
+                receiver: 10
                 signature:
-                  kind: 30
+                  kind: 12
                   name: -1
                   value: -1
                   fun:
-                    kind: 31
+                    kind: 13
                     name: -1
                     value: -1
                     args:
-                      - kind: 2
-                        name: 8
+                      - kind: 0
+                        name: 6
                         value: -1
                         raw: -1
-                        pkg: 23
-                        type: 8
-                        position: 147
+                        pkg: 2
+                        type: 6
+                        position: 11
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
@@ -483,60 +483,60 @@ packages:
                   pkg: -1
                   type: -1
                   position: -1
-                  resolved_type: 8
+                  resolved_type: 6
                   generic_type_name: -1
-                signature_str: 36
-                position: 148
-                scope: 48
-                filename: 149
+                signature_str: 17
+                position: 14
+                scope: 15
+                filename: 16
                 return_vars:
-                  - kind: 10
+                  - kind: 8
                     name: -1
                     value: -1
                     x:
-                      kind: 2
-                      name: 142
+                      kind: 0
+                      name: 1
                       value: -1
                       raw: -1
-                      pkg: 23
-                      type: 33
-                      position: 143
+                      pkg: 2
+                      type: 3
+                      position: 4
                       resolved_type: -1
                       generic_type_name: -1
                     sel:
-                      kind: 2
-                      name: 144
+                      kind: 0
+                      name: 5
                       value: -1
                       raw: -1
-                      pkg: 23
-                      type: 8
-                      position: 145
+                      pkg: 2
+                      type: 6
+                      position: 7
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
-                    pkg: 23
-                    type: 8
-                    position: 143
+                    pkg: 2
+                    type: 6
+                    position: 4
                     resolved_type: -1
                     generic_type_name: -1
-              - name: 42
-                receiver: 146
+              - name: 22
+                receiver: 10
                 signature:
-                  kind: 30
+                  kind: 12
                   name: -1
                   value: -1
                   fun:
-                    kind: 31
+                    kind: 13
                     name: -1
                     value: -1
                     args:
-                      - kind: 2
-                        name: 14
+                      - kind: 0
+                        name: 20
                         value: -1
                         raw: -1
-                        pkg: 23
-                        type: 14
-                        position: 153
+                        pkg: 2
+                        type: 20
+                        position: 23
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
@@ -549,68 +549,68 @@ packages:
                   pkg: -1
                   type: -1
                   position: -1
-                  resolved_type: 14
+                  resolved_type: 20
                   generic_type_name: -1
-                signature_str: 43
-                position: 154
-                scope: 48
-                filename: 149
+                signature_str: 25
+                position: 24
+                scope: 15
+                filename: 16
                 return_vars:
-                  - kind: 10
+                  - kind: 8
                     name: -1
                     value: -1
                     x:
-                      kind: 2
-                      name: 142
+                      kind: 0
+                      name: 1
                       value: -1
                       raw: -1
-                      pkg: 23
-                      type: 33
-                      position: 150
+                      pkg: 2
+                      type: 3
+                      position: 18
                       resolved_type: -1
                       generic_type_name: -1
                     sel:
-                      kind: 2
-                      name: 151
+                      kind: 0
+                      name: 19
                       value: -1
                       raw: -1
-                      pkg: 23
-                      type: 14
-                      position: 152
+                      pkg: 2
+                      type: 20
+                      position: 21
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
-                    pkg: 23
-                    type: 14
-                    position: 150
+                    pkg: 2
+                    type: 20
+                    position: 18
                     resolved_type: -1
                     generic_type_name: -1
             comments: -1
           UserInterface:
-            name: 157
-            pkg: 23
-            kind: 61
+            name: 31
+            pkg: 2
+            kind: 30
             implemented_by:
               - 173
-            scope: 48
+            scope: 15
             methods:
-              - name: 35
+              - name: 9
                 signature:
-                  kind: 30
+                  kind: 12
                   name: -1
                   value: -1
                   fun:
-                    kind: 31
+                    kind: 13
                     name: -1
                     value: -1
                     args:
-                      - kind: 2
-                        name: 8
+                      - kind: 0
+                        name: 6
                         value: -1
                         raw: -1
-                        pkg: 23
-                        type: 8
-                        position: 158
+                        pkg: 2
+                        type: 6
+                        position: 32
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
@@ -623,28 +623,28 @@ packages:
                   pkg: -1
                   type: -1
                   position: -1
-                  resolved_type: 8
+                  resolved_type: 6
                   generic_type_name: -1
-                signature_str: 36
-                scope: 48
+                signature_str: 17
+                scope: 15
                 comments: -1
-              - name: 42
+              - name: 22
                 signature:
-                  kind: 30
+                  kind: 12
                   name: -1
                   value: -1
                   fun:
-                    kind: 31
+                    kind: 13
                     name: -1
                     value: -1
                     args:
-                      - kind: 2
-                        name: 14
+                      - kind: 0
+                        name: 20
                         value: -1
                         raw: -1
-                        pkg: 23
-                        type: 14
-                        position: 159
+                        pkg: 2
+                        type: 20
+                        position: 33
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
@@ -657,42 +657,42 @@ packages:
                   pkg: -1
                   type: -1
                   position: -1
-                  resolved_type: 14
+                  resolved_type: 20
                   generic_type_name: -1
-                signature_str: 43
-                scope: 48
+                signature_str: 25
+                scope: 15
                 comments: -1
             comments: -1
         functions:
           NewUser:
-            name: 79
-            pkg: 23
+            name: 46
+            pkg: 2
             signature:
-              kind: 30
+              kind: 12
               name: -1
               value: -1
               fun:
-                kind: 31
+                kind: 13
                 name: -1
                 value: -1
                 args:
-                  - kind: 27
+                  - kind: 50
                     name: -1
                     value: -1
                     x:
-                      kind: 2
-                      name: 25
+                      kind: 0
+                      name: 26
                       value: -1
                       raw: -1
-                      pkg: 23
-                      type: 25
-                      position: 168
+                      pkg: 2
+                      type: 26
+                      position: 49
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
                     pkg: -1
                     type: -1
-                    position: 169
+                    position: 51
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -702,169 +702,169 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 2
-                  name: 8
+                - kind: 0
+                  name: 6
                   value: -1
                   raw: -1
-                  pkg: 23
-                  type: 8
-                  position: 166
+                  pkg: 2
+                  type: 6
+                  position: 47
                   resolved_type: -1
                   generic_type_name: -1
-                - kind: 2
-                  name: 14
+                - kind: 0
+                  name: 20
                   value: -1
                   raw: -1
-                  pkg: 23
-                  type: 14
-                  position: 167
+                  pkg: 2
+                  type: 20
+                  position: 48
                   resolved_type: -1
                   generic_type_name: -1
               raw: -1
               pkg: -1
               type: -1
               position: -1
-              resolved_type: 146
+              resolved_type: 10
               generic_type_name: -1
-            signature_str: 171
-            position: 170
-            scope: 48
+            signature_str: 53
+            position: 52
+            scope: 15
             comments: -1
             return_vars:
-              - kind: 67
+              - kind: 43
                 name: -1
-                value: 68
+                value: 44
                 x:
-                  kind: 66
+                  kind: 42
                   name: -1
                   value: -1
                   x:
-                    kind: 2
-                    name: 25
+                    kind: 0
+                    name: 26
                     value: -1
                     raw: -1
-                    pkg: 23
-                    type: 25
-                    position: 160
+                    pkg: 2
+                    type: 26
+                    position: 34
                     resolved_type: -1
                     generic_type_name: -1
                   args:
-                    - kind: 65
+                    - kind: 38
                       name: -1
                       value: -1
                       x:
-                        kind: 2
-                        name: 144
+                        kind: 0
+                        name: 5
                         value: -1
                         raw: -1
-                        pkg: 23
-                        type: 8
-                        position: 161
+                        pkg: 2
+                        type: 6
+                        position: 35
                         resolved_type: -1
                         generic_type_name: -1
                       fun:
-                        kind: 2
-                        name: 11
+                        kind: 0
+                        name: 36
                         value: -1
                         raw: -1
-                        pkg: 23
-                        type: 8
-                        position: 162
+                        pkg: 2
+                        type: 6
+                        position: 37
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
                       pkg: -1
                       type: -1
-                      position: 161
+                      position: 35
                       resolved_type: -1
                       generic_type_name: -1
-                    - kind: 65
+                    - kind: 38
                       name: -1
                       value: -1
                       x:
-                        kind: 2
-                        name: 151
+                        kind: 0
+                        name: 19
                         value: -1
                         raw: -1
-                        pkg: 23
-                        type: 14
-                        position: 163
+                        pkg: 2
+                        type: 20
+                        position: 39
                         resolved_type: -1
                         generic_type_name: -1
                       fun:
-                        kind: 2
-                        name: 13
+                        kind: 0
+                        name: 40
                         value: -1
                         raw: -1
-                        pkg: 23
-                        type: 14
-                        position: 164
+                        pkg: 2
+                        type: 20
+                        position: 41
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
                       pkg: -1
                       type: -1
-                      position: 163
+                      position: 39
                       resolved_type: -1
                       generic_type_name: -1
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 160
+                  position: 34
                   resolved_type: -1
                   generic_type_name: -1
                 raw: -1
                 pkg: -1
                 type: -1
-                position: 165
+                position: 45
                 resolved_type: -1
                 generic_type_name: -1
         struct_instances:
-          - type: 25
-            pkg: 23
-            position: 160
+          - type: 26
+            pkg: 2
+            position: 34
             fields:
-              144: 11
-              151: 13
+              5: 36
+              19: 40
         imports: {}
     types:
       User:
-        name: 25
-        pkg: 23
-        kind: 60
+        name: 26
+        pkg: 2
+        kind: 27
         implements:
           - 172
         fields:
-          - name: 144
-            type: 8
-            tag: 155
-            scope: 48
+          - name: 5
+            type: 6
+            tag: 28
+            scope: 15
             comments: -1
-          - name: 151
-            type: 14
-            tag: 156
-            scope: 48
+          - name: 19
+            type: 20
+            tag: 29
+            scope: 15
             comments: -1
-        scope: 48
+        scope: 15
         methods:
-          - name: 35
-            receiver: 146
+          - name: 9
+            receiver: 10
             signature:
-              kind: 30
+              kind: 12
               name: -1
               value: -1
               fun:
-                kind: 31
+                kind: 13
                 name: -1
                 value: -1
                 args:
-                  - kind: 2
-                    name: 8
+                  - kind: 0
+                    name: 6
                     value: -1
                     raw: -1
-                    pkg: 23
-                    type: 8
-                    position: 147
+                    pkg: 2
+                    type: 6
+                    position: 11
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -877,60 +877,60 @@ packages:
               pkg: -1
               type: -1
               position: -1
-              resolved_type: 8
+              resolved_type: 6
               generic_type_name: -1
-            signature_str: 36
-            position: 148
-            scope: 48
-            filename: 149
+            signature_str: 17
+            position: 14
+            scope: 15
+            filename: 16
             return_vars:
-              - kind: 10
+              - kind: 8
                 name: -1
                 value: -1
                 x:
-                  kind: 2
-                  name: 142
+                  kind: 0
+                  name: 1
                   value: -1
                   raw: -1
-                  pkg: 23
-                  type: 33
-                  position: 143
+                  pkg: 2
+                  type: 3
+                  position: 4
                   resolved_type: -1
                   generic_type_name: -1
                 sel:
-                  kind: 2
-                  name: 144
+                  kind: 0
+                  name: 5
                   value: -1
                   raw: -1
-                  pkg: 23
-                  type: 8
-                  position: 145
+                  pkg: 2
+                  type: 6
+                  position: 7
                   resolved_type: -1
                   generic_type_name: -1
                 raw: -1
-                pkg: 23
-                type: 8
-                position: 143
+                pkg: 2
+                type: 6
+                position: 4
                 resolved_type: -1
                 generic_type_name: -1
-          - name: 42
-            receiver: 146
+          - name: 22
+            receiver: 10
             signature:
-              kind: 30
+              kind: 12
               name: -1
               value: -1
               fun:
-                kind: 31
+                kind: 13
                 name: -1
                 value: -1
                 args:
-                  - kind: 2
-                    name: 14
+                  - kind: 0
+                    name: 20
                     value: -1
                     raw: -1
-                    pkg: 23
-                    type: 14
-                    position: 153
+                    pkg: 2
+                    type: 20
+                    position: 23
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -943,67 +943,1217 @@ packages:
               pkg: -1
               type: -1
               position: -1
-              resolved_type: 14
+              resolved_type: 20
               generic_type_name: -1
-            signature_str: 43
-            position: 154
-            scope: 48
-            filename: 149
+            signature_str: 25
+            position: 24
+            scope: 15
+            filename: 16
             return_vars:
-              - kind: 10
+              - kind: 8
                 name: -1
                 value: -1
                 x:
-                  kind: 2
-                  name: 142
+                  kind: 0
+                  name: 1
                   value: -1
                   raw: -1
-                  pkg: 23
-                  type: 33
-                  position: 150
+                  pkg: 2
+                  type: 3
+                  position: 18
                   resolved_type: -1
                   generic_type_name: -1
                 sel:
-                  kind: 2
-                  name: 151
+                  kind: 0
+                  name: 19
                   value: -1
                   raw: -1
-                  pkg: 23
-                  type: 14
-                  position: 152
+                  pkg: 2
+                  type: 20
+                  position: 21
                   resolved_type: -1
                   generic_type_name: -1
                 raw: -1
-                pkg: 23
-                type: 14
-                position: 150
+                pkg: 2
+                type: 20
+                position: 18
                 resolved_type: -1
                 generic_type_name: -1
         comments: -1
       UserInterface:
-        name: 157
-        pkg: 23
-        kind: 61
+        name: 31
+        pkg: 2
+        kind: 30
         implemented_by:
           - 173
-        scope: 48
+        scope: 15
         methods:
-          - name: 35
+          - name: 9
             signature:
-              kind: 30
+              kind: 12
               name: -1
               value: -1
               fun:
-                kind: 31
+                kind: 13
                 name: -1
                 value: -1
                 args:
-                  - kind: 2
-                    name: 8
+                  - kind: 0
+                    name: 6
                     value: -1
                     raw: -1
-                    pkg: 23
-                    type: 8
+                    pkg: 2
+                    type: 6
+                    position: 32
+                    resolved_type: -1
+                    generic_type_name: -1
+                raw: -1
+                pkg: -1
+                type: -1
+                position: -1
+                resolved_type: -1
+                generic_type_name: -1
+              raw: -1
+              pkg: -1
+              type: -1
+              position: -1
+              resolved_type: 6
+              generic_type_name: -1
+            signature_str: 17
+            scope: 15
+            comments: -1
+          - name: 22
+            signature:
+              kind: 12
+              name: -1
+              value: -1
+              fun:
+                kind: 13
+                name: -1
+                value: -1
+                args:
+                  - kind: 0
+                    name: 20
+                    value: -1
+                    raw: -1
+                    pkg: 2
+                    type: 20
+                    position: 33
+                    resolved_type: -1
+                    generic_type_name: -1
+                raw: -1
+                pkg: -1
+                type: -1
+                position: -1
+                resolved_type: -1
+                generic_type_name: -1
+              raw: -1
+              pkg: -1
+              type: -1
+              position: -1
+              resolved_type: 20
+              generic_type_name: -1
+            signature_str: 25
+            scope: 15
+            comments: -1
+        comments: -1
+  multipackage/services:
+    files:
+      r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/services/user_service.go:
+        types:
+          UserService:
+            name: 96
+            pkg: 57
+            kind: 27
+            fields:
+              - name: 60
+                type: 6
+                tag: -1
+                scope: 79
+                comments: -1
+            scope: 15
+            methods:
+              - name: 80
+                receiver: 84
+                signature:
+                  kind: 12
+                  name: -1
+                  value: -1
+                  fun:
+                    kind: 13
+                    name: -1
+                    value: -1
+                    args:
+                      - kind: 0
+                        name: 6
+                        value: -1
+                        raw: -1
+                        pkg: 57
+                        type: 6
+                        position: 74
+                        resolved_type: -1
+                        generic_type_name: -1
+                    raw: -1
+                    pkg: -1
+                    type: -1
+                    position: -1
+                    resolved_type: -1
+                    generic_type_name: -1
+                  args:
+                    - kind: 50
+                      name: -1
+                      value: -1
+                      x:
+                        kind: 8
+                        name: -1
+                        value: -1
+                        x:
+                          kind: 0
+                          name: 70
+                          value: -1
+                          raw: -1
+                          pkg: 2
+                          type: -1
+                          position: 71
+                          resolved_type: -1
+                          generic_type_name: -1
+                        sel:
+                          kind: 0
+                          name: 26
+                          value: -1
+                          raw: -1
+                          pkg: 2
+                          type: 26
+                          position: 72
+                          resolved_type: -1
+                          generic_type_name: -1
+                        raw: -1
+                        pkg: 2
+                        type: 26
+                        position: 71
+                        resolved_type: -1
+                        generic_type_name: -1
+                      raw: -1
+                      pkg: -1
+                      type: -1
+                      position: 73
+                      resolved_type: -1
+                      generic_type_name: -1
+                  raw: -1
+                  pkg: -1
+                  type: -1
+                  position: -1
+                  resolved_type: 6
+                  generic_type_name: -1
+                signature_str: 87
+                position: 85
+                scope: 15
+                filename: 86
+                return_vars:
+                  - kind: 69
+                    name: -1
+                    value: -1
+                    fun:
+                      kind: 8
+                      name: -1
+                      value: -1
+                      x:
+                        kind: 0
+                        name: 64
+                        value: -1
+                        raw: -1
+                        pkg: 64
+                        type: -1
+                        position: 65
+                        resolved_type: -1
+                        generic_type_name: -1
+                      sel:
+                        kind: 0
+                        name: 66
+                        value: -1
+                        raw: -1
+                        pkg: 64
+                        type: 67
+                        position: 68
+                        resolved_type: -1
+                        generic_type_name: -1
+                      raw: -1
+                      pkg: 64
+                      type: 67
+                      position: 65
+                      resolved_type: -1
+                      generic_type_name: -1
+                    args:
+                      - kind: 54
+                        name: -1
+                        value: 55
+                        raw: -1
+                        pkg: -1
+                        type: -1
+                        position: -1
+                        resolved_type: -1
+                        generic_type_name: -1
+                      - kind: 8
+                        name: -1
+                        value: -1
+                        x:
+                          kind: 0
+                          name: 56
+                          value: -1
+                          raw: -1
+                          pkg: 57
+                          type: 58
+                          position: 59
+                          resolved_type: -1
+                          generic_type_name: -1
+                        sel:
+                          kind: 0
+                          name: 60
+                          value: -1
+                          raw: -1
+                          pkg: 57
+                          type: 6
+                          position: 61
+                          resolved_type: -1
+                          generic_type_name: -1
+                        raw: -1
+                        pkg: 57
+                        type: 6
+                        position: 59
+                        resolved_type: -1
+                        generic_type_name: -1
+                      - kind: 0
+                        name: 36
+                        value: -1
+                        raw: -1
+                        pkg: 57
+                        type: 6
+                        position: 62
+                        resolved_type: -1
+                        generic_type_name: -1
+                      - kind: 0
+                        name: 40
+                        value: -1
+                        raw: -1
+                        pkg: 57
+                        type: 20
+                        position: 63
+                        resolved_type: -1
+                        generic_type_name: -1
+                    raw: -1
+                    pkg: -1
+                    type: -1
+                    position: 65
+                    resolved_type: -1
+                    generic_type_name: -1
+                assignments:
+                  age:
+                    - variable_name: 40
+                      pkg: 57
+                      concrete_type: 20
+                      position: 83
+                      scope: 79
+                      value:
+                        kind: 69
+                        name: -1
+                        value: -1
+                        fun:
+                          kind: 8
+                          name: -1
+                          value: -1
+                          x:
+                            kind: 0
+                            name: 75
+                            value: -1
+                            raw: -1
+                            pkg: 57
+                            type: 3
+                            position: 81
+                            resolved_type: -1
+                            generic_type_name: -1
+                          sel:
+                            kind: 0
+                            name: 22
+                            value: -1
+                            raw: -1
+                            pkg: 2
+                            type: 25
+                            position: 82
+                            resolved_type: -1
+                            generic_type_name: -1
+                          raw: -1
+                          pkg: 2
+                          type: 25
+                          position: 81
+                          resolved_type: -1
+                          generic_type_name: -1
+                          receiver_type:
+                            kind: 0
+                            name: 26
+                            value: -1
+                            raw: -1
+                            pkg: 2
+                            type: 26
+                            position: -1
+                            resolved_type: -1
+                            generic_type_name: -1
+                        raw: -1
+                        pkg: -1
+                        type: -1
+                        position: 81
+                        resolved_type: -1
+                        generic_type_name: -1
+                      lhs:
+                        kind: 0
+                        name: 40
+                        value: -1
+                        raw: -1
+                        pkg: 57
+                        type: 20
+                        position: 83
+                        resolved_type: -1
+                        generic_type_name: -1
+                      func: 80
+                      callee_func: GetAge
+                      callee_pkg: multipackage/models
+                  name:
+                    - variable_name: 36
+                      pkg: 57
+                      concrete_type: 6
+                      position: 78
+                      scope: 79
+                      value:
+                        kind: 69
+                        name: -1
+                        value: -1
+                        fun:
+                          kind: 8
+                          name: -1
+                          value: -1
+                          x:
+                            kind: 0
+                            name: 75
+                            value: -1
+                            raw: -1
+                            pkg: 57
+                            type: 3
+                            position: 76
+                            resolved_type: -1
+                            generic_type_name: -1
+                          sel:
+                            kind: 0
+                            name: 9
+                            value: -1
+                            raw: -1
+                            pkg: 2
+                            type: 17
+                            position: 77
+                            resolved_type: -1
+                            generic_type_name: -1
+                          raw: -1
+                          pkg: 2
+                          type: 17
+                          position: 76
+                          resolved_type: -1
+                          generic_type_name: -1
+                          receiver_type:
+                            kind: 0
+                            name: 26
+                            value: -1
+                            raw: -1
+                            pkg: 2
+                            type: 26
+                            position: -1
+                            resolved_type: -1
+                            generic_type_name: -1
+                        raw: -1
+                        pkg: -1
+                        type: -1
+                        position: 76
+                        resolved_type: -1
+                        generic_type_name: -1
+                      lhs:
+                        kind: 0
+                        name: 36
+                        value: -1
+                        raw: -1
+                        pkg: 57
+                        type: 6
+                        position: 78
+                        resolved_type: -1
+                        generic_type_name: -1
+                      func: 80
+                      callee_func: GetName
+                      callee_pkg: multipackage/models
+              - name: 93
+                receiver: 84
+                signature:
+                  kind: 12
+                  name: -1
+                  value: -1
+                  fun:
+                    kind: 13
+                    name: -1
+                    value: -1
+                    raw: -1
+                    pkg: -1
+                    type: -1
+                    position: -1
+                    resolved_type: -1
+                    generic_type_name: -1
+                  args:
+                    - kind: 0
+                      name: 6
+                      value: -1
+                      raw: -1
+                      pkg: 57
+                      type: 6
+                      position: 88
+                      resolved_type: -1
+                      generic_type_name: -1
+                  raw: -1
+                  pkg: -1
+                  type: -1
+                  position: -1
+                  resolved_type: -1
+                  generic_type_name: -1
+                signature_str: 95
+                position: 94
+                scope: 15
+                filename: 86
+                assignments:
+                  multipackage/services.UserService.prefix:
+                    - variable_name: 91
+                      pkg: 57
+                      concrete_type: 6
+                      position: 89
+                      scope: 8
+                      value:
+                        kind: 0
+                        name: 60
+                        value: -1
+                        raw: -1
+                        pkg: 57
+                        type: 6
+                        position: 92
+                        resolved_type: -1
+                        generic_type_name: -1
+                      lhs:
+                        kind: 8
+                        name: -1
+                        value: -1
+                        x:
+                          kind: 0
+                          name: 56
+                          value: -1
+                          raw: -1
+                          pkg: 57
+                          type: 58
+                          position: 89
+                          resolved_type: -1
+                          generic_type_name: -1
+                        sel:
+                          kind: 0
+                          name: 60
+                          value: -1
+                          raw: -1
+                          pkg: 57
+                          type: 6
+                          position: 90
+                          resolved_type: -1
+                          generic_type_name: -1
+                        raw: -1
+                        pkg: 57
+                        type: 6
+                        position: 89
+                        resolved_type: -1
+                        generic_type_name: -1
+            comments: -1
+        functions:
+          NewUserService:
+            name: 101
+            pkg: 57
+            signature:
+              kind: 12
+              name: -1
+              value: -1
+              fun:
+                kind: 13
+                name: -1
+                value: -1
+                args:
+                  - kind: 50
+                    name: -1
+                    value: -1
+                    x:
+                      kind: 0
+                      name: 96
+                      value: -1
+                      raw: -1
+                      pkg: 57
+                      type: 96
+                      position: 102
+                      resolved_type: -1
+                      generic_type_name: -1
+                    raw: -1
+                    pkg: -1
+                    type: -1
+                    position: 103
+                    resolved_type: -1
+                    generic_type_name: -1
+                raw: -1
+                pkg: -1
+                type: -1
+                position: -1
+                resolved_type: -1
+                generic_type_name: -1
+              raw: -1
+              pkg: -1
+              type: -1
+              position: -1
+              resolved_type: 84
+              generic_type_name: -1
+            signature_str: 105
+            position: 104
+            scope: 15
+            comments: -1
+            return_vars:
+              - kind: 43
+                name: -1
+                value: 44
+                x:
+                  kind: 42
+                  name: -1
+                  value: -1
+                  x:
+                    kind: 0
+                    name: 96
+                    value: -1
+                    raw: -1
+                    pkg: 57
+                    type: 96
+                    position: 97
+                    resolved_type: -1
+                    generic_type_name: -1
+                  args:
+                    - kind: 38
+                      name: -1
+                      value: -1
+                      x:
+                        kind: 0
+                        name: 60
+                        value: -1
+                        raw: -1
+                        pkg: 57
+                        type: 6
+                        position: 98
+                        resolved_type: -1
+                        generic_type_name: -1
+                      fun:
+                        kind: 54
+                        name: -1
+                        value: 99
+                        raw: -1
+                        pkg: -1
+                        type: -1
+                        position: -1
+                        resolved_type: -1
+                        generic_type_name: -1
+                      raw: -1
+                      pkg: -1
+                      type: -1
+                      position: 98
+                      resolved_type: -1
+                      generic_type_name: -1
+                  raw: -1
+                  pkg: -1
+                  type: -1
+                  position: 97
+                  resolved_type: -1
+                  generic_type_name: -1
+                raw: -1
+                pkg: -1
+                type: -1
+                position: 100
+                resolved_type: -1
+                generic_type_name: -1
+        struct_instances:
+          - type: 96
+            pkg: 57
+            position: 97
+            fields:
+              60: 106
+        imports:
+          2: 2
+          64: 64
+    types:
+      UserService:
+        name: 96
+        pkg: 57
+        kind: 27
+        fields:
+          - name: 60
+            type: 6
+            tag: -1
+            scope: 79
+            comments: -1
+        scope: 15
+        methods:
+          - name: 80
+            receiver: 84
+            signature:
+              kind: 12
+              name: -1
+              value: -1
+              fun:
+                kind: 13
+                name: -1
+                value: -1
+                args:
+                  - kind: 0
+                    name: 6
+                    value: -1
+                    raw: -1
+                    pkg: 57
+                    type: 6
+                    position: 74
+                    resolved_type: -1
+                    generic_type_name: -1
+                raw: -1
+                pkg: -1
+                type: -1
+                position: -1
+                resolved_type: -1
+                generic_type_name: -1
+              args:
+                - kind: 50
+                  name: -1
+                  value: -1
+                  x:
+                    kind: 8
+                    name: -1
+                    value: -1
+                    x:
+                      kind: 0
+                      name: 70
+                      value: -1
+                      raw: -1
+                      pkg: 2
+                      type: -1
+                      position: 71
+                      resolved_type: -1
+                      generic_type_name: -1
+                    sel:
+                      kind: 0
+                      name: 26
+                      value: -1
+                      raw: -1
+                      pkg: 2
+                      type: 26
+                      position: 72
+                      resolved_type: -1
+                      generic_type_name: -1
+                    raw: -1
+                    pkg: 2
+                    type: 26
+                    position: 71
+                    resolved_type: -1
+                    generic_type_name: -1
+                  raw: -1
+                  pkg: -1
+                  type: -1
+                  position: 73
+                  resolved_type: -1
+                  generic_type_name: -1
+              raw: -1
+              pkg: -1
+              type: -1
+              position: -1
+              resolved_type: 6
+              generic_type_name: -1
+            signature_str: 87
+            position: 85
+            scope: 15
+            filename: 86
+            return_vars:
+              - kind: 69
+                name: -1
+                value: -1
+                fun:
+                  kind: 8
+                  name: -1
+                  value: -1
+                  x:
+                    kind: 0
+                    name: 64
+                    value: -1
+                    raw: -1
+                    pkg: 64
+                    type: -1
+                    position: 65
+                    resolved_type: -1
+                    generic_type_name: -1
+                  sel:
+                    kind: 0
+                    name: 66
+                    value: -1
+                    raw: -1
+                    pkg: 64
+                    type: 67
+                    position: 68
+                    resolved_type: -1
+                    generic_type_name: -1
+                  raw: -1
+                  pkg: 64
+                  type: 67
+                  position: 65
+                  resolved_type: -1
+                  generic_type_name: -1
+                args:
+                  - kind: 54
+                    name: -1
+                    value: 55
+                    raw: -1
+                    pkg: -1
+                    type: -1
+                    position: -1
+                    resolved_type: -1
+                    generic_type_name: -1
+                  - kind: 8
+                    name: -1
+                    value: -1
+                    x:
+                      kind: 0
+                      name: 56
+                      value: -1
+                      raw: -1
+                      pkg: 57
+                      type: 58
+                      position: 59
+                      resolved_type: -1
+                      generic_type_name: -1
+                    sel:
+                      kind: 0
+                      name: 60
+                      value: -1
+                      raw: -1
+                      pkg: 57
+                      type: 6
+                      position: 61
+                      resolved_type: -1
+                      generic_type_name: -1
+                    raw: -1
+                    pkg: 57
+                    type: 6
+                    position: 59
+                    resolved_type: -1
+                    generic_type_name: -1
+                  - kind: 0
+                    name: 36
+                    value: -1
+                    raw: -1
+                    pkg: 57
+                    type: 6
+                    position: 62
+                    resolved_type: -1
+                    generic_type_name: -1
+                  - kind: 0
+                    name: 40
+                    value: -1
+                    raw: -1
+                    pkg: 57
+                    type: 20
+                    position: 63
+                    resolved_type: -1
+                    generic_type_name: -1
+                raw: -1
+                pkg: -1
+                type: -1
+                position: 65
+                resolved_type: -1
+                generic_type_name: -1
+            assignments:
+              age:
+                - variable_name: 40
+                  pkg: 57
+                  concrete_type: 20
+                  position: 83
+                  scope: 79
+                  value:
+                    kind: 69
+                    name: -1
+                    value: -1
+                    fun:
+                      kind: 8
+                      name: -1
+                      value: -1
+                      x:
+                        kind: 0
+                        name: 75
+                        value: -1
+                        raw: -1
+                        pkg: 57
+                        type: 3
+                        position: 81
+                        resolved_type: -1
+                        generic_type_name: -1
+                      sel:
+                        kind: 0
+                        name: 22
+                        value: -1
+                        raw: -1
+                        pkg: 2
+                        type: 25
+                        position: 82
+                        resolved_type: -1
+                        generic_type_name: -1
+                      raw: -1
+                      pkg: 2
+                      type: 25
+                      position: 81
+                      resolved_type: -1
+                      generic_type_name: -1
+                      receiver_type:
+                        kind: 0
+                        name: 26
+                        value: -1
+                        raw: -1
+                        pkg: 2
+                        type: 26
+                        position: -1
+                        resolved_type: -1
+                        generic_type_name: -1
+                    raw: -1
+                    pkg: -1
+                    type: -1
+                    position: 81
+                    resolved_type: -1
+                    generic_type_name: -1
+                  lhs:
+                    kind: 0
+                    name: 40
+                    value: -1
+                    raw: -1
+                    pkg: 57
+                    type: 20
+                    position: 83
+                    resolved_type: -1
+                    generic_type_name: -1
+                  func: 80
+                  callee_func: GetAge
+                  callee_pkg: multipackage/models
+              name:
+                - variable_name: 36
+                  pkg: 57
+                  concrete_type: 6
+                  position: 78
+                  scope: 79
+                  value:
+                    kind: 69
+                    name: -1
+                    value: -1
+                    fun:
+                      kind: 8
+                      name: -1
+                      value: -1
+                      x:
+                        kind: 0
+                        name: 75
+                        value: -1
+                        raw: -1
+                        pkg: 57
+                        type: 3
+                        position: 76
+                        resolved_type: -1
+                        generic_type_name: -1
+                      sel:
+                        kind: 0
+                        name: 9
+                        value: -1
+                        raw: -1
+                        pkg: 2
+                        type: 17
+                        position: 77
+                        resolved_type: -1
+                        generic_type_name: -1
+                      raw: -1
+                      pkg: 2
+                      type: 17
+                      position: 76
+                      resolved_type: -1
+                      generic_type_name: -1
+                      receiver_type:
+                        kind: 0
+                        name: 26
+                        value: -1
+                        raw: -1
+                        pkg: 2
+                        type: 26
+                        position: -1
+                        resolved_type: -1
+                        generic_type_name: -1
+                    raw: -1
+                    pkg: -1
+                    type: -1
+                    position: 76
+                    resolved_type: -1
+                    generic_type_name: -1
+                  lhs:
+                    kind: 0
+                    name: 36
+                    value: -1
+                    raw: -1
+                    pkg: 57
+                    type: 6
+                    position: 78
+                    resolved_type: -1
+                    generic_type_name: -1
+                  func: 80
+                  callee_func: GetName
+                  callee_pkg: multipackage/models
+          - name: 93
+            receiver: 84
+            signature:
+              kind: 12
+              name: -1
+              value: -1
+              fun:
+                kind: 13
+                name: -1
+                value: -1
+                raw: -1
+                pkg: -1
+                type: -1
+                position: -1
+                resolved_type: -1
+                generic_type_name: -1
+              args:
+                - kind: 0
+                  name: 6
+                  value: -1
+                  raw: -1
+                  pkg: 57
+                  type: 6
+                  position: 88
+                  resolved_type: -1
+                  generic_type_name: -1
+              raw: -1
+              pkg: -1
+              type: -1
+              position: -1
+              resolved_type: -1
+              generic_type_name: -1
+            signature_str: 95
+            position: 94
+            scope: 15
+            filename: 86
+            assignments:
+              multipackage/services.UserService.prefix:
+                - variable_name: 91
+                  pkg: 57
+                  concrete_type: 6
+                  position: 89
+                  scope: 8
+                  value:
+                    kind: 0
+                    name: 60
+                    value: -1
+                    raw: -1
+                    pkg: 57
+                    type: 6
+                    position: 92
+                    resolved_type: -1
+                    generic_type_name: -1
+                  lhs:
+                    kind: 8
+                    name: -1
+                    value: -1
+                    x:
+                      kind: 0
+                      name: 56
+                      value: -1
+                      raw: -1
+                      pkg: 57
+                      type: 58
+                      position: 89
+                      resolved_type: -1
+                      generic_type_name: -1
+                    sel:
+                      kind: 0
+                      name: 60
+                      value: -1
+                      raw: -1
+                      pkg: 57
+                      type: 6
+                      position: 90
+                      resolved_type: -1
+                      generic_type_name: -1
+                    raw: -1
+                    pkg: 57
+                    type: 6
+                    position: 89
+                    resolved_type: -1
+                    generic_type_name: -1
+        comments: -1
+  multipackage/utils:
+    files:
+      r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/utils/helper.go:
+        functions:
+          FormatString:
+            name: 142
+            pkg: 132
+            signature:
+              kind: 12
+              name: -1
+              value: -1
+              fun:
+                kind: 13
+                name: -1
+                value: -1
+                args:
+                  - kind: 0
+                    name: 6
+                    value: -1
+                    raw: -1
+                    pkg: 132
+                    type: 6
+                    position: 144
+                    resolved_type: -1
+                    generic_type_name: -1
+                raw: -1
+                pkg: -1
+                type: -1
+                position: -1
+                resolved_type: -1
+                generic_type_name: -1
+              args:
+                - kind: 0
+                  name: 6
+                  value: -1
+                  raw: -1
+                  pkg: 132
+                  type: 6
+                  position: 143
+                  resolved_type: -1
+                  generic_type_name: -1
+              raw: -1
+              pkg: -1
+              type: -1
+              position: -1
+              resolved_type: 6
+              generic_type_name: -1
+            signature_str: 146
+            position: 145
+            scope: 15
+            comments: -1
+            return_vars:
+              - kind: 69
+                name: -1
+                value: -1
+                fun:
+                  kind: 8
+                  name: -1
+                  value: -1
+                  x:
+                    kind: 0
+                    name: 134
+                    value: -1
+                    raw: -1
+                    pkg: 134
+                    type: -1
+                    position: 139
+                    resolved_type: -1
+                    generic_type_name: -1
+                  sel:
+                    kind: 0
+                    name: 140
+                    value: -1
+                    raw: -1
+                    pkg: 134
+                    type: 137
+                    position: 141
+                    resolved_type: -1
+                    generic_type_name: -1
+                  raw: -1
+                  pkg: 134
+                  type: 137
+                  position: 139
+                  resolved_type: -1
+                  generic_type_name: -1
+                args:
+                  - kind: 69
+                    name: -1
+                    value: -1
+                    fun:
+                      kind: 8
+                      name: -1
+                      value: -1
+                      x:
+                        kind: 0
+                        name: 134
+                        value: -1
+                        raw: -1
+                        pkg: 134
+                        type: -1
+                        position: 135
+                        resolved_type: -1
+                        generic_type_name: -1
+                      sel:
+                        kind: 0
+                        name: 136
+                        value: -1
+                        raw: -1
+                        pkg: 134
+                        type: 137
+                        position: 138
+                        resolved_type: -1
+                        generic_type_name: -1
+                      raw: -1
+                      pkg: 134
+                      type: 137
+                      position: 135
+                      resolved_type: -1
+                      generic_type_name: -1
+                    args:
+                      - kind: 0
+                        name: 131
+                        value: -1
+                        raw: -1
+                        pkg: 132
+                        type: 6
+                        position: 133
+                        resolved_type: -1
+                        generic_type_name: -1
+                    raw: -1
+                    pkg: -1
+                    type: -1
+                    position: 135
+                    resolved_type: -1
+                    generic_type_name: -1
+                raw: -1
+                pkg: -1
+                type: -1
+                position: 139
+                resolved_type: -1
+                generic_type_name: -1
+          ValidateAge:
+            name: 155
+            pkg: 132
+            signature:
+              kind: 12
+              name: -1
+              value: -1
+              fun:
+                kind: 13
+                name: -1
+                value: -1
+                args:
+                  - kind: 0
+                    name: 157
+                    value: -1
+                    raw: -1
+                    pkg: 132
+                    type: 157
                     position: 158
                     resolved_type: -1
                     generic_type_name: -1
@@ -1013,1198 +2163,48 @@ packages:
                 position: -1
                 resolved_type: -1
                 generic_type_name: -1
-              raw: -1
-              pkg: -1
-              type: -1
-              position: -1
-              resolved_type: 8
-              generic_type_name: -1
-            signature_str: 36
-            scope: 48
-            comments: -1
-          - name: 42
-            signature:
-              kind: 30
-              name: -1
-              value: -1
-              fun:
-                kind: 31
-                name: -1
-                value: -1
-                args:
-                  - kind: 2
-                    name: 14
-                    value: -1
-                    raw: -1
-                    pkg: 23
-                    type: 14
-                    position: 159
-                    resolved_type: -1
-                    generic_type_name: -1
-                raw: -1
-                pkg: -1
-                type: -1
-                position: -1
-                resolved_type: -1
-                generic_type_name: -1
-              raw: -1
-              pkg: -1
-              type: -1
-              position: -1
-              resolved_type: 14
-              generic_type_name: -1
-            signature_str: 43
-            scope: 48
-            comments: -1
-        comments: -1
-  multipackage/services:
-    files:
-      r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/services/user_service.go:
-        types:
-          UserService:
-            name: 59
-            pkg: 4
-            kind: 60
-            fields:
-              - name: 7
-                type: 8
-                tag: -1
-                scope: 39
-                comments: -1
-            scope: 48
-            methods:
-              - name: 40
-                receiver: 46
-                signature:
-                  kind: 30
-                  name: -1
+              args:
+                - kind: 0
+                  name: 20
                   value: -1
-                  fun:
-                    kind: 31
-                    name: -1
-                    value: -1
-                    args:
-                      - kind: 2
-                        name: 8
-                        value: -1
-                        raw: -1
-                        pkg: 4
-                        type: 8
-                        position: 29
-                        resolved_type: -1
-                        generic_type_name: -1
-                    raw: -1
-                    pkg: -1
-                    type: -1
-                    position: -1
-                    resolved_type: -1
-                    generic_type_name: -1
-                  args:
-                    - kind: 27
-                      name: -1
-                      value: -1
-                      x:
-                        kind: 10
-                        name: -1
-                        value: -1
-                        x:
-                          kind: 2
-                          name: 22
-                          value: -1
-                          raw: -1
-                          pkg: 23
-                          type: -1
-                          position: 24
-                          resolved_type: -1
-                          generic_type_name: -1
-                        sel:
-                          kind: 2
-                          name: 25
-                          value: -1
-                          raw: -1
-                          pkg: 23
-                          type: 25
-                          position: 26
-                          resolved_type: -1
-                          generic_type_name: -1
-                        raw: -1
-                        pkg: 23
-                        type: 25
-                        position: 24
-                        resolved_type: -1
-                        generic_type_name: -1
-                      raw: -1
-                      pkg: -1
-                      type: -1
-                      position: 28
-                      resolved_type: -1
-                      generic_type_name: -1
                   raw: -1
-                  pkg: -1
-                  type: -1
-                  position: -1
-                  resolved_type: 8
-                  generic_type_name: -1
-                signature_str: 50
-                position: 47
-                scope: 48
-                filename: 49
-                return_vars:
-                  - kind: 21
-                    name: -1
-                    value: -1
-                    fun:
-                      kind: 10
-                      name: -1
-                      value: -1
-                      x:
-                        kind: 2
-                        name: 16
-                        value: -1
-                        raw: -1
-                        pkg: 16
-                        type: -1
-                        position: 17
-                        resolved_type: -1
-                        generic_type_name: -1
-                      sel:
-                        kind: 2
-                        name: 18
-                        value: -1
-                        raw: -1
-                        pkg: 16
-                        type: 19
-                        position: 20
-                        resolved_type: -1
-                        generic_type_name: -1
-                      raw: -1
-                      pkg: 16
-                      type: 19
-                      position: 17
-                      resolved_type: -1
-                      generic_type_name: -1
-                    args:
-                      - kind: 0
-                        name: -1
-                        value: 1
-                        raw: -1
-                        pkg: -1
-                        type: -1
-                        position: -1
-                        resolved_type: -1
-                        generic_type_name: -1
-                      - kind: 10
-                        name: -1
-                        value: -1
-                        x:
-                          kind: 2
-                          name: 3
-                          value: -1
-                          raw: -1
-                          pkg: 4
-                          type: 5
-                          position: 6
-                          resolved_type: -1
-                          generic_type_name: -1
-                        sel:
-                          kind: 2
-                          name: 7
-                          value: -1
-                          raw: -1
-                          pkg: 4
-                          type: 8
-                          position: 9
-                          resolved_type: -1
-                          generic_type_name: -1
-                        raw: -1
-                        pkg: 4
-                        type: 8
-                        position: 6
-                        resolved_type: -1
-                        generic_type_name: -1
-                      - kind: 2
-                        name: 11
-                        value: -1
-                        raw: -1
-                        pkg: 4
-                        type: 8
-                        position: 12
-                        resolved_type: -1
-                        generic_type_name: -1
-                      - kind: 2
-                        name: 13
-                        value: -1
-                        raw: -1
-                        pkg: 4
-                        type: 14
-                        position: 15
-                        resolved_type: -1
-                        generic_type_name: -1
-                    raw: -1
-                    pkg: -1
-                    type: -1
-                    position: 17
-                    resolved_type: -1
-                    generic_type_name: -1
-                assignments:
-                  age:
-                    - variable_name: 13
-                      pkg: 4
-                      concrete_type: 14
-                      position: 45
-                      scope: 39
-                      value:
-                        kind: 21
-                        name: -1
-                        value: -1
-                        fun:
-                          kind: 10
-                          name: -1
-                          value: -1
-                          x:
-                            kind: 2
-                            name: 32
-                            value: -1
-                            raw: -1
-                            pkg: 4
-                            type: 33
-                            position: 41
-                            resolved_type: -1
-                            generic_type_name: -1
-                          sel:
-                            kind: 2
-                            name: 42
-                            value: -1
-                            raw: -1
-                            pkg: 23
-                            type: 43
-                            position: 44
-                            resolved_type: -1
-                            generic_type_name: -1
-                          raw: -1
-                          pkg: 23
-                          type: 43
-                          position: 41
-                          resolved_type: -1
-                          generic_type_name: -1
-                          receiver_type:
-                            kind: 2
-                            name: 25
-                            value: -1
-                            raw: -1
-                            pkg: 23
-                            type: 25
-                            position: -1
-                            resolved_type: -1
-                            generic_type_name: -1
-                        raw: -1
-                        pkg: -1
-                        type: -1
-                        position: 41
-                        resolved_type: -1
-                        generic_type_name: -1
-                      lhs:
-                        kind: 2
-                        name: 13
-                        value: -1
-                        raw: -1
-                        pkg: 4
-                        type: 14
-                        position: 45
-                        resolved_type: -1
-                        generic_type_name: -1
-                      func: 40
-                      callee_func: GetAge
-                      callee_pkg: multipackage/models
-                  name:
-                    - variable_name: 11
-                      pkg: 4
-                      concrete_type: 8
-                      position: 38
-                      scope: 39
-                      value:
-                        kind: 21
-                        name: -1
-                        value: -1
-                        fun:
-                          kind: 10
-                          name: -1
-                          value: -1
-                          x:
-                            kind: 2
-                            name: 32
-                            value: -1
-                            raw: -1
-                            pkg: 4
-                            type: 33
-                            position: 34
-                            resolved_type: -1
-                            generic_type_name: -1
-                          sel:
-                            kind: 2
-                            name: 35
-                            value: -1
-                            raw: -1
-                            pkg: 23
-                            type: 36
-                            position: 37
-                            resolved_type: -1
-                            generic_type_name: -1
-                          raw: -1
-                          pkg: 23
-                          type: 36
-                          position: 34
-                          resolved_type: -1
-                          generic_type_name: -1
-                          receiver_type:
-                            kind: 2
-                            name: 25
-                            value: -1
-                            raw: -1
-                            pkg: 23
-                            type: 25
-                            position: -1
-                            resolved_type: -1
-                            generic_type_name: -1
-                        raw: -1
-                        pkg: -1
-                        type: -1
-                        position: 34
-                        resolved_type: -1
-                        generic_type_name: -1
-                      lhs:
-                        kind: 2
-                        name: 11
-                        value: -1
-                        raw: -1
-                        pkg: 4
-                        type: 8
-                        position: 38
-                        resolved_type: -1
-                        generic_type_name: -1
-                      func: 40
-                      callee_func: GetName
-                      callee_pkg: multipackage/models
-              - name: 56
-                receiver: 46
-                signature:
-                  kind: 30
-                  name: -1
-                  value: -1
-                  fun:
-                    kind: 31
-                    name: -1
-                    value: -1
-                    raw: -1
-                    pkg: -1
-                    type: -1
-                    position: -1
-                    resolved_type: -1
-                    generic_type_name: -1
-                  args:
-                    - kind: 2
-                      name: 8
-                      value: -1
-                      raw: -1
-                      pkg: 4
-                      type: 8
-                      position: 51
-                      resolved_type: -1
-                      generic_type_name: -1
-                  raw: -1
-                  pkg: -1
-                  type: -1
-                  position: -1
+                  pkg: 132
+                  type: 20
+                  position: 156
                   resolved_type: -1
                   generic_type_name: -1
-                signature_str: 58
-                position: 57
-                scope: 48
-                filename: 49
-                assignments:
-                  multipackage/services.UserService.prefix:
-                    - variable_name: 54
-                      pkg: 4
-                      concrete_type: 8
-                      position: 52
-                      scope: 10
-                      value:
-                        kind: 2
-                        name: 7
-                        value: -1
-                        raw: -1
-                        pkg: 4
-                        type: 8
-                        position: 55
-                        resolved_type: -1
-                        generic_type_name: -1
-                      lhs:
-                        kind: 10
-                        name: -1
-                        value: -1
-                        x:
-                          kind: 2
-                          name: 3
-                          value: -1
-                          raw: -1
-                          pkg: 4
-                          type: 5
-                          position: 52
-                          resolved_type: -1
-                          generic_type_name: -1
-                        sel:
-                          kind: 2
-                          name: 7
-                          value: -1
-                          raw: -1
-                          pkg: 4
-                          type: 8
-                          position: 53
-                          resolved_type: -1
-                          generic_type_name: -1
-                        raw: -1
-                        pkg: 4
-                        type: 8
-                        position: 52
-                        resolved_type: -1
-                        generic_type_name: -1
-            comments: -1
-        functions:
-          NewUserService:
-            name: 70
-            pkg: 4
-            signature:
-              kind: 30
-              name: -1
-              value: -1
-              fun:
-                kind: 31
-                name: -1
-                value: -1
-                args:
-                  - kind: 27
-                    name: -1
-                    value: -1
-                    x:
-                      kind: 2
-                      name: 59
-                      value: -1
-                      raw: -1
-                      pkg: 4
-                      type: 59
-                      position: 71
-                      resolved_type: -1
-                      generic_type_name: -1
-                    raw: -1
-                    pkg: -1
-                    type: -1
-                    position: 72
-                    resolved_type: -1
-                    generic_type_name: -1
-                raw: -1
-                pkg: -1
-                type: -1
-                position: -1
-                resolved_type: -1
-                generic_type_name: -1
               raw: -1
               pkg: -1
               type: -1
               position: -1
-              resolved_type: 46
+              resolved_type: 157
               generic_type_name: -1
-            signature_str: 74
-            position: 73
-            scope: 48
+            signature_str: 160
+            position: 159
+            scope: 15
             comments: -1
             return_vars:
-              - kind: 67
+              - kind: 149
                 name: -1
-                value: 68
+                value: 154
                 x:
-                  kind: 66
+                  kind: 149
                   name: -1
-                  value: -1
+                  value: 150
                   x:
-                    kind: 2
-                    name: 59
+                    kind: 0
+                    name: 40
                     value: -1
                     raw: -1
-                    pkg: 4
-                    type: 59
-                    position: 62
-                    resolved_type: -1
-                    generic_type_name: -1
-                  args:
-                    - kind: 65
-                      name: -1
-                      value: -1
-                      x:
-                        kind: 2
-                        name: 7
-                        value: -1
-                        raw: -1
-                        pkg: 4
-                        type: 8
-                        position: 63
-                        resolved_type: -1
-                        generic_type_name: -1
-                      fun:
-                        kind: 0
-                        name: -1
-                        value: 64
-                        raw: -1
-                        pkg: -1
-                        type: -1
-                        position: -1
-                        resolved_type: -1
-                        generic_type_name: -1
-                      raw: -1
-                      pkg: -1
-                      type: -1
-                      position: 63
-                      resolved_type: -1
-                      generic_type_name: -1
-                  raw: -1
-                  pkg: -1
-                  type: -1
-                  position: 62
-                  resolved_type: -1
-                  generic_type_name: -1
-                raw: -1
-                pkg: -1
-                type: -1
-                position: 69
-                resolved_type: -1
-                generic_type_name: -1
-        struct_instances:
-          - type: 59
-            pkg: 4
-            position: 62
-            fields:
-              7: 75
-        imports:
-          16: 16
-          23: 23
-    types:
-      UserService:
-        name: 59
-        pkg: 4
-        kind: 60
-        fields:
-          - name: 7
-            type: 8
-            tag: -1
-            scope: 39
-            comments: -1
-        scope: 48
-        methods:
-          - name: 40
-            receiver: 46
-            signature:
-              kind: 30
-              name: -1
-              value: -1
-              fun:
-                kind: 31
-                name: -1
-                value: -1
-                args:
-                  - kind: 2
-                    name: 8
-                    value: -1
-                    raw: -1
-                    pkg: 4
-                    type: 8
-                    position: 29
-                    resolved_type: -1
-                    generic_type_name: -1
-                raw: -1
-                pkg: -1
-                type: -1
-                position: -1
-                resolved_type: -1
-                generic_type_name: -1
-              args:
-                - kind: 27
-                  name: -1
-                  value: -1
-                  x:
-                    kind: 10
-                    name: -1
-                    value: -1
-                    x:
-                      kind: 2
-                      name: 22
-                      value: -1
-                      raw: -1
-                      pkg: 23
-                      type: -1
-                      position: 24
-                      resolved_type: -1
-                      generic_type_name: -1
-                    sel:
-                      kind: 2
-                      name: 25
-                      value: -1
-                      raw: -1
-                      pkg: 23
-                      type: 25
-                      position: 26
-                      resolved_type: -1
-                      generic_type_name: -1
-                    raw: -1
-                    pkg: 23
-                    type: 25
-                    position: 24
-                    resolved_type: -1
-                    generic_type_name: -1
-                  raw: -1
-                  pkg: -1
-                  type: -1
-                  position: 28
-                  resolved_type: -1
-                  generic_type_name: -1
-              raw: -1
-              pkg: -1
-              type: -1
-              position: -1
-              resolved_type: 8
-              generic_type_name: -1
-            signature_str: 50
-            position: 47
-            scope: 48
-            filename: 49
-            return_vars:
-              - kind: 21
-                name: -1
-                value: -1
-                fun:
-                  kind: 10
-                  name: -1
-                  value: -1
-                  x:
-                    kind: 2
-                    name: 16
-                    value: -1
-                    raw: -1
-                    pkg: 16
-                    type: -1
-                    position: 17
-                    resolved_type: -1
-                    generic_type_name: -1
-                  sel:
-                    kind: 2
-                    name: 18
-                    value: -1
-                    raw: -1
-                    pkg: 16
-                    type: 19
-                    position: 20
-                    resolved_type: -1
-                    generic_type_name: -1
-                  raw: -1
-                  pkg: 16
-                  type: 19
-                  position: 17
-                  resolved_type: -1
-                  generic_type_name: -1
-                args:
-                  - kind: 0
-                    name: -1
-                    value: 1
-                    raw: -1
-                    pkg: -1
-                    type: -1
-                    position: -1
-                    resolved_type: -1
-                    generic_type_name: -1
-                  - kind: 10
-                    name: -1
-                    value: -1
-                    x:
-                      kind: 2
-                      name: 3
-                      value: -1
-                      raw: -1
-                      pkg: 4
-                      type: 5
-                      position: 6
-                      resolved_type: -1
-                      generic_type_name: -1
-                    sel:
-                      kind: 2
-                      name: 7
-                      value: -1
-                      raw: -1
-                      pkg: 4
-                      type: 8
-                      position: 9
-                      resolved_type: -1
-                      generic_type_name: -1
-                    raw: -1
-                    pkg: 4
-                    type: 8
-                    position: 6
-                    resolved_type: -1
-                    generic_type_name: -1
-                  - kind: 2
-                    name: 11
-                    value: -1
-                    raw: -1
-                    pkg: 4
-                    type: 8
-                    position: 12
-                    resolved_type: -1
-                    generic_type_name: -1
-                  - kind: 2
-                    name: 13
-                    value: -1
-                    raw: -1
-                    pkg: 4
-                    type: 14
-                    position: 15
-                    resolved_type: -1
-                    generic_type_name: -1
-                raw: -1
-                pkg: -1
-                type: -1
-                position: 17
-                resolved_type: -1
-                generic_type_name: -1
-            assignments:
-              age:
-                - variable_name: 13
-                  pkg: 4
-                  concrete_type: 14
-                  position: 45
-                  scope: 39
-                  value:
-                    kind: 21
-                    name: -1
-                    value: -1
-                    fun:
-                      kind: 10
-                      name: -1
-                      value: -1
-                      x:
-                        kind: 2
-                        name: 32
-                        value: -1
-                        raw: -1
-                        pkg: 4
-                        type: 33
-                        position: 41
-                        resolved_type: -1
-                        generic_type_name: -1
-                      sel:
-                        kind: 2
-                        name: 42
-                        value: -1
-                        raw: -1
-                        pkg: 23
-                        type: 43
-                        position: 44
-                        resolved_type: -1
-                        generic_type_name: -1
-                      raw: -1
-                      pkg: 23
-                      type: 43
-                      position: 41
-                      resolved_type: -1
-                      generic_type_name: -1
-                      receiver_type:
-                        kind: 2
-                        name: 25
-                        value: -1
-                        raw: -1
-                        pkg: 23
-                        type: 25
-                        position: -1
-                        resolved_type: -1
-                        generic_type_name: -1
-                    raw: -1
-                    pkg: -1
-                    type: -1
-                    position: 41
-                    resolved_type: -1
-                    generic_type_name: -1
-                  lhs:
-                    kind: 2
-                    name: 13
-                    value: -1
-                    raw: -1
-                    pkg: 4
-                    type: 14
-                    position: 45
-                    resolved_type: -1
-                    generic_type_name: -1
-                  func: 40
-                  callee_func: GetAge
-                  callee_pkg: multipackage/models
-              name:
-                - variable_name: 11
-                  pkg: 4
-                  concrete_type: 8
-                  position: 38
-                  scope: 39
-                  value:
-                    kind: 21
-                    name: -1
-                    value: -1
-                    fun:
-                      kind: 10
-                      name: -1
-                      value: -1
-                      x:
-                        kind: 2
-                        name: 32
-                        value: -1
-                        raw: -1
-                        pkg: 4
-                        type: 33
-                        position: 34
-                        resolved_type: -1
-                        generic_type_name: -1
-                      sel:
-                        kind: 2
-                        name: 35
-                        value: -1
-                        raw: -1
-                        pkg: 23
-                        type: 36
-                        position: 37
-                        resolved_type: -1
-                        generic_type_name: -1
-                      raw: -1
-                      pkg: 23
-                      type: 36
-                      position: 34
-                      resolved_type: -1
-                      generic_type_name: -1
-                      receiver_type:
-                        kind: 2
-                        name: 25
-                        value: -1
-                        raw: -1
-                        pkg: 23
-                        type: 25
-                        position: -1
-                        resolved_type: -1
-                        generic_type_name: -1
-                    raw: -1
-                    pkg: -1
-                    type: -1
-                    position: 34
-                    resolved_type: -1
-                    generic_type_name: -1
-                  lhs:
-                    kind: 2
-                    name: 11
-                    value: -1
-                    raw: -1
-                    pkg: 4
-                    type: 8
-                    position: 38
-                    resolved_type: -1
-                    generic_type_name: -1
-                  func: 40
-                  callee_func: GetName
-                  callee_pkg: multipackage/models
-          - name: 56
-            receiver: 46
-            signature:
-              kind: 30
-              name: -1
-              value: -1
-              fun:
-                kind: 31
-                name: -1
-                value: -1
-                raw: -1
-                pkg: -1
-                type: -1
-                position: -1
-                resolved_type: -1
-                generic_type_name: -1
-              args:
-                - kind: 2
-                  name: 8
-                  value: -1
-                  raw: -1
-                  pkg: 4
-                  type: 8
-                  position: 51
-                  resolved_type: -1
-                  generic_type_name: -1
-              raw: -1
-              pkg: -1
-              type: -1
-              position: -1
-              resolved_type: -1
-              generic_type_name: -1
-            signature_str: 58
-            position: 57
-            scope: 48
-            filename: 49
-            assignments:
-              multipackage/services.UserService.prefix:
-                - variable_name: 54
-                  pkg: 4
-                  concrete_type: 8
-                  position: 52
-                  scope: 10
-                  value:
-                    kind: 2
-                    name: 7
-                    value: -1
-                    raw: -1
-                    pkg: 4
-                    type: 8
-                    position: 55
-                    resolved_type: -1
-                    generic_type_name: -1
-                  lhs:
-                    kind: 10
-                    name: -1
-                    value: -1
-                    x:
-                      kind: 2
-                      name: 3
-                      value: -1
-                      raw: -1
-                      pkg: 4
-                      type: 5
-                      position: 52
-                      resolved_type: -1
-                      generic_type_name: -1
-                    sel:
-                      kind: 2
-                      name: 7
-                      value: -1
-                      raw: -1
-                      pkg: 4
-                      type: 8
-                      position: 53
-                      resolved_type: -1
-                      generic_type_name: -1
-                    raw: -1
-                    pkg: 4
-                    type: 8
-                    position: 52
-                    resolved_type: -1
-                    generic_type_name: -1
-        comments: -1
-  multipackage/utils:
-    files:
-      r1/w8tjj19x3nz2gpwll3xntf4r0000gn/T/001/multipackage/utils/helper.go:
-        functions:
-          FormatString:
-            name: 112
-            pkg: 102
-            signature:
-              kind: 30
-              name: -1
-              value: -1
-              fun:
-                kind: 31
-                name: -1
-                value: -1
-                args:
-                  - kind: 2
-                    name: 8
-                    value: -1
-                    raw: -1
-                    pkg: 102
-                    type: 8
-                    position: 114
-                    resolved_type: -1
-                    generic_type_name: -1
-                raw: -1
-                pkg: -1
-                type: -1
-                position: -1
-                resolved_type: -1
-                generic_type_name: -1
-              args:
-                - kind: 2
-                  name: 8
-                  value: -1
-                  raw: -1
-                  pkg: 102
-                  type: 8
-                  position: 113
-                  resolved_type: -1
-                  generic_type_name: -1
-              raw: -1
-              pkg: -1
-              type: -1
-              position: -1
-              resolved_type: 8
-              generic_type_name: -1
-            signature_str: 116
-            position: 115
-            scope: 48
-            comments: -1
-            return_vars:
-              - kind: 21
-                name: -1
-                value: -1
-                fun:
-                  kind: 10
-                  name: -1
-                  value: -1
-                  x:
-                    kind: 2
-                    name: 104
-                    value: -1
-                    raw: -1
-                    pkg: 104
-                    type: -1
-                    position: 109
-                    resolved_type: -1
-                    generic_type_name: -1
-                  sel:
-                    kind: 2
-                    name: 110
-                    value: -1
-                    raw: -1
-                    pkg: 104
-                    type: 107
-                    position: 111
-                    resolved_type: -1
-                    generic_type_name: -1
-                  raw: -1
-                  pkg: 104
-                  type: 107
-                  position: 109
-                  resolved_type: -1
-                  generic_type_name: -1
-                args:
-                  - kind: 21
-                    name: -1
-                    value: -1
-                    fun:
-                      kind: 10
-                      name: -1
-                      value: -1
-                      x:
-                        kind: 2
-                        name: 104
-                        value: -1
-                        raw: -1
-                        pkg: 104
-                        type: -1
-                        position: 105
-                        resolved_type: -1
-                        generic_type_name: -1
-                      sel:
-                        kind: 2
-                        name: 106
-                        value: -1
-                        raw: -1
-                        pkg: 104
-                        type: 107
-                        position: 108
-                        resolved_type: -1
-                        generic_type_name: -1
-                      raw: -1
-                      pkg: 104
-                      type: 107
-                      position: 105
-                      resolved_type: -1
-                      generic_type_name: -1
-                    args:
-                      - kind: 2
-                        name: 101
-                        value: -1
-                        raw: -1
-                        pkg: 102
-                        type: 8
-                        position: 103
-                        resolved_type: -1
-                        generic_type_name: -1
-                    raw: -1
-                    pkg: -1
-                    type: -1
-                    position: 105
-                    resolved_type: -1
-                    generic_type_name: -1
-                raw: -1
-                pkg: -1
-                type: -1
-                position: 109
-                resolved_type: -1
-                generic_type_name: -1
-          ValidateAge:
-            name: 125
-            pkg: 102
-            signature:
-              kind: 30
-              name: -1
-              value: -1
-              fun:
-                kind: 31
-                name: -1
-                value: -1
-                args:
-                  - kind: 2
-                    name: 127
-                    value: -1
-                    raw: -1
-                    pkg: 102
-                    type: 127
-                    position: 128
-                    resolved_type: -1
-                    generic_type_name: -1
-                raw: -1
-                pkg: -1
-                type: -1
-                position: -1
-                resolved_type: -1
-                generic_type_name: -1
-              args:
-                - kind: 2
-                  name: 14
-                  value: -1
-                  raw: -1
-                  pkg: 102
-                  type: 14
-                  position: 126
-                  resolved_type: -1
-                  generic_type_name: -1
-              raw: -1
-              pkg: -1
-              type: -1
-              position: -1
-              resolved_type: 127
-              generic_type_name: -1
-            signature_str: 130
-            position: 129
-            scope: 48
-            comments: -1
-            return_vars:
-              - kind: 119
-                name: -1
-                value: 124
-                x:
-                  kind: 119
-                  name: -1
-                  value: 120
-                  x:
-                    kind: 2
-                    name: 13
-                    value: -1
-                    raw: -1
-                    pkg: 102
-                    type: 14
-                    position: 117
+                    pkg: 132
+                    type: 20
+                    position: 147
                     resolved_type: -1
                     generic_type_name: -1
                   fun:
-                    kind: 0
+                    kind: 54
                     name: -1
-                    value: 118
+                    value: 148
                     raw: -1
                     pkg: -1
                     type: -1
@@ -2214,27 +2214,27 @@ packages:
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 117
+                  position: 147
                   resolved_type: -1
                   generic_type_name: -1
                 fun:
-                  kind: 119
+                  kind: 149
                   name: -1
-                  value: 123
+                  value: 153
                   x:
-                    kind: 2
-                    name: 13
+                    kind: 0
+                    name: 40
                     value: -1
                     raw: -1
-                    pkg: 102
-                    type: 14
-                    position: 121
+                    pkg: 132
+                    type: 20
+                    position: 151
                     resolved_type: -1
                     generic_type_name: -1
                   fun:
-                    kind: 0
+                    kind: 54
                     name: -1
-                    value: 122
+                    value: 152
                     raw: -1
                     pkg: -1
                     type: -1
@@ -2244,345 +2244,193 @@ packages:
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 121
+                  position: 151
                   resolved_type: -1
                   generic_type_name: -1
                 raw: -1
                 pkg: -1
                 type: -1
-                position: 117
+                position: 147
                 resolved_type: -1
                 generic_type_name: -1
         variables:
           DefaultFormat:
-            name: 137
-            tok: 138
-            pkg: 102
+            name: 167
+            tok: 168
+            pkg: 132
             type: -1
-            value: 141
-            position: 139
+            value: 171
+            position: 169
             comments: -1
             group_index: 1
           MaxAge:
-            name: 135
-            tok: 132
-            pkg: 102
+            name: 165
+            tok: 162
+            pkg: 132
             type: -1
-            resolved_type: 134
-            value: 100
+            resolved_type: 164
+            value: 130
             computed_value: 149
-            position: 136
+            position: 166
             comments: -1
             group_index: 1
           MinAge:
-            name: 131
-            tok: 132
-            pkg: 102
+            name: 161
+            tok: 162
+            pkg: 132
             type: -1
-            resolved_type: 134
-            value: 99
+            resolved_type: 164
+            value: 129
             computed_value: 1
-            position: 133
+            position: 163
             comments: -1
             group_index: 1
         imports:
-          104: 104
+          134: 134
 call_graph:
   - caller:
-      name: 112
-      pkg: 102
+      name: 80
+      pkg: 57
       position: -1
-      recv_type: -1
-      scope: 48
-      signature_str: 116
+      recv_type: 84
+      scope: 15
+      signature_str: 87
     callee:
-      name: 110
-      pkg: 104
-      position: 109
-      recv_type: -1
-      scope: 48
-      signature_str: 107
-    position: 109
-    args:
-      - kind: 21
-        name: -1
-        value: -1
-        fun:
-          kind: 10
-          name: -1
-          value: -1
-          x:
-            kind: 2
-            name: 104
-            value: -1
-            raw: -1
-            pkg: 104
-            type: -1
-            position: 105
-            resolved_type: -1
-            generic_type_name: -1
-          sel:
-            kind: 2
-            name: 106
-            value: -1
-            raw: -1
-            pkg: 104
-            type: 107
-            position: 108
-            resolved_type: -1
-            generic_type_name: -1
-          raw: -1
-          pkg: 104
-          type: 107
-          position: 105
-          resolved_type: -1
-          generic_type_name: -1
-        args:
-          - kind: 2
-            name: 101
-            value: -1
-            raw: -1
-            pkg: 102
-            type: 8
-            position: 103
-            resolved_type: -1
-            generic_type_name: -1
-        raw: -1
-        pkg: -1
-        type: -1
-        position: 105
-        resolved_type: -1
-        generic_type_name: -1
-    param_arg_map:
-      s:
-        kind: 21
-        name: -1
-        value: -1
-        fun:
-          kind: 10
-          name: -1
-          value: -1
-          x:
-            kind: 2
-            name: 104
-            value: -1
-            raw: -1
-            pkg: 104
-            type: -1
-            position: 105
-            resolved_type: -1
-            generic_type_name: -1
-          sel:
-            kind: 2
-            name: 106
-            value: -1
-            raw: -1
-            pkg: 104
-            type: 107
-            position: 108
-            resolved_type: -1
-            generic_type_name: -1
-          raw: -1
-          pkg: 104
-          type: 107
-          position: 105
-          resolved_type: -1
-          generic_type_name: -1
-        args:
-          - kind: 2
-            name: 101
-            value: -1
-            raw: -1
-            pkg: 102
-            type: 8
-            position: 103
-            resolved_type: -1
-            generic_type_name: -1
-        raw: -1
-        pkg: -1
-        type: -1
-        position: 105
-        resolved_type: -1
-        generic_type_name: -1
-  - caller:
-      name: 112
-      pkg: 102
-      position: -1
-      recv_type: -1
-      scope: 48
-      signature_str: 116
-    callee:
-      name: 106
-      pkg: 104
-      position: 105
-      recv_type: -1
-      scope: 48
-      signature_str: 107
-    position: 105
-    args:
-      - kind: 2
-        name: 101
-        value: -1
-        raw: -1
-        pkg: 102
-        type: 8
-        position: 103
-        resolved_type: -1
-        generic_type_name: -1
-    param_arg_map:
-      s:
-        kind: 2
-        name: 101
-        value: -1
-        raw: -1
-        pkg: 102
-        type: 8
-        position: 103
-        resolved_type: -1
-        generic_type_name: -1
-  - caller:
-      name: 40
-      pkg: 4
-      position: -1
-      recv_type: 46
-      scope: 48
-      signature_str: 50
-    callee:
-      name: 35
-      pkg: 23
-      position: 34
-      recv_type: 146
-      scope: 48
-      signature_str: 36
-    position: 34
+      name: 9
+      pkg: 2
+      position: 76
+      recv_type: 10
+      scope: 15
+      signature_str: 17
+    position: 76
     callee_var_name: user
     callee_recv_var_name: name
     chain_root: user
   - caller:
-      name: 40
-      pkg: 4
+      name: 80
+      pkg: 57
       position: -1
-      recv_type: 46
-      scope: 48
-      signature_str: 50
+      recv_type: 84
+      scope: 15
+      signature_str: 87
     callee:
-      name: 42
-      pkg: 23
-      position: 41
-      recv_type: 146
-      scope: 48
-      signature_str: 43
-    position: 41
+      name: 22
+      pkg: 2
+      position: 81
+      recv_type: 10
+      scope: 15
+      signature_str: 25
+    position: 81
     callee_var_name: user
     callee_recv_var_name: age
     chain_root: user
   - caller:
-      name: 40
-      pkg: 4
+      name: 80
+      pkg: 57
       position: -1
-      recv_type: 46
-      scope: 48
-      signature_str: 50
+      recv_type: 84
+      scope: 15
+      signature_str: 87
     callee:
-      name: 18
-      pkg: 16
-      position: 17
+      name: 66
+      pkg: 64
+      position: 65
       recv_type: -1
-      scope: 48
-      signature_str: 19
-    position: 17
+      scope: 15
+      signature_str: 67
+    position: 65
     args:
-      - kind: 0
+      - kind: 54
         name: -1
-        value: 1
+        value: 55
         raw: -1
         pkg: -1
         type: -1
         position: -1
         resolved_type: -1
         generic_type_name: -1
-      - kind: 10
+      - kind: 8
         name: -1
         value: -1
         x:
-          kind: 2
-          name: 3
+          kind: 0
+          name: 56
           value: -1
           raw: -1
-          pkg: 4
-          type: 5
-          position: 6
+          pkg: 57
+          type: 58
+          position: 59
           resolved_type: -1
           generic_type_name: -1
         sel:
-          kind: 2
-          name: 7
+          kind: 0
+          name: 60
           value: -1
           raw: -1
-          pkg: 4
-          type: 8
-          position: 9
+          pkg: 57
+          type: 6
+          position: 61
           resolved_type: -1
           generic_type_name: -1
         raw: -1
-        pkg: 4
-        type: 8
-        position: 6
+        pkg: 57
+        type: 6
+        position: 59
         resolved_type: -1
         generic_type_name: -1
-      - kind: 2
-        name: 11
+      - kind: 0
+        name: 36
         value: -1
         raw: -1
-        pkg: 4
-        type: 8
-        position: 12
+        pkg: 57
+        type: 6
+        position: 62
         resolved_type: -1
         generic_type_name: -1
-      - kind: 2
-        name: 13
+      - kind: 0
+        name: 40
         value: -1
         raw: -1
-        pkg: 4
-        type: 14
-        position: 15
+        pkg: 57
+        type: 20
+        position: 63
         resolved_type: -1
         generic_type_name: -1
     param_arg_map:
       a:
-        kind: 10
+        kind: 8
         name: -1
         value: -1
         x:
-          kind: 2
-          name: 3
+          kind: 0
+          name: 56
           value: -1
           raw: -1
-          pkg: 4
-          type: 5
-          position: 6
+          pkg: 57
+          type: 58
+          position: 59
           resolved_type: -1
           generic_type_name: -1
         sel:
-          kind: 2
-          name: 7
+          kind: 0
+          name: 60
           value: -1
           raw: -1
-          pkg: 4
-          type: 8
-          position: 9
+          pkg: 57
+          type: 6
+          position: 61
           resolved_type: -1
           generic_type_name: -1
         raw: -1
-        pkg: 4
-        type: 8
-        position: 6
+        pkg: 57
+        type: 6
+        position: 59
         resolved_type: -1
         generic_type_name: -1
       format:
-        kind: 0
+        kind: 54
         name: -1
-        value: 1
+        value: 55
         raw: -1
         pkg: -1
         type: -1
@@ -2590,33 +2438,33 @@ call_graph:
         resolved_type: -1
         generic_type_name: -1
   - caller:
-      name: 84
-      pkg: 82
+      name: 114
+      pkg: 112
       position: -1
       recv_type: -1
-      scope: 39
-      signature_str: 98
+      scope: 79
+      signature_str: 128
     callee:
-      name: 79
-      pkg: 23
-      position: 78
+      name: 46
+      pkg: 2
+      position: 109
       recv_type: -1
-      scope: 48
-      signature_str: 80
-    position: 78
+      scope: 15
+      signature_str: 110
+    position: 109
     args:
-      - kind: 0
+      - kind: 54
         name: -1
-        value: 76
+        value: 107
         raw: -1
         pkg: -1
         type: -1
         position: -1
         resolved_type: -1
         generic_type_name: -1
-      - kind: 0
+      - kind: 54
         name: -1
-        value: 77
+        value: 108
         raw: -1
         pkg: -1
         type: -1
@@ -2625,58 +2473,58 @@ call_graph:
         generic_type_name: -1
     assignments:
       user:
-        - variable_name: 32
-          pkg: 82
-          concrete_type: 33
-          position: 83
-          scope: 39
+        - variable_name: 75
+          pkg: 112
+          concrete_type: 3
+          position: 113
+          scope: 79
           value:
-            kind: 21
+            kind: 69
             name: -1
             value: -1
             fun:
-              kind: 10
+              kind: 8
               name: -1
               value: -1
               x:
-                kind: 2
-                name: 22
+                kind: 0
+                name: 70
                 value: -1
                 raw: -1
-                pkg: 23
+                pkg: 2
                 type: -1
-                position: 78
+                position: 109
                 resolved_type: -1
                 generic_type_name: -1
               sel:
-                kind: 2
-                name: 79
+                kind: 0
+                name: 46
                 value: -1
                 raw: -1
-                pkg: 23
-                type: 80
-                position: 81
+                pkg: 2
+                type: 110
+                position: 111
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
-              pkg: 23
-              type: 80
-              position: 78
+              pkg: 2
+              type: 110
+              position: 109
               resolved_type: -1
               generic_type_name: -1
             args:
-              - kind: 0
+              - kind: 54
                 name: -1
-                value: 76
+                value: 107
                 raw: -1
                 pkg: -1
                 type: -1
                 position: -1
                 resolved_type: -1
                 generic_type_name: -1
-              - kind: 0
+              - kind: 54
                 name: -1
-                value: 77
+                value: 108
                 raw: -1
                 pkg: -1
                 type: -1
@@ -2686,27 +2534,27 @@ call_graph:
             raw: -1
             pkg: -1
             type: -1
-            position: 78
+            position: 109
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 2
-            name: 32
+            kind: 0
+            name: 75
             value: -1
             raw: -1
-            pkg: 82
-            type: 33
-            position: 83
+            pkg: 112
+            type: 3
+            position: 113
             resolved_type: -1
             generic_type_name: -1
-          func: 84
+          func: 114
           callee_func: NewUser
           callee_pkg: multipackage/models
     param_arg_map:
       age:
-        kind: 0
+        kind: 54
         name: -1
-        value: 77
+        value: 108
         raw: -1
         pkg: -1
         type: -1
@@ -2714,9 +2562,9 @@ call_graph:
         resolved_type: -1
         generic_type_name: -1
       name:
-        kind: 0
+        kind: 54
         name: -1
-        value: 76
+        value: 107
         raw: -1
         pkg: -1
         type: -1
@@ -2725,371 +2573,523 @@ call_graph:
         generic_type_name: -1
     callee_recv_var_name: user
   - caller:
-      name: 84
-      pkg: 82
+      name: 114
+      pkg: 112
       position: -1
       recv_type: -1
-      scope: 39
-      signature_str: 98
+      scope: 79
+      signature_str: 128
     callee:
-      name: 70
-      pkg: 4
-      position: 86
+      name: 101
+      pkg: 57
+      position: 116
       recv_type: -1
-      scope: 48
-      signature_str: 87
-    position: 86
+      scope: 15
+      signature_str: 117
+    position: 116
     assignments:
       service:
-        - variable_name: 89
-          pkg: 82
-          concrete_type: 5
-          position: 90
-          scope: 39
+        - variable_name: 119
+          pkg: 112
+          concrete_type: 58
+          position: 120
+          scope: 79
           value:
-            kind: 21
+            kind: 69
             name: -1
             value: -1
             fun:
-              kind: 10
+              kind: 8
               name: -1
               value: -1
               x:
-                kind: 2
-                name: 85
+                kind: 0
+                name: 115
                 value: -1
                 raw: -1
-                pkg: 4
+                pkg: 57
                 type: -1
-                position: 86
+                position: 116
                 resolved_type: -1
                 generic_type_name: -1
               sel:
-                kind: 2
-                name: 70
+                kind: 0
+                name: 101
                 value: -1
                 raw: -1
-                pkg: 4
-                type: 87
-                position: 88
+                pkg: 57
+                type: 117
+                position: 118
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
-              pkg: 4
-              type: 87
-              position: 86
+              pkg: 57
+              type: 117
+              position: 116
               resolved_type: -1
               generic_type_name: -1
             raw: -1
             pkg: -1
             type: -1
-            position: 86
+            position: 116
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 2
-            name: 89
+            kind: 0
+            name: 119
             value: -1
             raw: -1
-            pkg: 82
-            type: 5
-            position: 90
+            pkg: 112
+            type: 58
+            position: 120
             resolved_type: -1
             generic_type_name: -1
-          func: 84
+          func: 114
           callee_func: NewUserService
           callee_pkg: multipackage/services
     callee_recv_var_name: service
   - caller:
-      name: 84
-      pkg: 82
+      name: 114
+      pkg: 112
       position: -1
       recv_type: -1
-      scope: 39
-      signature_str: 98
+      scope: 79
+      signature_str: 128
     callee:
-      name: 40
-      pkg: 4
-      position: 92
-      recv_type: 46
-      scope: 48
-      signature_str: 93
-    position: 92
+      name: 80
+      pkg: 57
+      position: 122
+      recv_type: 84
+      scope: 15
+      signature_str: 123
+    position: 122
     args:
-      - kind: 2
-        name: 32
+      - kind: 0
+        name: 75
         value: -1
         raw: -1
-        pkg: 82
-        type: 33
-        position: 91
+        pkg: 112
+        type: 3
+        position: 121
         resolved_type: -1
         generic_type_name: -1
     assignments:
       age:
-        - variable_name: 13
-          pkg: 4
-          concrete_type: 14
-          position: 45
-          scope: 39
+        - variable_name: 40
+          pkg: 57
+          concrete_type: 20
+          position: 83
+          scope: 79
           value:
-            kind: 21
+            kind: 69
             name: -1
             value: -1
             fun:
-              kind: 10
+              kind: 8
               name: -1
               value: -1
               x:
-                kind: 2
-                name: 32
+                kind: 0
+                name: 75
                 value: -1
                 raw: -1
-                pkg: 4
-                type: 33
-                position: 41
+                pkg: 57
+                type: 3
+                position: 81
                 resolved_type: -1
                 generic_type_name: -1
               sel:
-                kind: 2
-                name: 42
+                kind: 0
+                name: 22
                 value: -1
                 raw: -1
-                pkg: 23
-                type: 43
-                position: 44
+                pkg: 2
+                type: 25
+                position: 82
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
-              pkg: 23
-              type: 43
-              position: 41
+              pkg: 2
+              type: 25
+              position: 81
               resolved_type: -1
               generic_type_name: -1
               receiver_type:
-                kind: 2
-                name: 25
+                kind: 0
+                name: 26
                 value: -1
                 raw: -1
-                pkg: 23
-                type: 25
+                pkg: 2
+                type: 26
                 position: -1
                 resolved_type: -1
                 generic_type_name: -1
             raw: -1
             pkg: -1
             type: -1
-            position: 41
+            position: 81
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 2
-            name: 13
+            kind: 0
+            name: 40
             value: -1
             raw: -1
-            pkg: 4
-            type: 14
-            position: 45
+            pkg: 57
+            type: 20
+            position: 83
             resolved_type: -1
             generic_type_name: -1
-          func: 40
+          func: 80
           callee_func: GetAge
           callee_pkg: multipackage/models
       name:
-        - variable_name: 11
-          pkg: 4
-          concrete_type: 8
-          position: 38
-          scope: 39
+        - variable_name: 36
+          pkg: 57
+          concrete_type: 6
+          position: 78
+          scope: 79
           value:
-            kind: 21
+            kind: 69
             name: -1
             value: -1
             fun:
-              kind: 10
+              kind: 8
               name: -1
               value: -1
               x:
-                kind: 2
-                name: 32
+                kind: 0
+                name: 75
                 value: -1
                 raw: -1
-                pkg: 4
-                type: 33
-                position: 34
+                pkg: 57
+                type: 3
+                position: 76
                 resolved_type: -1
                 generic_type_name: -1
               sel:
-                kind: 2
-                name: 35
+                kind: 0
+                name: 9
                 value: -1
                 raw: -1
-                pkg: 23
-                type: 36
-                position: 37
+                pkg: 2
+                type: 17
+                position: 77
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
-              pkg: 23
-              type: 36
-              position: 34
+              pkg: 2
+              type: 17
+              position: 76
               resolved_type: -1
               generic_type_name: -1
               receiver_type:
-                kind: 2
-                name: 25
+                kind: 0
+                name: 26
                 value: -1
                 raw: -1
-                pkg: 23
-                type: 25
+                pkg: 2
+                type: 26
                 position: -1
                 resolved_type: -1
                 generic_type_name: -1
             raw: -1
             pkg: -1
             type: -1
-            position: 34
+            position: 76
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 2
-            name: 11
+            kind: 0
+            name: 36
             value: -1
             raw: -1
-            pkg: 4
-            type: 8
-            position: 38
+            pkg: 57
+            type: 6
+            position: 78
             resolved_type: -1
             generic_type_name: -1
-          func: 40
+          func: 80
           callee_func: GetName
           callee_pkg: multipackage/models
       result:
-        - variable_name: 95
-          pkg: 82
-          concrete_type: 8
-          position: 96
-          scope: 39
+        - variable_name: 125
+          pkg: 112
+          concrete_type: 6
+          position: 126
+          scope: 79
           value:
-            kind: 21
+            kind: 69
             name: -1
             value: -1
             fun:
-              kind: 10
+              kind: 8
               name: -1
               value: -1
               x:
-                kind: 2
-                name: 89
+                kind: 0
+                name: 119
                 value: -1
                 raw: -1
-                pkg: 82
-                type: 5
-                position: 92
+                pkg: 112
+                type: 58
+                position: 122
                 resolved_type: -1
                 generic_type_name: -1
               sel:
-                kind: 2
-                name: 40
+                kind: 0
+                name: 80
                 value: -1
                 raw: -1
-                pkg: 4
-                type: 93
-                position: 94
+                pkg: 57
+                type: 123
+                position: 124
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
-              pkg: 4
-              type: 93
-              position: 92
+              pkg: 57
+              type: 123
+              position: 122
               resolved_type: -1
               generic_type_name: -1
               receiver_type:
-                kind: 2
-                name: 59
+                kind: 0
+                name: 96
                 value: -1
                 raw: -1
-                pkg: 4
-                type: 59
+                pkg: 57
+                type: 96
                 position: -1
                 resolved_type: -1
                 generic_type_name: -1
             args:
-              - kind: 2
-                name: 32
+              - kind: 0
+                name: 75
                 value: -1
                 raw: -1
-                pkg: 82
-                type: 33
-                position: 91
+                pkg: 112
+                type: 3
+                position: 121
                 resolved_type: -1
                 generic_type_name: -1
             raw: -1
             pkg: -1
             type: -1
-            position: 92
+            position: 122
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 2
-            name: 95
+            kind: 0
+            name: 125
             value: -1
             raw: -1
-            pkg: 82
-            type: 8
-            position: 96
+            pkg: 112
+            type: 6
+            position: 126
             resolved_type: -1
             generic_type_name: -1
-          func: 84
+          func: 114
           callee_func: ProcessUser
           callee_pkg: multipackage/services
     param_arg_map:
       user:
-        kind: 2
-        name: 32
+        kind: 0
+        name: 75
         value: -1
         raw: -1
-        pkg: 82
-        type: 33
-        position: 91
+        pkg: 112
+        type: 3
+        position: 121
         resolved_type: -1
         generic_type_name: -1
     callee_var_name: service
     callee_recv_var_name: result
     chain_root: service
   - caller:
-      name: 84
-      pkg: 82
+      name: 114
+      pkg: 112
       position: -1
       recv_type: -1
-      scope: 39
-      signature_str: 98
+      scope: 79
+      signature_str: 128
     callee:
       name: 176
-      pkg: 16
+      pkg: 64
       position: 175
       recv_type: -1
-      scope: 48
+      scope: 15
       signature_str: 177
     position: 175
     args:
-      - kind: 2
-        name: 95
+      - kind: 0
+        name: 125
         value: -1
         raw: -1
-        pkg: 82
-        type: 8
+        pkg: 112
+        type: 6
         position: 174
         resolved_type: -1
         generic_type_name: -1
     param_arg_map:
       a:
-        kind: 2
-        name: 95
+        kind: 0
+        name: 125
         value: -1
         raw: -1
-        pkg: 82
-        type: 8
+        pkg: 112
+        type: 6
         position: 174
+        resolved_type: -1
+        generic_type_name: -1
+  - caller:
+      name: 142
+      pkg: 132
+      position: -1
+      recv_type: -1
+      scope: 15
+      signature_str: 146
+    callee:
+      name: 140
+      pkg: 134
+      position: 139
+      recv_type: -1
+      scope: 15
+      signature_str: 137
+    position: 139
+    args:
+      - kind: 69
+        name: -1
+        value: -1
+        fun:
+          kind: 8
+          name: -1
+          value: -1
+          x:
+            kind: 0
+            name: 134
+            value: -1
+            raw: -1
+            pkg: 134
+            type: -1
+            position: 135
+            resolved_type: -1
+            generic_type_name: -1
+          sel:
+            kind: 0
+            name: 136
+            value: -1
+            raw: -1
+            pkg: 134
+            type: 137
+            position: 138
+            resolved_type: -1
+            generic_type_name: -1
+          raw: -1
+          pkg: 134
+          type: 137
+          position: 135
+          resolved_type: -1
+          generic_type_name: -1
+        args:
+          - kind: 0
+            name: 131
+            value: -1
+            raw: -1
+            pkg: 132
+            type: 6
+            position: 133
+            resolved_type: -1
+            generic_type_name: -1
+        raw: -1
+        pkg: -1
+        type: -1
+        position: 135
+        resolved_type: -1
+        generic_type_name: -1
+    param_arg_map:
+      s:
+        kind: 69
+        name: -1
+        value: -1
+        fun:
+          kind: 8
+          name: -1
+          value: -1
+          x:
+            kind: 0
+            name: 134
+            value: -1
+            raw: -1
+            pkg: 134
+            type: -1
+            position: 135
+            resolved_type: -1
+            generic_type_name: -1
+          sel:
+            kind: 0
+            name: 136
+            value: -1
+            raw: -1
+            pkg: 134
+            type: 137
+            position: 138
+            resolved_type: -1
+            generic_type_name: -1
+          raw: -1
+          pkg: 134
+          type: 137
+          position: 135
+          resolved_type: -1
+          generic_type_name: -1
+        args:
+          - kind: 0
+            name: 131
+            value: -1
+            raw: -1
+            pkg: 132
+            type: 6
+            position: 133
+            resolved_type: -1
+            generic_type_name: -1
+        raw: -1
+        pkg: -1
+        type: -1
+        position: 135
+        resolved_type: -1
+        generic_type_name: -1
+  - caller:
+      name: 142
+      pkg: 132
+      position: -1
+      recv_type: -1
+      scope: 15
+      signature_str: 146
+    callee:
+      name: 136
+      pkg: 134
+      position: 135
+      recv_type: -1
+      scope: 15
+      signature_str: 137
+    position: 135
+    args:
+      - kind: 0
+        name: 131
+        value: -1
+        raw: -1
+        pkg: 132
+        type: 6
+        position: 133
+        resolved_type: -1
+        generic_type_name: -1
+    param_arg_map:
+      s:
+        kind: 0
+        name: 131
+        value: -1
+        raw: -1
+        pkg: 132
+        type: 6
+        position: 133
         resolved_type: -1
         generic_type_name: -1

--- a/testdata/dynamic_mount_prefix/go.mod
+++ b/testdata/dynamic_mount_prefix/go.mod
@@ -1,0 +1,5 @@
+module dynamic_mount_prefix
+
+go 1.21
+
+require github.com/go-chi/chi/v5 v5.0.10

--- a/testdata/dynamic_mount_prefix/go.sum
+++ b/testdata/dynamic_mount_prefix/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.0.10 h1:rLz5avzKpjqxrYwXNfmjkrYYXOyLJd37pz53UFHC6vk=
+github.com/go-chi/chi/v5 v5.0.10/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=

--- a/testdata/dynamic_mount_prefix/main.go
+++ b/testdata/dynamic_mount_prefix/main.go
@@ -77,7 +77,11 @@ func main() {
 
 	// A literal-mount sibling, to make sure the regression of the
 	// dynamic-mount case doesn't drag the literal case down with it.
-	r.Mount("/static", apiRoutes())
+	// Same sub-router (apiRoutes) mounted at a second, literal path. With
+	// the per-node visited map this second traversal short-circuited and
+	// none of /v2/api's routes appeared in the spec — see the visited
+	// map fix in extractor.go (now keyed by node + mountPath).
+	r.Mount("/v2/api", apiRoutes())
 
 	http.ListenAndServe(":8080", r)
 }

--- a/testdata/dynamic_mount_prefix/main.go
+++ b/testdata/dynamic_mount_prefix/main.go
@@ -1,0 +1,83 @@
+// Reproduction of issue #34 — dynamic mount prefix computed via a helper.
+//
+// At runtime mountPoint() collapses to "/api" when prefix is empty, so the
+// expected routes are /api, /api/{id}, /api/changepassword, etc. Today
+// APISpec can't evaluate the helper call and falls back to rendering the
+// call expression as text — producing routes prefixed with something like
+// /dynamic_mount_prefix.mountPoint/...
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// mountPoint mirrors the helper from issue #34: joins a configurable
+// prefix with a sub-path. Returns "/api" when prefix is empty.
+func mountPoint(prefix, point string) string {
+	if prefix == "" && point == "" {
+		return "/"
+	}
+
+	points := make([]string, 1, 10)
+
+	for _, v := range strings.Split(prefix, "/") {
+		if v != "" {
+			points = append(points, v)
+		}
+	}
+	for _, v := range strings.Split(point, "/") {
+		if v != "" {
+			points = append(points, v)
+		}
+	}
+	if len(points) == 1 {
+		return "/"
+	}
+	return strings.Join(points, "/")
+}
+
+// apiRoutes returns a sub-router with several routes under /api.
+func apiRoutes() chi.Router {
+	r := chi.NewRouter()
+
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("api root"))
+	})
+
+	r.Get("/{id}", func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		fmt.Println(id)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("api item"))
+	})
+
+	r.Post("/changepassword", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	r.Delete("/clear", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("cleared"))
+	})
+
+	return r
+}
+
+func main() {
+	// prefix is empty here, so mountPoint(prefix, "/api") == "/api".
+	prefix := ""
+
+	r := chi.NewRouter()
+	r.Mount(mountPoint(prefix, "/api"), apiRoutes())
+
+	// A literal-mount sibling, to make sure the regression of the
+	// dynamic-mount case doesn't drag the literal case down with it.
+	r.Mount("/static", apiRoutes())
+
+	http.ListenAndServe(":8080", r)
+}


### PR DESCRIPTION
When mount path containing a call. The call function name is added to the route. e.g. `r.Mount(mountPoint(prefix, "/api"), apiRoutes())` OpenAPI file will generate `/dynamic_mount_prefix.mountPoint` for mount function.

- Replace by component param e.g. `{mountPoint}`
- Fix 2 new bugs:
   - `visited` map collapses parallel mounts.
   - route dedup collapses by Function only. 