### PR TITLE
apispecui: auth-mapping UX, refresh persistence, security insight

### DIFF
--- a/cmd/apispecui/assets/js/actions.js
+++ b/cmd/apispecui/assets/js/actions.js
@@ -137,6 +137,10 @@ async function attachRun() {
     setState({ genElapsed: Date.now() - start });
   }, 200);
   try {
+    // Don't let a flaky progress endpoint strand the UI in "reconnecting…":
+    // on each progress failure fall back to /api/status, and give up after a
+    // few consecutive failures so the finally clause can clear the run.
+    let progressErrors = 0;
     await new Promise((resolve) => {
       const poll = setInterval(async () => {
         // Superseded (e.g. a Force restart took over) — stop tracking.
@@ -149,8 +153,23 @@ async function attachRun() {
         try {
           p = await api.progress();
         } catch {
+          progressErrors += 1;
+          try {
+            const st = await api.status();
+            progressErrors = 0;
+            if (!st || !st.running) {
+              clearInterval(poll);
+              resolve();
+            }
+          } catch {
+            if (progressErrors >= 3) {
+              clearInterval(poll);
+              resolve();
+            }
+          }
           return;
         }
+        progressErrors = 0;
         if (myRun !== activeRun || !p) return;
         if (p.phase) setState({ genPhase: p.phase });
         setState({ genStuckStopping: !!p.stopping && (p.stoppingMs || 0) > STUCK_STOP_MS });

--- a/cmd/apispecui/assets/js/actions.js
+++ b/cmd/apispecui/assets/js/actions.js
@@ -130,12 +130,17 @@ function fullGenerateRequest() {
   };
 }
 
-export async function generate() {
+// THRESHOLD after which a pending Stop the engine hasn't honoured escalates to
+// offering a Force restart in the UI.
+const STUCK_STOP_MS = 4000;
+
+export async function generate(opts = {}) {
   const s = getState();
   if (!s.project || s.generating) return;
+  const force = !!opts.force;
   const start = Date.now();
-  setState({ generating: true, genPhase: "starting…", genElapsed: 0, unresolvedSecurity: [] });
-  setStatus("generating…");
+  setState({ generating: true, genPhase: "starting…", genElapsed: 0, unresolvedSecurity: [], genBlocked: false, genStuckStopping: false });
+  setStatus(force ? "force-restarting…" : "generating…");
   // Live elapsed ticker — reassures the run is alive and makes a stall obvious
   // (a counter climbing on one phase reads as "stuck" where a static label hides it).
   const tick = setInterval(() => setState({ genElapsed: Date.now() - start }), 200);
@@ -143,12 +148,14 @@ export async function generate() {
     try {
       const p = await api.progress();
       if (p && p.phase) setState({ genPhase: p.phase });
+      // A Stop the engine hasn't acted on yet — let the UI escalate to Force.
+      if (p) setState({ genStuckStopping: !!p.stopping && (p.stoppingMs || 0) > STUCK_STOP_MS });
     } catch {
       /* ignore */
     }
   }, 600);
   try {
-    const res = await api.generate(fullGenerateRequest());
+    const res = await api.generate(fullGenerateRequest(), { force });
     if (res && res.cancelled) {
       setStatus(`generation stopped · ${fmtDur(Date.now() - start)}`, "warn");
     } else {
@@ -162,6 +169,7 @@ export async function generate() {
         specView: "swagger",
         skipped,
         unresolvedSecurity: res.unresolvedSecurity || [],
+        genBlocked: false,
       });
       if (skipped.length) {
         setStatus(`generated ${res.pathCount || 0} paths · ${skipped.length} package(s) skipped · ${took}`, "warn");
@@ -170,17 +178,44 @@ export async function generate() {
       }
     }
   } catch (e) {
-    // A rerun attempted while a stopped run is still winding down returns
-    // 409 ("in progress / stopping") — surface that as a soft warning.
-    if (/in progress|stopping/i.test(e.message)) {
-      setStatus(e.message, "warn");
+    // A rerun attempted while a prior run is in flight (or a stopped run is
+    // still winding down) returns 409 with {error, stopping, canForce}. Show a
+    // friendly message and flag genBlocked so the UI offers a Force restart —
+    // instead of dumping the raw JSON body the user used to see.
+    const info = parseErrBody(e.message);
+    if (info && info.canForce) {
+      setState({ genBlocked: true });
+      setStatus(
+        info.stopping
+          ? "the previous run is still stopping — use Force restart to start now"
+          : "a generation is already running — use Force restart to replace it",
+        "warn",
+      );
     } else {
-      setStatus("generation failed: " + e.message, "err");
+      setStatus("generation failed: " + ((info && info.error) || e.message), "err");
     }
   } finally {
     clearInterval(tick);
     clearInterval(poll);
     setState({ generating: false, genPhase: "", genElapsed: 0 });
+  }
+}
+
+// forceGenerate supersedes an in-flight or stuck-stopping run and starts fresh.
+export function forceGenerate() {
+  return generate({ force: true });
+}
+
+// parseErrBody best-effort parses a thrown error message that may be a JSON
+// error body ({error, stopping, canForce}). Returns null when it isn't JSON.
+function parseErrBody(msg) {
+  if (!msg || typeof msg !== "string") return null;
+  const t = msg.trim();
+  if (t[0] !== "{") return null;
+  try {
+    return JSON.parse(t);
+  } catch {
+    return null;
   }
 }
 

--- a/cmd/apispecui/assets/js/actions.js
+++ b/cmd/apispecui/assets/js/actions.js
@@ -64,6 +64,7 @@ export function applyDetect(d) {
     openapiVersion: d.openapiVersion || getState().openapiVersion,
     frameworkConfig: d.frameworkConfig || null,
     detected: d,
+    suggestedConfigPath: d.suggestedConfigPath || "",
     ready: true,
   });
   applyConfigSections(d);
@@ -79,10 +80,92 @@ export async function detectInitial() {
         apispecCommit: health.commit || "",
         apispecBuildTime: health.buildTime || "",
       });
-    setStatus("ready", "ok");
+    // Reconnect to whatever the server already has: a run still in flight, or
+    // the last completed spec/result. A refresh shouldn't lose progress.
+    await restoreFromServer();
+    if (!getState().generating) {
+      setStatus(getState().hasSpec ? "restored last generation" : "ready", "ok");
+    }
   } catch (e) {
     setStatus(e.message, "err");
     setState({ ready: true });
+  }
+}
+
+// applyStatusResult restores the last completed generation's result into the
+// store (so the spec viewer / insight / banners come back after a refresh).
+function applyStatusResult(st) {
+  const r = st && st.result;
+  if (r && r.ok) {
+    setState({
+      hasSpec: true,
+      lastPaths: r.pathCount || 0,
+      skipped: r.skippedPackages || [],
+      unresolvedSecurity: r.unresolvedSecurity || [],
+      lastGenTick: Date.now(),
+    });
+  } else if (st && st.hasSpec) {
+    setState({ hasSpec: true, lastGenTick: Date.now() });
+  }
+}
+
+// restoreFromServer pulls the server-side generation state and reattaches the
+// UI to it: restores the last result, and resumes live tracking if a run is
+// still in flight (the engine keeps running across a page refresh).
+export async function restoreFromServer() {
+  let st;
+  try {
+    st = await api.status();
+  } catch {
+    return;
+  }
+  if (!st) return;
+  applyStatusResult(st);
+  if (st.running) attachRun(); // fire-and-forget; updates state as it polls
+}
+
+// attachRun resumes live progress tracking for a generation already running on
+// the server (e.g. after a refresh), then restores its result when it finishes.
+async function attachRun() {
+  if (getState().generating) return; // already tracking
+  setState({ generating: true, genPhase: "reconnecting…", genElapsed: 0, genBlocked: false });
+  setStatus("reconnecting to a running generation…", "warn");
+  const start = Date.now();
+  const tick = setInterval(() => setState({ genElapsed: Date.now() - start }), 200);
+  try {
+    await new Promise((resolve) => {
+      const poll = setInterval(async () => {
+        let p;
+        try {
+          p = await api.progress();
+        } catch {
+          return;
+        }
+        if (!p) return;
+        if (p.phase) setState({ genPhase: p.phase });
+        setState({ genStuckStopping: !!p.stopping && (p.stoppingMs || 0) > STUCK_STOP_MS });
+        if (!p.inFlight) {
+          clearInterval(poll);
+          resolve();
+        }
+      }, 600);
+    });
+    let st;
+    try {
+      st = await api.status();
+    } catch {
+      st = null;
+    }
+    if (st) {
+      applyStatusResult(st);
+      const r = st.result;
+      if (r && r.ok) setStatus(`generated ${r.pathCount || 0} paths`, "ok");
+      else if (st.lastError) setStatus("generation failed: " + st.lastError, "err");
+      else setStatus("generation stopped", "warn");
+    }
+  } finally {
+    clearInterval(tick);
+    setState({ generating: false, genPhase: "", genElapsed: 0 });
   }
 }
 
@@ -98,7 +181,11 @@ export async function pickProject(dir) {
   setStatus("loading project…");
   try {
     applyDetect(await api.project(dir));
-    setStatus("project loaded", "ok");
+    // The server drops the previous project's spec on switch; clear the UI's
+    // copy too, then reconnect in case the new project already has output.
+    setState({ hasSpec: false, lastPaths: 0, skipped: [] });
+    await restoreFromServer();
+    if (!getState().generating) setStatus("project loaded", "ok");
   } catch (e) {
     setStatus(e.message, "err");
   }
@@ -297,6 +384,19 @@ async function saveConfigFile(path) {
   closeBrowse();
   if (!path) return;
   await doSave(path, false);
+}
+
+// useSuggestedConfig loads the apispec.yaml the server found in the project and
+// clears the suggestion. dismissSuggestedConfig just hides it for the session.
+export async function useSuggestedConfig() {
+  const path = getState().suggestedConfigPath;
+  if (!path) return;
+  await loadConfigFile(path);
+  setState({ suggestedConfigPath: "" });
+}
+
+export function dismissSuggestedConfig() {
+  setState({ suggestedConfigPath: "" });
 }
 
 async function doSave(path, overwrite) {

--- a/cmd/apispecui/assets/js/actions.js
+++ b/cmd/apispecui/assets/js/actions.js
@@ -128,20 +128,30 @@ export async function restoreFromServer() {
 // the server (e.g. after a refresh), then restores its result when it finishes.
 async function attachRun() {
   if (getState().generating) return; // already tracking
+  const myRun = ++activeRun;
   setState({ generating: true, genPhase: "reconnecting…", genElapsed: 0, genBlocked: false });
   setStatus("reconnecting to a running generation…", "warn");
   const start = Date.now();
-  const tick = setInterval(() => setState({ genElapsed: Date.now() - start }), 200);
+  const tick = setInterval(() => {
+    if (myRun !== activeRun) return;
+    setState({ genElapsed: Date.now() - start });
+  }, 200);
   try {
     await new Promise((resolve) => {
       const poll = setInterval(async () => {
+        // Superseded (e.g. a Force restart took over) — stop tracking.
+        if (myRun !== activeRun) {
+          clearInterval(poll);
+          resolve();
+          return;
+        }
         let p;
         try {
           p = await api.progress();
         } catch {
           return;
         }
-        if (!p) return;
+        if (myRun !== activeRun || !p) return;
         if (p.phase) setState({ genPhase: p.phase });
         setState({ genStuckStopping: !!p.stopping && (p.stoppingMs || 0) > STUCK_STOP_MS });
         if (!p.inFlight) {
@@ -150,12 +160,14 @@ async function attachRun() {
         }
       }, 600);
     });
+    if (myRun !== activeRun) return; // a newer run owns the state now
     let st;
     try {
       st = await api.status();
     } catch {
       st = null;
     }
+    if (myRun !== activeRun) return;
     if (st) {
       applyStatusResult(st);
       const r = st.result;
@@ -165,7 +177,7 @@ async function attachRun() {
     }
   } finally {
     clearInterval(tick);
-    setState({ generating: false, genPhase: "", genElapsed: 0 });
+    if (myRun === activeRun) setState({ generating: false, genPhase: "", genElapsed: 0 });
   }
 }
 
@@ -221,19 +233,36 @@ function fullGenerateRequest() {
 // offering a Force restart in the UI.
 const STUCK_STOP_MS = 4000;
 
+// activeRun tags the currently-tracked generation on the client. A new run
+// (including a Force restart) bumps it; older trackers (generate/attachRun) see
+// the mismatch and bow out without clobbering the newer run's state. This is
+// what lets Force supersede an attached, stuck-stopping run cleanly.
+let activeRun = 0;
+
 export async function generate(opts = {}) {
   const s = getState();
-  if (!s.project || s.generating) return;
   const force = !!opts.force;
+  // Force bypasses the in-progress guard so it can supersede a run that's
+  // already being tracked (e.g. a stuck-stopping attached run).
+  if (!s.project || (s.generating && !force)) return;
+  const myRun = ++activeRun;
   const start = Date.now();
   setState({ generating: true, genPhase: "starting…", genElapsed: 0, unresolvedSecurity: [], genBlocked: false, genStuckStopping: false });
   setStatus(force ? "force-restarting…" : "generating…");
   // Live elapsed ticker — reassures the run is alive and makes a stall obvious
   // (a counter climbing on one phase reads as "stuck" where a static label hides it).
-  const tick = setInterval(() => setState({ genElapsed: Date.now() - start }), 200);
+  const tick = setInterval(() => {
+    if (myRun !== activeRun) return;
+    setState({ genElapsed: Date.now() - start });
+  }, 200);
   const poll = setInterval(async () => {
+    if (myRun !== activeRun) {
+      clearInterval(poll);
+      return;
+    }
     try {
       const p = await api.progress();
+      if (myRun !== activeRun) return;
       if (p && p.phase) setState({ genPhase: p.phase });
       // A Stop the engine hasn't acted on yet — let the UI escalate to Force.
       if (p) setState({ genStuckStopping: !!p.stopping && (p.stoppingMs || 0) > STUCK_STOP_MS });
@@ -243,6 +272,7 @@ export async function generate(opts = {}) {
   }, 600);
   try {
     const res = await api.generate(fullGenerateRequest(), { force });
+    if (myRun !== activeRun) return; // superseded by a newer run — drop this result
     if (res && res.cancelled) {
       setStatus(`generation stopped · ${fmtDur(Date.now() - start)}`, "warn");
     } else {
@@ -265,6 +295,7 @@ export async function generate(opts = {}) {
       }
     }
   } catch (e) {
+    if (myRun !== activeRun) return;
     // A rerun attempted while a prior run is in flight (or a stopped run is
     // still winding down) returns 409 with {error, stopping, canForce}. Show a
     // friendly message and flag genBlocked so the UI offers a Force restart —
@@ -284,7 +315,7 @@ export async function generate(opts = {}) {
   } finally {
     clearInterval(tick);
     clearInterval(poll);
-    setState({ generating: false, genPhase: "", genElapsed: 0 });
+    if (myRun === activeRun) setState({ generating: false, genPhase: "", genElapsed: 0 });
   }
 }
 

--- a/cmd/apispecui/assets/js/api.js
+++ b/cmd/apispecui/assets/js/api.js
@@ -38,6 +38,6 @@ export const api = {
   project: (dir) => postJSON("/api/project", { dir }),
   health: () => getJSON("/api/health"),
   browse: (path, files) => getJSON("/api/browse" + qs({ path, files })),
-  generate: (body) => postJSON("/api/generate", body),
+  generate: (body, opts) => postJSON("/api/generate" + (opts && opts.force ? "?force=1" : ""), body),
   progress: () => getJSON("/api/generate/progress"),
 };

--- a/cmd/apispecui/assets/js/api.js
+++ b/cmd/apispecui/assets/js/api.js
@@ -40,4 +40,5 @@ export const api = {
   browse: (path, files) => getJSON("/api/browse" + qs({ path, files })),
   generate: (body, opts) => postJSON("/api/generate" + (opts && opts.force ? "?force=1" : ""), body),
   progress: () => getJSON("/api/generate/progress"),
+  status: () => getJSON("/api/status"),
 };

--- a/cmd/apispecui/assets/js/app.js
+++ b/cmd/apispecui/assets/js/app.js
@@ -12,6 +12,8 @@ import {
   closeBrowse,
   getBrowse,
   fmtDur,
+  useSuggestedConfig,
+  dismissSuggestedConfig,
 } from "/assets/js/actions.js";
 import { BrowseDialog } from "/assets/js/browse.js";
 import { SpecMode } from "/assets/js/spec.js";
@@ -135,6 +137,24 @@ function UnresolvedBanner({ s }) {
   `;
 }
 
+// SuggestedConfigBanner offers to load an apispec.yaml found in the project.
+// It's a suggestion only — nothing is applied until the user clicks Use.
+function SuggestedConfigBanner({ s }) {
+  if (!s.suggestedConfigPath) return "";
+  const name = s.suggestedConfigPath.split("/").pop();
+  return html`
+    <div
+      style="display:flex;align-items:center;gap:10px;padding:8px 14px;background:var(--info-bg,#06283a);border-bottom:1px solid var(--info,#2a7fb8);font-size:var(--fs-sm)"
+    >
+      <span>🛈 Found <code>${name}</code> in this project — use it as the config?</span>
+      <span class="muted" title=${s.suggestedConfigPath} style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:40%">${s.suggestedConfigPath}</span>
+      <span style="flex:1"></span>
+      <button class="btn sm" onClick=${useSuggestedConfig}>Use it</button>
+      <button class="btn ghost sm" onClick=${dismissSuggestedConfig}>Dismiss</button>
+    </div>
+  `;
+}
+
 function Main({ s }) {
   switch (s.mode) {
     case "configure":
@@ -161,6 +181,7 @@ function App() {
       <${Rail} s=${s} />
       <main class="shell-main">
         <div style="display:flex;flex-direction:column;flex:1 1 auto;min-width:0;min-height:0">
+          <${SuggestedConfigBanner} s=${s} />
           <${UnresolvedBanner} s=${s} />
           <${Main} s=${s} />
         </div>

--- a/cmd/apispecui/assets/js/app.js
+++ b/cmd/apispecui/assets/js/app.js
@@ -107,6 +107,23 @@ function Rail({ s }) {
   `;
 }
 
+// UnresolvedBanner points the user at the security-mapping picker after a
+// generation that detected middleware it couldn't map to a scheme. Without it
+// the picker is buried in a collapsed config section and easy to miss.
+function UnresolvedBanner({ s }) {
+  const n = (s.unresolvedSecurity || []).length;
+  if (s.generating || n === 0 || s.mode === "configure") return "";
+  return html`
+    <div
+      style="display:flex;align-items:center;gap:10px;padding:8px 14px;background:var(--warn-bg,#3a2c00);border-bottom:1px solid var(--warn,#b80);font-size:var(--fs-sm)"
+    >
+      <span>⚠ ${n} middleware detected on routes but not mapped to a security scheme — protected routes won't show as secured.</span>
+      <span style="flex:1"></span>
+      <button class="btn sm" onClick=${() => setState({ mode: "configure" })}>Map them →</button>
+    </div>
+  `;
+}
+
 function Main({ s }) {
   switch (s.mode) {
     case "configure":
@@ -131,7 +148,12 @@ function App() {
     <div class="shell">
       <${TopBar} s=${s} />
       <${Rail} s=${s} />
-      <main class="shell-main"><${Main} s=${s} /></main>
+      <main class="shell-main">
+        <div style="display:flex;flex-direction:column;flex:1 1 auto;min-width:0;min-height:0">
+          <${UnresolvedBanner} s=${s} />
+          <${Main} s=${s} />
+        </div>
+      </main>
       <${BrowseDialog}
         open=${b.open}
         mode=${b.mode}

--- a/cmd/apispecui/assets/js/app.js
+++ b/cmd/apispecui/assets/js/app.js
@@ -5,6 +5,7 @@ import { useStore, setState } from "/assets/js/store.js";
 import {
   detectInitial,
   generate,
+  forceGenerate,
   stopGenerate,
   openCallGraph,
   openProject,
@@ -81,6 +82,16 @@ function TopBar({ s }) {
           : "Generate ▸"}
       </button>
       ${s.generating ? html`<button class="btn danger" onClick=${stopGenerate} title="Stop the running engine">■ Stop</button>` : ""}
+      ${(s.genBlocked || s.genStuckStopping) && !s.generating && s.project
+        ? html`<button
+            class="btn"
+            style="background:var(--warn,#b80);border-color:var(--warn,#b80);color:#1a1300"
+            onClick=${forceGenerate}
+            title="Cancel the run that's still in flight / stuck stopping and start a fresh generation now"
+          >
+            ⚡ Force restart
+          </button>`
+        : ""}
       <span class="spacer"></span>
       ${s.status.text &&
       html`<span class=${"badge " + (s.status.kind === "err" ? "err" : s.status.kind === "ok" ? "ok" : s.status.kind === "warn" ? "warn" : "")}>

--- a/cmd/apispecui/assets/js/app.js
+++ b/cmd/apispecui/assets/js/app.js
@@ -84,7 +84,7 @@ function TopBar({ s }) {
           : "Generate ▸"}
       </button>
       ${s.generating ? html`<button class="btn danger" onClick=${stopGenerate} title="Stop the running engine">■ Stop</button>` : ""}
-      ${(s.genBlocked || s.genStuckStopping) && !s.generating && s.project
+      ${(s.genBlocked || s.genStuckStopping) && s.project
         ? html`<button
             class="btn"
             style="background:var(--warn,#b80);border-color:var(--warn,#b80);color:#1a1300"

--- a/cmd/apispecui/assets/js/config.js
+++ b/cmd/apispecui/assets/js/config.js
@@ -430,7 +430,7 @@ export function ConfigMode() {
             <${SecuritySchemes} c=${c} />
           <//>
 
-          <${Section} title="Security mappings" help="Map auth middleware to a security scheme so apispec can mark the routes it guards as protected. Each mapping matches the middleware by function name / package / receiver-type regex and applies the chosen scheme. Most well-known libraries (echo-jwt, gin-jwt, gofiber/contrib/jwt, golang-jwt, …) and custom wrappers around them are detected automatically; use these mappings for project-specific middleware that apispec couldn't resolve (see 'Unresolved auth middleware' after generating)." hint=${`${(c.securityMappings || []).length}`}>
+          <${Section} title="Security mappings" openDefault=${(s.unresolvedSecurity || []).length > 0} help="Map auth middleware to a security scheme so apispec can mark the routes it guards as protected. Each mapping matches the middleware by function name / package / receiver-type regex and applies the chosen scheme. Most well-known libraries (echo-jwt, gin-jwt, gofiber/contrib/jwt, golang-jwt, …) and custom wrappers around them are detected automatically; use these mappings for project-specific middleware that apispec couldn't resolve (see 'Unresolved auth middleware' after generating)." hint=${`${(c.securityMappings || []).length}`}>
             <${UnresolvedMiddleware} c=${c} />
             <${SecurityMappings} c=${c} />
           <//>

--- a/cmd/apispecui/assets/js/insight.js
+++ b/cmd/apispecui/assets/js/insight.js
@@ -2,7 +2,7 @@
 // view. Uses diverse SVG visualizations (gauge, donuts, layered call
 // graph) and ⓘ info tooltips on every metric.
 import { html, useState, useEffect } from "/assets/js/preact.js";
-import { useStore } from "/assets/js/store.js";
+import { useStore, setState } from "/assets/js/store.js";
 import { getJSON } from "/assets/js/api.js";
 import { Donut, Gauge, Info, TraceDiagram } from "/assets/js/components/charts.js";
 
@@ -15,6 +15,7 @@ function normalizeReport(d) {
   }
   d.health = d.health || { score: 0, cleanRoutes: 0, totalRoutes: 0 };
   d.callGraph = d.callGraph || { packages: 0, functions: 0, edges: 0 };
+  d.security = d.security || { schemesDefined: 0, schemes: [], protected: 0, public: 0, unsecured: 0, bySchemeUsage: [] };
   return d;
 }
 
@@ -55,6 +56,11 @@ const INFO = {
   ctype: "Request/response content types declared across the API.",
   tags: "OpenAPI tags grouping the routes.",
   toptypes: "Schemas referenced most often across request/response bodies.",
+  security:
+    "How authentication is applied across the API: how many operations require auth, are explicitly public, or have no security at all — plus the declared schemes and any middleware apispec couldn't map to a scheme.",
+  secops:
+    "Each operation by its effective security: protected (a requirement applies — its own or inherited from the document), public (an explicit security: [] opt-out), or no auth (no requirement at all).",
+  secschemes: "Security schemes declared under components.securitySchemes, and how many operations require each.",
   callgraph: "Coarse size of the analysed call graph backing the spec.",
   fanout:
     "How many distinct functions each function directly calls, within this endpoint's call subtree (Go builtins like len/append and standard-library calls like fmt/net/http are excluded, so only your code + frameworks count). Average = total direct calls ÷ functions that make at least one call — leaf functions (0 calls) are left out of the divisor, so it reflects the branching factor among branching functions rather than being diluted toward 0 by leaves. Max = the single most-branching function. Example: handler calls 3, A calls 2, B calls 0 → avg (3+2)/2 = 2.5, max 3. Higher = more branching.",
@@ -169,6 +175,8 @@ function Overview({ rep, onTag }) {
         : ""}
     </div>
 
+    <${SecurityCard} rep=${rep} />
+
     <div class="card" style="margin-bottom:var(--sp-3)">
       <div class="row">
         <h3>Needs attention</h3><span class="spacer"></span>
@@ -211,6 +219,62 @@ function Overview({ rep, onTag }) {
 
     <${CallGraphCard} cg=${rep.callGraph} />
     <${ExportModal} open=${exportOpen} onClose=${() => setExportOpen(false)} scope="all" />
+  `;
+}
+
+// SecurityCard visualises how auth is applied across the API (protected /
+// public / no-auth operations, declared schemes, per-scheme usage) and surfaces
+// any middleware apispec detected but couldn't map to a scheme.
+function SecurityCard({ rep }) {
+  const s = useStore();
+  const sec = rep.security || {};
+  const unresolved = (s.unresolvedSecurity || []).length;
+  const total = (sec.protected || 0) + (sec.public || 0) + (sec.unsecured || 0);
+  const donut = [
+    { name: "protected", count: sec.protected || 0, color: "var(--accent-2)" },
+    { name: "public", count: sec.public || 0, color: "var(--info)" },
+    { name: "no auth", count: sec.unsecured || 0, color: "var(--warn)" },
+  ].filter((d) => d.count > 0);
+  const usage = (sec.bySchemeUsage || []).map((d) => ({ name: d.name, count: d.count }));
+  const noAuth = !(sec.schemesDefined || sec.protected || unresolved);
+
+  return html`
+    <div class="card" style="margin-bottom:var(--sp-3)">
+      ${Title("Security", INFO.security)}
+      ${noAuth
+        ? html`<p class="muted">No authentication detected — no security schemes, and every operation is open. If routes are auth-guarded by a custom middleware, map it under Configure ▸ Security mappings.</p>`
+        : html`<div class="grid-cards" style="grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:var(--sp-4)">
+            <div>
+              <div class="shape-h">Operations <${Info} text=${INFO.secops} /></div>
+              ${donut.length
+                ? html`<${Donut} data=${donut} size=${120} thickness=${18} centerLabel=${total} centerSub="ops" />`
+                : html`<span class="muted">none</span>`}
+              <div class="row wrap" style="gap:var(--sp-3);margin-top:var(--sp-2);font-size:var(--fs-sm)">
+                <span><span class="dot" style="background:var(--accent-2)"></span> ${sec.protected || 0} protected</span>
+                <span><span class="dot" style="background:var(--info)"></span> ${sec.public || 0} public</span>
+                <span><span class="dot" style="background:var(--warn)"></span> ${sec.unsecured || 0} no auth</span>
+              </div>
+            </div>
+            <div>
+              <div class="shape-h">Schemes <${Info} text=${INFO.secschemes} /></div>
+              ${(sec.schemes || []).length
+                ? html`<div class="chips">${sec.schemes.map((n) => html`<span class="chip">${n}</span>`)}</div>`
+                : html`<span class="muted">none defined</span>`}
+              ${usage.length ? html`<div style="margin-top:var(--sp-2)"><${Bars} data=${usage} color="var(--accent-2)" /></div>` : ""}
+              ${sec.globalSecurity
+                ? html`<p class="muted" style="font-size:var(--fs-xs);margin-top:var(--sp-2)">A document-level security requirement applies by default.</p>`
+                : ""}
+            </div>
+          </div>`}
+      ${unresolved
+        ? html`<div class="row" style="margin-top:var(--sp-3);gap:var(--sp-2);align-items:center;flex-wrap:wrap">
+            <span class="badge err"><span class="dot"></span>${unresolved} unresolved</span>
+            <span class="muted" style="font-size:var(--fs-sm)">middleware detected on routes but not mapped to a scheme</span>
+            <span class="spacer"></span>
+            <button class="btn sm" onClick=${() => setState({ mode: "configure" })}>Map them →</button>
+          </div>`
+        : ""}
+    </div>
   `;
 }
 

--- a/cmd/apispecui/assets/js/store.js
+++ b/cmd/apispecui/assets/js/store.js
@@ -37,6 +37,8 @@ const state = {
   generating: false,
   genPhase: "",
   genElapsed: 0, // ms since the current generation started (live ticker)
+  genBlocked: false, // last generate hit a 409 (a prior run is in flight / stuck stopping) — offer Force
+  genStuckStopping: false, // a Stop the engine hasn't honoured for a while — escalate to Force
   hasSpec: false,
   lastPaths: 0,
   skipped: [], // [{package, reason}] dropped due to type errors (project didn't build)

--- a/cmd/apispecui/assets/js/store.js
+++ b/cmd/apispecui/assets/js/store.js
@@ -45,7 +45,37 @@ const state = {
   unresolvedSecurity: [], // [{functionName,pkg,recvType,position}] auth middleware not mapped to a scheme
   specView: "swagger", // swagger | redoc | scalar
   panelCollapsed: false,
+  suggestedConfigPath: "", // apispec.yaml found in the project — offer to load it
 };
+
+// View prefs persisted across refreshes so a reload lands the user back where
+// they were (which tab, which spec viewer, panel layout).
+const PERSIST_KEYS = ["mode", "specView", "panelCollapsed"];
+const PERSIST_LS_KEY = "apispecui.view";
+
+function loadPersistedView() {
+  try {
+    const raw = localStorage.getItem(PERSIST_LS_KEY);
+    if (!raw) return;
+    const saved = JSON.parse(raw);
+    for (const k of PERSIST_KEYS) {
+      if (saved[k] !== undefined) state[k] = saved[k];
+    }
+  } catch {
+    /* ignore malformed / unavailable storage */
+  }
+}
+loadPersistedView();
+
+function persistView() {
+  try {
+    const out = {};
+    for (const k of PERSIST_KEYS) out[k] = state[k];
+    localStorage.setItem(PERSIST_LS_KEY, JSON.stringify(out));
+  } catch {
+    /* ignore */
+  }
+}
 
 const listeners = new Set();
 
@@ -55,6 +85,13 @@ export function getState() {
 
 export function setState(patch) {
   Object.assign(state, patch);
+  // Persist view prefs only when one of them changed (setState runs often).
+  for (const k of PERSIST_KEYS) {
+    if (k in patch) {
+      persistView();
+      break;
+    }
+  }
   listeners.forEach((fn) => fn());
 }
 

--- a/cmd/apispecui/main.go
+++ b/cmd/apispecui/main.go
@@ -135,6 +135,11 @@ type DetectResponse struct {
 	// param/mount patterns) for the detected framework — pre-filled so the UI
 	// can render every pattern editor.
 	Framework spec.FrameworkConfig `json:"frameworkConfig"`
+
+	// SuggestedConfigPath is the path to an apispec.yaml-style config file found
+	// in the project that parses as a real config. Empty when none is found or a
+	// --config was already supplied. The UI suggests (but does not auto-apply) it.
+	SuggestedConfigPath string `json:"suggestedConfigPath,omitempty"`
 }
 
 // ProjectRequest is what POST /api/project accepts.
@@ -214,6 +219,11 @@ type UIServer struct {
 	// metaCache is keyed by absolute input dir. Cleared on project switch.
 	metaCache map[string]*MetadataSummary
 
+	// lastResult is the response of the most recent successful generation,
+	// retained so a page refresh can restore the result (path count, unresolved
+	// security, skipped packages) via /api/status without re-running anything.
+	lastResult *GenerateResponse
+
 	// diag serves the embedded call-graph / tracker-tree visualization.
 	// Routes are mounted under /diagram (UI) and /api/diagram/* (API).
 	diag *diagserver.Server
@@ -248,8 +258,19 @@ func (s *UIServer) currentDir() string {
 
 func (s *UIServer) setDir(d string) {
 	s.mu.Lock()
+	changed := s.inputDir != d
 	s.inputDir = d
 	s.metaCache = nil // invalidate metadata cache
+	if changed {
+		// Switching projects: the previous spec/result no longer applies, so a
+		// refresh shouldn't restore another project's output.
+		s.currentSpec = nil
+		s.currentMeta = nil
+		s.currentCfg = nil
+		s.lastResult = nil
+		s.lastGen = time.Time{}
+		s.lastErr = ""
+	}
 	diag := s.diag
 	s.mu.Unlock()
 
@@ -295,6 +316,7 @@ func main() {
 	mux.HandleFunc("/api/generate", srv.handleGenerate)
 	mux.HandleFunc("/api/generate/progress", srv.handleGenerateProgress)
 	mux.HandleFunc("/api/generate/cancel", srv.handleGenerateCancel)
+	mux.HandleFunc("/api/status", srv.handleStatus)
 	mux.HandleFunc("/api/spec.json", srv.handleSpecJSON)
 	mux.HandleFunc("/api/spec.yaml", srv.handleSpecYAML)
 	mux.HandleFunc("/api/config.yaml", srv.handleConfigYAML)
@@ -549,6 +571,13 @@ func (s *UIServer) buildDetectResponse(dir string) DetectResponse {
 		}
 	}
 
+	// Suggest an apispec.yaml-style config found in the project — but only when
+	// the operator didn't already pass one via --config.
+	suggested := ""
+	if s.cfg.ConfigFile == "" {
+		suggested = findSuggestedConfig(dir, root)
+	}
+
 	return DetectResponse{
 		InputDir:            dir,
 		ModuleRoot:          root,
@@ -570,7 +599,56 @@ func (s *UIServer) buildDetectResponse(dir string) DetectResponse {
 		Include:             base.Include,
 		Exclude:             base.Exclude,
 		Framework:           base.Framework,
+		SuggestedConfigPath: suggested,
 	}
+}
+
+// suggestedConfigNames are the conventional apispec config filenames, in
+// priority order, looked up in the project dir and the module root.
+var suggestedConfigNames = []string{"apispec.yaml", "apispec.yml", ".apispec.yaml", ".apispec.yml"}
+
+// findSuggestedConfig returns the first conventional config file under dir or
+// the module root that parses as a real apispec config, or "" if none.
+func findSuggestedConfig(dir, root string) string {
+	seen := map[string]bool{}
+	for _, base := range []string{dir, root} {
+		if base == "" || seen[base] {
+			continue
+		}
+		seen[base] = true
+		for _, name := range suggestedConfigNames {
+			path := filepath.Join(base, name)
+			if st, err := os.Stat(path); err != nil || st.IsDir() {
+				continue
+			}
+			if looksLikeAPISpecConfig(path) {
+				return path
+			}
+		}
+	}
+	return ""
+}
+
+// looksLikeAPISpecConfig reports whether path loads as an apispec config and
+// carries at least one meaningful section — so a stray empty/unrelated YAML
+// isn't suggested.
+func looksLikeAPISpecConfig(path string) bool {
+	cfg, err := spec.LoadAPISpecConfig(path)
+	if err != nil || cfg == nil {
+		return false
+	}
+	fw := cfg.Framework
+	return cfg.Info.Title != "" ||
+		len(fw.RoutePatterns) > 0 ||
+		len(fw.RequestBodyPatterns) > 0 ||
+		len(fw.ResponsePatterns) > 0 ||
+		len(fw.ParamPatterns) > 0 ||
+		len(fw.MountPatterns) > 0 ||
+		len(fw.SecurityPatterns) > 0 ||
+		len(cfg.SecurityMappings) > 0 ||
+		len(cfg.TypeMapping) > 0 ||
+		len(cfg.ExternalTypes) > 0 ||
+		len(cfg.Overrides) > 0
 }
 
 func (s *UIServer) handleDetect(w http.ResponseWriter, r *http.Request) {
@@ -861,7 +939,7 @@ func (s *UIServer) handleGenerate(w http.ResponseWriter, r *http.Request) {
 		if len(skipped) > 0 {
 			msg = fmt.Sprintf("%d package(s) skipped because they failed to type-check — the spec may be incomplete. Ensure the project builds (go build ./...).", len(skipped))
 		}
-		writeJSON(w, http.StatusOK, GenerateResponse{
+		resp := GenerateResponse{
 			OK:                 true,
 			Framework:          req.Framework,
 			PathCount:          len(out.Paths),
@@ -870,7 +948,12 @@ func (s *UIServer) handleGenerate(w http.ResponseWriter, r *http.Request) {
 			Message:            msg,
 			SkippedPackages:    skipped,
 			UnresolvedSecurity: gen.GetUnresolvedSecurity(),
-		})
+		}
+		// Retain for /api/status so a page refresh can restore this result.
+		s.mu.Lock()
+		s.lastResult = &resp
+		s.mu.Unlock()
+		writeJSON(w, http.StatusOK, resp)
 		return
 	}
 }
@@ -905,6 +988,46 @@ func (s *UIServer) handleGenerateProgress(w http.ResponseWriter, r *http.Request
 		"inFlight":   inFlight,
 		"stopping":   stopping,
 		"stoppingMs": stoppingMs,
+	})
+}
+
+// handleStatus returns the full server-side generation state so a freshly
+// loaded (or refreshed) page can reattach to a run still in flight and restore
+// the last result without re-running anything. The engine runs detached from
+// the originating request, so a refresh never interrupts it.
+func (s *UIServer) handleStatus(w http.ResponseWriter, r *http.Request) {
+	s.mu.RLock()
+	phase := s.genPhase
+	at := s.genPhaseAt
+	running := s.genRunning
+	stopping := s.genStopping
+	stopAt := s.genStopAt
+	hasSpec := s.currentSpec != nil
+	lastGen := s.lastGen
+	lastErr := s.lastErr
+	dir := s.inputDir
+	result := s.lastResult
+	s.mu.RUnlock()
+
+	var sinceMs, stoppingMs int64
+	if !at.IsZero() {
+		sinceMs = time.Since(at).Milliseconds()
+	}
+	if stopping && !stopAt.IsZero() {
+		stoppingMs = time.Since(stopAt).Milliseconds()
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"running":    running,
+		"stopping":   stopping,
+		"phase":      phase,
+		"sinceMs":    sinceMs,
+		"stoppingMs": stoppingMs,
+		"hasSpec":    hasSpec,
+		"lastGenAt":  lastGen,
+		"lastError":  lastErr,
+		"projectDir": dir,
+		"result":     result, // nil until the first successful generation
 	})
 }
 

--- a/cmd/apispecui/main.go
+++ b/cmd/apispecui/main.go
@@ -638,6 +638,9 @@ func looksLikeAPISpecConfig(path string) bool {
 		return false
 	}
 	fw := cfg.Framework
+	ie := func(x spec.IncludeExclude) bool {
+		return len(x.Files) > 0 || len(x.Packages) > 0 || len(x.Functions) > 0 || len(x.Types) > 0
+	}
 	return cfg.Info.Title != "" ||
 		len(fw.RoutePatterns) > 0 ||
 		len(fw.RequestBodyPatterns) > 0 ||
@@ -648,7 +651,17 @@ func looksLikeAPISpecConfig(path string) bool {
 		len(cfg.SecurityMappings) > 0 ||
 		len(cfg.TypeMapping) > 0 ||
 		len(cfg.ExternalTypes) > 0 ||
-		len(cfg.Overrides) > 0
+		len(cfg.Overrides) > 0 ||
+		// Sections the UI also surfaces in DetectResponse — a config that only
+		// sets these is still meaningful and worth suggesting.
+		len(cfg.Servers) > 0 ||
+		len(cfg.Security) > 0 ||
+		len(cfg.SecuritySchemes) > 0 ||
+		len(cfg.Tags) > 0 ||
+		cfg.ExternalDocs != nil ||
+		cfg.Defaults != (spec.Defaults{}) ||
+		ie(cfg.Include) ||
+		ie(cfg.Exclude)
 }
 
 func (s *UIServer) handleDetect(w http.ResponseWriter, r *http.Request) {

--- a/cmd/apispecui/main.go
+++ b/cmd/apispecui/main.go
@@ -218,9 +218,17 @@ type UIServer struct {
 	// Routes are mounted under /diagram (UI) and /api/diagram/* (API).
 	diag *diagserver.Server
 
-	// genMu serializes Generate requests so a frantic double-click doesn't
-	// stack two parallel analyses (each consuming a full CPU+RAM hit).
-	genMu sync.Mutex
+	// genRunning marks that an engine run is in flight (or still winding down
+	// after a Stop). genEpoch tags each run so a stale/abandoned run can't
+	// clobber a newer one's results or state — this is what lets a Force start
+	// a fresh run even when the previous one is stuck in a phase that doesn't
+	// honour cancellation promptly. genStopping/genStopAt record a Stop the
+	// engine hasn't acted on yet so the UI can show "stopping… Ns" and offer a
+	// Force. All guarded by mu.
+	genRunning  bool
+	genEpoch    uint64
+	genStopping bool
+	genStopAt   time.Time
 
 	// genCancel cancels the in-flight generation, if any. Guarded by mu.
 	genCancel context.CancelFunc
@@ -617,16 +625,10 @@ func (s *UIServer) handleGenerate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Serialize generates. A second request that arrives while one is in
-	// flight (or while a stopped run is still winding down) gets a clear
-	// 409 instead of stacking another full engine run on top of the first.
-	// NOTE: the lock is released manually — on a Stop we return to the
-	// client immediately but keep the lock until the engine goroutine
-	// actually exits, so a rerun can't start a second concurrent analysis.
-	if !s.genMu.TryLock() {
-		writeError(w, http.StatusConflict, "a generation is in progress (or stopping) — try again in a moment")
-		return
-	}
+	// force=1 supersedes an in-flight (or stuck-stopping) run — see the gate
+	// below. Read it before parsing the body so a malformed body still reports
+	// a body error rather than silently blocking.
+	force := r.URL.Query().Get("force") == "1" || r.URL.Query().Get("force") == "true"
 
 	var req GenerateRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -661,14 +663,46 @@ func (s *UIServer) handleGenerate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Serialize generates. A second request that arrives while one is in
+	// flight (or while a stopped run is still winding down) gets a clear 409
+	// instead of stacking another full engine run — UNLESS it passes ?force=1,
+	// which cancels and abandons the in-flight run (its results are discarded
+	// via the epoch check) and starts fresh. Force is the escape hatch when the
+	// engine is wedged in a phase that doesn't honour cancellation promptly.
+	// The gate sits after request parsing/validation so a bad request never
+	// claims the run slot.
 	start := time.Now()
-
-	// Reset progress at the start of each generate so stale phase strings
-	// from a previous run don't leak into the new one.
-	// Cancellable context so the UI can stop this run via
-	// /api/generate/cancel. Stored under mu and cleared when done.
 	genCtx, cancel := context.WithCancel(context.Background())
 	s.mu.Lock()
+	if s.genRunning {
+		if !force {
+			stopping := s.genStopping
+			var sinceMs int64
+			if stopping && !s.genStopAt.IsZero() {
+				sinceMs = time.Since(s.genStopAt).Milliseconds()
+			}
+			s.mu.Unlock()
+			cancel()
+			writeJSON(w, http.StatusConflict, map[string]interface{}{
+				"error":    "a generation is in progress (or stopping) — try again in a moment",
+				"stopping": stopping,
+				"sinceMs":  sinceMs,
+				"canForce": true,
+			})
+			return
+		}
+		// Force: cancel and abandon the in-flight run. We do NOT wait for it —
+		// the epoch bump below makes its eventual result a no-op.
+		if s.genCancel != nil {
+			s.genCancel()
+		}
+	}
+	s.genEpoch++
+	epoch := s.genEpoch
+	s.genRunning = true
+	s.genStopping = false
+	s.genStopAt = time.Time{}
+	// Reset progress so stale phase strings from a previous run don't leak in.
 	s.genPhase = "loading packages…"
 	s.genPhaseAt = time.Now()
 	s.genCancel = cancel
@@ -717,12 +751,31 @@ func (s *UIServer) handleGenerate(w http.ResponseWriter, r *http.Request) {
 
 	// Run the engine in a goroutine so a Stop can unblock the request
 	// immediately. The engine still honours genCtx and exits at its next
-	// checkpoint; until it does we keep genMu held (in the drain below) so
-	// a rerun can't start a second concurrent analysis.
+	// checkpoint. finishRun clears the run slot only if this run is still the
+	// current epoch — a Force may have superseded it, in which case the stale
+	// run must touch nothing.
 	type genResult struct {
 		out  *pubspec.OpenAPISpec
 		meta *metadata.Metadata
 		err  error
+	}
+	finishRun := func() {
+		s.mu.Lock()
+		if s.genEpoch == epoch {
+			s.genRunning = false
+			s.genStopping = false
+			s.genStopAt = time.Time{}
+			s.genCancel = nil
+			s.genPhase = ""
+		}
+		s.mu.Unlock()
+	}
+	// superseded reports whether a Force has started a newer run, making this
+	// one's results stale.
+	superseded := func() bool {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+		return s.genEpoch != epoch
 	}
 	done := make(chan genResult, 1)
 	go func() {
@@ -736,29 +789,33 @@ func (s *UIServer) handleGenerate(w http.ResponseWriter, r *http.Request) {
 
 	select {
 	case <-genCtx.Done():
-		// User pressed Stop — respond now; release the lock only once the
-		// engine goroutine has actually wound down.
+		// Stop requested (or this run was superseded by a Force). Respond now;
+		// drain the engine goroutine in the background and clear the run slot
+		// when it actually exits.
 		s.mu.Lock()
-		s.genPhase = "stopping…"
+		if s.genEpoch == epoch {
+			s.genStopping = true
+			s.genStopAt = time.Now()
+			s.genPhase = "stopping…"
+		}
 		s.mu.Unlock()
 		go func() {
 			<-done
 			cancel()
-			s.mu.Lock()
-			s.genCancel = nil
-			s.genPhase = ""
-			s.mu.Unlock()
-			s.genMu.Unlock()
+			finishRun()
 		}()
 		writeJSON(w, http.StatusOK, map[string]interface{}{"ok": false, "cancelled": true, "message": "generation stopped"})
 		return
 
 	case res := <-done:
 		cancel()
-		s.mu.Lock()
-		s.genCancel = nil
-		s.mu.Unlock()
-		defer s.genMu.Unlock()
+		// If a Force superseded this run, discard its results untouched — the
+		// newer run owns the shared state and the client reply.
+		if superseded() {
+			writeJSON(w, http.StatusOK, map[string]interface{}{"ok": false, "cancelled": true, "message": "superseded by a newer generation"})
+			return
+		}
+		defer finishRun()
 
 		if res.err != nil {
 			s.mu.Lock()
@@ -826,26 +883,28 @@ func (s *UIServer) handleGenerateProgress(w http.ResponseWriter, r *http.Request
 	s.mu.RLock()
 	phase := s.genPhase
 	at := s.genPhaseAt
+	inFlight := s.genRunning
+	stopping := s.genStopping
+	stopAt := s.genStopAt
 	s.mu.RUnlock()
-
-	// Probe the generate mutex without blocking. If we can acquire it, no
-	// generate is running — release immediately. If not, a generate is in
-	// flight.
-	inFlight := true
-	if s.genMu.TryLock() {
-		inFlight = false
-		s.genMu.Unlock()
-	}
 
 	var sinceMs int64
 	if !at.IsZero() {
 		sinceMs = time.Since(at).Milliseconds()
 	}
+	// How long a Stop has been pending without the engine honouring it — the UI
+	// uses this to escalate from "stopping…" to offering a Force.
+	var stoppingMs int64
+	if stopping && !stopAt.IsZero() {
+		stoppingMs = time.Since(stopAt).Milliseconds()
+	}
 
 	writeJSON(w, http.StatusOK, map[string]interface{}{
-		"phase":    phase,
-		"sinceMs":  sinceMs,
-		"inFlight": inFlight,
+		"phase":      phase,
+		"sinceMs":    sinceMs,
+		"inFlight":   inFlight,
+		"stopping":   stopping,
+		"stoppingMs": stoppingMs,
 	})
 }
 

--- a/internal/insight/overview.go
+++ b/internal/insight/overview.go
@@ -243,6 +243,20 @@ func securityStats(s *spec.OpenAPISpec) SecurityStats {
 				st.Unsecured++
 				continue
 			}
+			// An empty requirement object {} inside the array permits anonymous
+			// access (optional auth), so the operation is effectively public —
+			// not protected — regardless of any sibling requirements.
+			anonymous := false
+			for _, req := range eff {
+				if len(req) == 0 {
+					anonymous = true
+					break
+				}
+			}
+			if anonymous {
+				st.Public++
+				continue
+			}
 			st.Protected++
 			seen := map[string]bool{}
 			for _, req := range eff {

--- a/internal/insight/overview.go
+++ b/internal/insight/overview.go
@@ -64,6 +64,17 @@ type RouteRef struct {
 	Tags   []string `json:"tags"`
 }
 
+// SecurityStats summarises how authentication is applied across the API.
+type SecurityStats struct {
+	SchemesDefined int      `json:"schemesDefined"` // count of components.securitySchemes
+	Schemes        []string `json:"schemes"`        // their names (sorted)
+	GlobalSecurity bool     `json:"globalSecurity"` // a document-level security requirement is set
+	Protected      int      `json:"protected"`      // operations that require auth (explicit or inherited)
+	Public         int      `json:"public"`         // operations explicitly opted out (security: [])
+	Unsecured      int      `json:"unsecured"`      // operations with no security at all (no auth)
+	BySchemeUsage  []Count  `json:"bySchemeUsage"`  // operations requiring each scheme
+}
+
 // OverviewReport is the whole-API insight payload.
 type OverviewReport struct {
 	Routes        int            `json:"routes"`     // distinct path templates
@@ -76,6 +87,7 @@ type OverviewReport struct {
 	Components    int            `json:"components"`
 	TopTypes      []Count        `json:"topTypes"`
 	Health        Health         `json:"health"`
+	Security      SecurityStats  `json:"security"`
 	Issues        []Issue        `json:"issues"`
 	CallGraph     CallGraphStats `json:"callGraph"`
 }
@@ -190,8 +202,61 @@ func BuildOverview(s *spec.OpenAPISpec, meta *metadata.Metadata) *OverviewReport
 		rep.Issues = []Issue{}
 	}
 
+	rep.Security = securityStats(s)
 	rep.CallGraph = callGraphStats(meta)
 	return rep
+}
+
+// securityStats classifies every operation as protected / public / unsecured,
+// honouring OpenAPI inheritance: an operation with no `security` field inherits
+// the document-level requirement, an explicit empty `security: []` opts out
+// (public), and a non-empty requirement (own or inherited) means protected.
+func securityStats(s *spec.OpenAPISpec) SecurityStats {
+	st := SecurityStats{Schemes: []string{}, BySchemeUsage: []Count{}}
+	if s == nil {
+		return st
+	}
+	if s.Components != nil {
+		for name := range s.Components.SecuritySchemes {
+			st.Schemes = append(st.Schemes, name)
+		}
+		sort.Strings(st.Schemes)
+		st.SchemesDefined = len(st.Schemes)
+	}
+	st.GlobalSecurity = len(s.Security) > 0
+
+	usage := map[string]int{}
+	for _, p := range s.Paths {
+		for _, mo := range operationsOf(p) {
+			// Resolve the effective requirement for this operation.
+			var eff []spec.SecurityRequirement
+			if mo.Op.Security != nil {
+				if len(*mo.Op.Security) == 0 {
+					st.Public++ // explicit security: []
+					continue
+				}
+				eff = *mo.Op.Security
+			} else {
+				eff = s.Security // inherit document-level
+			}
+			if len(eff) == 0 {
+				st.Unsecured++
+				continue
+			}
+			st.Protected++
+			seen := map[string]bool{}
+			for _, req := range eff {
+				for name := range req {
+					if !seen[name] {
+						seen[name] = true
+						usage[name]++
+					}
+				}
+			}
+		}
+	}
+	st.BySchemeUsage = sortedCounts(usage, true)
+	return st
 }
 
 func collectOperationIssues(method, path string, op *spec.Operation, comps map[string]*spec.Schema, statusC, ctC, typeC map[string]int) []Issue {

--- a/internal/insight/overview_security_test.go
+++ b/internal/insight/overview_security_test.go
@@ -1,0 +1,78 @@
+package insight
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/spec"
+)
+
+func reqPtr(r ...spec.SecurityRequirement) *[]spec.SecurityRequirement {
+	s := append([]spec.SecurityRequirement{}, r...)
+	return &s
+}
+
+// TestSecurityStats covers the protected / public / no-auth classification,
+// including OpenAPI's empty requirement object {} (anonymous access) and
+// document-level inheritance.
+func TestSecurityStats(t *testing.T) {
+	s := &spec.OpenAPISpec{
+		Components: &spec.Components{
+			SecuritySchemes: map[string]spec.SecurityScheme{
+				"bearerAuth": {Type: "http", Scheme: "bearer"},
+			},
+		},
+		Paths: map[string]spec.PathItem{
+			// protected: a real requirement
+			"/a": {Get: &spec.Operation{Security: reqPtr(spec.SecurityRequirement{"bearerAuth": {}})}},
+			// public: explicit security: [] (override / opt out)
+			"/b": {Get: &spec.Operation{Security: reqPtr()}},
+			// no auth: nothing declared, no global default
+			"/c": {Get: &spec.Operation{}},
+			// public: [{}] — empty requirement object permits anonymous access
+			"/d": {Get: &spec.Operation{Security: reqPtr(spec.SecurityRequirement{})}},
+			// public: [{}, {bearerAuth}] — anonymous allowed alongside bearer
+			"/e": {Get: &spec.Operation{Security: reqPtr(spec.SecurityRequirement{}, spec.SecurityRequirement{"bearerAuth": {}})}},
+		},
+	}
+
+	st := securityStats(s)
+
+	if st.Protected != 1 {
+		t.Errorf("Protected = %d, want 1", st.Protected)
+	}
+	if st.Public != 3 { // /b, /d, /e
+		t.Errorf("Public = %d, want 3", st.Public)
+	}
+	if st.Unsecured != 1 { // /c
+		t.Errorf("Unsecured = %d, want 1", st.Unsecured)
+	}
+	if st.SchemesDefined != 1 || len(st.Schemes) != 1 || st.Schemes[0] != "bearerAuth" {
+		t.Errorf("schemes = %+v (defined %d), want [bearerAuth]", st.Schemes, st.SchemesDefined)
+	}
+	// Only the genuinely-protected /a contributes to scheme usage.
+	if len(st.BySchemeUsage) != 1 || st.BySchemeUsage[0].Name != "bearerAuth" || st.BySchemeUsage[0].Count != 1 {
+		t.Errorf("BySchemeUsage = %+v, want bearerAuth:1", st.BySchemeUsage)
+	}
+}
+
+// TestSecurityStatsGlobalInheritance verifies that an operation with no security
+// field inherits the document-level requirement.
+func TestSecurityStatsGlobalInheritance(t *testing.T) {
+	s := &spec.OpenAPISpec{
+		Security: []spec.SecurityRequirement{{"bearerAuth": {}}},
+		Paths: map[string]spec.PathItem{
+			"/inherits": {Get: &spec.Operation{}},                   // inherits global -> protected
+			"/optsout":  {Get: &spec.Operation{Security: reqPtr()}}, // security: [] -> public
+		},
+	}
+	st := securityStats(s)
+	if !st.GlobalSecurity {
+		t.Error("GlobalSecurity = false, want true")
+	}
+	if st.Protected != 1 {
+		t.Errorf("Protected = %d, want 1 (inherited)", st.Protected)
+	}
+	if st.Public != 1 {
+		t.Errorf("Public = %d, want 1", st.Public)
+	}
+}


### PR DESCRIPTION
Builds on the merged auth-detection work (#88, #89) with a set of apispecui UX improvements. All four commits are apispecui-only (plus the insight backend).

## What's in here

**1. Surface unresolved auth middleware (`15a255c`)**
The picker to map detected-but-unmapped middleware to a security scheme lived only inside a collapsed config section the user isn't on after generating — effectively invisible. Now a banner appears after a generation that left middleware unmapped (with a "Map them →" jump), and the "Security mappings" section auto-expands when there are unresolved items.

**2. Force-restart escape hatch for a stuck generation (`5123a60`)**
A Stop the engine doesn't honour promptly left the run "stopping" with the lock held, so every new generate returned a raw 409 blob with no way out but restarting the server. Replaced the serializing mutex with an epoch-tagged run slot: `?force=1` cancels and abandons the in-flight run (result discarded via the epoch check — no double-unlock) and starts fresh. The 409 now returns `{stopping, sinceMs, canForce}`; a "⚡ Force restart" button appears when blocked/stuck. Also moves the run-slot gate after request validation (a bad request no longer wedges generation). Verified `-race` clean under concurrent generate + cancel + force.

**3. Security in the Insight dashboard (`0beac97`)**
`BuildOverview` now computes `SecurityStats` from the spec: declared schemes, per-scheme operation usage, and every operation classified protected / public (`security: []`) / no-auth, honouring OpenAPI document-level inheritance. Insight renders a Security card and surfaces the unmapped-middleware count with a jump to Configure.

**4. Refresh persistence + apispec.yaml suggestion (`7368235`)**
Generation runs detached from the HTTP request, so a refresh no longer loses it. New `/api/status` returns running/phase + the last result (retained server-side); on load the UI reattaches to a run still in flight (resumes live progress) and restores the last spec/result. Active view (tab, spec viewer, panel) persists to localStorage. Separately: when an `apispec.yaml`/`.yml` that parses as a real config is found in the project (and no `--config` was passed), `/api/detect` returns its path and the UI shows a dismissible "use it as config?" banner.

## Testing
- `go build ./...`, `go vet`, full `go test ./...` pass; `internal/insight` tests pass.
- JS syntax-checked; served assets confirmed to include the new code.
- End-to-end verified against testdata fixtures and external projects (status persistence, insight security counts, force-restart supersede, apispec.yaml detection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an API security overview with auth coverage breakdowns, per-scheme usage, and an unresolved-mappings banner to switch into configuration mode.
  * Introduced a suggested config banner with actions to apply or dismiss it.
  * Added “Force restart” and improved generation recovery to resume/continue when possible.

* **Bug Fixes**
  * Improved refresh and project switching to reliably restore the latest completed result and avoid showing superseded runs.
  * Refined generation control and error handling for stuck/stopping states; added persistence for selected view preferences.

* **Tests**
  * Added unit tests covering security classification logic (protected/public/unsecured).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->