### PR TITLE
refactor: collapse three parallel regex caches into one (#4 of audit)

### DIFF
--- a/internal/spec/body_source.go
+++ b/internal/spec/body_source.go
@@ -28,12 +28,12 @@ func newBodySourceResolver(cfg *APISpecConfig, contextProvider ContextProvider) 
 		return r
 	}
 	for _, p := range cfg.Framework.RequestContext.TypeRegexes {
-		if re, err := getCachedPatternRegex(p); err == nil {
+		if re, err := cachedRegex(p); err == nil {
 			r.typeREs = append(r.typeREs, re)
 		}
 	}
 	for _, p := range cfg.Framework.RequestContext.BodyAccessors {
-		if re, err := getCachedPatternRegex(p); err == nil {
+		if re, err := cachedRegex(p); err == nil {
 			r.accessorREs = append(r.accessorREs, re)
 		}
 	}

--- a/internal/spec/coverage_improvement_test.go
+++ b/internal/spec/coverage_improvement_test.go
@@ -133,7 +133,7 @@ func TestInferMethodFromContext(t *testing.T) {
 
 func TestGetCachedRegex(t *testing.T) {
 	// Test with empty pattern
-	regex, err := getCachedRegex("")
+	regex, err := cachedRegex("")
 	if regex == nil {
 		t.Error("Expected non-nil regex for empty pattern")
 	}
@@ -142,7 +142,7 @@ func TestGetCachedRegex(t *testing.T) {
 	}
 
 	// Test with simple pattern
-	regex, err = getCachedRegex("test")
+	regex, err = cachedRegex("test")
 	if regex == nil {
 		t.Error("Expected non-nil regex for simple pattern")
 	}
@@ -151,7 +151,7 @@ func TestGetCachedRegex(t *testing.T) {
 	}
 
 	// Test with complex pattern
-	regex, err = getCachedRegex("^test[0-9]+$")
+	regex, err = cachedRegex("^test[0-9]+$")
 	if regex == nil {
 		t.Error("Expected non-nil regex for complex pattern")
 	}
@@ -160,15 +160,15 @@ func TestGetCachedRegex(t *testing.T) {
 	}
 
 	// Test with invalid regex pattern
-	_, err = getCachedRegex("[invalid")
+	_, err = cachedRegex("[invalid")
 	if err == nil {
 		t.Error("Expected error for invalid pattern")
 	}
 	// The regex might be nil for invalid patterns, which is acceptable
 
 	// Test caching - same pattern should return same regex
-	regex1, _ := getCachedRegex("cached")
-	regex2, _ := getCachedRegex("cached")
+	regex1, _ := cachedRegex("cached")
+	regex2, _ := cachedRegex("cached")
 	if regex1 != regex2 {
 		t.Error("Expected cached regex to return same instance")
 	}

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -2,45 +2,11 @@ package spec
 
 import (
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/ehabterra/apispec/internal/metadata"
 )
-
-// Regex cache for performance optimization
-var (
-	regexCache = make(map[string]*regexp.Regexp)
-	regexMutex sync.RWMutex
-)
-
-// getCachedRegex returns a cached compiled regex or compiles and caches a new one
-func getCachedRegex(pattern string) (*regexp.Regexp, error) {
-	regexMutex.RLock()
-	if re, exists := regexCache[pattern]; exists {
-		regexMutex.RUnlock()
-		return re, nil
-	}
-	regexMutex.RUnlock()
-
-	regexMutex.Lock()
-	defer regexMutex.Unlock()
-
-	// Double-check after acquiring write lock
-	if re, exists := regexCache[pattern]; exists {
-		return re, nil
-	}
-
-	re, err := regexp.Compile(pattern)
-	if err != nil {
-		return nil, err
-	}
-
-	regexCache[pattern] = re
-	return re, nil
-}
 
 const (
 	TypeSep    = "-->"
@@ -591,7 +557,7 @@ func (r *ResponsePatternMatcherImpl) MatchNode(node TrackerNodeInterface) bool {
 
 	// Check receiver type
 	if r.pattern.RecvTypeRegex != "" {
-		re, err := getCachedRegex(r.pattern.RecvTypeRegex)
+		re, err := cachedRegex(r.pattern.RecvTypeRegex)
 		if err != nil || !re.MatchString(fqRecvType) {
 			return false
 		}
@@ -896,7 +862,7 @@ func (p *ParamPatternMatcherImpl) MatchNode(node TrackerNodeInterface) bool {
 
 	// Check receiver type
 	if p.pattern.RecvTypeRegex != "" {
-		re, err := getCachedRegex(p.pattern.RecvTypeRegex)
+		re, err := cachedRegex(p.pattern.RecvTypeRegex)
 		if err != nil || !re.MatchString(fqRecvType) {
 			return false
 		}

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -6,44 +6,14 @@ import (
 	"maps"
 	"net/http"
 	"os"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 
 	"gopkg.in/yaml.v3"
 
 	"github.com/ehabterra/apispec/internal/metadata"
 )
-
-// Regex cache for performance optimization
-var (
-	mapperRegexCache = make(map[string]*regexp.Regexp)
-	mapperRegexMutex sync.RWMutex
-)
-
-// getCachedMapperRegex returns a cached compiled regex or compiles and caches a new one
-func getCachedMapperRegex(pattern string) *regexp.Regexp {
-	mapperRegexMutex.RLock()
-	if re, exists := mapperRegexCache[pattern]; exists {
-		mapperRegexMutex.RUnlock()
-		return re
-	}
-	mapperRegexMutex.RUnlock()
-
-	mapperRegexMutex.Lock()
-	defer mapperRegexMutex.Unlock()
-
-	// Double-check after acquiring write lock
-	if re, exists := mapperRegexCache[pattern]; exists {
-		return re
-	}
-
-	re := regexp.MustCompile(pattern)
-	mapperRegexCache[pattern] = re
-	return re
-}
 
 const (
 	refComponentsSchemasPrefix = "#/components/schemas/"
@@ -214,7 +184,7 @@ func ensureAllPathParams(openAPIPath string, params []Parameter) []Parameter {
 		}
 	}
 	// Find all {param} in the path
-	re := getCachedMapperRegex(`\{([a-zA-Z_][a-zA-Z0-9_]*)\}`)
+	re := mustCachedRegex(`\{([a-zA-Z_][a-zA-Z0-9_]*)\}`)
 	matches := re.FindAllStringSubmatch(openAPIPath, -1)
 	for _, match := range matches {
 		name := match[1]
@@ -405,7 +375,7 @@ func setOperationOnPathItem(item *PathItem, method string, op *Operation) {
 func convertPathToOpenAPI(path string) string {
 	// Regular expression to match :param format
 	// This matches a colon followed by one or more word characters (letters, digits, underscore)
-	re := getCachedMapperRegex(`:([a-zA-Z_][a-zA-Z0-9_]*)`)
+	re := mustCachedRegex(`:([a-zA-Z_][a-zA-Z0-9_]*)`)
 
 	// Replace all matches with {param} format
 	result := re.ReplaceAllString(path, "{$1}")
@@ -739,7 +709,7 @@ func generateStructSchema(usedTypes map[string]*Schema, key string, typ *metadat
 			isPrimitive := metadata.IsPrimitiveType(fieldType)
 
 			if !isPrimitive && !strings.Contains(fieldType, ".") {
-				re := getCachedMapperRegex(`((\[\])?\*?)(.+)$`)
+				re := mustCachedRegex(`((\[\])?\*?)(.+)$`)
 				matches := re.FindStringSubmatch(fieldType)
 				if len(matches) >= 4 {
 					fieldType = matches[1] + pkgName + "." + matches[3]
@@ -992,7 +962,7 @@ func extractValidationConstraints(tag string) *ValidationConstraints {
 			// - Simple rules: required, email, url, etc.
 			// - Rules with values: min=5, max=10, len=8
 			// - Rules with complex values: regexp=^[a-z]{2,3}$, oneof=val1 val2 val3
-			rules := getCachedMapperRegex(`([a-zA-Z_][a-zA-Z0-9_]*(?:=(?:[^,{}]|{[^}]*})*)?)`).FindAllStringSubmatch(validateTag, -1)
+			rules := mustCachedRegex(`([a-zA-Z_][a-zA-Z0-9_]*(?:=(?:[^,{}]|{[^}]*})*)?)`).FindAllStringSubmatch(validateTag, -1)
 			for _, ruleSet := range rules {
 				rule := strings.TrimSpace(ruleSet[1])
 				if rule == "required" {

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -2,44 +2,10 @@ package spec
 
 import (
 	"net/http"
-	"regexp"
 	"strings"
-	"sync"
 
 	"github.com/ehabterra/apispec/internal/metadata"
 )
-
-// Regex cache for pattern matchers
-var (
-	patternRegexCache = make(map[string]*regexp.Regexp)
-	patternRegexMutex sync.RWMutex
-)
-
-// getCachedPatternRegex returns a cached compiled regex or compiles and caches a new one
-func getCachedPatternRegex(pattern string) (*regexp.Regexp, error) {
-	patternRegexMutex.RLock()
-	if re, exists := patternRegexCache[pattern]; exists {
-		patternRegexMutex.RUnlock()
-		return re, nil
-	}
-	patternRegexMutex.RUnlock()
-
-	patternRegexMutex.Lock()
-	defer patternRegexMutex.Unlock()
-
-	// Double-check after acquiring write lock
-	if re, exists := patternRegexCache[pattern]; exists {
-		return re, nil
-	}
-
-	re, err := regexp.Compile(pattern)
-	if err != nil {
-		return nil, err
-	}
-
-	patternRegexCache[pattern] = re
-	return re, nil
-}
 
 // BasePatternMatcher provides common functionality for all pattern matchers
 type BasePatternMatcher struct {
@@ -138,7 +104,7 @@ func (r *RoutePatternMatcherImpl) MatchNode(node TrackerNodeInterface) bool {
 
 	// Check receiver type
 	if r.pattern.RecvTypeRegex != "" {
-		re, err := getCachedPatternRegex(r.pattern.RecvTypeRegex)
+		re, err := cachedRegex(r.pattern.RecvTypeRegex)
 		if err != nil || !re.MatchString(fqRecvType) {
 			return false
 		}
@@ -435,7 +401,7 @@ func (m *MountPatternMatcherImpl) MatchNode(node TrackerNodeInterface) bool {
 
 	// Check receiver type
 	if m.pattern.RecvTypeRegex != "" {
-		re, err := getCachedPatternRegex(m.pattern.RecvTypeRegex)
+		re, err := cachedRegex(m.pattern.RecvTypeRegex)
 		if err != nil || !re.MatchString(fqRecvType) {
 			return false
 		}
@@ -547,7 +513,7 @@ func (r *RequestPatternMatcherImpl) MatchNode(node TrackerNodeInterface) bool {
 
 	// Check receiver type
 	if r.pattern.RecvTypeRegex != "" {
-		re, err := getCachedPatternRegex(r.pattern.RecvTypeRegex)
+		re, err := cachedRegex(r.pattern.RecvTypeRegex)
 		if err != nil || !re.MatchString(fqRecvType) {
 			return false
 		}
@@ -656,7 +622,7 @@ func (b *BasePatternMatcher) matchPattern(pattern, value string) bool {
 	if pattern == "" {
 		return false
 	}
-	re, err := getCachedPatternRegex(pattern)
+	re, err := cachedRegex(pattern)
 	if err != nil {
 		return false
 	}

--- a/internal/spec/regex_cache.go
+++ b/internal/spec/regex_cache.go
@@ -1,0 +1,57 @@
+package spec
+
+import (
+	"regexp"
+	"sync"
+)
+
+// Shared compile cache for regexes used across pattern matching, mount
+// extraction, parameter parsing, and validator-tag scanning. Compiling
+// the same pattern repeatedly was a measurable cost when this project
+// first ran on large codebases (pattern matchers iterate over every
+// call-graph edge), and the two earlier copies of this cache —
+// previously in pattern_matchers.go and mapper.go — drifted in subtle
+// ways. Keeping one cache here avoids that drift and lets all callers
+// benefit from one shared compile.
+var (
+	regexCache   = make(map[string]*regexp.Regexp)
+	regexCacheMu sync.RWMutex
+)
+
+// cachedRegex returns a cached compiled regex, compiling on miss.
+// Concurrent callers coexist via a double-checked write lock.
+func cachedRegex(pattern string) (*regexp.Regexp, error) {
+	regexCacheMu.RLock()
+	if re, ok := regexCache[pattern]; ok {
+		regexCacheMu.RUnlock()
+		return re, nil
+	}
+	regexCacheMu.RUnlock()
+
+	regexCacheMu.Lock()
+	defer regexCacheMu.Unlock()
+
+	// Double-check after acquiring the write lock — another goroutine
+	// may have compiled it between our RUnlock and Lock.
+	if re, ok := regexCache[pattern]; ok {
+		return re, nil
+	}
+
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, err
+	}
+	regexCache[pattern] = re
+	return re, nil
+}
+
+// mustCachedRegex is the panic-on-error variant for compile-time-constant
+// regex literals — the developer has already validated the pattern, so a
+// compile failure is a contract violation, not a runtime condition.
+func mustCachedRegex(pattern string) *regexp.Regexp {
+	re, err := cachedRegex(pattern)
+	if err != nil {
+		panic("spec: invalid regex literal: " + err.Error())
+	}
+	return re
+}


### PR DESCRIPTION
Second step in the code-quality cleanup tracked in \`docs/CODE_QUALITY_AUDIT.md\`. Addresses **finding #4 — Two parallel regex caches**.

## What I actually found

The audit called out two duplicates; on inspection there were **three**:

| File | Func | Variant |
|---|---|---|
| \`internal/spec/extractor.go\` | \`getCachedRegex\` | error-returning |
| \`internal/spec/pattern_matchers.go\` | \`getCachedPatternRegex\` | error-returning |
| \`internal/spec/mapper.go\` | \`getCachedMapperRegex\` | \`MustCompile\` |

Each had its own map and its own mutex. They had already drifted (the third used \`MustCompile\` instead of returning an error, two used different variable naming conventions).

## What changed

- New \`internal/spec/regex_cache.go\` holds the one shared cache plus two thin helpers:
  - \`cachedRegex(pattern) (*regexp.Regexp, error)\` — error-returning
  - \`mustCachedRegex(pattern) *regexp.Regexp\` — panic-on-invalid-literal, for compile-time-constant patterns
- All three old impls deleted.
- Callers renamed across \`extractor.go\`, \`pattern_matchers.go\`, \`mapper.go\`, \`body_source.go\`, and \`coverage_improvement_test.go\`.

## Net effect

- **-41 LOC** (75 added in new file, 116 removed across the old impls and callers).
- One source of truth for compile reuse.
- Callers don't have to remember which file's cache to use.

## Test plan
- [x] \`go test ./...\` — all green, including the existing \`TestGetCachedRegex\` (now exercising the consolidated impl).

🤖 Generated with [Claude Code](https://claude.com/claude-code)