### PR TITLE
refactor: extract framework defaults into per-framework files + helpers (#3 + #2 of audit)

### DIFF
--- a/internal/spec/config.go
+++ b/internal/spec/config.go
@@ -641,4 +641,3 @@ func stdDefaults(responseStatus int) Defaults {
 		ResponseStatus:      responseStatus,
 	}
 }
-

--- a/internal/spec/config.go
+++ b/internal/spec/config.go
@@ -526,978 +526,119 @@ var (
 	}
 )
 
-func DefaultChiConfig() *APISpecConfig {
-	return &APISpecConfig{
-		Framework: FrameworkConfig{
-			RoutePatterns: []RoutePattern{
-				{
-					CallRegex:       `(?i)(GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD)$`,
-					MethodFromCall:  true,
-					PathFromArg:     true,
-					HandlerFromArg:  true,
-					PathArgIndex:    0,
-					HandlerArgIndex: 1,
-					RecvTypeRegex:   "^github.com/go-chi/chi(/v\\d)?\\.\\*?(Router|Mux)$",
-				},
-			},
-			RequestContext: netHTTPRequestContext,
-			RequestBodyPatterns: []RequestBodyPattern{
-				{
-					CallRegex:            `^DecodeJSON$`,
-					TypeArgIndex:         1,
-					TypeFromArg:          true,
-					Deref:                true,
-					RecvTypeRegex:        "^github\\.com/go-chi/render$",
-					RequireRequestSource: true,
-					BodySourceArgIndex:   0,
-				},
-				{
-					CallRegex:            `^Decode$`,
-					TypeArgIndex:         0,
-					TypeFromArg:          true,
-					Deref:                true,
-					RecvTypeRegex:        ".*json(iter)?\\.\\*Decoder",
-					RequireRequestSource: true,
-					BodyFromReceiver:     true,
-				},
-				{
-					CallRegex:            `^Unmarshal$`,
-					TypeArgIndex:         1,
-					TypeFromArg:          true,
-					Deref:                true,
-					RecvTypeRegex:        "json",
-					RequireRequestSource: true,
-					BodySourceArgIndex:   0,
-				},
-			},
-			ResponsePatterns: []ResponsePattern{
-				{
-					CallRegex:      `^WriteHeader$`,
-					StatusArgIndex: 0,
-					StatusFromArg:  true,
-					TypeArgIndex:   -1,
-					RecvTypeRegex:  `^net/http\.ResponseWriter$`,
-				},
-				{
-					CallRegex:     `^Write$`,
-					TypeArgIndex:  0,
-					TypeFromArg:   true,
-					Deref:         true,
-					RecvTypeRegex: `^net/http\.ResponseWriter$`,
-				},
-				{
-					CallRegex:          `^Error$`,
-					StatusArgIndex:     2,
-					StatusFromArg:      true,
-					TypeFromArg:        true,
-					TypeArgIndex:       1,
-					RecvTypeRegex:      `^net/http$`,
-					DefaultContentType: "text/plain; charset=utf-8",
-				},
-				{
-					CallRegex:      `^NotFound$`,
-					StatusArgIndex: -1, // Always 404
-					StatusFromArg:  false,
-					TypeArgIndex:   -1,
-					RecvTypeRegex:  `^net/http$`,
-					DefaultStatus:  http.StatusNotFound,
-				},
-				{
-					CallRegex:      `^Redirect$`,
-					StatusArgIndex: 3,
-					StatusFromArg:  true,
-					TypeArgIndex:   -1,
-					RecvTypeRegex:  `^net/http$`,
-				},
-				{
-					CallRegex:     `^JSON$`,
-					TypeArgIndex:  2,
-					TypeFromArg:   true,
-					StatusFromArg: false,
-					Deref:         true,
-					RecvTypeRegex: "^github\\.com/go-chi/render$",
-				},
-				{
-					CallRegex:      `^Status$`,
-					StatusArgIndex: 1,
-					StatusFromArg:  true,
-					RecvTypeRegex:  "^github\\.com/go-chi/render$",
-				},
-				{
-					CallRegex:    `^Marshal$`,
-					TypeArgIndex: 0,
-					TypeFromArg:  true,
-					Deref:        true,
-				},
-				{
-					CallRegex:     `^Encode$`,
-					TypeArgIndex:  0,
-					TypeFromArg:   true,
-					Deref:         true,
-					RecvTypeRegex: ".*json(iter)?\\.\\*?Encoder",
-				},
-			},
-			ParamPatterns: []ParamPattern{
-				{
-					CallRegex:     "^URLParam$",
-					ParamIn:       "path",
-					ParamArgIndex: 1,
-					RecvTypeRegex: "^github\\.com/go-chi/chi(/v\\d)?$",
-				},
-				{
-					CallRegex:     "^URLParam$",
-					ParamIn:       "path",
-					ParamArgIndex: 0,
-					RecvTypeRegex: "^github\\.com/go-chi/chi(/v\\d)?\\.\\*?Context$",
-				},
-				{
-					CallRegex:     "^URLParamFromCtx$",
-					ParamIn:       "path",
-					ParamArgIndex: 1,
-					RecvTypeRegex: "^github\\.com/go-chi/chi(/v\\d)?$",
-				},
-				{
-					CallRegex:     "^FormValue$",
-					ParamIn:       "form",
-					ParamArgIndex: 0,
-				},
-				{
-					CallRegex:     "^Get$",
-					ParamIn:       "query",
-					ParamArgIndex: 0,
-					RecvType:      "net/url.Values",
-				},
-				{
-					CallRegex:     "^PathValue$",
-					ParamIn:       "path",
-					ParamArgIndex: 0,
-					RecvType:      "net/http.*Request",
-				},
-			},
-			MountPatterns: []MountPattern{
-				{
-					CallRegex:      `^Mount$`,
-					PathFromArg:    true,
-					RouterFromArg:  true,
-					PathArgIndex:   0,
-					RouterArgIndex: 1,
-					IsMount:        true,
-				},
-				{
-					CallRegex:      `^Route$`,
-					PathFromArg:    true,
-					RouterFromArg:  true,
-					PathArgIndex:   0,
-					RouterArgIndex: 1,
-					IsMount:        true,
-				},
-			},
+// Shared pattern helpers used by the framework defaults. These collapse
+// duplication that previously sat in every Default*Config function — for
+// example the five net/http ResponseWriter patterns were copied verbatim
+// across all six configs, drifting slightly over time (audit finding #3 /
+// #11). Each helper returns a fresh value so callers can append to it
+// without worrying about shared mutable state.
+
+// netHTTPResponsePatterns returns the standard ResponseWriter and net/http
+// helper response patterns. Identical across every framework default.
+func netHTTPResponsePatterns() []ResponsePattern {
+	return []ResponsePattern{
+		{
+			CallRegex:      `^WriteHeader$`,
+			StatusArgIndex: 0,
+			StatusFromArg:  true,
+			TypeArgIndex:   -1,
+			RecvTypeRegex:  `^net/http\.ResponseWriter$`,
 		},
-		Defaults: Defaults{
-			RequestContentType:  defaultRequestContentType,
-			ResponseContentType: defaultResponseContentType,
-			ResponseStatus:      defaultResponseStatus,
+		{
+			CallRegex:     `^Write$`,
+			TypeArgIndex:  0,
+			TypeFromArg:   true,
+			Deref:         true,
+			RecvTypeRegex: `^net/http\.ResponseWriter$`,
+		},
+		{
+			CallRegex:          `^Error$`,
+			StatusArgIndex:     2,
+			StatusFromArg:      true,
+			TypeFromArg:        true,
+			TypeArgIndex:       1,
+			RecvTypeRegex:      `^net/http$`,
+			DefaultContentType: "text/plain; charset=utf-8",
+		},
+		{
+			CallRegex:      `^NotFound$`,
+			StatusArgIndex: -1, // Always 404
+			StatusFromArg:  false,
+			TypeArgIndex:   -1,
+			RecvTypeRegex:  `^net/http$`,
+			DefaultStatus:  http.StatusNotFound,
+		},
+		{
+			CallRegex:      `^Redirect$`,
+			StatusArgIndex: 3,
+			StatusFromArg:  true,
+			TypeArgIndex:   -1,
+			RecvTypeRegex:  `^net/http$`,
 		},
 	}
 }
 
-// DefaultEchoConfig returns a default configuration for Echo framework
-func DefaultEchoConfig() *APISpecConfig {
-	return &APISpecConfig{
-		Framework: FrameworkConfig{
-			RoutePatterns: []RoutePattern{
-				{
-					CallRegex:       `^(?i)(GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD)$`,
-					MethodFromCall:  true,
-					PathFromArg:     true,
-					HandlerFromArg:  true,
-					PathArgIndex:    0,
-					HandlerArgIndex: 1,
-					RecvTypeRegex:   "^github\\.com/labstack/echo(/v\\d)?\\.\\*(Echo|Group)$",
-				},
-			},
-			RequestContext: echoRequestContext,
-			RequestBodyPatterns: []RequestBodyPattern{
-				{
-					CallRegex:     `^(?i)(Bind)$`,
-					TypeArgIndex:  0,
-					TypeFromArg:   true,
-					Deref:         true,
-					RecvTypeRegex: "github\\.com/labstack/echo/v\\d\\.Context",
-				},
-				{
-					CallRegex:            `^Decode$`,
-					TypeArgIndex:         0,
-					TypeFromArg:          true,
-					Deref:                true,
-					RecvTypeRegex:        ".*json(iter)?\\.\\*Decoder",
-					RequireRequestSource: true,
-					BodyFromReceiver:     true,
-				},
-				{
-					CallRegex:            `^Unmarshal$`,
-					TypeArgIndex:         1,
-					TypeFromArg:          true,
-					Deref:                true,
-					RecvTypeRegex:        "json",
-					RequireRequestSource: true,
-					BodySourceArgIndex:   0,
-				},
-			},
-			ResponsePatterns: []ResponsePattern{
-				{
-					CallRegex:      `^WriteHeader$`,
-					StatusArgIndex: 0,
-					StatusFromArg:  true,
-					TypeArgIndex:   -1,
-					RecvTypeRegex:  `^net/http\.ResponseWriter$`,
-				},
-				{
-					CallRegex:     `^Write$`,
-					TypeArgIndex:  0,
-					TypeFromArg:   true,
-					Deref:         true,
-					RecvTypeRegex: `^net/http\.ResponseWriter$`,
-				},
-				{
-					CallRegex:          `^Error$`,
-					StatusArgIndex:     2,
-					StatusFromArg:      true,
-					TypeFromArg:        true,
-					TypeArgIndex:       1,
-					RecvTypeRegex:      `^net/http$`,
-					DefaultContentType: "text/plain; charset=utf-8",
-				},
-				{
-					CallRegex:      `^NotFound$`,
-					StatusArgIndex: -1, // Always 404
-					StatusFromArg:  false,
-					TypeArgIndex:   -1,
-					RecvTypeRegex:  `^net/http$`,
-					DefaultStatus:  http.StatusNotFound,
-				},
-				{
-					CallRegex:      `^Redirect$`,
-					StatusArgIndex: 3,
-					StatusFromArg:  true,
-					TypeArgIndex:   -1,
-					RecvTypeRegex:  `^net/http$`,
-				},
-				{
-					CallRegex:      `^(?i)(JSON|String|XML|YAML|ProtoBuf|Data|File|Redirect)$`,
-					StatusArgIndex: 0,
-					TypeArgIndex:   1,
-					TypeFromArg:    true,
-					StatusFromArg:  true,
-					Deref:          true,
-					RecvTypeRegex:  "github\\.com/labstack/echo/v\\d\\.Context",
-				},
-				{
-					CallRegex:      `^(?i)(NoContent)$`,
-					StatusArgIndex: 0,
-					StatusFromArg:  true,
-					TypeArgIndex:   -1,
-					RecvTypeRegex:  "github\\.com/labstack/echo/v\\d\\.Context",
-				},
-				{
-					CallRegex:    `^Marshal$`,
-					TypeArgIndex: 0,
-					TypeFromArg:  true,
-					Deref:        true,
-				},
-				{
-					CallRegex:     `^Encode$`,
-					TypeArgIndex:  0,
-					TypeFromArg:   true,
-					Deref:         true,
-					RecvTypeRegex: ".*json(iter)?\\.\\*?Encoder",
-				},
-			},
-			ParamPatterns: []ParamPattern{
-				{
-					CallRegex:     "^Param$",
-					ParamIn:       "path",
-					ParamArgIndex: 0,
-				},
-				{
-					CallRegex:     "^QueryParam$",
-					ParamIn:       "query",
-					ParamArgIndex: 0,
-					RecvTypeRegex: "github\\.com/labstack/echo/v\\d\\.Context",
-				},
-				{
-					CallRegex:     "^FormValue$",
-					ParamIn:       "form",
-					ParamArgIndex: 0,
-				},
-				{
-					CallRegex:     "^Cookie$",
-					ParamIn:       "cookie",
-					ParamArgIndex: 0,
-				},
-			},
-			MountPatterns: []MountPattern{
-				{
-					CallRegex:      `^Group$`,
-					PathFromArg:    true,
-					RouterFromArg:  true,
-					PathArgIndex:   0,
-					RouterArgIndex: 1,
-					IsMount:        true,
-					RecvTypeRegex:  "^github\\.com/labstack/echo(/v\\d)?\\.\\*(Echo|Group)$",
-				},
-			},
-		},
-		Defaults: Defaults{
-			RequestContentType:  defaultRequestContentType,
-			ResponseContentType: defaultResponseContentType,
-			ResponseStatus:      http.StatusOK,
-		},
+// jsonMarshalPattern returns the encoding/json.Marshal-style response
+// pattern. Identical across every framework default.
+func jsonMarshalPattern() ResponsePattern {
+	return ResponsePattern{
+		CallRegex:    `^Marshal$`,
+		TypeArgIndex: 0,
+		TypeFromArg:  true,
+		Deref:        true,
 	}
 }
 
-// DefaultFiberConfig returns a default configuration for Fiber framework
-func DefaultFiberConfig() *APISpecConfig {
-	return &APISpecConfig{
-		Framework: FrameworkConfig{
-			RoutePatterns: []RoutePattern{
-				{
-					CallRegex:       `^(?i)(GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD)$`,
-					MethodFromCall:  true,
-					PathFromArg:     true,
-					HandlerFromArg:  true,
-					PathArgIndex:    0,
-					HandlerArgIndex: 1,
-					RecvTypeRegex:   `^github\.com/gofiber/fiber(/v\d)?\.\*?(App|Router|Group)$`,
-				},
-			},
-			RequestContext: fiberRequestContext,
-			RequestBodyPatterns: []RequestBodyPattern{
-				{
-					CallRegex:     `^BodyParser$`,
-					TypeArgIndex:  0,
-					TypeFromArg:   true,
-					Deref:         true,
-					RecvTypeRegex: `^github\.com/gofiber/fiber(/v\d)?\.\*?Ctx$`,
-				},
-				{
-					CallRegex:            `^Decode$`,
-					TypeArgIndex:         0,
-					TypeFromArg:          true,
-					Deref:                true,
-					RecvTypeRegex:        ".*json(iter)?\\.\\*?Decoder",
-					RequireRequestSource: true,
-					BodyFromReceiver:     true,
-				},
-				{
-					CallRegex:            `^Unmarshal$`,
-					TypeArgIndex:         1,
-					TypeFromArg:          true,
-					Deref:                true,
-					RecvTypeRegex:        "json",
-					RequireRequestSource: true,
-					BodySourceArgIndex:   0,
-				},
-			},
-			ResponsePatterns: []ResponsePattern{
-				{
-					CallRegex:      `^WriteHeader$`,
-					StatusArgIndex: 0,
-					StatusFromArg:  true,
-					TypeArgIndex:   -1,
-					RecvTypeRegex:  `^net/http\.ResponseWriter$`,
-				},
-				{
-					CallRegex:     `^Write$`,
-					TypeArgIndex:  0,
-					TypeFromArg:   true,
-					Deref:         true,
-					RecvTypeRegex: `^net/http\.ResponseWriter$`,
-				},
-				{
-					CallRegex:          `^Error$`,
-					StatusArgIndex:     2,
-					StatusFromArg:      true,
-					TypeFromArg:        true,
-					TypeArgIndex:       1,
-					RecvTypeRegex:      `^net/http$`,
-					DefaultContentType: "text/plain; charset=utf-8",
-				},
-				{
-					CallRegex:      `^NotFound$`,
-					StatusArgIndex: -1, // Always 404
-					StatusFromArg:  false,
-					TypeArgIndex:   -1,
-					RecvTypeRegex:  `^net/http$`,
-					DefaultStatus:  http.StatusNotFound,
-				},
-				{
-					CallRegex:      `^Redirect$`,
-					StatusArgIndex: 3,
-					StatusFromArg:  true,
-					TypeArgIndex:   -1,
-					RecvTypeRegex:  `^net/http$`,
-				},
-				{
-					CallRegex:      `^JSON$`,
-					StatusArgIndex: -1, // Fiber's c.JSON does not take status, only data
-					TypeArgIndex:   0,
-					TypeFromArg:    true,
-					Deref:          true,
-					RecvTypeRegex:  `^github\.com/gofiber/fiber(/v\d)?\.\*Ctx$`,
-				},
-				{
-					CallRegex:      `^Status$`,
-					StatusArgIndex: 0,
-					StatusFromArg:  true,
-					TypeArgIndex:   -1,
-					RecvTypeRegex:  `^github\.com/gofiber/fiber(/v\d)?\.\*Ctx$`,
-				},
-				{
-					CallRegex:      `^SendString$`,
-					StatusArgIndex: -1,
-					TypeArgIndex:   0,
-					TypeFromArg:    true,
-					RecvTypeRegex:  `^github\.com/gofiber/fiber(/v\d)?\.\*Ctx$`,
-				},
-				{
-					CallRegex:      `^SendStatus$`,
-					StatusArgIndex: 0,
-					TypeArgIndex:   -1,
-					RecvTypeRegex:  `^github\.com/gofiber/fiber(/v\d)?\.\*Ctx$`,
-				},
-				{
-					CallRegex:    `^Marshal$`,
-					TypeArgIndex: 0,
-					TypeFromArg:  true,
-					Deref:        true,
-				},
-				{
-					CallRegex:     `^Encode$`,
-					TypeArgIndex:  0,
-					TypeFromArg:   true,
-					Deref:         true,
-					RecvTypeRegex: ".*json(iter)?\\.\\*?Encoder",
-				},
-			},
-			ParamPatterns: []ParamPattern{
-				{
-					CallRegex:     "^Params$",
-					ParamIn:       "path",
-					ParamArgIndex: 0,
-					RecvTypeRegex: `^github\.com/gofiber/fiber(/v\d)?\.\*Ctx$`,
-				},
-				{
-					CallRegex:     "^Query$",
-					ParamIn:       "query",
-					ParamArgIndex: 0,
-					RecvTypeRegex: `^github\.com/gofiber/fiber(/v\d)?\.\*Ctx$`,
-				},
-				{
-					CallRegex:     "^FormValue$",
-					ParamIn:       "form",
-					ParamArgIndex: 0,
-					RecvTypeRegex: `^github\.com/gofiber/fiber(/v\d)?\.\*Ctx$`,
-				},
-				{
-					CallRegex:     "^Cookies$",
-					ParamIn:       "cookie",
-					ParamArgIndex: 0,
-					RecvTypeRegex: `^github\.com/gofiber/fiber(/v\d)?\.\*Ctx$`,
-				},
-			},
-			MountPatterns: []MountPattern{
-				{
-					CallRegex:      `^Mount$`,
-					PathFromArg:    true,
-					RouterFromArg:  true,
-					PathArgIndex:   0,
-					RouterArgIndex: 1,
-					IsMount:        true,
-				},
-				{
-					CallRegex:      `^Group$`,
-					PathFromArg:    true,
-					RouterFromArg:  true,
-					PathArgIndex:   0,
-					RouterArgIndex: 1,
-					IsMount:        true,
-					RecvTypeRegex:  `^github\.com/gofiber/fiber(/v\d)?\.\*?(App|Router|Group)$`,
-				},
-				{
-					CallRegex:     `^Use$`,
-					PathFromArg:   false,
-					RouterFromArg: false,
-					IsMount:       false,
-					RecvTypeRegex: `^github\.com/gofiber/fiber(/v\d)?\.\*?(App|Router|Group)$`,
-				},
-			},
-		},
-		Defaults: Defaults{
-			RequestContentType:  defaultRequestContentType,
-			ResponseContentType: defaultResponseContentType,
-			ResponseStatus:      http.StatusOK,
-		},
-		ExternalTypes: []ExternalType{
-			{
-				Name: "github.com/gofiber/fiber.Map",
-				OpenAPIType: &Schema{
-					Type: "object",
-				},
-			},
-		},
+// jsonEncodePattern returns the json.Encoder.Encode response pattern.
+// recvTypeRegex varies between frameworks: pass "" to match any receiver,
+// or `.*json(iter)?\.\*?Encoder` to restrict to JSON encoders specifically.
+func jsonEncodePattern(recvTypeRegex string) ResponsePattern {
+	return ResponsePattern{
+		CallRegex:     `^Encode$`,
+		TypeArgIndex:  0,
+		TypeFromArg:   true,
+		Deref:         true,
+		RecvTypeRegex: recvTypeRegex,
 	}
 }
 
-// DefaultGinConfig returns a default configuration for Gin framework
-func DefaultGinConfig() *APISpecConfig {
-	return &APISpecConfig{
-		Framework: FrameworkConfig{
-			RoutePatterns: []RoutePattern{
-				{
-					CallRegex:       `^(?i)(GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD)$`,
-					MethodFromCall:  true,
-					PathFromArg:     true,
-					HandlerFromArg:  true,
-					PathArgIndex:    0,
-					HandlerArgIndex: 1,
-					RecvTypeRegex:   "^github\\.com/gin-gonic/gin\\.\\*(Engine|RouterGroup)$",
-				},
-			},
-			RequestContext: ginRequestContext,
-			RequestBodyPatterns: []RequestBodyPattern{
-				{
-					CallRegex:    `^(?i)(BindJSON|ShouldBindJSON|BindXML|BindYAML|BindForm|ShouldBind)$`,
-					TypeArgIndex: 0,
-					TypeFromArg:  true,
-					Deref:        true,
-				},
-				{
-					CallRegex:            `^Decode$`,
-					TypeArgIndex:         0,
-					TypeFromArg:          true,
-					Deref:                true,
-					RequireRequestSource: true,
-					BodyFromReceiver:     true,
-				},
-				{
-					CallRegex:            `^Unmarshal$`,
-					TypeArgIndex:         1,
-					TypeFromArg:          true,
-					Deref:                true,
-					RequireRequestSource: true,
-					BodySourceArgIndex:   0,
-				},
-			},
-			ResponsePatterns: []ResponsePattern{
-				{
-					CallRegex:      `^WriteHeader$`,
-					StatusArgIndex: 0,
-					StatusFromArg:  true,
-					TypeArgIndex:   -1,
-					RecvTypeRegex:  `^net/http\.ResponseWriter$`,
-				},
-				{
-					CallRegex:     `^Write$`,
-					TypeArgIndex:  0,
-					TypeFromArg:   true,
-					Deref:         true,
-					RecvTypeRegex: `^net/http\.ResponseWriter$`,
-				},
-				{
-					CallRegex:          `^Error$`,
-					StatusArgIndex:     2,
-					StatusFromArg:      true,
-					TypeFromArg:        true,
-					TypeArgIndex:       1,
-					RecvTypeRegex:      `^net/http$`,
-					DefaultContentType: "text/plain; charset=utf-8",
-				},
-				{
-					CallRegex:      `^NotFound$`,
-					StatusArgIndex: -1, // Always 404
-					StatusFromArg:  false,
-					TypeArgIndex:   -1,
-					RecvTypeRegex:  `^net/http$`,
-					DefaultStatus:  http.StatusNotFound,
-				},
-				{
-					CallRegex:      `^Redirect$`,
-					StatusArgIndex: 3,
-					StatusFromArg:  true,
-					TypeArgIndex:   -1,
-					RecvTypeRegex:  `^net/http$`,
-				},
-				{
-					CallRegex:      `^(?i)(JSON|String|XML|YAML|ProtoBuf|Data|File|Redirect)$`,
-					StatusArgIndex: 0,
-					TypeArgIndex:   1,
-					TypeFromArg:    true,
-					StatusFromArg:  true,
-				},
-				{
-					CallRegex:    `^Marshal$`,
-					TypeArgIndex: 0,
-					TypeFromArg:  true,
-					Deref:        true,
-				},
-				{
-					CallRegex:    `^Encode$`,
-					TypeArgIndex: 0,
-					TypeFromArg:  true,
-					Deref:        true,
-				},
-			},
-			ParamPatterns: []ParamPattern{
-				{
-					CallRegex:     "^Param$",
-					ParamIn:       "path",
-					ParamArgIndex: 0,
-				},
-				{
-					CallRegex:     "^Query$",
-					ParamIn:       "query",
-					ParamArgIndex: 0,
-				},
-				{
-					CallRegex:     "^DefaultQuery$",
-					ParamIn:       "query",
-					ParamArgIndex: 0,
-				},
-				{
-					CallRegex:     "^GetHeader$",
-					ParamIn:       "header",
-					ParamArgIndex: 0,
-				},
-			},
-			MountPatterns: []MountPattern{
-				{
-					CallRegex:      `^Group$`,
-					PathFromArg:    true,
-					RouterFromArg:  true,
-					PathArgIndex:   0,
-					RouterArgIndex: 1,
-					IsMount:        true,
-					RecvTypeRegex:  "^github\\.com/gin-gonic/gin\\.\\*(Engine|RouterGroup)$",
-				},
-			},
-		},
-		Defaults: Defaults{
-			RequestContentType:  defaultRequestContentType,
-			ResponseContentType: defaultResponseContentType,
-			ResponseStatus:      http.StatusOK,
-		},
-		ExternalTypes: []ExternalType{
-			{
-				Name: "github.com/gin-gonic/gin.H",
-				OpenAPIType: &Schema{
-					Type: "object",
-				},
-			},
-		},
+// jsonDecodeRequestPattern returns the json.Decoder.Decode request-body
+// pattern. recvTypeRegex varies between frameworks (some restrict to
+// *Decoder, some accept any receiver).
+func jsonDecodeRequestPattern(recvTypeRegex string) RequestBodyPattern {
+	return RequestBodyPattern{
+		CallRegex:            `^Decode$`,
+		TypeArgIndex:         0,
+		TypeFromArg:          true,
+		Deref:                true,
+		RecvTypeRegex:        recvTypeRegex,
+		RequireRequestSource: true,
+		BodyFromReceiver:     true,
 	}
 }
 
-// DefaultMethodExtractionConfig returns a default method extraction configuration
-func DefaultMethodExtractionConfig() *MethodExtractionConfig {
-	return &MethodExtractionConfig{
-		MethodMappings: []MethodMapping{
-			{Patterns: []string{"get", "list", "show", "find", "fetch", "retrieve"}, Method: "GET", Priority: 10},
-			{Patterns: []string{"post", "create", "add", "new", "insert"}, Method: "POST", Priority: 10},
-			{Patterns: []string{"put", "update", "edit", "modify", "replace"}, Method: "PUT", Priority: 10},
-			{Patterns: []string{"delete", "remove", "destroy"}, Method: "DELETE", Priority: 10},
-			{Patterns: []string{"patch", "partial"}, Method: "PATCH", Priority: 10},
-			{Patterns: []string{"options"}, Method: "OPTIONS", Priority: 10},
-			{Patterns: []string{"head"}, Method: "HEAD", Priority: 10},
-		},
-		UsePrefix:        true,
-		UseContains:      true,
-		CaseSensitive:    false,
-		DefaultMethod:    "GET",
-		InferFromContext: true,
+// jsonUnmarshalRequestPattern returns the encoding/json.Unmarshal
+// request-body pattern. recvTypeRegex varies similarly to Decode.
+func jsonUnmarshalRequestPattern(recvTypeRegex string) RequestBodyPattern {
+	return RequestBodyPattern{
+		CallRegex:            `^Unmarshal$`,
+		TypeArgIndex:         1,
+		TypeFromArg:          true,
+		Deref:                true,
+		RecvTypeRegex:        recvTypeRegex,
+		RequireRequestSource: true,
+		BodySourceArgIndex:   0,
 	}
 }
 
-// DefaultMuxConfig returns a default configuration for Gorilla Mux framework
-func DefaultMuxConfig() *APISpecConfig {
-	return &APISpecConfig{
-		Framework: FrameworkConfig{
-			RoutePatterns: []RoutePattern{
-				{
-					CallRegex:        `^HandleFunc$`,
-					PathFromArg:      true,
-					HandlerFromArg:   true,
-					PathArgIndex:     0,
-					HandlerArgIndex:  1,
-					RecvTypeRegex:    `^github\.com/gorilla/mux\.\*?Router$`,
-					MethodExtraction: DefaultMethodExtractionConfig(),
-				},
-				{
-					CallRegex:        `^Handle$`,
-					PathFromArg:      true,
-					HandlerFromArg:   true,
-					PathArgIndex:     0,
-					HandlerArgIndex:  1,
-					RecvTypeRegex:    `^github\.com/gorilla/mux\.\*?Router$`,
-					MethodExtraction: DefaultMethodExtractionConfig(),
-				},
-				{
-					CallRegex:        `^HandlerFunc$`,
-					HandlerFromArg:   true,
-					HandlerArgIndex:  0,
-					RecvTypeRegex:    `^github\.com/gorilla/mux\.\*?Route$`,
-					MethodExtraction: DefaultMethodExtractionConfig(),
-				},
-				{
-					CallRegex:        `^Handler$`,
-					HandlerFromArg:   true,
-					HandlerArgIndex:  0,
-					RecvTypeRegex:    `^github\.com/gorilla/mux\.\*?Route$`,
-					MethodExtraction: DefaultMethodExtractionConfig(),
-				},
-				{
-					CallRegex:        `^Path$`,
-					PathFromArg:      true,
-					PathArgIndex:     0,
-					RecvTypeRegex:    `^github\.com/gorilla/mux\.\*?(Router|Route)$`,
-					MethodExtraction: DefaultMethodExtractionConfig(),
-				},
-				{
-					CallRegex:         `^Methods$`,
-					MethodFromHandler: true,
-					MethodArgIndex:    0,
-					RecvTypeRegex:     `^github\.com/gorilla/mux\.\*?(Router|Route)$`,
-					MethodExtraction:  DefaultMethodExtractionConfig(),
-				},
-			},
-			RequestContext: netHTTPRequestContext,
-			RequestBodyPatterns: []RequestBodyPattern{
-				{
-					CallRegex:            `^Decode$`,
-					TypeArgIndex:         0,
-					TypeFromArg:          true,
-					Deref:                true,
-					RecvTypeRegex:        ".*json(iter)?\\.\\*?Decoder",
-					RequireRequestSource: true,
-					BodyFromReceiver:     true,
-				},
-				{
-					CallRegex:            `^Unmarshal$`,
-					TypeArgIndex:         1,
-					TypeFromArg:          true,
-					Deref:                true,
-					RecvTypeRegex:        "json",
-					RequireRequestSource: true,
-					BodySourceArgIndex:   0,
-				},
-			},
-			ResponsePatterns: []ResponsePattern{
-				{
-					CallRegex:      `^WriteHeader$`,
-					StatusArgIndex: 0,
-					StatusFromArg:  true,
-					TypeArgIndex:   -1,
-					RecvTypeRegex:  `^net/http\.ResponseWriter$`,
-				},
-				{
-					CallRegex:     `^Write$`,
-					TypeArgIndex:  0,
-					TypeFromArg:   true,
-					Deref:         true,
-					RecvTypeRegex: `^net/http\.ResponseWriter$`,
-				},
-				{
-					CallRegex:          `^Error$`,
-					StatusArgIndex:     2,
-					StatusFromArg:      true,
-					TypeFromArg:        true,
-					TypeArgIndex:       1,
-					RecvTypeRegex:      `^net/http$`,
-					DefaultContentType: "text/plain; charset=utf-8",
-				},
-				{
-					CallRegex:      `^NotFound$`,
-					StatusArgIndex: -1, // Always 404
-					StatusFromArg:  false,
-					TypeArgIndex:   -1,
-					RecvTypeRegex:  `^net/http$`,
-					DefaultStatus:  http.StatusNotFound,
-				},
-				{
-					CallRegex:      `^Redirect$`,
-					StatusArgIndex: 3,
-					StatusFromArg:  true,
-					TypeArgIndex:   -1,
-					RecvTypeRegex:  `^net/http$`,
-				},
-				{
-					CallRegex:    `^Marshal$`,
-					TypeArgIndex: 0,
-					TypeFromArg:  true,
-					Deref:        true,
-				},
-				{
-					CallRegex:     `^Encode$`,
-					TypeArgIndex:  0,
-					TypeFromArg:   true,
-					Deref:         true,
-					RecvTypeRegex: ".*json(iter)?\\.\\*?Encoder",
-				},
-			},
-			ParamPatterns: []ParamPattern{ // @note: mux does not have a ParamPattern and it's not supported in this version
-				{
-					CallRegex:     `^Vars$`,
-					ParamIn:       "path",
-					ParamArgIndex: 0,
-					RecvTypeRegex: `^github\.com/gorilla/mux$`,
-				},
-			},
-			MountPatterns: []MountPattern{
-				{
-					CallRegex:     `^PathPrefix$`,
-					PathFromArg:   true,
-					PathArgIndex:  0,
-					IsMount:       true,
-					RecvTypeRegex: `^github\.com/gorilla/mux\.\*?Router$`,
-				},
-				{
-					CallRegex:     `^Subrouter$`,
-					IsMount:       true,
-					RecvTypeRegex: `^github\.com/gorilla/mux\.\*?Route$`,
-				},
-			},
-		},
-		Defaults: Defaults{
-			RequestContentType:  defaultRequestContentType,
-			ResponseContentType: defaultResponseContentType,
-			ResponseStatus:      http.StatusOK,
-		},
+// stdDefaults returns the Defaults block shared by every framework config,
+// parameterised on responseStatus (HTTP-style defaults all use 200; Chi's
+// older config kept its own constant — preserved here for parity).
+func stdDefaults(responseStatus int) Defaults {
+	return Defaults{
+		RequestContentType:  defaultRequestContentType,
+		ResponseContentType: defaultResponseContentType,
+		ResponseStatus:      responseStatus,
 	}
 }
 
-// DefaultHTTPConfig returns a default configuration for net/http
-func DefaultHTTPConfig() *APISpecConfig {
-	return &APISpecConfig{
-		Framework: FrameworkConfig{
-			RoutePatterns: []RoutePattern{
-				{
-					CallRegex:       `^HandleFunc$`,
-					PathFromArg:     true,
-					HandlerFromArg:  true,
-					PathArgIndex:    0,
-					MethodArgIndex:  -1,
-					HandlerArgIndex: 1,
-					RecvTypeRegex:   "^net/http(\\.\\*ServeMux)?$",
-				},
-				{
-					CallRegex:       `^Handle$`,
-					PathFromArg:     true,
-					HandlerFromArg:  true,
-					PathArgIndex:    0,
-					MethodArgIndex:  -1,
-					HandlerArgIndex: 1,
-				},
-			},
-			RequestContext: netHTTPRequestContext,
-			RequestBodyPatterns: []RequestBodyPattern{
-				{
-					CallRegex:            `^Decode$`,
-					TypeArgIndex:         0,
-					TypeFromArg:          true,
-					Deref:                true,
-					RequireRequestSource: true,
-					BodyFromReceiver:     true,
-				},
-				{
-					CallRegex:            `^Unmarshal$`,
-					TypeArgIndex:         1,
-					TypeFromArg:          true,
-					Deref:                true,
-					RequireRequestSource: true,
-					BodySourceArgIndex:   0,
-				},
-			},
-			ResponsePatterns: []ResponsePattern{
-				{
-					CallRegex:      `^WriteHeader$`,
-					StatusArgIndex: 0,
-					StatusFromArg:  true,
-					TypeArgIndex:   -1,
-					RecvTypeRegex:  `^net/http\.ResponseWriter$`,
-				},
-				{
-					CallRegex:     `^Write$`,
-					TypeArgIndex:  0,
-					TypeFromArg:   true,
-					Deref:         true,
-					RecvTypeRegex: `^net/http\.ResponseWriter$`,
-				},
-				{
-					CallRegex:          `^Error$`,
-					StatusArgIndex:     2,
-					StatusFromArg:      true,
-					TypeFromArg:        true,
-					TypeArgIndex:       1,
-					RecvTypeRegex:      `^net/http$`,
-					DefaultContentType: "text/plain; charset=utf-8",
-				},
-				{
-					CallRegex:      `^NotFound$`,
-					StatusArgIndex: -1, // Always 404
-					StatusFromArg:  false,
-					TypeArgIndex:   -1,
-					RecvTypeRegex:  `^net/http$`,
-					DefaultStatus:  http.StatusNotFound,
-				},
-				{
-					CallRegex:      `^Redirect$`,
-					StatusArgIndex: 3,
-					StatusFromArg:  true,
-					TypeArgIndex:   -1,
-					RecvTypeRegex:  `^net/http$`,
-				},
-				{
-					CallRegex:      `^(?i)(JSON|String|XML|YAML|ProtoBuf|Data|File|Redirect)$`,
-					StatusArgIndex: 0,
-					TypeArgIndex:   1,
-					TypeFromArg:    true,
-					Deref:          true,
-				},
-				{
-					CallRegex:    `^Marshal$`,
-					TypeArgIndex: 0,
-					TypeFromArg:  true,
-					Deref:        true,
-				},
-				{
-					CallRegex:    `^Encode$`,
-					TypeArgIndex: 0,
-					TypeFromArg:  true,
-					Deref:        true,
-				},
-			},
-			ParamPatterns: []ParamPattern{
-				{
-					CallRegex:     "^FormValue$",
-					ParamIn:       "form",
-					ParamArgIndex: 0,
-				},
-				{
-					CallRegex:     "^Get$",
-					ParamIn:       "header",
-					ParamArgIndex: 0,
-				},
-				{
-					CallRegex:     "^Cookie$",
-					ParamIn:       "cookie",
-					ParamArgIndex: 0,
-				},
-			},
-		},
-		Defaults: Defaults{
-			RequestContentType:  defaultRequestContentType,
-			ResponseContentType: defaultResponseContentType,
-			ResponseStatus:      http.StatusOK,
-		},
-	}
-}

--- a/internal/spec/config.go
+++ b/internal/spec/config.go
@@ -483,48 +483,12 @@ func (p *RoutePattern) MatchFunctionName(functionName string) bool {
 	return p.MatchPattern(p.FunctionNameRegex, functionName)
 }
 
-// DefaultChiConfig returns a default configuration for Chi router
-// Request-context presets used by the framework defaults. These describe
-// which parameter types carry an HTTP request and how its body is accessed,
-// so that generic decoders (json.Decode, json.Unmarshal, render.DecodeJSON)
-// can be gated on whether their input actually originates from a request.
-var (
-	netHTTPRequestContext = RequestContextConfig{
-		TypeRegexes:   []string{`^\*?net/http\.Request$`},
-		BodyAccessors: []string{`^Body$`},
-	}
-
-	ginRequestContext = RequestContextConfig{
-		TypeRegexes: []string{
-			`^\*?github\.com/gin-gonic/gin\.Context$`,
-			`^\*?net/http\.Request$`,
-		},
-		BodyAccessors: []string{
-			`^Request\.Body$`,
-			`^Body$`,
-		},
-	}
-
-	echoRequestContext = RequestContextConfig{
-		TypeRegexes: []string{
-			`^github\.com/labstack/echo(/v\d+)?\.Context$`,
-			`^\*?net/http\.Request$`,
-		},
-		BodyAccessors: []string{
-			`^Request\(\)\.Body$`,
-			`^Body$`,
-		},
-	}
-
-	fiberRequestContext = RequestContextConfig{
-		TypeRegexes: []string{
-			`^\*?github\.com/gofiber/fiber(/v\d+)?\.Ctx$`,
-		},
-		BodyAccessors: []string{
-			`^Body\(\)$`,
-		},
-	}
-)
+// The four per-framework RequestContext presets — netHTTPRequestContext,
+// ginRequestContext, echoRequestContext, fiberRequestContext — used to
+// live in this file. They now sit next to the framework default that owns
+// them, in config_http.go, config_gin.go, config_echo.go, config_fiber.go.
+// Chi and Mux reference netHTTPRequestContext from config_http.go directly
+// (same package, no import needed).
 
 // Shared pattern helpers used by the framework defaults. These collapse
 // duplication that previously sat in every Default*Config function — for

--- a/internal/spec/config_chi.go
+++ b/internal/spec/config_chi.go
@@ -1,0 +1,114 @@
+package spec
+
+// DefaultChiConfig returns a default configuration for the Chi router.
+func DefaultChiConfig() *APISpecConfig {
+	// Chi composes net/http response patterns with chi-render's JSON/Status,
+	// then the generic Marshal/Encode pair. Order preserved from the
+	// pre-refactor config so the matcher priority resolution is unchanged.
+	responsePatterns := netHTTPResponsePatterns()
+	responsePatterns = append(responsePatterns,
+		ResponsePattern{
+			CallRegex:     `^JSON$`,
+			TypeArgIndex:  2,
+			TypeFromArg:   true,
+			StatusFromArg: false,
+			Deref:         true,
+			RecvTypeRegex: "^github\\.com/go-chi/render$",
+		},
+		ResponsePattern{
+			CallRegex:      `^Status$`,
+			StatusArgIndex: 1,
+			StatusFromArg:  true,
+			RecvTypeRegex:  "^github\\.com/go-chi/render$",
+		},
+		jsonMarshalPattern(),
+		jsonEncodePattern(".*json(iter)?\\.\\*?Encoder"),
+	)
+
+	return &APISpecConfig{
+		Framework: FrameworkConfig{
+			RoutePatterns: []RoutePattern{
+				{
+					CallRegex:       `(?i)(GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD)$`,
+					MethodFromCall:  true,
+					PathFromArg:     true,
+					HandlerFromArg:  true,
+					PathArgIndex:    0,
+					HandlerArgIndex: 1,
+					RecvTypeRegex:   "^github.com/go-chi/chi(/v\\d)?\\.\\*?(Router|Mux)$",
+				},
+			},
+			RequestContext: netHTTPRequestContext,
+			RequestBodyPatterns: []RequestBodyPattern{
+				{
+					CallRegex:            `^DecodeJSON$`,
+					TypeArgIndex:         1,
+					TypeFromArg:          true,
+					Deref:                true,
+					RecvTypeRegex:        "^github\\.com/go-chi/render$",
+					RequireRequestSource: true,
+					BodySourceArgIndex:   0,
+				},
+				jsonDecodeRequestPattern(".*json(iter)?\\.\\*Decoder"),
+				jsonUnmarshalRequestPattern("json"),
+			},
+			ResponsePatterns: responsePatterns,
+			ParamPatterns: []ParamPattern{
+				{
+					CallRegex:     "^URLParam$",
+					ParamIn:       "path",
+					ParamArgIndex: 1,
+					RecvTypeRegex: "^github\\.com/go-chi/chi(/v\\d)?$",
+				},
+				{
+					CallRegex:     "^URLParam$",
+					ParamIn:       "path",
+					ParamArgIndex: 0,
+					RecvTypeRegex: "^github\\.com/go-chi/chi(/v\\d)?\\.\\*?Context$",
+				},
+				{
+					CallRegex:     "^URLParamFromCtx$",
+					ParamIn:       "path",
+					ParamArgIndex: 1,
+					RecvTypeRegex: "^github\\.com/go-chi/chi(/v\\d)?$",
+				},
+				{
+					CallRegex:     "^FormValue$",
+					ParamIn:       "form",
+					ParamArgIndex: 0,
+				},
+				{
+					CallRegex:     "^Get$",
+					ParamIn:       "query",
+					ParamArgIndex: 0,
+					RecvType:      "net/url.Values",
+				},
+				{
+					CallRegex:     "^PathValue$",
+					ParamIn:       "path",
+					ParamArgIndex: 0,
+					RecvType:      "net/http.*Request",
+				},
+			},
+			MountPatterns: []MountPattern{
+				{
+					CallRegex:      `^Mount$`,
+					PathFromArg:    true,
+					RouterFromArg:  true,
+					PathArgIndex:   0,
+					RouterArgIndex: 1,
+					IsMount:        true,
+				},
+				{
+					CallRegex:      `^Route$`,
+					PathFromArg:    true,
+					RouterFromArg:  true,
+					PathArgIndex:   0,
+					RouterArgIndex: 1,
+					IsMount:        true,
+				},
+			},
+		},
+		Defaults: stdDefaults(defaultResponseStatus),
+	}
+}

--- a/internal/spec/config_echo.go
+++ b/internal/spec/config_echo.go
@@ -2,6 +2,19 @@ package spec
 
 import "net/http"
 
+// echoRequestContext is the RequestContext preset for the Echo framework:
+// handlers receive an echo.Context whose Request() method yields the body.
+var echoRequestContext = RequestContextConfig{
+	TypeRegexes: []string{
+		`^github\.com/labstack/echo(/v\d+)?\.Context$`,
+		`^\*?net/http\.Request$`,
+	},
+	BodyAccessors: []string{
+		`^Request\(\)\.Body$`,
+		`^Body$`,
+	},
+}
+
 // DefaultEchoConfig returns a default configuration for the Echo framework.
 func DefaultEchoConfig() *APISpecConfig {
 	responsePatterns := netHTTPResponsePatterns()

--- a/internal/spec/config_echo.go
+++ b/internal/spec/config_echo.go
@@ -1,0 +1,92 @@
+package spec
+
+import "net/http"
+
+// DefaultEchoConfig returns a default configuration for the Echo framework.
+func DefaultEchoConfig() *APISpecConfig {
+	responsePatterns := netHTTPResponsePatterns()
+	responsePatterns = append(responsePatterns,
+		ResponsePattern{
+			CallRegex:      `^(?i)(JSON|String|XML|YAML|ProtoBuf|Data|File|Redirect)$`,
+			StatusArgIndex: 0,
+			TypeArgIndex:   1,
+			TypeFromArg:    true,
+			StatusFromArg:  true,
+			Deref:          true,
+			RecvTypeRegex:  "github\\.com/labstack/echo/v\\d\\.Context",
+		},
+		ResponsePattern{
+			CallRegex:      `^(?i)(NoContent)$`,
+			StatusArgIndex: 0,
+			StatusFromArg:  true,
+			TypeArgIndex:   -1,
+			RecvTypeRegex:  "github\\.com/labstack/echo/v\\d\\.Context",
+		},
+		jsonMarshalPattern(),
+		jsonEncodePattern(".*json(iter)?\\.\\*?Encoder"),
+	)
+
+	return &APISpecConfig{
+		Framework: FrameworkConfig{
+			RoutePatterns: []RoutePattern{
+				{
+					CallRegex:       `^(?i)(GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD)$`,
+					MethodFromCall:  true,
+					PathFromArg:     true,
+					HandlerFromArg:  true,
+					PathArgIndex:    0,
+					HandlerArgIndex: 1,
+					RecvTypeRegex:   "^github\\.com/labstack/echo(/v\\d)?\\.\\*(Echo|Group)$",
+				},
+			},
+			RequestContext: echoRequestContext,
+			RequestBodyPatterns: []RequestBodyPattern{
+				{
+					CallRegex:     `^(?i)(Bind)$`,
+					TypeArgIndex:  0,
+					TypeFromArg:   true,
+					Deref:         true,
+					RecvTypeRegex: "github\\.com/labstack/echo/v\\d\\.Context",
+				},
+				jsonDecodeRequestPattern(".*json(iter)?\\.\\*Decoder"),
+				jsonUnmarshalRequestPattern("json"),
+			},
+			ResponsePatterns: responsePatterns,
+			ParamPatterns: []ParamPattern{
+				{
+					CallRegex:     "^Param$",
+					ParamIn:       "path",
+					ParamArgIndex: 0,
+				},
+				{
+					CallRegex:     "^QueryParam$",
+					ParamIn:       "query",
+					ParamArgIndex: 0,
+					RecvTypeRegex: "github\\.com/labstack/echo/v\\d\\.Context",
+				},
+				{
+					CallRegex:     "^FormValue$",
+					ParamIn:       "form",
+					ParamArgIndex: 0,
+				},
+				{
+					CallRegex:     "^Cookie$",
+					ParamIn:       "cookie",
+					ParamArgIndex: 0,
+				},
+			},
+			MountPatterns: []MountPattern{
+				{
+					CallRegex:      `^Group$`,
+					PathFromArg:    true,
+					RouterFromArg:  true,
+					PathArgIndex:   0,
+					RouterArgIndex: 1,
+					IsMount:        true,
+					RecvTypeRegex:  "^github\\.com/labstack/echo(/v\\d)?\\.\\*(Echo|Group)$",
+				},
+			},
+		},
+		Defaults: stdDefaults(http.StatusOK),
+	}
+}

--- a/internal/spec/config_fiber.go
+++ b/internal/spec/config_fiber.go
@@ -2,6 +2,17 @@ package spec
 
 import "net/http"
 
+// fiberRequestContext is the RequestContext preset for the Fiber framework:
+// handlers receive a *fiber.Ctx whose Body() method yields the bytes.
+var fiberRequestContext = RequestContextConfig{
+	TypeRegexes: []string{
+		`^\*?github\.com/gofiber/fiber(/v\d+)?\.Ctx$`,
+	},
+	BodyAccessors: []string{
+		`^Body\(\)$`,
+	},
+}
+
 // DefaultFiberConfig returns a default configuration for the Fiber framework.
 func DefaultFiberConfig() *APISpecConfig {
 	responsePatterns := netHTTPResponsePatterns()

--- a/internal/spec/config_fiber.go
+++ b/internal/spec/config_fiber.go
@@ -1,0 +1,130 @@
+package spec
+
+import "net/http"
+
+// DefaultFiberConfig returns a default configuration for the Fiber framework.
+func DefaultFiberConfig() *APISpecConfig {
+	responsePatterns := netHTTPResponsePatterns()
+	responsePatterns = append(responsePatterns,
+		ResponsePattern{
+			CallRegex:      `^JSON$`,
+			StatusArgIndex: -1, // Fiber's c.JSON does not take status, only data
+			TypeArgIndex:   0,
+			TypeFromArg:    true,
+			Deref:          true,
+			RecvTypeRegex:  `^github\.com/gofiber/fiber(/v\d)?\.\*Ctx$`,
+		},
+		ResponsePattern{
+			CallRegex:      `^Status$`,
+			StatusArgIndex: 0,
+			StatusFromArg:  true,
+			TypeArgIndex:   -1,
+			RecvTypeRegex:  `^github\.com/gofiber/fiber(/v\d)?\.\*Ctx$`,
+		},
+		ResponsePattern{
+			CallRegex:      `^SendString$`,
+			StatusArgIndex: -1,
+			TypeArgIndex:   0,
+			TypeFromArg:    true,
+			RecvTypeRegex:  `^github\.com/gofiber/fiber(/v\d)?\.\*Ctx$`,
+		},
+		ResponsePattern{
+			CallRegex:      `^SendStatus$`,
+			StatusArgIndex: 0,
+			TypeArgIndex:   -1,
+			RecvTypeRegex:  `^github\.com/gofiber/fiber(/v\d)?\.\*Ctx$`,
+		},
+		jsonMarshalPattern(),
+		jsonEncodePattern(".*json(iter)?\\.\\*?Encoder"),
+	)
+
+	return &APISpecConfig{
+		Framework: FrameworkConfig{
+			RoutePatterns: []RoutePattern{
+				{
+					CallRegex:       `^(?i)(GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD)$`,
+					MethodFromCall:  true,
+					PathFromArg:     true,
+					HandlerFromArg:  true,
+					PathArgIndex:    0,
+					HandlerArgIndex: 1,
+					RecvTypeRegex:   `^github\.com/gofiber/fiber(/v\d)?\.\*?(App|Router|Group)$`,
+				},
+			},
+			RequestContext: fiberRequestContext,
+			RequestBodyPatterns: []RequestBodyPattern{
+				{
+					CallRegex:     `^BodyParser$`,
+					TypeArgIndex:  0,
+					TypeFromArg:   true,
+					Deref:         true,
+					RecvTypeRegex: `^github\.com/gofiber/fiber(/v\d)?\.\*?Ctx$`,
+				},
+				jsonDecodeRequestPattern(".*json(iter)?\\.\\*?Decoder"),
+				jsonUnmarshalRequestPattern("json"),
+			},
+			ResponsePatterns: responsePatterns,
+			ParamPatterns: []ParamPattern{
+				{
+					CallRegex:     "^Params$",
+					ParamIn:       "path",
+					ParamArgIndex: 0,
+					RecvTypeRegex: `^github\.com/gofiber/fiber(/v\d)?\.\*Ctx$`,
+				},
+				{
+					CallRegex:     "^Query$",
+					ParamIn:       "query",
+					ParamArgIndex: 0,
+					RecvTypeRegex: `^github\.com/gofiber/fiber(/v\d)?\.\*Ctx$`,
+				},
+				{
+					CallRegex:     "^FormValue$",
+					ParamIn:       "form",
+					ParamArgIndex: 0,
+					RecvTypeRegex: `^github\.com/gofiber/fiber(/v\d)?\.\*Ctx$`,
+				},
+				{
+					CallRegex:     "^Cookies$",
+					ParamIn:       "cookie",
+					ParamArgIndex: 0,
+					RecvTypeRegex: `^github\.com/gofiber/fiber(/v\d)?\.\*Ctx$`,
+				},
+			},
+			MountPatterns: []MountPattern{
+				{
+					CallRegex:      `^Mount$`,
+					PathFromArg:    true,
+					RouterFromArg:  true,
+					PathArgIndex:   0,
+					RouterArgIndex: 1,
+					IsMount:        true,
+				},
+				{
+					CallRegex:      `^Group$`,
+					PathFromArg:    true,
+					RouterFromArg:  true,
+					PathArgIndex:   0,
+					RouterArgIndex: 1,
+					IsMount:        true,
+					RecvTypeRegex:  `^github\.com/gofiber/fiber(/v\d)?\.\*?(App|Router|Group)$`,
+				},
+				{
+					CallRegex:     `^Use$`,
+					PathFromArg:   false,
+					RouterFromArg: false,
+					IsMount:       false,
+					RecvTypeRegex: `^github\.com/gofiber/fiber(/v\d)?\.\*?(App|Router|Group)$`,
+				},
+			},
+		},
+		Defaults: stdDefaults(http.StatusOK),
+		ExternalTypes: []ExternalType{
+			{
+				Name: "github.com/gofiber/fiber.Map",
+				OpenAPIType: &Schema{
+					Type: "object",
+				},
+			},
+		},
+	}
+}

--- a/internal/spec/config_gin.go
+++ b/internal/spec/config_gin.go
@@ -2,6 +2,19 @@ package spec
 
 import "net/http"
 
+// ginRequestContext is the RequestContext preset for the Gin framework:
+// handlers receive a *gin.Context whose Request field carries the body.
+var ginRequestContext = RequestContextConfig{
+	TypeRegexes: []string{
+		`^\*?github\.com/gin-gonic/gin\.Context$`,
+		`^\*?net/http\.Request$`,
+	},
+	BodyAccessors: []string{
+		`^Request\.Body$`,
+		`^Body$`,
+	},
+}
+
 // DefaultGinConfig returns a default configuration for the Gin framework.
 func DefaultGinConfig() *APISpecConfig {
 	responsePatterns := netHTTPResponsePatterns()

--- a/internal/spec/config_gin.go
+++ b/internal/spec/config_gin.go
@@ -1,0 +1,89 @@
+package spec
+
+import "net/http"
+
+// DefaultGinConfig returns a default configuration for the Gin framework.
+func DefaultGinConfig() *APISpecConfig {
+	responsePatterns := netHTTPResponsePatterns()
+	responsePatterns = append(responsePatterns,
+		ResponsePattern{
+			CallRegex:      `^(?i)(JSON|String|XML|YAML|ProtoBuf|Data|File|Redirect)$`,
+			StatusArgIndex: 0,
+			TypeArgIndex:   1,
+			TypeFromArg:    true,
+			StatusFromArg:  true,
+		},
+		jsonMarshalPattern(),
+		jsonEncodePattern(""),
+	)
+
+	return &APISpecConfig{
+		Framework: FrameworkConfig{
+			RoutePatterns: []RoutePattern{
+				{
+					CallRegex:       `^(?i)(GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD)$`,
+					MethodFromCall:  true,
+					PathFromArg:     true,
+					HandlerFromArg:  true,
+					PathArgIndex:    0,
+					HandlerArgIndex: 1,
+					RecvTypeRegex:   "^github\\.com/gin-gonic/gin\\.\\*(Engine|RouterGroup)$",
+				},
+			},
+			RequestContext: ginRequestContext,
+			RequestBodyPatterns: []RequestBodyPattern{
+				{
+					CallRegex:    `^(?i)(BindJSON|ShouldBindJSON|BindXML|BindYAML|BindForm|ShouldBind)$`,
+					TypeArgIndex: 0,
+					TypeFromArg:  true,
+					Deref:        true,
+				},
+				jsonDecodeRequestPattern(""),
+				jsonUnmarshalRequestPattern(""),
+			},
+			ResponsePatterns: responsePatterns,
+			ParamPatterns: []ParamPattern{
+				{
+					CallRegex:     "^Param$",
+					ParamIn:       "path",
+					ParamArgIndex: 0,
+				},
+				{
+					CallRegex:     "^Query$",
+					ParamIn:       "query",
+					ParamArgIndex: 0,
+				},
+				{
+					CallRegex:     "^DefaultQuery$",
+					ParamIn:       "query",
+					ParamArgIndex: 0,
+				},
+				{
+					CallRegex:     "^GetHeader$",
+					ParamIn:       "header",
+					ParamArgIndex: 0,
+				},
+			},
+			MountPatterns: []MountPattern{
+				{
+					CallRegex:      `^Group$`,
+					PathFromArg:    true,
+					RouterFromArg:  true,
+					PathArgIndex:   0,
+					RouterArgIndex: 1,
+					IsMount:        true,
+					RecvTypeRegex:  "^github\\.com/gin-gonic/gin\\.\\*(Engine|RouterGroup)$",
+				},
+			},
+		},
+		Defaults: stdDefaults(http.StatusOK),
+		ExternalTypes: []ExternalType{
+			{
+				Name: "github.com/gin-gonic/gin.H",
+				OpenAPIType: &Schema{
+					Type: "object",
+				},
+			},
+		},
+	}
+}

--- a/internal/spec/config_http.go
+++ b/internal/spec/config_http.go
@@ -1,0 +1,70 @@
+package spec
+
+import "net/http"
+
+// DefaultHTTPConfig returns a default configuration for net/http.
+func DefaultHTTPConfig() *APISpecConfig {
+	// net/http response patterns come from netHTTPResponsePatterns(); the
+	// only HTTP-specific renderer is the (?i)(JSON|String|XML|...) catch-all
+	// for the helper packages that wrap ResponseWriter.
+	responsePatterns := netHTTPResponsePatterns()
+	responsePatterns = append(responsePatterns,
+		ResponsePattern{
+			CallRegex:      `^(?i)(JSON|String|XML|YAML|ProtoBuf|Data|File|Redirect)$`,
+			StatusArgIndex: 0,
+			TypeArgIndex:   1,
+			TypeFromArg:    true,
+			Deref:          true,
+		},
+		jsonMarshalPattern(),
+		jsonEncodePattern(""),
+	)
+
+	return &APISpecConfig{
+		Framework: FrameworkConfig{
+			RoutePatterns: []RoutePattern{
+				{
+					CallRegex:       `^HandleFunc$`,
+					PathFromArg:     true,
+					HandlerFromArg:  true,
+					PathArgIndex:    0,
+					MethodArgIndex:  -1,
+					HandlerArgIndex: 1,
+					RecvTypeRegex:   "^net/http(\\.\\*ServeMux)?$",
+				},
+				{
+					CallRegex:       `^Handle$`,
+					PathFromArg:     true,
+					HandlerFromArg:  true,
+					PathArgIndex:    0,
+					MethodArgIndex:  -1,
+					HandlerArgIndex: 1,
+				},
+			},
+			RequestContext: netHTTPRequestContext,
+			RequestBodyPatterns: []RequestBodyPattern{
+				jsonDecodeRequestPattern(""),
+				jsonUnmarshalRequestPattern(""),
+			},
+			ResponsePatterns: responsePatterns,
+			ParamPatterns: []ParamPattern{
+				{
+					CallRegex:     "^FormValue$",
+					ParamIn:       "form",
+					ParamArgIndex: 0,
+				},
+				{
+					CallRegex:     "^Get$",
+					ParamIn:       "header",
+					ParamArgIndex: 0,
+				},
+				{
+					CallRegex:     "^Cookie$",
+					ParamIn:       "cookie",
+					ParamArgIndex: 0,
+				},
+			},
+		},
+		Defaults: stdDefaults(http.StatusOK),
+	}
+}

--- a/internal/spec/config_http.go
+++ b/internal/spec/config_http.go
@@ -2,6 +2,14 @@ package spec
 
 import "net/http"
 
+// netHTTPRequestContext is the RequestContext preset for plain net/http
+// handlers. Chi and Mux share it because their handlers also bind to
+// *http.Request; both refer to it directly within this package.
+var netHTTPRequestContext = RequestContextConfig{
+	TypeRegexes:   []string{`^\*?net/http\.Request$`},
+	BodyAccessors: []string{`^Body$`},
+}
+
 // DefaultHTTPConfig returns a default configuration for net/http.
 func DefaultHTTPConfig() *APISpecConfig {
 	// net/http response patterns come from netHTTPResponsePatterns(); the

--- a/internal/spec/config_mux.go
+++ b/internal/spec/config_mux.go
@@ -1,0 +1,113 @@
+package spec
+
+import "net/http"
+
+// DefaultMethodExtractionConfig returns the default verb-from-handler-name
+// method extraction rules used by frameworks that don't carry the HTTP
+// method on the registration call itself (Mux's HandleFunc/Handle).
+func DefaultMethodExtractionConfig() *MethodExtractionConfig {
+	return &MethodExtractionConfig{
+		MethodMappings: []MethodMapping{
+			{Patterns: []string{"get", "list", "show", "find", "fetch", "retrieve"}, Method: "GET", Priority: 10},
+			{Patterns: []string{"post", "create", "add", "new", "insert"}, Method: "POST", Priority: 10},
+			{Patterns: []string{"put", "update", "edit", "modify", "replace"}, Method: "PUT", Priority: 10},
+			{Patterns: []string{"delete", "remove", "destroy"}, Method: "DELETE", Priority: 10},
+			{Patterns: []string{"patch", "partial"}, Method: "PATCH", Priority: 10},
+			{Patterns: []string{"options"}, Method: "OPTIONS", Priority: 10},
+			{Patterns: []string{"head"}, Method: "HEAD", Priority: 10},
+		},
+		UsePrefix:        true,
+		UseContains:      true,
+		CaseSensitive:    false,
+		DefaultMethod:    "GET",
+		InferFromContext: true,
+	}
+}
+
+// DefaultMuxConfig returns a default configuration for Gorilla Mux.
+func DefaultMuxConfig() *APISpecConfig {
+	return &APISpecConfig{
+		Framework: FrameworkConfig{
+			RoutePatterns: []RoutePattern{
+				{
+					CallRegex:        `^HandleFunc$`,
+					PathFromArg:      true,
+					HandlerFromArg:   true,
+					PathArgIndex:     0,
+					HandlerArgIndex:  1,
+					RecvTypeRegex:    `^github\.com/gorilla/mux\.\*?Router$`,
+					MethodExtraction: DefaultMethodExtractionConfig(),
+				},
+				{
+					CallRegex:        `^Handle$`,
+					PathFromArg:      true,
+					HandlerFromArg:   true,
+					PathArgIndex:     0,
+					HandlerArgIndex:  1,
+					RecvTypeRegex:    `^github\.com/gorilla/mux\.\*?Router$`,
+					MethodExtraction: DefaultMethodExtractionConfig(),
+				},
+				{
+					CallRegex:        `^HandlerFunc$`,
+					HandlerFromArg:   true,
+					HandlerArgIndex:  0,
+					RecvTypeRegex:    `^github\.com/gorilla/mux\.\*?Route$`,
+					MethodExtraction: DefaultMethodExtractionConfig(),
+				},
+				{
+					CallRegex:        `^Handler$`,
+					HandlerFromArg:   true,
+					HandlerArgIndex:  0,
+					RecvTypeRegex:    `^github\.com/gorilla/mux\.\*?Route$`,
+					MethodExtraction: DefaultMethodExtractionConfig(),
+				},
+				{
+					CallRegex:        `^Path$`,
+					PathFromArg:      true,
+					PathArgIndex:     0,
+					RecvTypeRegex:    `^github\.com/gorilla/mux\.\*?(Router|Route)$`,
+					MethodExtraction: DefaultMethodExtractionConfig(),
+				},
+				{
+					CallRegex:         `^Methods$`,
+					MethodFromHandler: true,
+					MethodArgIndex:    0,
+					RecvTypeRegex:     `^github\.com/gorilla/mux\.\*?(Router|Route)$`,
+					MethodExtraction:  DefaultMethodExtractionConfig(),
+				},
+			},
+			RequestContext: netHTTPRequestContext,
+			RequestBodyPatterns: []RequestBodyPattern{
+				jsonDecodeRequestPattern(".*json(iter)?\\.\\*?Decoder"),
+				jsonUnmarshalRequestPattern("json"),
+			},
+			ResponsePatterns: append(netHTTPResponsePatterns(),
+				jsonMarshalPattern(),
+				jsonEncodePattern(".*json(iter)?\\.\\*?Encoder"),
+			),
+			ParamPatterns: []ParamPattern{ // @note: mux does not have a ParamPattern and it's not supported in this version
+				{
+					CallRegex:     `^Vars$`,
+					ParamIn:       "path",
+					ParamArgIndex: 0,
+					RecvTypeRegex: `^github\.com/gorilla/mux$`,
+				},
+			},
+			MountPatterns: []MountPattern{
+				{
+					CallRegex:     `^PathPrefix$`,
+					PathFromArg:   true,
+					PathArgIndex:  0,
+					IsMount:       true,
+					RecvTypeRegex: `^github\.com/gorilla/mux\.\*?Router$`,
+				},
+				{
+					CallRegex:     `^Subrouter$`,
+					IsMount:       true,
+					RecvTypeRegex: `^github\.com/gorilla/mux\.\*?Route$`,
+				},
+			},
+		},
+		Defaults: stdDefaults(http.StatusOK),
+	}
+}


### PR DESCRIPTION
Third step in the code-quality cleanup tracked in \`docs/CODE_QUALITY_AUDIT.md\`. Bundles **finding #3 (Default*Config table-ization)** with the relevant slice of **finding #2 (config.go splits)** since the same code is touched.

## What changed

**1. Shared pattern helpers** in \`config.go\`:

| Helper | What it returns |
|---|---|
| \`netHTTPResponsePatterns()\` | The 5 shared net/http response entries (WriteHeader, Write, Error, NotFound, Redirect) |
| \`jsonMarshalPattern()\` | encoding/json.Marshal pattern |
| \`jsonEncodePattern(recvRegex)\` | json.Encoder.Encode with per-framework receiver |
| \`jsonDecodeRequestPattern(recvRegex)\` | json.Decoder.Decode body extractor |
| \`jsonUnmarshalRequestPattern(recvRegex)\` | encoding/json.Unmarshal body extractor |
| \`stdDefaults(status)\` | The common Defaults block parameterised on status |

Order of patterns preserved exactly inside each framework so matcher priority resolution stays byte-identical.

**2. Per-framework file split**:

\`\`\`
internal/spec/
  config.go            644 LOC  (types + RequestContext presets + shared helpers)
  config_chi.go        114 LOC
  config_echo.go        92 LOC
  config_fiber.go      130 LOC
  config_gin.go         89 LOC
  config_http.go        70 LOC
  config_mux.go        113 LOC
\`\`\`

## Net effect

| File | Before | After |
|---|---:|---:|
| \`config.go\` | 1503 | 644 |
| Total config-related | 1503 | 1252 |

**-251 LOC, plus per-framework reviewability.**

A PR that touches \"how Chi extracts request bodies\" now touches only \`config_chi.go\` instead of sharing a file with five other frameworks.

## Verification

- \`go build ./...\` and \`go test ./...\` — all green
- End-to-end check on \`testdata/dynamic_mount_prefix\` — generated spec is byte-identical (paths, components.parameters, refs all match)
- Order of every ResponsePattern / RequestBodyPattern preserved exactly so the matcher priority resolution doesn't shift

## Why bundled

Audit suggested doing \`Default*Config\` table-ization (#3) before the per-file split (part of #2). Doing both in the same PR avoids a churn cycle where #3's diff would have crossed the file boundaries that #2 was about to introduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)