### PR TITLE
Resolve all status codes for a response helper called from multiple b…

### DIFF
--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -487,7 +487,7 @@ func (e *Extractor) extractRouteChildren(routeNode TrackerNodeInterface, route *
 		// Extract responses (multiple if status fan-out applies — see
 		// ExtractResponse / issue #39). Each emitted ResponseInfo lands
 		// under its own status-keyed slot in route.Response.
-		for _, resp := range e.extractResponseFromNode(child, route, visitedEdges) {
+		for _, resp := range e.extractResponseFromNode(child, route, visitedEdges, routeNode.GetKey()) {
 			if resp != nil && (resp.BodyType != "" || resp.StatusCode != 0) {
 				route.Response[fmt.Sprintf("%d", resp.StatusCode)] = resp
 			}
@@ -603,21 +603,26 @@ func (e *Extractor) extractRequestFromNode(node TrackerNodeInterface, route *Rou
 // extractResponseFromNode extracts response information from a node.
 // Returns a slice because a single call site can yield multiple responses
 // when conditional status codes apply (see ExtractResponse / issue #39).
-func (e *Extractor) extractResponseFromNode(node TrackerNodeInterface, route *RouteInfo, visitedEdges map[string]bool) []*ResponseInfo {
-	// Ensure that each edge is visited only once
+//
+// The visited-edge key is qualified by parentKey (the node through which this
+// one was reached). A response helper invoked from several branches with
+// different statuses — e.g. respondWithError(w,…,400) and
+// respondWithError(w,…,500), both reaching the SAME WriteHeader edge — would
+// otherwise be deduped by callee alone and collapse to the first status seen.
+// Qualifying by the call site lets each distinct status be resolved. (The same
+// node also gets reached via internal encoder-chain paths with no status
+// context; those yield a "default" that buildResponses drops when it carries no
+// new body information — see uninformativeDefault.)
+func (e *Extractor) extractResponseFromNode(node TrackerNodeInterface, route *RouteInfo, visitedEdges map[string]bool, parentKey string) []*ResponseInfo {
 	if node == nil || node.GetEdge() == nil {
 		return nil
 	}
-
 	edge := node.GetEdge()
-	edgeID := edge.Callee.ID()
+	edgeID := parentKey + "|" + edge.Callee.ID()
 	if visitedEdges[edgeID] {
-		return nil // Edge already processed
+		return nil // already processed via this same call site
 	}
-
-	// Mark edge as visited before processing to ensure MatchNode is only called once per edge
 	visitedEdges[edgeID] = true
-
 	for _, matcher := range e.responseMatchers {
 		if matcher.MatchNode(node) {
 			return matcher.ExtractResponse(node, route)

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -352,6 +352,37 @@ func deduplicateParameters(params []Parameter) []Parameter {
 }
 
 // buildResponses builds OpenAPI responses from response info
+// uninformativeDefault reports whether the "could not determine status"
+// response `def` adds no response-body information beyond the resolved-status
+// responses already in `chosen`: either its body duplicates a resolved one, or
+// it is the bare generic `object` fallback.
+func uninformativeDefault(def *ResponseInfo, chosen map[string]*ResponseInfo) bool {
+	if isGenericObjectResponse(def) {
+		return true
+	}
+	for status, r := range chosen {
+		if status != "default" && r.BodyType == def.BodyType {
+			return true
+		}
+	}
+	return false
+}
+
+// isGenericObjectResponse reports whether a response body is the featureless
+// `{type: object}` fallback (no $ref, properties, composition, or items) — the
+// least-informative possible body.
+func isGenericObjectResponse(r *ResponseInfo) bool {
+	s := r.Schema
+	if s == nil {
+		return true
+	}
+	if s.Ref != "" || len(s.Properties) > 0 || len(s.AllOf) > 0 || len(s.OneOf) > 0 ||
+		len(s.AnyOf) > 0 || s.Items != nil || s.AdditionalProperties != nil {
+		return false
+	}
+	return s.Type == "" || s.Type == "object"
+}
+
 func buildResponses(respInfo map[string]*ResponseInfo) map[string]Response {
 	responses := make(map[string]Response)
 
@@ -394,6 +425,19 @@ func buildResponses(respInfo map[string]*ResponseInfo) map[string]Response {
 			continue
 		}
 		chosen[statusCode] = resp
+	}
+
+	// "default" here means "status could not be determined" — a fallback, not an
+	// OpenAPI catch-all. Once concrete statuses are resolved, a default adds
+	// nothing if it carries no new response-body information: either (a) its
+	// body is already emitted under a resolved status (the status WAS
+	// determined for that body via another call path), or (b) its body is the
+	// bare generic `object` fallback (e.g. an `any` parameter that couldn't be
+	// traced through an indirection helper). Drop it in those cases; keep a
+	// default whose body is concrete and distinct — that's a real response
+	// whose status genuinely couldn't be resolved.
+	if def := chosen["default"]; def != nil && len(chosen) > 1 && uninformativeDefault(def, chosen) {
+		delete(chosen, "default")
 	}
 
 	for statusCode, resp := range chosen {

--- a/internal/spec/response_default_test.go
+++ b/internal/spec/response_default_test.go
@@ -1,0 +1,49 @@
+package spec
+
+import "testing"
+
+func TestBuildResponses_UninformativeDefaultDropped(t *testing.T) {
+	ref := func(name string) *Schema { return &Schema{Ref: "#/components/schemas/" + name} }
+
+	t.Run("redundant default (same body as resolved) is dropped", func(t *testing.T) {
+		r := buildResponses(map[string]*ResponseInfo{
+			"201": {StatusCode: 201, ContentType: "application/json", BodyType: "User", Schema: ref("User")},
+			"-1":  {StatusCode: -1, ContentType: "application/json", BodyType: "User", Schema: ref("User")},
+		})
+		if _, ok := r["default"]; ok {
+			t.Error("default with a body already at a resolved status should be dropped")
+		}
+		if _, ok := r["201"]; !ok {
+			t.Error("the resolved 201 must remain")
+		}
+	})
+
+	t.Run("generic-object default is dropped when resolved statuses exist", func(t *testing.T) {
+		r := buildResponses(map[string]*ResponseInfo{
+			"200": {StatusCode: 200, ContentType: "application/json", BodyType: "[]Item", Schema: &Schema{Type: "array", Items: ref("Item")}},
+			"-1":  {StatusCode: -1, ContentType: "application/json", BodyType: "any", Schema: &Schema{Type: "object"}},
+		})
+		if _, ok := r["default"]; ok {
+			t.Error("bare generic-object default should be dropped alongside resolved statuses")
+		}
+	})
+
+	t.Run("distinct concrete default is kept", func(t *testing.T) {
+		r := buildResponses(map[string]*ResponseInfo{
+			"400": {StatusCode: 400, ContentType: "application/json", BodyType: "ErrorResponse", Schema: ref("ErrorResponse")},
+			"-1":  {StatusCode: -1, ContentType: "application/json", BodyType: "User", Schema: ref("User")},
+		})
+		if _, ok := r["default"]; !ok {
+			t.Error("a default carrying a distinct concrete body must be kept")
+		}
+	})
+
+	t.Run("default kept when it is the only response", func(t *testing.T) {
+		r := buildResponses(map[string]*ResponseInfo{
+			"-1": {StatusCode: -1, ContentType: "application/json", BodyType: "User", Schema: ref("User")},
+		})
+		if _, ok := r["default"]; !ok {
+			t.Error("a sole default must be kept")
+		}
+	})
+}


### PR DESCRIPTION
…ranches

A handler whose responses go through one indirection helper called from several branches with different status literals — e.g. HandleRequest's wrapper doing respondWithError(w,…,400) on decode failure and respondWithError(w,…,500) on a handler error — only surfaced the first status. extractResponseFromNode deduped by the callee edge alone, so the second branch found the shared WriteHeader edge already visited and dropped its 500.

Qualify the visited-edge key by the call site (parent node key) so each distinct status is resolved. That also surfaces the helper's response via internal encoder-chain paths that carry no status context, producing a redundant "default"; buildResponses now drops a "default" that adds no response-body information (its body already appears at a resolved status, or it is the bare generic `object` fallback) while keeping a default whose body is concrete and distinct. testdata/generic now yields 200/400/500 instead of just 200/400.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved response handling so duplicate results are no longer collapsed across different route paths.
  * Cleaned up API response output by omitting unhelpful `default` responses when a more specific response is already available.
  * Preserved meaningful `default` responses when they add distinct information or are the only response returned.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->