### PR TITLE
perf: stop re-sorting tracker maps on every traversal step

### DIFF
--- a/internal/spec/tracker.go
+++ b/internal/spec/tracker.go
@@ -78,6 +78,7 @@ func (at ArgumentType) String() string {
 // TrackerNode represents a node in the call graph tree.
 type TrackerNode struct {
 	key      string
+	keyReady bool // key has been computed + normalized (deref-trimmed)
 	Parent   *TrackerNode
 	Children []*TrackerNode
 	*metadata.CallGraphEdge
@@ -95,16 +96,22 @@ type TrackerNode struct {
 }
 
 func (nd *TrackerNode) Key() string {
-	switch {
-	case nd.key != "":
-	case nd.CallArgument != nil:
-		nd.key = nd.ID()
-	case nd.CallGraphEdge != nil:
-		nd.key = nd.Callee.ID()
+	// Compute + normalize once. Key() is called per-node inside the hot
+	// traverseTree passes, so doing the TrimPrefix on every call (even when the
+	// key is already cached) showed up in profiles — cache the final value.
+	if nd.keyReady {
+		return nd.key
 	}
-
+	if nd.key == "" {
+		switch {
+		case nd.CallArgument != nil:
+			nd.key = nd.ID()
+		case nd.CallGraphEdge != nil:
+			nd.key = nd.Callee.ID()
+		}
+	}
 	nd.key = strings.TrimPrefix(nd.key, "*")
-
+	nd.keyReady = true
 	return nd.key
 }
 
@@ -687,46 +694,61 @@ func (t *TrackerTree) findNodeInSubtreeWithVisited(node *TrackerNode, edgeID str
 
 type assignmentNodes struct {
 	assignmentIndex assigmentIndexMap
+	sorted          []*TrackerNode // cached stable order, built once on first Assign
 }
 
 func (a *assignmentNodes) Assign(f func(*TrackerNode) bool) {
 	// Stable order: this map is walked against the tree to attach assignment
 	// nodes, so a random order would attach ambiguous matches differently each
 	// run (flipping which route claims a shared node, and the final spec).
-	nds := make([]*TrackerNode, 0, len(a.assignmentIndex))
-	for _, nd := range a.assignmentIndex {
-		nds = append(nds, nd)
+	//
+	// traverseTree calls Assign once per visited node, but the map is immutable
+	// for the whole traversal — so sort once and reuse the slice instead of
+	// re-sorting (and re-allocating) on every node, which is O(nodes·N·logN).
+	if a.sorted == nil {
+		a.sorted = make([]*TrackerNode, 0, len(a.assignmentIndex))
+		for _, nd := range a.assignmentIndex {
+			a.sorted = append(a.sorted, nd)
+		}
+		sort.Slice(a.sorted, func(i, j int) bool { return a.sorted[i].Key() < a.sorted[j].Key() })
 	}
-	sort.Slice(nds, func(i, j int) bool { return nds[i].Key() < nds[j].Key() })
-	for _, nd := range nds {
+	for _, nd := range a.sorted {
 		f(nd)
 	}
 }
 
 type variableNodes struct {
 	variables map[paramKey][]*TrackerNode
+	sorted    []*TrackerNode // cached first-of-each-key in stable order
 }
 
 func (v *variableNodes) Assign(f func(*TrackerNode) bool) {
-	// Stable order (see assignmentNodes.Assign): iterate the map's keys sorted.
-	keys := make([]paramKey, 0, len(v.variables))
-	for k := range v.variables {
-		keys = append(keys, k)
+	// Stable order (see assignmentNodes.Assign): build the sorted first-nodes
+	// once and reuse across every traverseTree visit (the map doesn't change).
+	if v.sorted == nil {
+		keys := make([]paramKey, 0, len(v.variables))
+		for k := range v.variables {
+			keys = append(keys, k)
+		}
+		sort.Slice(keys, func(i, j int) bool {
+			a, b := keys[i], keys[j]
+			if a.Name != b.Name {
+				return a.Name < b.Name
+			}
+			if a.Pkg != b.Pkg {
+				return a.Pkg < b.Pkg
+			}
+			return a.Container < b.Container
+		})
+		v.sorted = make([]*TrackerNode, 0, len(keys))
+		for _, k := range keys {
+			if nds := v.variables[k]; len(nds) > 0 {
+				v.sorted = append(v.sorted, nds[0])
+			}
+		}
 	}
-	sort.Slice(keys, func(i, j int) bool {
-		a, b := keys[i], keys[j]
-		if a.Name != b.Name {
-			return a.Name < b.Name
-		}
-		if a.Pkg != b.Pkg {
-			return a.Pkg < b.Pkg
-		}
-		return a.Container < b.Container
-	})
-	for _, k := range keys {
-		if nds := v.variables[k]; len(nds) > 0 {
-			f(nds[0])
-		}
+	for _, nd := range v.sorted {
+		f(nd)
 	}
 }
 

--- a/internal/spec/tracker.go
+++ b/internal/spec/tracker.go
@@ -697,7 +697,7 @@ type assignmentNodes struct {
 	sorted          []*TrackerNode // cached stable order, built once on first Assign
 }
 
-func (a *assignmentNodes) Assign(f func(*TrackerNode) bool) {
+func (a *assignmentNodes) Assign(f func(*TrackerNode)) {
 	// Stable order: this map is walked against the tree to attach assignment
 	// nodes, so a random order would attach ambiguous matches differently each
 	// run (flipping which route claims a shared node, and the final spec).
@@ -722,7 +722,7 @@ type variableNodes struct {
 	sorted    []*TrackerNode // cached first-of-each-key in stable order
 }
 
-func (v *variableNodes) Assign(f func(*TrackerNode) bool) {
+func (v *variableNodes) Assign(f func(*TrackerNode)) {
 	// Stable order (see assignmentNodes.Assign): build the sorted first-nodes
 	// once and reuse across every traverseTree visit (the map doesn't change).
 	if v.sorted == nil {
@@ -752,7 +752,7 @@ func (v *variableNodes) Assign(f func(*TrackerNode) bool) {
 	}
 }
 
-func traverseTree(nodes []*TrackerNode, mapObject interface{ Assign(func(*TrackerNode) bool) }, limit int, nodeCount map[string]int) bool {
+func traverseTree(nodes []*TrackerNode, mapObject interface{ Assign(func(*TrackerNode)) }, limit int, nodeCount map[string]int) bool {
 	if nodeCount == nil {
 		nodeCount = map[string]int{}
 	}
@@ -773,7 +773,7 @@ func traverseTree(nodes []*TrackerNode, mapObject interface{ Assign(func(*Tracke
 			}
 		}
 
-		mapObject.Assign(func(tn *TrackerNode) bool {
+		mapObject.Assign(func(tn *TrackerNode) {
 			if nodeKey != "" && nodeKey == tn.Key() {
 				nodeTypeParams := node.TypeParams()
 				nodeCount[nodeKey]++
@@ -787,7 +787,6 @@ func traverseTree(nodes []*TrackerNode, mapObject interface{ Assign(func(*Tracke
 					} else {
 						node.AddChildren(tn.Children)
 					}
-					return true
 				} else if tn.Parent != nil {
 					if len(nodeTypeParams) > 0 {
 						// Filter out parent that have type parameters that are not in the node type parameters
@@ -797,10 +796,8 @@ func traverseTree(nodes []*TrackerNode, mapObject interface{ Assign(func(*Tracke
 					} else {
 						tn.Parent.AddChild(node)
 					}
-					return true
 				}
 			}
-			return false
 		})
 
 		if traverseTree(node.Children, mapObject, limit, nodeCount) {


### PR DESCRIPTION
## Problem
The determinism fix (#88) sorted `assignmentNodes`/`variableNodes` inside their `Assign()` method. But `traverseTree` calls `Assign()` **once per visited node**, across two whole-tree passes — and the underlying maps are immutable for the duration of the traversal. So every node re-sorted (and re-allocated) the entire map: **O(nodes · N · logN)** instead of O(nodes · N).

On lmd-core this regressed `apispec` generation from ~5.5s to ~40s.

## Fix
- Cache the sorted slice once per traversal (built lazily on first `Assign`) and reuse it — restoring O(nodes · N) with a single up-front sort.
- Cache `TrackerNode.Key()`'s normalized value so the per-call `strings.TrimPrefix` (hot inside `traverseTree`) runs once instead of on every call.

Determinism is unchanged — same sort comparators, same order.

## Measured (lmd-core, ~5,464 call edges)
| build | time |
|---|---|
| before fix (per-node re-sort) | ~37–42s |
| Assign cache | ~5.5s |
| + Key() cache | ~4.8s |

Output verified byte-identical across repeated runs. Full `go test ./...` + `go vet` pass. CPU profile after the fix shows no sort hotspot (dominated by AST walk + GC, as expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when processing assignment and variable relationships, reducing order-related instability in complex graphs.

* **Performance**
  * Speeds up repeated node lookups and traversal by caching computed keys and deterministically ordered node lists, avoiding unnecessary recomputation during subsequent passes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->