### PR TITLE
refactor: route tracker warnings through Logger interface (#7 of audit)

### DIFF
--- a/cmd/apidiag/main.go
+++ b/cmd/apidiag/main.go
@@ -416,7 +416,7 @@ func (s *DiagramServer) getAllData(diagramType string, includeFullDepth bool) *s
 			MaxArgsPerFunction: 100,
 			MaxNestedArgsDepth: 100,
 			MaxRecursionDepth:  maxDepth,
-		})
+		}, nil)
 		data = spec.DrawTrackerTreeCytoscapeWithMetadata(trackerTree.GetRoots(), s.metadata)
 	} else {
 		data = spec.DrawCallGraphCytoscape(s.metadata)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -52,6 +52,16 @@ func (vl *VerboseLogger) Print(args ...interface{}) {
 	}
 }
 
+// Warnf writes an always-on warning to stderr. Unlike Printf/Println/Print,
+// it is not gated on the verbose flag: warnings about limit overruns or
+// recoverable failures are surfaced to the consumer either way.
+func (vl *VerboseLogger) Warnf(format string, args ...interface{}) {
+	_, err := fmt.Fprintf(os.Stderr, format, args...)
+	if err != nil {
+		return
+	}
+}
+
 const (
 	// Default values for OpenAPI generation
 	DefaultOutputFile         = "openapi.json"
@@ -477,7 +487,7 @@ func (e *Engine) GenerateOpenAPI() (*spec.OpenAPISpec, error) {
 		MaxNestedArgsDepth: e.config.MaxNestedArgsDepth,
 		MaxRecursionDepth:  e.config.MaxRecursionDepth,
 	}
-	tree := intspec.NewTrackerTree(meta, limits)
+	tree := intspec.NewTrackerTree(meta, limits, NewVerboseLogger(e.config.Verbose))
 
 	// Generate OpenAPI spec
 	openAPISpec, err := intspec.MapMetadataToOpenAPI(tree, apispecConfig, generatorConfig)

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -132,11 +132,16 @@ func GenerateMetadata(pkgs map[string]map[string]*ast.File, fileToInfo map[*ast.
 	return GenerateMetadataWithLogger(pkgs, fileToInfo, importPaths, fset, nil)
 }
 
-// VerboseLogger interface for conditional logging
+// VerboseLogger is the cross-cutting logging contract for the analyzer
+// pipeline. Printf/Println/Print are progress-style entries gated on a
+// verbose flag in the implementation. Warnf is for conditions the consumer
+// likely wants to see regardless of verbosity — limit truncations, suspect
+// inputs, recoverable extraction failures.
 type VerboseLogger interface {
 	Printf(format string, args ...any)
 	Println(args ...any)
 	Print(args ...any)
+	Warnf(format string, args ...any)
 }
 
 func GenerateMetadataWithLogger(pkgs map[string]map[string]*ast.File, fileToInfo map[*ast.File]*types.Info, importPaths map[string]string, fset *token.FileSet, logger VerboseLogger) *Metadata {

--- a/internal/spec/export_test.go
+++ b/internal/spec/export_test.go
@@ -28,7 +28,7 @@ func TestGenerateCytoscapeHTML(t *testing.T) {
 		MaxArgsPerFunction: 5,
 		MaxNestedArgsDepth: 3,
 	}
-	tree := NewTrackerTree(meta, limits)
+	tree := NewTrackerTree(meta, limits, nil)
 
 	// Test HTML generation
 	outputPath := filepath.Join(tempDir, "test_diagram.html")

--- a/internal/spec/tracker.go
+++ b/internal/spec/tracker.go
@@ -3,6 +3,7 @@ package spec
 import (
 	"fmt"
 	"maps"
+	"os"
 	"strings"
 	"sync"
 
@@ -271,6 +272,10 @@ type TrackerTree struct {
 	roots     []*TrackerNode
 	limits    metadata.TrackerLimits
 
+	// logger receives traversal-time warnings (limit truncations, etc.).
+	// May be nil; callers should reach it via t.warn / t.info.
+	logger metadata.VerboseLogger
+
 	// Enhanced tracking indices
 	variableNodes map[paramKey][]*TrackerNode // Track variable nodes by name
 
@@ -283,6 +288,16 @@ type TrackerTree struct {
 	// Performance optimizations
 	nodeMap map[string]*TrackerNode // O(1) node lookup by edge ID
 	idCache map[string]string       // Cache for ID generation
+}
+
+// warn forwards to the configured logger, defaulting to stderr when none
+// was supplied so existing CLI behaviour is preserved verbatim.
+func (t *TrackerTree) warn(format string, args ...any) {
+	if t == nil || t.logger == nil {
+		fmt.Fprintf(os.Stderr, format, args...)
+		return
+	}
+	t.logger.Warnf(format, args...)
 }
 
 type paramKey struct {
@@ -316,11 +331,14 @@ func (k interfaceKey) String() string {
 }
 
 // NewTrackerTree constructs a TrackerTree from metadata and limits.
-func NewTrackerTree(meta *metadata.Metadata, limits metadata.TrackerLimits) *TrackerTree {
+// logger may be nil — warnings then route directly to stderr so the CLI
+// behaviour callers had before this parameter existed is preserved.
+func NewTrackerTree(meta *metadata.Metadata, limits metadata.TrackerLimits, logger metadata.VerboseLogger) *TrackerTree {
 	t := &TrackerTree{
 		meta:          meta,
 		positions:     make(map[string]bool, 100), // Pre-allocate with estimated capacity
 		variableNodes: make(map[paramKey][]*TrackerNode, 50),
+		logger:        logger,
 
 		limits:                 limits,
 		chainParentMap:         make(map[string]*metadata.CallGraphEdge, 100),
@@ -714,7 +732,7 @@ func processArguments(tree *TrackerTree, meta *metadata.Metadata, parentNode *Tr
 		argCount++
 
 		if argCount >= limits.MaxArgsPerFunction {
-			fmt.Printf("Warning: MaxArgsPerFunction limit (%d) reached for function %s.%s, truncating arguments\n",
+			tree.warn("Warning: MaxArgsPerFunction limit (%d) reached for function %s.%s, truncating arguments\n",
 				limits.MaxArgsPerFunction, getString(meta, edge.Caller.Name), getString(meta, edge.Callee.Name))
 			break
 		}
@@ -1157,13 +1175,13 @@ func NewTrackerNode(tree *TrackerTree, meta *metadata.Metadata, parentID, id str
 
 	// Use configurable recursion depth limit to prevent infinite recursion
 	if currentDepth >= limits.MaxRecursionDepth {
-		fmt.Printf("Warning: MaxRecursionDepth limit (%d) reached for node %s\n", limits.MaxRecursionDepth, id)
+		tree.warn("Warning: MaxRecursionDepth limit (%d) reached for node %s\n", limits.MaxRecursionDepth, id)
 		return nil
 	}
 
 	// Limit total nodes to prevent memory explosion
 	if len(visited) > limits.MaxNodesPerTree {
-		fmt.Printf("Warning: MaxNodesPerTree limit (%d) reached, truncating tree at node %s\n", limits.MaxNodesPerTree, id)
+		tree.warn("Warning: MaxNodesPerTree limit (%d) reached, truncating tree at node %s\n", limits.MaxNodesPerTree, id)
 		node := getTrackerNode()
 		node.CallGraphEdge = parentEdge
 		node.CallArgument = callArg
@@ -1272,7 +1290,7 @@ func NewTrackerNode(tree *TrackerTree, meta *metadata.Metadata, parentID, id str
 
 		for i := range edges {
 			if childCount >= limits.MaxChildrenPerNode {
-				fmt.Printf("Warning: MaxChildrenPerNode limit (%d) reached for node %s, truncating children\n",
+				tree.warn("Warning: MaxChildrenPerNode limit (%d) reached for node %s, truncating children\n",
 					limits.MaxChildrenPerNode, id)
 				break
 			}

--- a/internal/spec/tracker_test.go
+++ b/internal/spec/tracker_test.go
@@ -14,12 +14,12 @@ import (
 // TestTrackerWarnings tests the new debug warning functionality
 func TestTrackerWarnings(t *testing.T) {
 	// Capture stdout to test warning messages
-	oldStdout := os.Stdout
+	oldStderr := os.Stderr
 	r, w, _ := os.Pipe()
-	os.Stdout = w
+	os.Stderr = w
 
 	defer func() {
-		os.Stdout = oldStdout
+		os.Stderr = oldStderr
 		_ = w.Close()
 	}()
 
@@ -46,9 +46,9 @@ func TestTrackerWarnings(t *testing.T) {
 	// Test MaxArgsPerFunction warning
 	t.Run("MaxArgsPerFunction warning", func(t *testing.T) {
 		// Reset stdout capture
-		os.Stdout = oldStdout
+		os.Stderr = oldStderr
 		r, w, _ = os.Pipe()
-		os.Stdout = w
+		os.Stderr = w
 
 		// Create a tracker with very low limits
 		limits := metadata.TrackerLimits{
@@ -102,9 +102,9 @@ func TestTrackerWarnings(t *testing.T) {
 	// Test MaxNodesPerTree warning
 	t.Run("MaxNodesPerTree warning", func(t *testing.T) {
 		// Reset stdout capture
-		os.Stdout = oldStdout
+		os.Stderr = oldStderr
 		r, w, _ = os.Pipe()
-		os.Stdout = w
+		os.Stderr = w
 
 		// Create a tracker with very low limits
 		limits := metadata.TrackerLimits{
@@ -137,9 +137,9 @@ func TestTrackerWarnings(t *testing.T) {
 	// Test MaxChildrenPerNode warning
 	t.Run("MaxChildrenPerNode warning", func(t *testing.T) {
 		// Reset stdout capture
-		os.Stdout = oldStdout
+		os.Stderr = oldStderr
 		r, w, _ = os.Pipe()
-		os.Stdout = w
+		os.Stderr = w
 
 		// Create a tracker with very low limits
 		limits := metadata.TrackerLimits{
@@ -191,12 +191,12 @@ func TestTrackerWarnings(t *testing.T) {
 // TestTrackerWithoutWarnings tests that no warnings are printed when limits are not exceeded
 func TestTrackerWithoutWarnings(t *testing.T) {
 	// Capture stdout to test that no warnings are printed
-	oldStdout := os.Stdout
+	oldStderr := os.Stderr
 	r, w, _ := os.Pipe()
-	os.Stdout = w
+	os.Stderr = w
 
 	defer func() {
-		os.Stdout = oldStdout
+		os.Stderr = oldStderr
 		_ = w.Close()
 	}()
 
@@ -279,12 +279,12 @@ func TestTrackerWithoutWarnings(t *testing.T) {
 // TestTrackerLimitsIntegration tests the integration of all limit checks
 func TestTrackerLimitsIntegration(t *testing.T) {
 	// Capture stdout to test warning messages
-	oldStdout := os.Stdout
+	oldStderr := os.Stderr
 	r, w, _ := os.Pipe()
-	os.Stdout = w
+	os.Stderr = w
 
 	defer func() {
-		os.Stdout = oldStdout
+		os.Stderr = oldStderr
 		_ = w.Close()
 	}()
 
@@ -394,7 +394,7 @@ func TestFindNodeInSubtree_CycleDetection(t *testing.T) {
 		MaxArgsPerFunction: 100,
 		MaxNestedArgsDepth: 10,
 	}
-	tree := NewTrackerTree(meta, limits)
+	tree := NewTrackerTree(meta, limits, nil)
 
 	// Create simple nodes for testing
 	node1 := &TrackerNode{
@@ -439,7 +439,7 @@ func TestFindNodeInSubtreeWithVisited_CycleDetection(t *testing.T) {
 		MaxArgsPerFunction: 100,
 		MaxNestedArgsDepth: 10,
 	}
-	tree := NewTrackerTree(meta, limits)
+	tree := NewTrackerTree(meta, limits, nil)
 
 	node1 := &TrackerNode{
 		Children: make([]*TrackerNode, 0),
@@ -489,7 +489,7 @@ func TestFindNodeInSubtree_NoCycle(t *testing.T) {
 		MaxArgsPerFunction: 100,
 		MaxNestedArgsDepth: 10,
 	}
-	tree := NewTrackerTree(meta, limits)
+	tree := NewTrackerTree(meta, limits, nil)
 
 	node1 := &TrackerNode{
 		Children: make([]*TrackerNode, 0),
@@ -523,7 +523,7 @@ func TestFindNodeInSubtree_Performance(t *testing.T) {
 		MaxArgsPerFunction: 100,
 		MaxNestedArgsDepth: 10,
 	}
-	tree := NewTrackerTree(meta, limits)
+	tree := NewTrackerTree(meta, limits, nil)
 
 	// Create a deep tree (100 levels)
 	root := &TrackerNode{
@@ -583,7 +583,7 @@ func TestProcessArguments_ArgTypeSelector_NestedSelector(t *testing.T) {
 		MaxRecursionDepth:  10,
 	}
 
-	tree := NewTrackerTree(meta, limits)
+	tree := NewTrackerTree(meta, limits, nil)
 	parentNode := &TrackerNode{
 		Children: make([]*TrackerNode, 0),
 	}
@@ -850,7 +850,7 @@ func TestProcessArguments_ArgTypeSelector_FunctionType(t *testing.T) {
 		MaxRecursionDepth:  10,
 	}
 
-	tree := NewTrackerTree(meta, limits)
+	tree := NewTrackerTree(meta, limits, nil)
 	parentNode := &TrackerNode{
 		Children: make([]*TrackerNode, 0),
 	}
@@ -1141,7 +1141,7 @@ func TestAssignmentNodeParentLinking(t *testing.T) {
 		MaxRecursionDepth:  10,
 	}
 
-	tree := NewTrackerTree(meta, limits)
+	tree := NewTrackerTree(meta, limits, nil)
 	parentNode := &TrackerNode{
 		Children: make([]*TrackerNode, 0),
 	}


### PR DESCRIPTION
First step in the code-quality cleanup tracked in \`docs/CODE_QUALITY_AUDIT.md\`. Addresses **finding #7 — Ad-hoc logging via fmt.Printf inside library code**.

## What changed

- Added \`Warnf\` (always-on) to the existing \`metadata.VerboseLogger\` interface. \`Printf/Println/Print\` remain verbose-gated; \`Warnf\` is for limit truncations and recoverable failures the consumer should see regardless of verbosity.
- Implemented \`Warnf\` on \`engine.VerboseLogger\`, writing to stderr.
- Added a \`logger\` field on \`TrackerTree\` plus a small \`warn\` helper that routes through the logger when set and falls back to stderr when nil.
- Changed \`NewTrackerTree\` to take a \`metadata.VerboseLogger\` parameter. Nil is accepted; the helper handles it.
- Replaced the four \`fmt.Printf(\"Warning: ...\")\` calls in \`tracker.go\` (MaxArgsPerFunction, MaxRecursionDepth, MaxNodesPerTree, MaxChildrenPerNode) with \`tree.warn(...)\`.
- Updated callers (\`engine\`, \`apidiag\`) to pass a logger (or nil where not needed).
- Updated \`tracker_test.go\` warning-capture tests to read from stderr instead of stdout.

## Behavioural change

Warnings now go to **stderr** instead of stdout. This is the correct destination for a warning channel — it lets consumers tee or suppress warnings independently from the spec output. CLI users who only watched stdout will now see a cleaner output stream; CI consumers that wanted warnings can capture stderr explicitly.

## Why this is the right starting point

The audit suggested this as step 1 of 9 because it has the smallest surface and unblocks downstream work — every future refactor (especially function decomposition #1) will want a logger handy, and threading it in once now means later changes don't each have to ship their own plumbing.

## Test plan
- [x] \`go test ./...\` — all green
- [x] End-to-end smoke check against \`testdata/dynamic_mount_prefix\` — output unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)