### PR TITLE
test: promote internal/spec/tests YAMLs to real golden fixtures

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Golden fixtures are byte-compared by TestGenerateMetadata; a CRLF checkout
+# (e.g. core.autocrlf=true on Windows) must not alter them.
+internal/spec/tests/*.yaml text eol=lf

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,7 +39,6 @@ jobs:
         
         # Add changes
         git add README.md
-        git restore internal/spec/tests/
         
         # Check if there are changes to commit
         if git diff --quiet && git diff --staged --quiet; then

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,3 @@ playground*.go
 apispecui-demo.mp4
 apispecui-short.mp4
 video-kit/parts/
-
-# test yaml files
-internal/spec/tests

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -1896,7 +1896,7 @@ func processCallExpression(call *ast.CallExpr, file *ast.File, pkgs map[string]m
 		// Use funcMap to get callee function declaration
 		var assignmentsInFunc = make(map[string][]Assignment)
 
-		calleeAstFile := astFileFromFn(calleePkg, calleeFunc, pkgs, metadata)
+		calleeAstFile := astFileFromFn(calleePkg, calleeFunc, calleeParts, pkgs, metadata)
 
 		if calleeAstFile != nil {
 			fnInfo := fileToInfo[calleeAstFile]
@@ -1994,29 +1994,48 @@ func processCallExpression(call *ast.CallExpr, file *ast.File, pkgs map[string]m
 	}
 }
 
-func astFileFromFn(pkgName, fnName string, pkgs map[string]map[string]*ast.File, metadata *Metadata) *ast.File {
-	var astFile *ast.File
+// astFileFromFn locates the *ast.File declaring fnName in pkgName. recvType
+// (may be empty for plain functions) disambiguates methods: several types can
+// share a method name (e.g. Name()), and the previous name-only scan over the
+// unsorted Files map returned whichever match the map order surfaced last,
+// making the recorded callee assignments flip between runs. Files and types
+// are walked in sorted order so even the fallback (name match on a different
+// receiver) is deterministic.
+func astFileFromFn(pkgName, fnName, recvType string, pkgs map[string]map[string]*ast.File, metadata *Metadata) *ast.File {
+	pkg, pkgExists := metadata.Packages[pkgName]
+	if !pkgExists {
+		return nil
+	}
+	recvType = strings.TrimPrefix(recvType, "*")
 
-	if pkg, pkgExists := metadata.Packages[pkgName]; pkgExists {
-		for fileName, f := range pkg.Files {
-			if _, ok := f.Functions[fnName]; ok {
-				astFile = pkgs[pkgName][fileName]
-				break
+	var fallback *ast.File
+	for _, fileName := range slices.Sorted(maps.Keys(pkg.Files)) {
+		f := pkg.Files[fileName]
+		if _, ok := f.Functions[fnName]; ok {
+			if recvType == "" {
+				return pkgs[pkgName][fileName]
 			}
-			for _, t := range f.Types {
-				for _, method := range t.Methods {
-					methodName := metadata.StringPool.GetString(method.Name)
-					if methodName == fnName {
-						astFile = pkgs[pkgName][metadata.StringPool.GetString(method.Filename)]
-						break
-					}
+			if fallback == nil {
+				fallback = pkgs[pkgName][fileName]
+			}
+		}
+		for _, typeName := range slices.Sorted(maps.Keys(f.Types)) {
+			for _, method := range f.Types[typeName].Methods {
+				if metadata.StringPool.GetString(method.Name) != fnName {
+					continue
+				}
+				methodFile := pkgs[pkgName][metadata.StringPool.GetString(method.Filename)]
+				if recvType != "" && strings.TrimPrefix(metadata.StringPool.GetString(method.Receiver), "*") == recvType {
+					return methodFile
+				}
+				if fallback == nil {
+					fallback = methodFile
 				}
 			}
-
 		}
 	}
 
-	return astFile
+	return fallback
 }
 
 // extractRootVariable recursively extracts the root variable from a chained expression

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -2008,15 +2008,20 @@ func astFileFromFn(pkgName, fnName, recvType string, pkgs map[string]map[string]
 	}
 	recvType = strings.TrimPrefix(recvType, "*")
 
-	var fallback *ast.File
+	// Track method and function candidates separately: for a receiver lookup
+	// (recvType != "") a same-named method on another type is a far better
+	// guess than a same-named top-level function, and the file returned here
+	// feeds fileToInfo/processAssignment — the wrong AST/info pair silently
+	// corrupts the extracted assignments.
+	var funcFallback, methodFallback *ast.File
 	for _, fileName := range slices.Sorted(maps.Keys(pkg.Files)) {
 		f := pkg.Files[fileName]
 		if _, ok := f.Functions[fnName]; ok {
 			if recvType == "" {
 				return pkgs[pkgName][fileName]
 			}
-			if fallback == nil {
-				fallback = pkgs[pkgName][fileName]
+			if funcFallback == nil {
+				funcFallback = pkgs[pkgName][fileName]
 			}
 		}
 		for _, typeName := range slices.Sorted(maps.Keys(f.Types)) {
@@ -2028,14 +2033,17 @@ func astFileFromFn(pkgName, fnName, recvType string, pkgs map[string]map[string]
 				if recvType != "" && strings.TrimPrefix(metadata.StringPool.GetString(method.Receiver), "*") == recvType {
 					return methodFile
 				}
-				if fallback == nil {
-					fallback = methodFile
+				if methodFallback == nil {
+					methodFallback = methodFile
 				}
 			}
 		}
 	}
 
-	return fallback
+	if methodFallback != nil {
+		return methodFallback
+	}
+	return funcFallback
 }
 
 // extractRootVariable recursively extracts the root variable from a chained expression

--- a/internal/metadata/metadata_test.go
+++ b/internal/metadata/metadata_test.go
@@ -1,6 +1,8 @@
 package metadata_test
 
 import (
+	"bytes"
+	"flag"
 	"fmt"
 	"go/ast"
 	"go/token"
@@ -13,7 +15,14 @@ import (
 	"github.com/ehabterra/apispec/internal/metadata"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/tools/go/packages"
+	"gopkg.in/yaml.v3"
 )
+
+// updateGolden rewrites the golden metadata fixtures under
+// internal/spec/tests instead of comparing against them:
+//
+//	go test ./internal/metadata/ -run TestGenerateMetadata -update
+var updateGolden = flag.Bool("update", false, "rewrite golden files under internal/spec/tests")
 
 // testModule describes a module to materialize on disk for a test.
 type testModule struct {
@@ -794,13 +803,25 @@ var DefaultFormat = "uppercase"`,
 
 			meta := metadata.GenerateMetadata(pkgsMetadata, fileToInfo, importPaths, fset)
 
-			// sanitizeMetadataForTest removes temporary directory paths from metadata to ensure consistent test output
-			sanitizedMeta := sanitizeMetadataForTest(meta)
+			// sanitizeMetadataForTest strips the per-test temp root (and any
+			// leftover machine-specific path parts) so the serialized form is
+			// stable across machines and runs.
+			sanitizedMeta := sanitizeMetadataForTest(meta, tempRoots(t, cfg.Dir)...)
 
-			// Only write metadata files during development/testing, not during CI/CD
-			// This prevents temporary directory paths from being committed to git
-			if err := metadata.WriteMetadata(sanitizedMeta, fmt.Sprintf("../spec/tests/%s.yaml", tc.src[0].Name)); err != nil {
-				t.Errorf("Failed to write metadata.yaml: %v", err)
+			// Golden comparison: generation is deterministic, so the sanitized
+			// metadata must match internal/spec/tests/<name>.yaml byte-for-byte.
+			// Regenerate with -update after intentional changes.
+			goldenPath := filepath.Join("..", "spec", "tests", tc.src[0].Name+".yaml")
+			got := marshalMetadataYAML(t, sanitizedMeta)
+			if *updateGolden {
+				if err := os.WriteFile(goldenPath, got, 0o644); err != nil {
+					t.Fatalf("failed to update golden %s: %v", goldenPath, err)
+				}
+			} else if want, err := os.ReadFile(goldenPath); err != nil {
+				t.Errorf("failed to read golden %s (run with -update to create it): %v", goldenPath, err)
+			} else if !bytes.Equal(want, got) {
+				t.Errorf("sanitized metadata differs from golden %s (run with -update to regenerate):\n%s",
+					goldenPath, firstDiff(string(want), string(got)))
 			}
 
 			// Validate packages
@@ -1391,17 +1412,17 @@ func main() {
 	t.Logf("Total call graph edges: %d", len(meta.CallGraph))
 	t.Logf("Package count: %d", len(meta.Packages))
 } // sanitizeMetadataForTest removes temporary directory paths from metadata to ensure consistent test output.
-func sanitizeMetadataForTest(meta *metadata.Metadata) *metadata.Metadata {
+func sanitizeMetadataForTest(meta *metadata.Metadata, roots ...string) *metadata.Metadata {
 	// Create a copy to avoid mutating the original
 	sanitized := &metadata.Metadata{
-		StringPool: sanitizeStringPool(meta.StringPool),
+		StringPool: sanitizeStringPool(meta.StringPool, roots),
 		CallGraph:  meta.CallGraph,
 		Packages:   make(map[string]*metadata.Package),
 	}
 
 	for pkgPath, pkg := range meta.Packages {
 		// Normalize package path by removing temp directories and test suffixes
-		sanitizedPath := sanitizeFilePath(pkgPath)
+		sanitizedPath := sanitizeFilePath(pkgPath, roots)
 
 		// Copy package with sanitized file paths
 		sanitizedPkg := &metadata.Package{}
@@ -1409,7 +1430,7 @@ func sanitizeMetadataForTest(meta *metadata.Metadata) *metadata.Metadata {
 		sanitizedPkg.Files = make(map[string]*metadata.File)
 
 		for filePath, file := range pkg.Files {
-			cleanPath := sanitizeFilePath(filePath)
+			cleanPath := sanitizeFilePath(filePath, roots)
 			sanitizedPkg.Files[cleanPath] = file
 		}
 
@@ -1419,8 +1440,53 @@ func sanitizeMetadataForTest(meta *metadata.Metadata) *metadata.Metadata {
 	return sanitized
 }
 
+// tempRoots returns the per-test temp directory that moduleDir lives in, plus
+// its symlink-resolved form (macOS surfaces t.TempDir() as /var/folders/…
+// while go/token positions may carry the resolved /private/var/folders/…).
+// Stripping these exact prefixes is what makes the sanitized output
+// machine-independent; the heuristic in sanitizeFilePath is only a backstop.
+func tempRoots(t *testing.T, moduleDir string) []string {
+	t.Helper()
+	root := filepath.Dir(moduleDir)
+	roots := []string{root}
+	if resolved, err := filepath.EvalSymlinks(root); err == nil && resolved != root {
+		roots = append(roots, resolved)
+	}
+	return roots
+}
+
+// stripRoots removes a leading temp-root prefix (if any) from s, turning an
+// absolute per-run path into a stable module-relative one.
+func stripRoots(s string, roots []string) string {
+	for _, root := range roots {
+		if root == "" {
+			continue
+		}
+		if rest, ok := strings.CutPrefix(s, root+string(filepath.Separator)); ok {
+			return rest
+		}
+	}
+	return s
+}
+
+// marshalMetadataYAML serializes metadata with the same encoder settings as
+// metadata.WriteMetadata, so golden files keep their historical formatting.
+func marshalMetadataYAML(t *testing.T, meta *metadata.Metadata) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(meta); err != nil {
+		t.Fatalf("failed to marshal metadata: %v", err)
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatalf("failed to flush metadata encoder: %v", err)
+	}
+	return buf.Bytes()
+}
+
 // sanitizeStringPool removes temporary directory paths from string pool entries.
-func sanitizeStringPool(pool *metadata.StringPool) *metadata.StringPool {
+func sanitizeStringPool(pool *metadata.StringPool, roots []string) *metadata.StringPool {
 	if pool == nil {
 		return nil
 	}
@@ -1430,7 +1496,7 @@ func sanitizeStringPool(pool *metadata.StringPool) *metadata.StringPool {
 
 	for i := 0; i < pool.GetSize(); i++ {
 		orig := pool.GetString(i)
-		clean := sanitizeString(orig)
+		clean := sanitizeString(orig, roots)
 		stringMap[orig] = clean
 	}
 
@@ -1441,21 +1507,24 @@ func sanitizeStringPool(pool *metadata.StringPool) *metadata.StringPool {
 	return sanitized
 }
 
-// sanitizeString detects file-like strings and normalizes their paths.
-func sanitizeString(s string) string {
+// sanitizeString strips the exact temp roots first, then falls back to the
+// heuristic path cleanup for any file-like string it still recognizes.
+func sanitizeString(s string, roots []string) string {
+	s = stripRoots(s, roots)
 	if strings.Contains(s, "/") &&
 		(strings.HasSuffix(s, ".go") ||
 			strings.Contains(s, ".go:") ||
 			strings.Contains(s, "/var/") ||
 			strings.Contains(s, "/tmp/") ||
 			strings.Contains(s, "TestGenerateMetadata")) {
-		return sanitizeFilePath(s)
+		return sanitizeFilePath(s, roots)
 	}
 	return s
 }
 
 // sanitizeFilePath strips system temp paths, random test IDs, and keeps a meaningful structure.
-func sanitizeFilePath(path string) string {
+func sanitizeFilePath(path string, roots []string) string {
+	path = stripRoots(path, roots)
 	parts := strings.Split(path, string(filepath.Separator))
 	var meaningful []string
 

--- a/internal/spec/tests/complex.yaml
+++ b/internal/spec/tests/complex.yaml
@@ -3,115 +3,115 @@ string_pool:
   - s
   - complex
   - '*complex.Service'
-  - claude-501/001/complex/service.go:10:9
+  - complex/service.go:10:9
   - name
   - string
-  - claude-501/001/complex/service.go:10:11
+  - complex/service.go:10:11
   - selector
   - GetName
   - '*Service'
-  - claude-501/001/complex/service.go:9:29
+  - complex/service.go:9:29
   - func_type
   - func_results
-  - claude-501/001/complex/service.go:9:1
+  - complex/service.go:9:1
   - exported
-  - claude-501/001/complex/service.go
+  - complex/service.go
   - func() string
   - result
-  - claude-501/001/complex/service.go:15:9
-  - claude-501/001/complex/service.go:13:32
+  - complex/service.go:15:9
+  - complex/service.go:13:32
   - data
-  - claude-501/001/complex/service.go:13:40
+  - complex/service.go:13:40
   - literal
   - '"Processing: %s"'
-  - claude-501/001/complex/service.go:14:42
+  - complex/service.go:14:42
   - fmt
-  - claude-501/001/complex/service.go:14:12
+  - complex/service.go:14:12
   - Sprintf
   - func(format string, a ...any) string
-  - claude-501/001/complex/service.go:14:16
+  - complex/service.go:14:16
   - call
-  - claude-501/001/complex/service.go:14:2
+  - complex/service.go:14:2
   - unexported
   - Process
-  - claude-501/001/complex/service.go:13:1
+  - complex/service.go:13:1
   - func(string) string
-  - claude-501/001/complex/service.go:22:32
+  - complex/service.go:22:32
   - input
   - h
   - '*complex.Handler'
-  - claude-501/001/complex/service.go:23:10
+  - complex/service.go:23:10
   - service
-  - claude-501/001/complex/service.go:23:12
-  - claude-501/001/complex/service.go:23:20
+  - complex/service.go:23:12
+  - complex/service.go:23:20
   - Service
-  - claude-501/001/complex/service.go:23:2
+  - complex/service.go:23:2
   - Handle
-  - claude-501/001/complex/service.go:24:33
-  - claude-501/001/complex/service.go:24:15
-  - claude-501/001/complex/service.go:24:17
+  - complex/service.go:24:33
+  - complex/service.go:24:15
+  - complex/service.go:24:17
   - func(data string) string
-  - claude-501/001/complex/service.go:24:25
+  - complex/service.go:24:25
   - processed
-  - claude-501/001/complex/service.go:24:2
+  - complex/service.go:24:2
   - '*Handler'
-  - claude-501/001/complex/service.go:22:1
+  - complex/service.go:22:1
   - 'func(string) '
   - struct
   - interface
   - Handler
-  - claude-501/001/complex/service.go:29:10
-  - claude-501/001/complex/service.go:29:18
-  - claude-501/001/complex/service.go:29:24
+  - complex/service.go:29:10
+  - complex/service.go:29:18
+  - complex/service.go:29:24
   - key_value
   - composite_lit
   - unary
   - '&'
-  - claude-501/001/complex/service.go:29:9
+  - complex/service.go:29:9
   - NewService
-  - claude-501/001/complex/service.go:28:22
-  - claude-501/001/complex/service.go:28:31
+  - complex/service.go:28:22
+  - complex/service.go:28:31
   - star
-  - claude-501/001/complex/service.go:28:30
-  - claude-501/001/complex/service.go:28:1
+  - complex/service.go:28:30
+  - complex/service.go:28:1
   - func(string) *Service
-  - claude-501/001/complex/service.go:33:10
-  - claude-501/001/complex/service.go:33:18
+  - complex/service.go:33:10
+  - complex/service.go:33:18
   - svc
-  - claude-501/001/complex/service.go:33:27
-  - claude-501/001/complex/service.go:33:9
+  - complex/service.go:33:27
+  - complex/service.go:33:9
   - NewHandler
-  - claude-501/001/complex/service.go:32:22
-  - claude-501/001/complex/service.go:32:21
-  - claude-501/001/complex/service.go:32:32
-  - claude-501/001/complex/service.go:32:31
-  - claude-501/001/complex/service.go:32:1
+  - complex/service.go:32:22
+  - complex/service.go:32:21
+  - complex/service.go:32:32
+  - complex/service.go:32:31
+  - complex/service.go:32:1
   - func(*Service) *Handler
   - '"test-service"'
   - func(name string) *complex.Service
-  - claude-501/001/complex/service.go:37:9
-  - claude-501/001/complex/service.go:37:2
+  - complex/service.go:37:9
+  - complex/service.go:37:2
   - main
-  - claude-501/001/complex/service.go:38:24
+  - complex/service.go:38:24
   - func(svc *complex.Service) *complex.Handler
-  - claude-501/001/complex/service.go:38:13
+  - complex/service.go:38:13
   - handler
-  - claude-501/001/complex/service.go:38:2
-  - claude-501/001/complex/service.go:36:1
+  - complex/service.go:38:2
+  - complex/service.go:36:1
   - 'func() '
   - '"Handler %s: %s\n"'
-  - claude-501/001/complex/service.go:25:33
-  - claude-501/001/complex/service.go:25:39
-  - claude-501/001/complex/service.go:25:2
+  - complex/service.go:25:33
+  - complex/service.go:25:39
+  - complex/service.go:25:2
   - Printf
   - func(format string, a ...any) (n int, err error)
   - '"test-data"'
-  - claude-501/001/complex/service.go:39:2
+  - complex/service.go:39:2
   - func(input string)
 packages:
   complex:
     files:
-      claude-501/001/complex/service.go:
+      complex/service.go:
         types:
           Handler:
             name: 60

--- a/internal/spec/tests/constants.yaml
+++ b/internal/spec/tests/constants.yaml
@@ -10,41 +10,41 @@ string_pool:
   - string
   - Message
   - constants
-  - claude-501/001/constants/const.go:15:2
+  - constants/const.go:15:2
   - exported
   - init
-  - claude-501/001/constants/const.go:14:1
+  - constants/const.go:14:1
   - unexported
   - 'func() '
   - MaxSize
   - untyped int
-  - claude-501/001/constants/const.go:19:10
+  - constants/const.go:19:10
   - int
   - size
-  - claude-501/001/constants/const.go:19:2
+  - constants/const.go:19:2
   - UseConstants
   - Name
   - untyped string
-  - claude-501/001/constants/const.go:20:10
+  - constants/const.go:20:10
   - name
-  - claude-501/001/constants/const.go:20:2
-  - claude-501/001/constants/const.go:18:1
+  - constants/const.go:20:2
+  - constants/const.go:18:1
   - const
-  - claude-501/001/constants/const.go:4:2
-  - claude-501/001/constants/const.go:5:2
+  - constants/const.go:4:2
+  - constants/const.go:5:2
   - test
   - Pi
-  - claude-501/001/constants/const.go:6:2
+  - constants/const.go:6:2
   - untyped float
   - GlobalVar
   - var
-  - claude-501/001/constants/const.go:10:2
+  - constants/const.go:10:2
   - "42"
-  - claude-501/001/constants/const.go:11:2
+  - constants/const.go:11:2
 packages:
   constants:
     files:
-      claude-501/001/constants/const.go:
+      constants/const.go:
         functions:
           UseConstants:
             name: 23

--- a/internal/spec/tests/example.yaml
+++ b/internal/spec/tests/example.yaml
@@ -3,30 +3,30 @@ string_pool:
   - u
   - example
   - '*example.User'
-  - claude-501/001/example/types.go:21:9
+  - example/types.go:21:9
   - Name
   - string
-  - claude-501/001/example/types.go:21:11
+  - example/types.go:21:11
   - selector
   - GetName
   - '*User'
-  - claude-501/001/example/types.go:20:26
+  - example/types.go:20:26
   - func_type
   - func_results
-  - claude-501/001/example/types.go:20:1
+  - example/types.go:20:1
   - exported
-  - claude-501/001/example/types.go
+  - example/types.go
   - func() string
   - int
-  - claude-501/001/example/types.go:24:27
+  - example/types.go:24:27
   - age
-  - claude-501/001/example/types.go:25:2
+  - example/types.go:25:2
   - Age
-  - claude-501/001/example/types.go:25:4
+  - example/types.go:25:4
   - example.User.Age
-  - claude-501/001/example/types.go:25:10
+  - example/types.go:25:10
   - SetAge
-  - claude-501/001/example/types.go:24:1
+  - example/types.go:24:1
   - 'func(int) '
   - User
   - struct
@@ -34,61 +34,61 @@ string_pool:
   - json:"age"
   - interface
   - Namer
-  - claude-501/001/example/types.go:9:12
+  - example/types.go:9:12
   - Ager
-  - claude-501/001/example/types.go:13:13
+  - example/types.go:13:13
   - Phoner
   - SetPhone
-  - claude-501/001/example/types.go:17:16
+  - example/types.go:17:16
   - numb
   - 'func(string) '
-  - claude-501/001/example/types.go:36:9
-  - claude-501/001/example/types.go:28:19
+  - example/types.go:36:9
+  - example/types.go:28:19
   - name
-  - claude-501/001/example/types.go:28:31
-  - claude-501/001/example/types.go:28:37
+  - example/types.go:28:31
+  - example/types.go:28:37
   - star
-  - claude-501/001/example/types.go:28:36
-  - claude-501/001/example/types.go:29:8
-  - claude-501/001/example/types.go:30:3
-  - claude-501/001/example/types.go:30:9
+  - example/types.go:28:36
+  - example/types.go:29:8
+  - example/types.go:30:3
+  - example/types.go:30:9
   - key_value
-  - claude-501/001/example/types.go:31:3
-  - claude-501/001/example/types.go:31:9
+  - example/types.go:31:3
+  - example/types.go:31:9
   - composite_lit
   - unary
   - '&'
-  - claude-501/001/example/types.go:29:7
-  - claude-501/001/example/types.go:29:2
+  - example/types.go:29:7
+  - example/types.go:29:2
   - unexported
   - NewUser
-  - claude-501/001/example/types.go:28:1
+  - example/types.go:28:1
   - func(string, int) *User
   - literal
   - '"User Name"'
   - "40"
   - func(name string, age int) *example.User
-  - claude-501/001/example/types.go:40:10
+  - example/types.go:40:10
   - call
   - user
-  - claude-501/001/example/types.go:40:2
+  - example/types.go:40:2
   - main
-  - claude-501/001/example/types.go:39:1
+  - example/types.go:39:1
   - 'func() '
-  - example.Namer
-  - example.User
   - example.Ager
-  - claude-501/001/example/types.go:34:11
-  - claude-501/001/example/types.go:34:2
+  - example.User
+  - example.Namer
+  - example/types.go:34:11
+  - example/types.go:34:2
   - func(age int)
-  - claude-501/001/example/types.go:41:15
-  - claude-501/001/example/types.go:41:14
-  - claude-501/001/example/types.go:41:2
+  - example/types.go:41:15
+  - example/types.go:41:14
+  - example/types.go:41:2
   - Println
 packages:
   example:
     files:
-      claude-501/001/example/types.go:
+      example/types.go:
         types:
           Ager:
             name: 36

--- a/internal/spec/tests/example.yaml
+++ b/internal/spec/tests/example.yaml
@@ -989,6 +989,53 @@ call_graph:
         position: 79
         resolved_type: -1
         generic_type_name: -1
+    assignments:
+      example.User.Age:
+        - variable_name: 24
+          pkg: 2
+          concrete_type: 18
+          position: 21
+          scope: 8
+          value:
+            kind: 0
+            name: 20
+            value: -1
+            raw: -1
+            pkg: 2
+            type: 18
+            position: 25
+            resolved_type: -1
+            generic_type_name: -1
+          lhs:
+            kind: 8
+            name: -1
+            value: -1
+            x:
+              kind: 0
+              name: 1
+              value: -1
+              raw: -1
+              pkg: 2
+              type: 3
+              position: 21
+              resolved_type: -1
+              generic_type_name: -1
+            sel:
+              kind: 0
+              name: 22
+              value: -1
+              raw: -1
+              pkg: 2
+              type: 18
+              position: 23
+              resolved_type: -1
+              generic_type_name: -1
+            raw: -1
+            pkg: 2
+            type: 18
+            position: 21
+            resolved_type: -1
+            generic_type_name: -1
     param_arg_map:
       age:
         kind: 0

--- a/internal/spec/tests/generic.yaml
+++ b/internal/spec/tests/generic.yaml
@@ -3,110 +3,110 @@ string_pool:
   - c
   - generic
   - '*generic.Container[T]'
-  - claude-501/001/generic/generic.go:8:9
+  - generic/generic.go:8:9
   - Value
   - T
-  - claude-501/001/generic/generic.go:8:11
+  - generic/generic.go:8:11
   - selector
   - Get
   - '*Container[T]'
-  - claude-501/001/generic/generic.go:7:30
+  - generic/generic.go:7:30
   - func_type
   - func_results
-  - claude-501/001/generic/generic.go:7:1
+  - generic/generic.go:7:1
   - exported
-  - claude-501/001/generic/generic.go
+  - generic/generic.go
   - func() T
-  - claude-501/001/generic/generic.go:11:34
+  - generic/generic.go:11:34
   - value
-  - claude-501/001/generic/generic.go:12:2
-  - claude-501/001/generic/generic.go:12:4
+  - generic/generic.go:12:2
+  - generic/generic.go:12:4
   - generic.Container[T].Value
-  - claude-501/001/generic/generic.go:12:12
+  - generic/generic.go:12:12
   - Set
-  - claude-501/001/generic/generic.go:11:1
+  - generic/generic.go:11:1
   - 'func(T) '
   - Container
   - struct
   - interface
   - Container[T any]
-  - claude-501/001/generic/generic.go:16:10
-  - claude-501/001/generic/generic.go:16:20
+  - generic/generic.go:16:10
+  - generic/generic.go:16:20
   - index
-  - claude-501/001/generic/generic.go:16:23
-  - claude-501/001/generic/generic.go:16:30
+  - generic/generic.go:16:23
+  - generic/generic.go:16:30
   - key_value
   - composite_lit
   - unary
   - '&'
-  - claude-501/001/generic/generic.go:16:9
+  - generic/generic.go:16:9
   - NewContainer
-  - claude-501/001/generic/generic.go:15:32
+  - generic/generic.go:15:32
   - any
-  - claude-501/001/generic/generic.go:15:21
-  - claude-501/001/generic/generic.go:15:36
-  - claude-501/001/generic/generic.go:15:46
+  - generic/generic.go:15:21
+  - generic/generic.go:15:36
+  - generic/generic.go:15:46
   - star
-  - claude-501/001/generic/generic.go:15:35
-  - claude-501/001/generic/generic.go:15:1
+  - generic/generic.go:15:35
+  - generic/generic.go:15:1
   - func[T any](T) *Container[T any][T]
   - zero
-  - claude-501/001/generic/generic.go:22:10
+  - generic/generic.go:22:10
   - Process
-  - claude-501/001/generic/generic.go:19:36
+  - generic/generic.go:19:36
   - array_type
-  - claude-501/001/generic/generic.go:19:34
+  - generic/generic.go:19:34
   - items
   - comparable
-  - claude-501/001/generic/generic.go:19:16
-  - claude-501/001/generic/generic.go:19:39
-  - claude-501/001/generic/generic.go:19:1
+  - generic/generic.go:19:16
+  - generic/generic.go:19:39
+  - generic/generic.go:19:1
   - func[T comparable]([]T) T
   - literal
   - "42"
   - func[T any](value T) *generic.Container[T]
-  - claude-501/001/generic/generic.go:28:7
+  - generic/generic.go:28:7
   - int
-  - claude-501/001/generic/generic.go:28:20
+  - generic/generic.go:28:20
   - call
   - '*generic.Container[int]'
-  - claude-501/001/generic/generic.go:28:2
+  - generic/generic.go:28:2
   - unexported
   - main
-  - claude-501/001/generic/generic.go:29:9
+  - generic/generic.go:29:9
   - func() int
-  - claude-501/001/generic/generic.go:29:11
+  - generic/generic.go:29:11
   - Container[int]
   - val
-  - claude-501/001/generic/generic.go:29:2
+  - generic/generic.go:29:2
   - string
-  - claude-501/001/generic/generic.go:32:30
-  - claude-501/001/generic/generic.go:32:28
+  - generic/generic.go:32:30
+  - generic/generic.go:32:28
   - '"hello"'
   - '"world"'
   - func[T comparable](items []T) T
-  - claude-501/001/generic/generic.go:32:12
-  - claude-501/001/generic/generic.go:32:20
+  - generic/generic.go:32:12
+  - generic/generic.go:32:20
   - result
-  - claude-501/001/generic/generic.go:32:2
-  - claude-501/001/generic/generic.go:27:1
+  - generic/generic.go:32:2
+  - generic/generic.go:27:1
   - 'func() '
   - Container[T]
   - '[]string'
   - '[]T'
-  - claude-501/001/generic/generic.go:21:9
-  - claude-501/001/generic/generic.go:21:5
+  - generic/generic.go:21:9
+  - generic/generic.go:21:5
   - len
   - func([]T) int
   - '*Container'
   - "100"
-  - claude-501/001/generic/generic.go:30:2
+  - generic/generic.go:30:2
   - func(value int)
   - '*'
 packages:
   generic:
     files:
-      claude-501/001/generic/generic.go:
+      generic/generic.go:
         types:
           Container:
             name: 27

--- a/internal/spec/tests/main.yaml
+++ b/internal/spec/tests/main.yaml
@@ -7,39 +7,39 @@ string_pool:
   - int
   - x
   - main
-  - claude-501/001/main/test.go:9:2
+  - main/test.go:9:2
   - unexported
   - '"hello"'
   - string
   - "y"
-  - claude-501/001/main/test.go:10:2
+  - main/test.go:10:2
   - '"%d"'
-  - claude-501/001/main/test.go:11:25
+  - main/test.go:11:25
   - fmt
-  - claude-501/001/main/test.go:11:7
+  - main/test.go:11:7
   - Sprintf
   - func(format string, a ...any) string
-  - claude-501/001/main/test.go:11:11
+  - main/test.go:11:11
   - selector
   - call
   - z
-  - claude-501/001/main/test.go:11:2
-  - claude-501/001/main/test.go:8:1
+  - main/test.go:11:2
+  - main/test.go:8:1
   - 'func() '
   - strings
   - exported
-  - claude-501/001/main/test.go:12:14
-  - claude-501/001/main/test.go:12:2
+  - main/test.go:12:14
+  - main/test.go:12:2
   - Println
   - func(a ...any) (n int, err error)
-  - claude-501/001/main/test.go:13:18
-  - claude-501/001/main/test.go:13:2
+  - main/test.go:13:18
+  - main/test.go:13:2
   - ToUpper
   - func(s string) string
 packages:
   main:
     files:
-      claude-501/001/main/test.go:
+      main/test.go:
         functions:
           main:
             name: 7

--- a/internal/spec/tests/multipackage.yaml
+++ b/internal/spec/tests/multipackage.yaml
@@ -1,29 +1,63 @@
 string_pool:
-  - ident
-  - u
-  - multipackage/models
-  - '*multipackage/models.User'
-  - claude-501/001/multipackage/models/user.go:14:9
-  - Name
-  - string
-  - claude-501/001/multipackage/models/user.go:14:11
-  - selector
-  - GetName
-  - '*User'
-  - claude-501/001/multipackage/models/user.go:13:26
   - func_type
   - func_results
-  - claude-501/001/multipackage/models/user.go:13:1
+  - literal
+  - '"John"'
+  - "25"
+  - ident
+  - models
+  - multipackage/models
+  - multipackage/main.go:10:10
+  - NewUser
+  - func(name string, age int) *multipackage/models.User
+  - multipackage/main.go:10:17
+  - selector
+  - call
+  - '*multipackage/models.User'
+  - user
+  - multipackage
+  - multipackage/main.go:10:2
+  - unexported
+  - main
+  - services
+  - multipackage/services
+  - multipackage/main.go:11:13
+  - NewUserService
+  - func() *multipackage/services.UserService
+  - multipackage/main.go:11:22
+  - '*multipackage/services.UserService'
+  - service
+  - multipackage/main.go:11:2
+  - multipackage/main.go:13:32
+  - multipackage/main.go:13:12
+  - ProcessUser
+  - func(user *multipackage/models.User) string
+  - multipackage/main.go:13:20
+  - UserService
+  - string
+  - result
+  - multipackage/main.go:13:2
+  - multipackage/main.go:9:1
+  - 'func() '
+  - fmt
+  - u
+  - multipackage/models/user.go:14:9
+  - Name
+  - multipackage/models/user.go:14:11
+  - GetName
+  - '*User'
+  - multipackage/models/user.go:13:26
+  - multipackage/models/user.go:13:1
   - exported
-  - claude-501/001/multipackage/models/user.go
+  - multipackage/models/user.go
   - func() string
-  - claude-501/001/multipackage/models/user.go:18:9
+  - multipackage/models/user.go:18:9
   - Age
   - int
-  - claude-501/001/multipackage/models/user.go:18:11
+  - multipackage/models/user.go:18:11
   - GetAge
-  - claude-501/001/multipackage/models/user.go:17:25
-  - claude-501/001/multipackage/models/user.go:17:1
+  - multipackage/models/user.go:17:25
+  - multipackage/models/user.go:17:1
   - func() int
   - User
   - struct
@@ -31,166 +65,132 @@ string_pool:
   - json:"age"
   - interface
   - UserInterface
-  - claude-501/001/multipackage/models/user.go:9:12
-  - claude-501/001/multipackage/models/user.go:10:11
-  - claude-501/001/multipackage/models/user.go:22:10
-  - claude-501/001/multipackage/models/user.go:23:3
+  - multipackage/models/user.go:9:12
+  - multipackage/models/user.go:10:11
+  - multipackage/models/user.go:22:10
+  - multipackage/models/user.go:23:3
   - name
-  - claude-501/001/multipackage/models/user.go:23:9
+  - multipackage/models/user.go:23:9
   - key_value
-  - claude-501/001/multipackage/models/user.go:24:3
+  - multipackage/models/user.go:24:3
   - age
-  - claude-501/001/multipackage/models/user.go:24:9
+  - multipackage/models/user.go:24:9
   - composite_lit
   - unary
   - '&'
-  - claude-501/001/multipackage/models/user.go:22:9
-  - NewUser
-  - claude-501/001/multipackage/models/user.go:21:19
-  - claude-501/001/multipackage/models/user.go:21:31
-  - claude-501/001/multipackage/models/user.go:21:37
+  - multipackage/models/user.go:22:9
+  - multipackage/models/user.go:21:19
+  - multipackage/models/user.go:21:31
+  - multipackage/models/user.go:21:37
   - star
-  - claude-501/001/multipackage/models/user.go:21:36
-  - claude-501/001/multipackage/models/user.go:21:1
+  - multipackage/models/user.go:21:36
+  - multipackage/models/user.go:21:1
   - func(string, int) *User
-  - literal
   - '"%s %s is %d years old"'
   - s
-  - multipackage/services
-  - '*multipackage/services.UserService'
-  - claude-501/001/multipackage/services/user_service.go:19:46
+  - multipackage/services/user_service.go:19:46
   - prefix
-  - claude-501/001/multipackage/services/user_service.go:19:48
-  - claude-501/001/multipackage/services/user_service.go:19:56
-  - claude-501/001/multipackage/services/user_service.go:19:62
-  - fmt
-  - claude-501/001/multipackage/services/user_service.go:19:9
+  - multipackage/services/user_service.go:19:48
+  - multipackage/services/user_service.go:19:56
+  - multipackage/services/user_service.go:19:62
+  - multipackage/services/user_service.go:19:9
   - Sprintf
   - func(format string, a ...any) string
-  - claude-501/001/multipackage/services/user_service.go:19:13
-  - call
-  - models
-  - claude-501/001/multipackage/services/user_service.go:16:41
-  - claude-501/001/multipackage/services/user_service.go:16:48
-  - claude-501/001/multipackage/services/user_service.go:16:40
-  - user
-  - claude-501/001/multipackage/services/user_service.go:16:54
-  - claude-501/001/multipackage/services/user_service.go:17:10
-  - claude-501/001/multipackage/services/user_service.go:17:15
-  - claude-501/001/multipackage/services/user_service.go:17:2
-  - unexported
-  - ProcessUser
-  - claude-501/001/multipackage/services/user_service.go:18:9
-  - claude-501/001/multipackage/services/user_service.go:18:14
-  - claude-501/001/multipackage/services/user_service.go:18:2
+  - multipackage/services/user_service.go:19:13
+  - multipackage/services/user_service.go:16:41
+  - multipackage/services/user_service.go:16:48
+  - multipackage/services/user_service.go:16:40
+  - multipackage/services/user_service.go:16:54
+  - multipackage/services/user_service.go:17:10
+  - multipackage/services/user_service.go:17:15
+  - multipackage/services/user_service.go:17:2
+  - multipackage/services/user_service.go:18:9
+  - multipackage/services/user_service.go:18:14
+  - multipackage/services/user_service.go:18:2
   - '*UserService'
-  - claude-501/001/multipackage/services/user_service.go:16:1
-  - claude-501/001/multipackage/services/user_service.go
+  - multipackage/services/user_service.go:16:1
+  - multipackage/services/user_service.go
   - func(*models.User) string
-  - claude-501/001/multipackage/services/user_service.go:22:40
-  - claude-501/001/multipackage/services/user_service.go:23:2
-  - claude-501/001/multipackage/services/user_service.go:23:4
+  - multipackage/services/user_service.go:22:40
+  - multipackage/services/user_service.go:23:2
+  - multipackage/services/user_service.go:23:4
   - multipackage/services.UserService.prefix
-  - claude-501/001/multipackage/services/user_service.go:23:13
+  - multipackage/services/user_service.go:23:13
   - SetPrefix
-  - claude-501/001/multipackage/services/user_service.go:22:1
+  - multipackage/services/user_service.go:22:1
   - 'func(string) '
-  - UserService
-  - claude-501/001/multipackage/services/user_service.go:13:10
-  - claude-501/001/multipackage/services/user_service.go:13:22
+  - multipackage/services/user_service.go:13:10
+  - multipackage/services/user_service.go:13:22
   - '"User:"'
-  - claude-501/001/multipackage/services/user_service.go:13:9
-  - NewUserService
-  - claude-501/001/multipackage/services/user_service.go:12:24
-  - claude-501/001/multipackage/services/user_service.go:12:23
-  - claude-501/001/multipackage/services/user_service.go:12:1
+  - multipackage/services/user_service.go:13:9
+  - multipackage/services/user_service.go:12:24
+  - multipackage/services/user_service.go:12:23
+  - multipackage/services/user_service.go:12:1
   - func() *UserService
   - 'User:'
-  - '"John"'
-  - "25"
-  - claude-501/001/multipackage/main.go:10:10
-  - func(name string, age int) *multipackage/models.User
-  - claude-501/001/multipackage/main.go:10:17
-  - multipackage
-  - claude-501/001/multipackage/main.go:10:2
-  - main
-  - services
-  - claude-501/001/multipackage/main.go:11:13
-  - func() *multipackage/services.UserService
-  - claude-501/001/multipackage/main.go:11:22
-  - service
-  - claude-501/001/multipackage/main.go:11:2
-  - claude-501/001/multipackage/main.go:13:32
-  - claude-501/001/multipackage/main.go:13:12
-  - func(user *multipackage/models.User) string
-  - claude-501/001/multipackage/main.go:13:20
-  - result
-  - claude-501/001/multipackage/main.go:13:2
-  - claude-501/001/multipackage/main.go:9:1
-  - 'func() '
   - "1"
   - "149"
   - input
   - multipackage/utils
-  - claude-501/001/multipackage/utils/helper.go:6:43
+  - multipackage/utils/helper.go:6:43
   - strings
-  - claude-501/001/multipackage/utils/helper.go:6:25
+  - multipackage/utils/helper.go:6:25
   - TrimSpace
   - func(s string) string
-  - claude-501/001/multipackage/utils/helper.go:6:33
-  - claude-501/001/multipackage/utils/helper.go:6:9
+  - multipackage/utils/helper.go:6:33
+  - multipackage/utils/helper.go:6:9
   - ToUpper
-  - claude-501/001/multipackage/utils/helper.go:6:17
+  - multipackage/utils/helper.go:6:17
   - FormatString
-  - claude-501/001/multipackage/utils/helper.go:5:25
-  - claude-501/001/multipackage/utils/helper.go:5:33
-  - claude-501/001/multipackage/utils/helper.go:5:1
+  - multipackage/utils/helper.go:5:25
+  - multipackage/utils/helper.go:5:33
+  - multipackage/utils/helper.go:5:1
   - func(string) string
-  - claude-501/001/multipackage/utils/helper.go:10:9
+  - multipackage/utils/helper.go:10:9
   - "0"
   - binary
   - '>'
-  - claude-501/001/multipackage/utils/helper.go:10:20
+  - multipackage/utils/helper.go:10:20
   - "150"
   - <
   - '&&'
   - ValidateAge
-  - claude-501/001/multipackage/utils/helper.go:9:22
+  - multipackage/utils/helper.go:9:22
   - bool
-  - claude-501/001/multipackage/utils/helper.go:9:27
-  - claude-501/001/multipackage/utils/helper.go:9:1
+  - multipackage/utils/helper.go:9:27
+  - multipackage/utils/helper.go:9:1
   - func(int) bool
   - MinAge
   - const
-  - claude-501/001/multipackage/utils/helper.go:14:2
+  - multipackage/utils/helper.go:14:2
   - untyped int
   - MaxAge
-  - claude-501/001/multipackage/utils/helper.go:15:2
+  - multipackage/utils/helper.go:15:2
   - DefaultFormat
   - var
-  - claude-501/001/multipackage/utils/helper.go:18:5
+  - multipackage/utils/helper.go:18:5
   - '"uppercase"'
   - uppercase
   - multipackage/models.UserInterface
   - multipackage/models.User
-  - claude-501/001/multipackage/main.go:14:14
-  - claude-501/001/multipackage/main.go:14:2
+  - multipackage/main.go:14:14
+  - multipackage/main.go:14:2
   - Println
   - func(a ...any) (n int, err error)
 packages:
   multipackage:
     files:
-      claude-501/001/multipackage/main.go:
+      multipackage/main.go:
         functions:
           main:
-            name: 114
-            pkg: 112
+            name: 19
+            pkg: 16
             signature:
-              kind: 12
+              kind: 0
               name: -1
               value: -1
               fun:
-                kind: 13
+                kind: 1
                 name: -1
                 value: -1
                 raw: -1
@@ -205,338 +205,272 @@ packages:
               position: -1
               resolved_type: -1
               generic_type_name: -1
-            signature_str: 128
-            position: 127
-            scope: 79
+            signature_str: 39
+            position: 38
+            scope: 18
             comments: -1
             assignments:
               result:
-                - variable_name: 125
-                  pkg: 112
-                  concrete_type: 6
-                  position: 126
-                  scope: 79
+                - variable_name: 36
+                  pkg: 16
+                  concrete_type: 35
+                  position: 37
+                  scope: 18
                   value:
-                    kind: 69
+                    kind: 13
                     name: -1
                     value: -1
                     fun:
-                      kind: 8
+                      kind: 12
                       name: -1
                       value: -1
                       x:
-                        kind: 0
-                        name: 119
+                        kind: 5
+                        name: 27
                         value: -1
                         raw: -1
-                        pkg: 112
-                        type: 58
-                        position: 122
+                        pkg: 16
+                        type: 26
+                        position: 30
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 0
-                        name: 80
+                        kind: 5
+                        name: 31
                         value: -1
                         raw: -1
-                        pkg: 57
-                        type: 123
-                        position: 124
+                        pkg: 21
+                        type: 32
+                        position: 33
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 57
-                      type: 123
-                      position: 122
+                      pkg: 21
+                      type: 32
+                      position: 30
                       resolved_type: -1
                       generic_type_name: -1
                       receiver_type:
-                        kind: 0
-                        name: 96
+                        kind: 5
+                        name: 34
                         value: -1
                         raw: -1
-                        pkg: 57
-                        type: 96
+                        pkg: 21
+                        type: 34
                         position: -1
                         resolved_type: -1
                         generic_type_name: -1
                     args:
-                      - kind: 0
-                        name: 74
+                      - kind: 5
+                        name: 15
                         value: -1
                         raw: -1
-                        pkg: 112
-                        type: 3
-                        position: 121
+                        pkg: 16
+                        type: 14
+                        position: 29
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
                     pkg: -1
-                    type: 6
-                    position: 122
+                    type: 35
+                    position: 30
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 0
-                    name: 125
+                    kind: 5
+                    name: 36
                     value: -1
                     raw: -1
-                    pkg: 112
-                    type: 6
-                    position: 126
+                    pkg: 16
+                    type: 35
+                    position: 37
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 114
+                  func: 19
                   callee_func: ProcessUser
                   callee_pkg: multipackage/services
               service:
-                - variable_name: 119
-                  pkg: 112
-                  concrete_type: 58
-                  position: 120
-                  scope: 79
+                - variable_name: 27
+                  pkg: 16
+                  concrete_type: 26
+                  position: 28
+                  scope: 18
                   value:
-                    kind: 69
-                    name: -1
-                    value: -1
-                    fun:
-                      kind: 8
-                      name: -1
-                      value: -1
-                      x:
-                        kind: 0
-                        name: 115
-                        value: -1
-                        raw: -1
-                        pkg: 57
-                        type: -1
-                        position: 116
-                        resolved_type: -1
-                        generic_type_name: -1
-                      sel:
-                        kind: 0
-                        name: 101
-                        value: -1
-                        raw: -1
-                        pkg: 57
-                        type: 117
-                        position: 118
-                        resolved_type: -1
-                        generic_type_name: -1
-                      raw: -1
-                      pkg: 57
-                      type: 117
-                      position: 116
-                      resolved_type: -1
-                      generic_type_name: -1
-                    raw: -1
-                    pkg: -1
-                    type: 58
-                    position: 116
-                    resolved_type: -1
-                    generic_type_name: -1
-                  lhs:
-                    kind: 0
-                    name: 119
-                    value: -1
-                    raw: -1
-                    pkg: 112
-                    type: 58
-                    position: 120
-                    resolved_type: -1
-                    generic_type_name: -1
-                  func: 114
-                  callee_func: NewUserService
-                  callee_pkg: multipackage/services
-              user:
-                - variable_name: 74
-                  pkg: 112
-                  concrete_type: 3
-                  position: 113
-                  scope: 79
-                  value:
-                    kind: 69
-                    name: -1
-                    value: -1
-                    fun:
-                      kind: 8
-                      name: -1
-                      value: -1
-                      x:
-                        kind: 0
-                        name: 70
-                        value: -1
-                        raw: -1
-                        pkg: 2
-                        type: -1
-                        position: 109
-                        resolved_type: -1
-                        generic_type_name: -1
-                      sel:
-                        kind: 0
-                        name: 46
-                        value: -1
-                        raw: -1
-                        pkg: 2
-                        type: 110
-                        position: 111
-                        resolved_type: -1
-                        generic_type_name: -1
-                      raw: -1
-                      pkg: 2
-                      type: 110
-                      position: 109
-                      resolved_type: -1
-                      generic_type_name: -1
-                    args:
-                      - kind: 54
-                        name: -1
-                        value: 107
-                        raw: -1
-                        pkg: -1
-                        type: -1
-                        position: -1
-                        resolved_type: -1
-                        generic_type_name: -1
-                      - kind: 54
-                        name: -1
-                        value: 108
-                        raw: -1
-                        pkg: -1
-                        type: -1
-                        position: -1
-                        resolved_type: -1
-                        generic_type_name: -1
-                    raw: -1
-                    pkg: -1
-                    type: 3
-                    position: 109
-                    resolved_type: -1
-                    generic_type_name: -1
-                  lhs:
-                    kind: 0
-                    name: 74
-                    value: -1
-                    raw: -1
-                    pkg: 112
-                    type: 3
-                    position: 113
-                    resolved_type: -1
-                    generic_type_name: -1
-                  func: 114
-                  callee_func: NewUser
-                  callee_pkg: multipackage/models
-        imports:
-          2: 2
-          57: 57
-          64: 64
-  multipackage/models:
-    files:
-      claude-501/001/multipackage/models/user.go:
-        types:
-          User:
-            name: 26
-            pkg: 2
-            kind: 27
-            implements:
-              - 172
-            fields:
-              - name: 5
-                type: 6
-                tag: 28
-                scope: 15
-                comments: -1
-              - name: 19
-                type: 20
-                tag: 29
-                scope: 15
-                comments: -1
-            scope: 15
-            methods:
-              - name: 9
-                receiver: 10
-                signature:
-                  kind: 12
-                  name: -1
-                  value: -1
-                  fun:
                     kind: 13
                     name: -1
                     value: -1
-                    args:
-                      - kind: 0
-                        name: 6
-                        value: -1
-                        raw: -1
-                        pkg: -1
-                        type: 6
-                        position: 11
-                        resolved_type: -1
-                        generic_type_name: -1
-                    raw: -1
-                    pkg: -1
-                    type: -1
-                    position: -1
-                    resolved_type: -1
-                    generic_type_name: -1
-                  raw: -1
-                  pkg: -1
-                  type: -1
-                  position: -1
-                  resolved_type: 6
-                  generic_type_name: -1
-                signature_str: 17
-                position: 14
-                scope: 15
-                filename: 16
-                return_vars:
-                  - kind: 8
-                    name: -1
-                    value: -1
-                    x:
-                      kind: 0
-                      name: 1
+                    fun:
+                      kind: 12
+                      name: -1
                       value: -1
-                      raw: -1
-                      pkg: 2
-                      type: 3
-                      position: 4
-                      resolved_type: -1
-                      generic_type_name: -1
-                    sel:
-                      kind: 0
-                      name: 5
-                      value: -1
-                      raw: -1
-                      pkg: 2
-                      type: 6
-                      position: 7
-                      resolved_type: -1
-                      generic_type_name: -1
-                    raw: -1
-                    pkg: 2
-                    type: 6
-                    position: 4
-                    resolved_type: -1
-                    generic_type_name: -1
-              - name: 22
-                receiver: 10
-                signature:
-                  kind: 12
-                  name: -1
-                  value: -1
-                  fun:
-                    kind: 13
-                    name: -1
-                    value: -1
-                    args:
-                      - kind: 0
+                      x:
+                        kind: 5
                         name: 20
                         value: -1
                         raw: -1
+                        pkg: 21
+                        type: -1
+                        position: 22
+                        resolved_type: -1
+                        generic_type_name: -1
+                      sel:
+                        kind: 5
+                        name: 23
+                        value: -1
+                        raw: -1
+                        pkg: 21
+                        type: 24
+                        position: 25
+                        resolved_type: -1
+                        generic_type_name: -1
+                      raw: -1
+                      pkg: 21
+                      type: 24
+                      position: 22
+                      resolved_type: -1
+                      generic_type_name: -1
+                    raw: -1
+                    pkg: -1
+                    type: 26
+                    position: 22
+                    resolved_type: -1
+                    generic_type_name: -1
+                  lhs:
+                    kind: 5
+                    name: 27
+                    value: -1
+                    raw: -1
+                    pkg: 16
+                    type: 26
+                    position: 28
+                    resolved_type: -1
+                    generic_type_name: -1
+                  func: 19
+                  callee_func: NewUserService
+                  callee_pkg: multipackage/services
+              user:
+                - variable_name: 15
+                  pkg: 16
+                  concrete_type: 14
+                  position: 17
+                  scope: 18
+                  value:
+                    kind: 13
+                    name: -1
+                    value: -1
+                    fun:
+                      kind: 12
+                      name: -1
+                      value: -1
+                      x:
+                        kind: 5
+                        name: 6
+                        value: -1
+                        raw: -1
+                        pkg: 7
+                        type: -1
+                        position: 8
+                        resolved_type: -1
+                        generic_type_name: -1
+                      sel:
+                        kind: 5
+                        name: 9
+                        value: -1
+                        raw: -1
+                        pkg: 7
+                        type: 10
+                        position: 11
+                        resolved_type: -1
+                        generic_type_name: -1
+                      raw: -1
+                      pkg: 7
+                      type: 10
+                      position: 8
+                      resolved_type: -1
+                      generic_type_name: -1
+                    args:
+                      - kind: 2
+                        name: -1
+                        value: 3
+                        raw: -1
                         pkg: -1
-                        type: 20
-                        position: 23
+                        type: -1
+                        position: -1
+                        resolved_type: -1
+                        generic_type_name: -1
+                      - kind: 2
+                        name: -1
+                        value: 4
+                        raw: -1
+                        pkg: -1
+                        type: -1
+                        position: -1
+                        resolved_type: -1
+                        generic_type_name: -1
+                    raw: -1
+                    pkg: -1
+                    type: 14
+                    position: 8
+                    resolved_type: -1
+                    generic_type_name: -1
+                  lhs:
+                    kind: 5
+                    name: 15
+                    value: -1
+                    raw: -1
+                    pkg: 16
+                    type: 14
+                    position: 17
+                    resolved_type: -1
+                    generic_type_name: -1
+                  func: 19
+                  callee_func: NewUser
+                  callee_pkg: multipackage/models
+        imports:
+          7: 7
+          21: 21
+          40: 40
+  multipackage/models:
+    files:
+      multipackage/models/user.go:
+        types:
+          User:
+            name: 60
+            pkg: 7
+            kind: 61
+            implements:
+              - 172
+            fields:
+              - name: 43
+                type: 35
+                tag: 62
+                scope: 49
+                comments: -1
+              - name: 53
+                type: 54
+                tag: 63
+                scope: 49
+                comments: -1
+            scope: 49
+            methods:
+              - name: 45
+                receiver: 46
+                signature:
+                  kind: 0
+                  name: -1
+                  value: -1
+                  fun:
+                    kind: 1
+                    name: -1
+                    value: -1
+                    args:
+                      - kind: 5
+                        name: 35
+                        value: -1
+                        raw: -1
+                        pkg: -1
+                        type: 35
+                        position: 47
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
@@ -549,68 +483,134 @@ packages:
                   pkg: -1
                   type: -1
                   position: -1
-                  resolved_type: 20
+                  resolved_type: 35
                   generic_type_name: -1
-                signature_str: 25
-                position: 24
-                scope: 15
-                filename: 16
+                signature_str: 51
+                position: 48
+                scope: 49
+                filename: 50
                 return_vars:
-                  - kind: 8
+                  - kind: 12
                     name: -1
                     value: -1
                     x:
-                      kind: 0
-                      name: 1
+                      kind: 5
+                      name: 41
                       value: -1
                       raw: -1
-                      pkg: 2
-                      type: 3
-                      position: 18
+                      pkg: 7
+                      type: 14
+                      position: 42
                       resolved_type: -1
                       generic_type_name: -1
                     sel:
-                      kind: 0
-                      name: 19
+                      kind: 5
+                      name: 43
                       value: -1
                       raw: -1
-                      pkg: 2
-                      type: 20
-                      position: 21
+                      pkg: 7
+                      type: 35
+                      position: 44
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
-                    pkg: 2
-                    type: 20
-                    position: 18
+                    pkg: 7
+                    type: 35
+                    position: 42
+                    resolved_type: -1
+                    generic_type_name: -1
+              - name: 56
+                receiver: 46
+                signature:
+                  kind: 0
+                  name: -1
+                  value: -1
+                  fun:
+                    kind: 1
+                    name: -1
+                    value: -1
+                    args:
+                      - kind: 5
+                        name: 54
+                        value: -1
+                        raw: -1
+                        pkg: -1
+                        type: 54
+                        position: 57
+                        resolved_type: -1
+                        generic_type_name: -1
+                    raw: -1
+                    pkg: -1
+                    type: -1
+                    position: -1
+                    resolved_type: -1
+                    generic_type_name: -1
+                  raw: -1
+                  pkg: -1
+                  type: -1
+                  position: -1
+                  resolved_type: 54
+                  generic_type_name: -1
+                signature_str: 59
+                position: 58
+                scope: 49
+                filename: 50
+                return_vars:
+                  - kind: 12
+                    name: -1
+                    value: -1
+                    x:
+                      kind: 5
+                      name: 41
+                      value: -1
+                      raw: -1
+                      pkg: 7
+                      type: 14
+                      position: 52
+                      resolved_type: -1
+                      generic_type_name: -1
+                    sel:
+                      kind: 5
+                      name: 53
+                      value: -1
+                      raw: -1
+                      pkg: 7
+                      type: 54
+                      position: 55
+                      resolved_type: -1
+                      generic_type_name: -1
+                    raw: -1
+                    pkg: 7
+                    type: 54
+                    position: 52
                     resolved_type: -1
                     generic_type_name: -1
             comments: -1
           UserInterface:
-            name: 31
-            pkg: 2
-            kind: 30
+            name: 65
+            pkg: 7
+            kind: 64
             implemented_by:
               - 173
-            scope: 15
+            scope: 49
             methods:
-              - name: 9
+              - name: 45
                 signature:
-                  kind: 12
+                  kind: 0
                   name: -1
                   value: -1
                   fun:
-                    kind: 13
+                    kind: 1
                     name: -1
                     value: -1
                     args:
-                      - kind: 0
-                        name: 6
+                      - kind: 5
+                        name: 35
                         value: -1
                         raw: -1
                         pkg: -1
-                        type: 6
-                        position: 32
+                        type: 35
+                        position: 66
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
@@ -623,28 +623,28 @@ packages:
                   pkg: -1
                   type: -1
                   position: -1
-                  resolved_type: 6
+                  resolved_type: 35
                   generic_type_name: -1
-                signature_str: 17
-                scope: 15
+                signature_str: 51
+                scope: 49
                 comments: -1
-              - name: 22
+              - name: 56
                 signature:
-                  kind: 12
+                  kind: 0
                   name: -1
                   value: -1
                   fun:
-                    kind: 13
+                    kind: 1
                     name: -1
                     value: -1
                     args:
-                      - kind: 0
-                        name: 20
+                      - kind: 5
+                        name: 54
                         value: -1
                         raw: -1
                         pkg: -1
-                        type: 20
-                        position: 33
+                        type: 54
+                        position: 67
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
@@ -657,42 +657,42 @@ packages:
                   pkg: -1
                   type: -1
                   position: -1
-                  resolved_type: 20
+                  resolved_type: 54
                   generic_type_name: -1
-                signature_str: 25
-                scope: 15
+                signature_str: 59
+                scope: 49
                 comments: -1
             comments: -1
         functions:
           NewUser:
-            name: 46
-            pkg: 2
+            name: 9
+            pkg: 7
             signature:
-              kind: 12
+              kind: 0
               name: -1
               value: -1
               fun:
-                kind: 13
+                kind: 1
                 name: -1
                 value: -1
                 args:
-                  - kind: 50
+                  - kind: 83
                     name: -1
                     value: -1
                     x:
-                      kind: 0
-                      name: 26
+                      kind: 5
+                      name: 60
                       value: -1
                       raw: -1
-                      pkg: 2
-                      type: 26
-                      position: 49
+                      pkg: 7
+                      type: 60
+                      position: 82
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
                     pkg: -1
                     type: -1
-                    position: 51
+                    position: 84
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -702,435 +702,103 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 0
-                  name: 36
+                - kind: 5
+                  name: 70
                   value: -1
                   raw: -1
                   pkg: -1
-                  type: 6
-                  position: 47
+                  type: 35
+                  position: 80
                   resolved_type: -1
                   generic_type_name: -1
-                - kind: 0
-                  name: 40
+                - kind: 5
+                  name: 74
                   value: -1
                   raw: -1
                   pkg: -1
-                  type: 20
-                  position: 48
+                  type: 54
+                  position: 81
                   resolved_type: -1
                   generic_type_name: -1
               raw: -1
               pkg: -1
               type: -1
               position: -1
-              resolved_type: 10
+              resolved_type: 46
               generic_type_name: -1
-            signature_str: 53
-            position: 52
-            scope: 15
+            signature_str: 86
+            position: 85
+            scope: 49
             comments: -1
             return_vars:
-              - kind: 43
+              - kind: 77
                 name: -1
-                value: 44
+                value: 78
                 x:
-                  kind: 42
+                  kind: 76
                   name: -1
                   value: -1
                   x:
-                    kind: 0
-                    name: 26
+                    kind: 5
+                    name: 60
                     value: -1
                     raw: -1
-                    pkg: 2
-                    type: 26
-                    position: 34
+                    pkg: 7
+                    type: 60
+                    position: 68
                     resolved_type: -1
                     generic_type_name: -1
                   args:
-                    - kind: 38
+                    - kind: 72
                       name: -1
                       value: -1
                       x:
-                        kind: 0
-                        name: 5
+                        kind: 5
+                        name: 43
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 6
-                        position: 35
+                        pkg: 7
+                        type: 35
+                        position: 69
                         resolved_type: -1
                         generic_type_name: -1
                       fun:
-                        kind: 0
-                        name: 36
+                        kind: 5
+                        name: 70
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 6
-                        position: 37
-                        resolved_type: -1
-                        generic_type_name: -1
-                      raw: -1
-                      pkg: -1
-                      type: -1
-                      position: 35
-                      resolved_type: -1
-                      generic_type_name: -1
-                    - kind: 38
-                      name: -1
-                      value: -1
-                      x:
-                        kind: 0
-                        name: 19
-                        value: -1
-                        raw: -1
-                        pkg: 2
-                        type: 20
-                        position: 39
-                        resolved_type: -1
-                        generic_type_name: -1
-                      fun:
-                        kind: 0
-                        name: 40
-                        value: -1
-                        raw: -1
-                        pkg: 2
-                        type: 20
-                        position: 41
-                        resolved_type: -1
-                        generic_type_name: -1
-                      raw: -1
-                      pkg: -1
-                      type: -1
-                      position: 39
-                      resolved_type: -1
-                      generic_type_name: -1
-                  raw: -1
-                  pkg: -1
-                  type: -1
-                  position: 34
-                  resolved_type: -1
-                  generic_type_name: -1
-                raw: -1
-                pkg: -1
-                type: -1
-                position: 45
-                resolved_type: -1
-                generic_type_name: -1
-        struct_instances:
-          - type: 26
-            pkg: 2
-            position: 34
-            fields:
-              5: 36
-              19: 40
-        imports: {}
-    types:
-      User:
-        name: 26
-        pkg: 2
-        kind: 27
-        implements:
-          - 172
-        fields:
-          - name: 5
-            type: 6
-            tag: 28
-            scope: 15
-            comments: -1
-          - name: 19
-            type: 20
-            tag: 29
-            scope: 15
-            comments: -1
-        scope: 15
-        methods:
-          - name: 9
-            receiver: 10
-            signature:
-              kind: 12
-              name: -1
-              value: -1
-              fun:
-                kind: 13
-                name: -1
-                value: -1
-                args:
-                  - kind: 0
-                    name: 6
-                    value: -1
-                    raw: -1
-                    pkg: -1
-                    type: 6
-                    position: 11
-                    resolved_type: -1
-                    generic_type_name: -1
-                raw: -1
-                pkg: -1
-                type: -1
-                position: -1
-                resolved_type: -1
-                generic_type_name: -1
-              raw: -1
-              pkg: -1
-              type: -1
-              position: -1
-              resolved_type: 6
-              generic_type_name: -1
-            signature_str: 17
-            position: 14
-            scope: 15
-            filename: 16
-            return_vars:
-              - kind: 8
-                name: -1
-                value: -1
-                x:
-                  kind: 0
-                  name: 1
-                  value: -1
-                  raw: -1
-                  pkg: 2
-                  type: 3
-                  position: 4
-                  resolved_type: -1
-                  generic_type_name: -1
-                sel:
-                  kind: 0
-                  name: 5
-                  value: -1
-                  raw: -1
-                  pkg: 2
-                  type: 6
-                  position: 7
-                  resolved_type: -1
-                  generic_type_name: -1
-                raw: -1
-                pkg: 2
-                type: 6
-                position: 4
-                resolved_type: -1
-                generic_type_name: -1
-          - name: 22
-            receiver: 10
-            signature:
-              kind: 12
-              name: -1
-              value: -1
-              fun:
-                kind: 13
-                name: -1
-                value: -1
-                args:
-                  - kind: 0
-                    name: 20
-                    value: -1
-                    raw: -1
-                    pkg: -1
-                    type: 20
-                    position: 23
-                    resolved_type: -1
-                    generic_type_name: -1
-                raw: -1
-                pkg: -1
-                type: -1
-                position: -1
-                resolved_type: -1
-                generic_type_name: -1
-              raw: -1
-              pkg: -1
-              type: -1
-              position: -1
-              resolved_type: 20
-              generic_type_name: -1
-            signature_str: 25
-            position: 24
-            scope: 15
-            filename: 16
-            return_vars:
-              - kind: 8
-                name: -1
-                value: -1
-                x:
-                  kind: 0
-                  name: 1
-                  value: -1
-                  raw: -1
-                  pkg: 2
-                  type: 3
-                  position: 18
-                  resolved_type: -1
-                  generic_type_name: -1
-                sel:
-                  kind: 0
-                  name: 19
-                  value: -1
-                  raw: -1
-                  pkg: 2
-                  type: 20
-                  position: 21
-                  resolved_type: -1
-                  generic_type_name: -1
-                raw: -1
-                pkg: 2
-                type: 20
-                position: 18
-                resolved_type: -1
-                generic_type_name: -1
-        comments: -1
-      UserInterface:
-        name: 31
-        pkg: 2
-        kind: 30
-        implemented_by:
-          - 173
-        scope: 15
-        methods:
-          - name: 9
-            signature:
-              kind: 12
-              name: -1
-              value: -1
-              fun:
-                kind: 13
-                name: -1
-                value: -1
-                args:
-                  - kind: 0
-                    name: 6
-                    value: -1
-                    raw: -1
-                    pkg: -1
-                    type: 6
-                    position: 32
-                    resolved_type: -1
-                    generic_type_name: -1
-                raw: -1
-                pkg: -1
-                type: -1
-                position: -1
-                resolved_type: -1
-                generic_type_name: -1
-              raw: -1
-              pkg: -1
-              type: -1
-              position: -1
-              resolved_type: 6
-              generic_type_name: -1
-            signature_str: 17
-            scope: 15
-            comments: -1
-          - name: 22
-            signature:
-              kind: 12
-              name: -1
-              value: -1
-              fun:
-                kind: 13
-                name: -1
-                value: -1
-                args:
-                  - kind: 0
-                    name: 20
-                    value: -1
-                    raw: -1
-                    pkg: -1
-                    type: 20
-                    position: 33
-                    resolved_type: -1
-                    generic_type_name: -1
-                raw: -1
-                pkg: -1
-                type: -1
-                position: -1
-                resolved_type: -1
-                generic_type_name: -1
-              raw: -1
-              pkg: -1
-              type: -1
-              position: -1
-              resolved_type: 20
-              generic_type_name: -1
-            signature_str: 25
-            scope: 15
-            comments: -1
-        comments: -1
-  multipackage/services:
-    files:
-      claude-501/001/multipackage/services/user_service.go:
-        types:
-          UserService:
-            name: 96
-            pkg: 57
-            kind: 27
-            fields:
-              - name: 60
-                type: 6
-                tag: -1
-                scope: 79
-                comments: -1
-            scope: 15
-            methods:
-              - name: 80
-                receiver: 84
-                signature:
-                  kind: 12
-                  name: -1
-                  value: -1
-                  fun:
-                    kind: 13
-                    name: -1
-                    value: -1
-                    args:
-                      - kind: 0
-                        name: 6
-                        value: -1
-                        raw: -1
-                        pkg: -1
-                        type: 6
-                        position: 75
-                        resolved_type: -1
-                        generic_type_name: -1
-                    raw: -1
-                    pkg: -1
-                    type: -1
-                    position: -1
-                    resolved_type: -1
-                    generic_type_name: -1
-                  args:
-                    - kind: 50
-                      name: 74
-                      value: -1
-                      x:
-                        kind: 8
-                        name: -1
-                        value: -1
-                        x:
-                          kind: 0
-                          name: 70
-                          value: -1
-                          raw: -1
-                          pkg: 2
-                          type: -1
-                          position: 71
-                          resolved_type: -1
-                          generic_type_name: -1
-                        sel:
-                          kind: 0
-                          name: 26
-                          value: -1
-                          raw: -1
-                          pkg: 2
-                          type: 26
-                          position: 72
-                          resolved_type: -1
-                          generic_type_name: -1
-                        raw: -1
-                        pkg: 2
-                        type: 26
+                        pkg: 7
+                        type: 35
                         position: 71
+                        resolved_type: -1
+                        generic_type_name: -1
+                      raw: -1
+                      pkg: -1
+                      type: -1
+                      position: 69
+                      resolved_type: -1
+                      generic_type_name: -1
+                    - kind: 72
+                      name: -1
+                      value: -1
+                      x:
+                        kind: 5
+                        name: 53
+                        value: -1
+                        raw: -1
+                        pkg: 7
+                        type: 54
+                        position: 73
+                        resolved_type: -1
+                        generic_type_name: -1
+                      fun:
+                        kind: 5
+                        name: 74
+                        value: -1
+                        raw: -1
+                        pkg: 7
+                        type: 54
+                        position: 75
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
@@ -1142,257 +810,589 @@ packages:
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: -1
-                  resolved_type: 6
+                  position: 68
+                  resolved_type: -1
                   generic_type_name: -1
-                signature_str: 87
-                position: 85
-                scope: 15
-                filename: 86
-                return_vars:
-                  - kind: 69
+                raw: -1
+                pkg: -1
+                type: -1
+                position: 79
+                resolved_type: -1
+                generic_type_name: -1
+        struct_instances:
+          - type: 60
+            pkg: 7
+            position: 68
+            fields:
+              43: 70
+              53: 74
+        imports: {}
+    types:
+      User:
+        name: 60
+        pkg: 7
+        kind: 61
+        implements:
+          - 172
+        fields:
+          - name: 43
+            type: 35
+            tag: 62
+            scope: 49
+            comments: -1
+          - name: 53
+            type: 54
+            tag: 63
+            scope: 49
+            comments: -1
+        scope: 49
+        methods:
+          - name: 45
+            receiver: 46
+            signature:
+              kind: 0
+              name: -1
+              value: -1
+              fun:
+                kind: 1
+                name: -1
+                value: -1
+                args:
+                  - kind: 5
+                    name: 35
+                    value: -1
+                    raw: -1
+                    pkg: -1
+                    type: 35
+                    position: 47
+                    resolved_type: -1
+                    generic_type_name: -1
+                raw: -1
+                pkg: -1
+                type: -1
+                position: -1
+                resolved_type: -1
+                generic_type_name: -1
+              raw: -1
+              pkg: -1
+              type: -1
+              position: -1
+              resolved_type: 35
+              generic_type_name: -1
+            signature_str: 51
+            position: 48
+            scope: 49
+            filename: 50
+            return_vars:
+              - kind: 12
+                name: -1
+                value: -1
+                x:
+                  kind: 5
+                  name: 41
+                  value: -1
+                  raw: -1
+                  pkg: 7
+                  type: 14
+                  position: 42
+                  resolved_type: -1
+                  generic_type_name: -1
+                sel:
+                  kind: 5
+                  name: 43
+                  value: -1
+                  raw: -1
+                  pkg: 7
+                  type: 35
+                  position: 44
+                  resolved_type: -1
+                  generic_type_name: -1
+                raw: -1
+                pkg: 7
+                type: 35
+                position: 42
+                resolved_type: -1
+                generic_type_name: -1
+          - name: 56
+            receiver: 46
+            signature:
+              kind: 0
+              name: -1
+              value: -1
+              fun:
+                kind: 1
+                name: -1
+                value: -1
+                args:
+                  - kind: 5
+                    name: 54
+                    value: -1
+                    raw: -1
+                    pkg: -1
+                    type: 54
+                    position: 57
+                    resolved_type: -1
+                    generic_type_name: -1
+                raw: -1
+                pkg: -1
+                type: -1
+                position: -1
+                resolved_type: -1
+                generic_type_name: -1
+              raw: -1
+              pkg: -1
+              type: -1
+              position: -1
+              resolved_type: 54
+              generic_type_name: -1
+            signature_str: 59
+            position: 58
+            scope: 49
+            filename: 50
+            return_vars:
+              - kind: 12
+                name: -1
+                value: -1
+                x:
+                  kind: 5
+                  name: 41
+                  value: -1
+                  raw: -1
+                  pkg: 7
+                  type: 14
+                  position: 52
+                  resolved_type: -1
+                  generic_type_name: -1
+                sel:
+                  kind: 5
+                  name: 53
+                  value: -1
+                  raw: -1
+                  pkg: 7
+                  type: 54
+                  position: 55
+                  resolved_type: -1
+                  generic_type_name: -1
+                raw: -1
+                pkg: 7
+                type: 54
+                position: 52
+                resolved_type: -1
+                generic_type_name: -1
+        comments: -1
+      UserInterface:
+        name: 65
+        pkg: 7
+        kind: 64
+        implemented_by:
+          - 173
+        scope: 49
+        methods:
+          - name: 45
+            signature:
+              kind: 0
+              name: -1
+              value: -1
+              fun:
+                kind: 1
+                name: -1
+                value: -1
+                args:
+                  - kind: 5
+                    name: 35
+                    value: -1
+                    raw: -1
+                    pkg: -1
+                    type: 35
+                    position: 66
+                    resolved_type: -1
+                    generic_type_name: -1
+                raw: -1
+                pkg: -1
+                type: -1
+                position: -1
+                resolved_type: -1
+                generic_type_name: -1
+              raw: -1
+              pkg: -1
+              type: -1
+              position: -1
+              resolved_type: 35
+              generic_type_name: -1
+            signature_str: 51
+            scope: 49
+            comments: -1
+          - name: 56
+            signature:
+              kind: 0
+              name: -1
+              value: -1
+              fun:
+                kind: 1
+                name: -1
+                value: -1
+                args:
+                  - kind: 5
+                    name: 54
+                    value: -1
+                    raw: -1
+                    pkg: -1
+                    type: 54
+                    position: 67
+                    resolved_type: -1
+                    generic_type_name: -1
+                raw: -1
+                pkg: -1
+                type: -1
+                position: -1
+                resolved_type: -1
+                generic_type_name: -1
+              raw: -1
+              pkg: -1
+              type: -1
+              position: -1
+              resolved_type: 54
+              generic_type_name: -1
+            signature_str: 59
+            scope: 49
+            comments: -1
+        comments: -1
+  multipackage/services:
+    files:
+      multipackage/services/user_service.go:
+        types:
+          UserService:
+            name: 34
+            pkg: 21
+            kind: 61
+            fields:
+              - name: 90
+                type: 35
+                tag: -1
+                scope: 18
+                comments: -1
+            scope: 49
+            methods:
+              - name: 31
+                receiver: 108
+                signature:
+                  kind: 0
+                  name: -1
+                  value: -1
+                  fun:
+                    kind: 1
                     name: -1
                     value: -1
-                    fun:
-                      kind: 8
-                      name: -1
-                      value: -1
-                      x:
-                        kind: 0
-                        name: 64
+                    args:
+                      - kind: 5
+                        name: 35
                         value: -1
                         raw: -1
-                        pkg: 64
-                        type: -1
-                        position: 65
+                        pkg: -1
+                        type: 35
+                        position: 101
                         resolved_type: -1
                         generic_type_name: -1
-                      sel:
-                        kind: 0
-                        name: 66
+                    raw: -1
+                    pkg: -1
+                    type: -1
+                    position: -1
+                    resolved_type: -1
+                    generic_type_name: -1
+                  args:
+                    - kind: 83
+                      name: 15
+                      value: -1
+                      x:
+                        kind: 12
+                        name: -1
                         value: -1
+                        x:
+                          kind: 5
+                          name: 6
+                          value: -1
+                          raw: -1
+                          pkg: 7
+                          type: -1
+                          position: 98
+                          resolved_type: -1
+                          generic_type_name: -1
+                        sel:
+                          kind: 5
+                          name: 60
+                          value: -1
+                          raw: -1
+                          pkg: 7
+                          type: 60
+                          position: 99
+                          resolved_type: -1
+                          generic_type_name: -1
                         raw: -1
-                        pkg: 64
-                        type: 67
-                        position: 68
+                        pkg: 7
+                        type: 60
+                        position: 98
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 64
-                      type: 67
-                      position: 65
+                      pkg: -1
+                      type: -1
+                      position: 100
+                      resolved_type: -1
+                      generic_type_name: -1
+                  raw: -1
+                  pkg: -1
+                  type: -1
+                  position: -1
+                  resolved_type: 35
+                  generic_type_name: -1
+                signature_str: 111
+                position: 109
+                scope: 49
+                filename: 110
+                return_vars:
+                  - kind: 13
+                    name: -1
+                    value: -1
+                    fun:
+                      kind: 12
+                      name: -1
+                      value: -1
+                      x:
+                        kind: 5
+                        name: 40
+                        value: -1
+                        raw: -1
+                        pkg: 40
+                        type: -1
+                        position: 94
+                        resolved_type: -1
+                        generic_type_name: -1
+                      sel:
+                        kind: 5
+                        name: 95
+                        value: -1
+                        raw: -1
+                        pkg: 40
+                        type: 96
+                        position: 97
+                        resolved_type: -1
+                        generic_type_name: -1
+                      raw: -1
+                      pkg: 40
+                      type: 96
+                      position: 94
                       resolved_type: -1
                       generic_type_name: -1
                     args:
-                      - kind: 54
+                      - kind: 2
                         name: -1
-                        value: 55
+                        value: 87
                         raw: -1
                         pkg: -1
                         type: -1
                         position: -1
                         resolved_type: -1
                         generic_type_name: -1
-                      - kind: 8
+                      - kind: 12
                         name: -1
                         value: -1
                         x:
-                          kind: 0
-                          name: 56
+                          kind: 5
+                          name: 88
                           value: -1
                           raw: -1
-                          pkg: 57
-                          type: 58
-                          position: 59
+                          pkg: 21
+                          type: 26
+                          position: 89
                           resolved_type: -1
                           generic_type_name: -1
                         sel:
-                          kind: 0
-                          name: 60
+                          kind: 5
+                          name: 90
                           value: -1
                           raw: -1
-                          pkg: 57
-                          type: 6
-                          position: 61
+                          pkg: 21
+                          type: 35
+                          position: 91
                           resolved_type: -1
                           generic_type_name: -1
                         raw: -1
-                        pkg: 57
-                        type: 6
-                        position: 59
+                        pkg: 21
+                        type: 35
+                        position: 89
                         resolved_type: -1
                         generic_type_name: -1
-                      - kind: 0
-                        name: 36
+                      - kind: 5
+                        name: 70
                         value: -1
                         raw: -1
-                        pkg: 57
-                        type: 6
-                        position: 62
+                        pkg: 21
+                        type: 35
+                        position: 92
                         resolved_type: -1
                         generic_type_name: -1
-                      - kind: 0
-                        name: 40
+                      - kind: 5
+                        name: 74
                         value: -1
                         raw: -1
-                        pkg: 57
-                        type: 20
-                        position: 63
+                        pkg: 21
+                        type: 54
+                        position: 93
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
                     pkg: -1
-                    type: 6
-                    position: 65
+                    type: 35
+                    position: 94
                     resolved_type: -1
                     generic_type_name: -1
                 assignments:
                   age:
-                    - variable_name: 40
-                      pkg: 57
-                      concrete_type: 20
-                      position: 83
-                      scope: 79
+                    - variable_name: 74
+                      pkg: 21
+                      concrete_type: 54
+                      position: 107
+                      scope: 18
                       value:
-                        kind: 69
+                        kind: 13
                         name: -1
                         value: -1
                         fun:
-                          kind: 8
+                          kind: 12
                           name: -1
                           value: -1
                           x:
-                            kind: 0
-                            name: 74
+                            kind: 5
+                            name: 15
                             value: -1
                             raw: -1
-                            pkg: 57
-                            type: 3
-                            position: 81
+                            pkg: 21
+                            type: 14
+                            position: 105
                             resolved_type: -1
                             generic_type_name: -1
                           sel:
-                            kind: 0
-                            name: 22
+                            kind: 5
+                            name: 56
                             value: -1
                             raw: -1
-                            pkg: 2
-                            type: 25
-                            position: 82
+                            pkg: 7
+                            type: 59
+                            position: 106
                             resolved_type: -1
                             generic_type_name: -1
                           raw: -1
-                          pkg: 2
-                          type: 25
-                          position: 81
+                          pkg: 7
+                          type: 59
+                          position: 105
                           resolved_type: -1
                           generic_type_name: -1
                           receiver_type:
-                            kind: 0
-                            name: 26
+                            kind: 5
+                            name: 60
                             value: -1
                             raw: -1
-                            pkg: 2
-                            type: 26
+                            pkg: 7
+                            type: 60
                             position: -1
                             resolved_type: -1
                             generic_type_name: -1
                         raw: -1
                         pkg: -1
-                        type: 20
-                        position: 81
+                        type: 54
+                        position: 105
                         resolved_type: -1
                         generic_type_name: -1
                       lhs:
-                        kind: 0
-                        name: 40
+                        kind: 5
+                        name: 74
                         value: -1
                         raw: -1
-                        pkg: 57
-                        type: 20
-                        position: 83
+                        pkg: 21
+                        type: 54
+                        position: 107
                         resolved_type: -1
                         generic_type_name: -1
-                      func: 80
+                      func: 31
                       callee_func: GetAge
                       callee_pkg: multipackage/models
                   name:
-                    - variable_name: 36
-                      pkg: 57
-                      concrete_type: 6
-                      position: 78
-                      scope: 79
+                    - variable_name: 70
+                      pkg: 21
+                      concrete_type: 35
+                      position: 104
+                      scope: 18
                       value:
-                        kind: 69
+                        kind: 13
                         name: -1
                         value: -1
                         fun:
-                          kind: 8
+                          kind: 12
                           name: -1
                           value: -1
                           x:
-                            kind: 0
-                            name: 74
+                            kind: 5
+                            name: 15
                             value: -1
                             raw: -1
-                            pkg: 57
-                            type: 3
-                            position: 76
+                            pkg: 21
+                            type: 14
+                            position: 102
                             resolved_type: -1
                             generic_type_name: -1
                           sel:
-                            kind: 0
-                            name: 9
+                            kind: 5
+                            name: 45
                             value: -1
                             raw: -1
-                            pkg: 2
-                            type: 17
-                            position: 77
+                            pkg: 7
+                            type: 51
+                            position: 103
                             resolved_type: -1
                             generic_type_name: -1
                           raw: -1
-                          pkg: 2
-                          type: 17
-                          position: 76
+                          pkg: 7
+                          type: 51
+                          position: 102
                           resolved_type: -1
                           generic_type_name: -1
                           receiver_type:
-                            kind: 0
-                            name: 26
+                            kind: 5
+                            name: 60
                             value: -1
                             raw: -1
-                            pkg: 2
-                            type: 26
+                            pkg: 7
+                            type: 60
                             position: -1
                             resolved_type: -1
                             generic_type_name: -1
                         raw: -1
                         pkg: -1
-                        type: 6
-                        position: 76
+                        type: 35
+                        position: 102
                         resolved_type: -1
                         generic_type_name: -1
                       lhs:
-                        kind: 0
-                        name: 36
+                        kind: 5
+                        name: 70
                         value: -1
                         raw: -1
-                        pkg: 57
-                        type: 6
-                        position: 78
+                        pkg: 21
+                        type: 35
+                        position: 104
                         resolved_type: -1
                         generic_type_name: -1
-                      func: 80
+                      func: 31
                       callee_func: GetName
                       callee_pkg: multipackage/models
-              - name: 93
-                receiver: 84
+              - name: 117
+                receiver: 108
                 signature:
-                  kind: 12
+                  kind: 0
                   name: -1
                   value: -1
                   fun:
-                    kind: 13
+                    kind: 1
                     name: -1
                     value: -1
                     raw: -1
@@ -1402,13 +1402,13 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   args:
-                    - kind: 0
-                      name: 60
+                    - kind: 5
+                      name: 90
                       value: -1
                       raw: -1
                       pkg: -1
-                      type: 6
-                      position: 88
+                      type: 35
+                      position: 112
                       resolved_type: -1
                       generic_type_name: -1
                   raw: -1
@@ -1417,88 +1417,88 @@ packages:
                   position: -1
                   resolved_type: -1
                   generic_type_name: -1
-                signature_str: 95
-                position: 94
-                scope: 15
-                filename: 86
+                signature_str: 119
+                position: 118
+                scope: 49
+                filename: 110
                 assignments:
                   multipackage/services.UserService.prefix:
-                    - variable_name: 91
-                      pkg: 57
-                      concrete_type: 6
-                      position: 89
-                      scope: 8
+                    - variable_name: 115
+                      pkg: 21
+                      concrete_type: 35
+                      position: 113
+                      scope: 12
                       value:
-                        kind: 0
-                        name: 60
+                        kind: 5
+                        name: 90
                         value: -1
                         raw: -1
-                        pkg: 57
-                        type: 6
-                        position: 92
+                        pkg: 21
+                        type: 35
+                        position: 116
                         resolved_type: -1
                         generic_type_name: -1
                       lhs:
-                        kind: 8
+                        kind: 12
                         name: -1
                         value: -1
                         x:
-                          kind: 0
-                          name: 56
+                          kind: 5
+                          name: 88
                           value: -1
                           raw: -1
-                          pkg: 57
-                          type: 58
-                          position: 89
+                          pkg: 21
+                          type: 26
+                          position: 113
                           resolved_type: -1
                           generic_type_name: -1
                         sel:
-                          kind: 0
-                          name: 60
+                          kind: 5
+                          name: 90
                           value: -1
                           raw: -1
-                          pkg: 57
-                          type: 6
-                          position: 90
+                          pkg: 21
+                          type: 35
+                          position: 114
                           resolved_type: -1
                           generic_type_name: -1
                         raw: -1
-                        pkg: 57
-                        type: 6
-                        position: 89
+                        pkg: 21
+                        type: 35
+                        position: 113
                         resolved_type: -1
                         generic_type_name: -1
             comments: -1
         functions:
           NewUserService:
-            name: 101
-            pkg: 57
+            name: 23
+            pkg: 21
             signature:
-              kind: 12
+              kind: 0
               name: -1
               value: -1
               fun:
-                kind: 13
+                kind: 1
                 name: -1
                 value: -1
                 args:
-                  - kind: 50
+                  - kind: 83
                     name: -1
                     value: -1
                     x:
-                      kind: 0
-                      name: 96
+                      kind: 5
+                      name: 34
                       value: -1
                       raw: -1
-                      pkg: 57
-                      type: 96
-                      position: 102
+                      pkg: 21
+                      type: 34
+                      position: 124
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
                     pkg: -1
                     type: -1
-                    position: 103
+                    position: 125
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -1511,48 +1511,48 @@ packages:
               pkg: -1
               type: -1
               position: -1
-              resolved_type: 84
+              resolved_type: 108
               generic_type_name: -1
-            signature_str: 105
-            position: 104
-            scope: 15
+            signature_str: 127
+            position: 126
+            scope: 49
             comments: -1
             return_vars:
-              - kind: 43
+              - kind: 77
                 name: -1
-                value: 44
+                value: 78
                 x:
-                  kind: 42
+                  kind: 76
                   name: -1
                   value: -1
                   x:
-                    kind: 0
-                    name: 96
+                    kind: 5
+                    name: 34
                     value: -1
                     raw: -1
-                    pkg: 57
-                    type: 96
-                    position: 97
+                    pkg: 21
+                    type: 34
+                    position: 120
                     resolved_type: -1
                     generic_type_name: -1
                   args:
-                    - kind: 38
+                    - kind: 72
                       name: -1
                       value: -1
                       x:
-                        kind: 0
-                        name: 60
+                        kind: 5
+                        name: 90
                         value: -1
                         raw: -1
-                        pkg: 57
-                        type: 6
-                        position: 98
+                        pkg: 21
+                        type: 35
+                        position: 121
                         resolved_type: -1
                         generic_type_name: -1
                       fun:
-                        kind: 54
+                        kind: 2
                         name: -1
-                        value: 99
+                        value: 122
                         raw: -1
                         pkg: -1
                         type: -1
@@ -1562,61 +1562,61 @@ packages:
                       raw: -1
                       pkg: -1
                       type: -1
-                      position: 98
+                      position: 121
                       resolved_type: -1
                       generic_type_name: -1
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 97
+                  position: 120
                   resolved_type: -1
                   generic_type_name: -1
                 raw: -1
                 pkg: -1
                 type: -1
-                position: 100
+                position: 123
                 resolved_type: -1
                 generic_type_name: -1
         struct_instances:
-          - type: 96
-            pkg: 57
-            position: 97
+          - type: 34
+            pkg: 21
+            position: 120
             fields:
-              60: 106
+              90: 128
         imports:
-          2: 2
-          64: 64
+          7: 7
+          40: 40
     types:
       UserService:
-        name: 96
-        pkg: 57
-        kind: 27
+        name: 34
+        pkg: 21
+        kind: 61
         fields:
-          - name: 60
-            type: 6
+          - name: 90
+            type: 35
             tag: -1
-            scope: 79
+            scope: 18
             comments: -1
-        scope: 15
+        scope: 49
         methods:
-          - name: 80
-            receiver: 84
+          - name: 31
+            receiver: 108
             signature:
-              kind: 12
+              kind: 0
               name: -1
               value: -1
               fun:
-                kind: 13
+                kind: 1
                 name: -1
                 value: -1
                 args:
-                  - kind: 0
-                    name: 6
+                  - kind: 5
+                    name: 35
                     value: -1
                     raw: -1
                     pkg: -1
-                    type: 6
-                    position: 75
+                    type: 35
+                    position: 101
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -1626,299 +1626,299 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 50
-                  name: 74
+                - kind: 83
+                  name: 15
                   value: -1
                   x:
-                    kind: 8
+                    kind: 12
                     name: -1
                     value: -1
                     x:
-                      kind: 0
-                      name: 70
+                      kind: 5
+                      name: 6
                       value: -1
                       raw: -1
-                      pkg: 2
+                      pkg: 7
                       type: -1
-                      position: 71
+                      position: 98
                       resolved_type: -1
                       generic_type_name: -1
                     sel:
-                      kind: 0
-                      name: 26
+                      kind: 5
+                      name: 60
                       value: -1
                       raw: -1
-                      pkg: 2
-                      type: 26
-                      position: 72
+                      pkg: 7
+                      type: 60
+                      position: 99
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
-                    pkg: 2
-                    type: 26
-                    position: 71
+                    pkg: 7
+                    type: 60
+                    position: 98
                     resolved_type: -1
                     generic_type_name: -1
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 73
+                  position: 100
                   resolved_type: -1
                   generic_type_name: -1
               raw: -1
               pkg: -1
               type: -1
               position: -1
-              resolved_type: 6
+              resolved_type: 35
               generic_type_name: -1
-            signature_str: 87
-            position: 85
-            scope: 15
-            filename: 86
+            signature_str: 111
+            position: 109
+            scope: 49
+            filename: 110
             return_vars:
-              - kind: 69
+              - kind: 13
                 name: -1
                 value: -1
                 fun:
-                  kind: 8
+                  kind: 12
                   name: -1
                   value: -1
                   x:
-                    kind: 0
-                    name: 64
+                    kind: 5
+                    name: 40
                     value: -1
                     raw: -1
-                    pkg: 64
+                    pkg: 40
                     type: -1
-                    position: 65
+                    position: 94
                     resolved_type: -1
                     generic_type_name: -1
                   sel:
-                    kind: 0
-                    name: 66
+                    kind: 5
+                    name: 95
                     value: -1
                     raw: -1
-                    pkg: 64
-                    type: 67
-                    position: 68
+                    pkg: 40
+                    type: 96
+                    position: 97
                     resolved_type: -1
                     generic_type_name: -1
                   raw: -1
-                  pkg: 64
-                  type: 67
-                  position: 65
+                  pkg: 40
+                  type: 96
+                  position: 94
                   resolved_type: -1
                   generic_type_name: -1
                 args:
-                  - kind: 54
+                  - kind: 2
                     name: -1
-                    value: 55
+                    value: 87
                     raw: -1
                     pkg: -1
                     type: -1
                     position: -1
                     resolved_type: -1
                     generic_type_name: -1
-                  - kind: 8
+                  - kind: 12
                     name: -1
                     value: -1
                     x:
-                      kind: 0
-                      name: 56
+                      kind: 5
+                      name: 88
                       value: -1
                       raw: -1
-                      pkg: 57
-                      type: 58
-                      position: 59
+                      pkg: 21
+                      type: 26
+                      position: 89
                       resolved_type: -1
                       generic_type_name: -1
                     sel:
-                      kind: 0
-                      name: 60
+                      kind: 5
+                      name: 90
                       value: -1
                       raw: -1
-                      pkg: 57
-                      type: 6
-                      position: 61
+                      pkg: 21
+                      type: 35
+                      position: 91
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
-                    pkg: 57
-                    type: 6
-                    position: 59
+                    pkg: 21
+                    type: 35
+                    position: 89
                     resolved_type: -1
                     generic_type_name: -1
-                  - kind: 0
-                    name: 36
+                  - kind: 5
+                    name: 70
                     value: -1
                     raw: -1
-                    pkg: 57
-                    type: 6
-                    position: 62
+                    pkg: 21
+                    type: 35
+                    position: 92
                     resolved_type: -1
                     generic_type_name: -1
-                  - kind: 0
-                    name: 40
+                  - kind: 5
+                    name: 74
                     value: -1
                     raw: -1
-                    pkg: 57
-                    type: 20
-                    position: 63
+                    pkg: 21
+                    type: 54
+                    position: 93
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
                 pkg: -1
-                type: 6
-                position: 65
+                type: 35
+                position: 94
                 resolved_type: -1
                 generic_type_name: -1
             assignments:
               age:
-                - variable_name: 40
-                  pkg: 57
-                  concrete_type: 20
-                  position: 83
-                  scope: 79
+                - variable_name: 74
+                  pkg: 21
+                  concrete_type: 54
+                  position: 107
+                  scope: 18
                   value:
-                    kind: 69
+                    kind: 13
                     name: -1
                     value: -1
                     fun:
-                      kind: 8
+                      kind: 12
                       name: -1
                       value: -1
                       x:
-                        kind: 0
-                        name: 74
+                        kind: 5
+                        name: 15
                         value: -1
                         raw: -1
-                        pkg: 57
-                        type: 3
-                        position: 81
+                        pkg: 21
+                        type: 14
+                        position: 105
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 0
-                        name: 22
+                        kind: 5
+                        name: 56
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 25
-                        position: 82
+                        pkg: 7
+                        type: 59
+                        position: 106
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 2
-                      type: 25
-                      position: 81
+                      pkg: 7
+                      type: 59
+                      position: 105
                       resolved_type: -1
                       generic_type_name: -1
                       receiver_type:
-                        kind: 0
-                        name: 26
+                        kind: 5
+                        name: 60
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 26
+                        pkg: 7
+                        type: 60
                         position: -1
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
                     pkg: -1
-                    type: 20
-                    position: 81
+                    type: 54
+                    position: 105
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 0
-                    name: 40
+                    kind: 5
+                    name: 74
                     value: -1
                     raw: -1
-                    pkg: 57
-                    type: 20
-                    position: 83
+                    pkg: 21
+                    type: 54
+                    position: 107
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 80
+                  func: 31
                   callee_func: GetAge
                   callee_pkg: multipackage/models
               name:
-                - variable_name: 36
-                  pkg: 57
-                  concrete_type: 6
-                  position: 78
-                  scope: 79
+                - variable_name: 70
+                  pkg: 21
+                  concrete_type: 35
+                  position: 104
+                  scope: 18
                   value:
-                    kind: 69
+                    kind: 13
                     name: -1
                     value: -1
                     fun:
-                      kind: 8
+                      kind: 12
                       name: -1
                       value: -1
                       x:
-                        kind: 0
-                        name: 74
+                        kind: 5
+                        name: 15
                         value: -1
                         raw: -1
-                        pkg: 57
-                        type: 3
-                        position: 76
+                        pkg: 21
+                        type: 14
+                        position: 102
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 0
-                        name: 9
+                        kind: 5
+                        name: 45
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 17
-                        position: 77
+                        pkg: 7
+                        type: 51
+                        position: 103
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 2
-                      type: 17
-                      position: 76
+                      pkg: 7
+                      type: 51
+                      position: 102
                       resolved_type: -1
                       generic_type_name: -1
                       receiver_type:
-                        kind: 0
-                        name: 26
+                        kind: 5
+                        name: 60
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 26
+                        pkg: 7
+                        type: 60
                         position: -1
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
                     pkg: -1
-                    type: 6
-                    position: 76
+                    type: 35
+                    position: 102
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 0
-                    name: 36
+                    kind: 5
+                    name: 70
                     value: -1
                     raw: -1
-                    pkg: 57
-                    type: 6
-                    position: 78
+                    pkg: 21
+                    type: 35
+                    position: 104
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 80
+                  func: 31
                   callee_func: GetName
                   callee_pkg: multipackage/models
-          - name: 93
-            receiver: 84
+          - name: 117
+            receiver: 108
             signature:
-              kind: 12
+              kind: 0
               name: -1
               value: -1
               fun:
-                kind: 13
+                kind: 1
                 name: -1
                 value: -1
                 raw: -1
@@ -1928,13 +1928,13 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 0
-                  name: 60
+                - kind: 5
+                  name: 90
                   value: -1
                   raw: -1
                   pkg: -1
-                  type: 6
-                  position: 88
+                  type: 35
+                  position: 112
                   resolved_type: -1
                   generic_type_name: -1
               raw: -1
@@ -1943,80 +1943,80 @@ packages:
               position: -1
               resolved_type: -1
               generic_type_name: -1
-            signature_str: 95
-            position: 94
-            scope: 15
-            filename: 86
+            signature_str: 119
+            position: 118
+            scope: 49
+            filename: 110
             assignments:
               multipackage/services.UserService.prefix:
-                - variable_name: 91
-                  pkg: 57
-                  concrete_type: 6
-                  position: 89
-                  scope: 8
+                - variable_name: 115
+                  pkg: 21
+                  concrete_type: 35
+                  position: 113
+                  scope: 12
                   value:
-                    kind: 0
-                    name: 60
+                    kind: 5
+                    name: 90
                     value: -1
                     raw: -1
-                    pkg: 57
-                    type: 6
-                    position: 92
+                    pkg: 21
+                    type: 35
+                    position: 116
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 8
+                    kind: 12
                     name: -1
                     value: -1
                     x:
-                      kind: 0
-                      name: 56
+                      kind: 5
+                      name: 88
                       value: -1
                       raw: -1
-                      pkg: 57
-                      type: 58
-                      position: 89
+                      pkg: 21
+                      type: 26
+                      position: 113
                       resolved_type: -1
                       generic_type_name: -1
                     sel:
-                      kind: 0
-                      name: 60
+                      kind: 5
+                      name: 90
                       value: -1
                       raw: -1
-                      pkg: 57
-                      type: 6
-                      position: 90
+                      pkg: 21
+                      type: 35
+                      position: 114
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
-                    pkg: 57
-                    type: 6
-                    position: 89
+                    pkg: 21
+                    type: 35
+                    position: 113
                     resolved_type: -1
                     generic_type_name: -1
         comments: -1
   multipackage/utils:
     files:
-      claude-501/001/multipackage/utils/helper.go:
+      multipackage/utils/helper.go:
         functions:
           FormatString:
             name: 142
             pkg: 132
             signature:
-              kind: 12
+              kind: 0
               name: -1
               value: -1
               fun:
-                kind: 13
+                kind: 1
                 name: -1
                 value: -1
                 args:
-                  - kind: 0
-                    name: 6
+                  - kind: 5
+                    name: 35
                     value: -1
                     raw: -1
                     pkg: -1
-                    type: 6
+                    type: 35
                     position: 144
                     resolved_type: -1
                     generic_type_name: -1
@@ -2027,12 +2027,12 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 0
+                - kind: 5
                   name: 131
                   value: -1
                   raw: -1
                   pkg: -1
-                  type: 6
+                  type: 35
                   position: 143
                   resolved_type: -1
                   generic_type_name: -1
@@ -2040,22 +2040,22 @@ packages:
               pkg: -1
               type: -1
               position: -1
-              resolved_type: 6
+              resolved_type: 35
               generic_type_name: -1
             signature_str: 146
             position: 145
-            scope: 15
+            scope: 49
             comments: -1
             return_vars:
-              - kind: 69
+              - kind: 13
                 name: -1
                 value: -1
                 fun:
-                  kind: 8
+                  kind: 12
                   name: -1
                   value: -1
                   x:
-                    kind: 0
+                    kind: 5
                     name: 134
                     value: -1
                     raw: -1
@@ -2065,7 +2065,7 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   sel:
-                    kind: 0
+                    kind: 5
                     name: 140
                     value: -1
                     raw: -1
@@ -2081,15 +2081,15 @@ packages:
                   resolved_type: -1
                   generic_type_name: -1
                 args:
-                  - kind: 69
+                  - kind: 13
                     name: -1
                     value: -1
                     fun:
-                      kind: 8
+                      kind: 12
                       name: -1
                       value: -1
                       x:
-                        kind: 0
+                        kind: 5
                         name: 134
                         value: -1
                         raw: -1
@@ -2099,7 +2099,7 @@ packages:
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 0
+                        kind: 5
                         name: 136
                         value: -1
                         raw: -1
@@ -2115,24 +2115,24 @@ packages:
                       resolved_type: -1
                       generic_type_name: -1
                     args:
-                      - kind: 0
+                      - kind: 5
                         name: 131
                         value: -1
                         raw: -1
                         pkg: 132
-                        type: 6
+                        type: 35
                         position: 133
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
                     pkg: -1
-                    type: 6
+                    type: 35
                     position: 135
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
                 pkg: -1
-                type: 6
+                type: 35
                 position: 139
                 resolved_type: -1
                 generic_type_name: -1
@@ -2140,15 +2140,15 @@ packages:
             name: 155
             pkg: 132
             signature:
-              kind: 12
+              kind: 0
               name: -1
               value: -1
               fun:
-                kind: 13
+                kind: 1
                 name: -1
                 value: -1
                 args:
-                  - kind: 0
+                  - kind: 5
                     name: 157
                     value: -1
                     raw: -1
@@ -2164,12 +2164,12 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 0
-                  name: 40
+                - kind: 5
+                  name: 74
                   value: -1
                   raw: -1
                   pkg: -1
-                  type: 20
+                  type: 54
                   position: 156
                   resolved_type: -1
                   generic_type_name: -1
@@ -2181,7 +2181,7 @@ packages:
               generic_type_name: -1
             signature_str: 160
             position: 159
-            scope: 15
+            scope: 49
             comments: -1
             return_vars:
               - kind: 149
@@ -2192,17 +2192,17 @@ packages:
                   name: -1
                   value: 150
                   x:
-                    kind: 0
-                    name: 40
+                    kind: 5
+                    name: 74
                     value: -1
                     raw: -1
                     pkg: 132
-                    type: 20
+                    type: 54
                     position: 147
                     resolved_type: -1
                     generic_type_name: -1
                   fun:
-                    kind: 54
+                    kind: 2
                     name: -1
                     value: 148
                     raw: -1
@@ -2222,17 +2222,17 @@ packages:
                   name: -1
                   value: 153
                   x:
-                    kind: 0
-                    name: 40
+                    kind: 5
+                    name: 74
                     value: -1
                     raw: -1
                     pkg: 132
-                    type: 20
+                    type: 54
                     position: 151
                     resolved_type: -1
                     generic_type_name: -1
                   fun:
-                    kind: 54
+                    kind: 2
                     name: -1
                     value: 152
                     raw: -1
@@ -2289,182 +2289,33 @@ packages:
           134: 134
 call_graph:
   - caller:
-      name: 80
-      pkg: 57
+      name: 19
+      pkg: 16
       position: -1
-      recv_type: 84
-      scope: 15
-      signature_str: 87
+      recv_type: -1
+      scope: 18
+      signature_str: 39
     callee:
       name: 9
-      pkg: 2
-      position: 76
-      recv_type: 10
-      scope: 15
-      signature_str: 17
-    position: 76
-    callee_var_name: user
-    callee_recv_var_name: name
-    chain_root: user
-  - caller:
-      name: 80
-      pkg: 57
-      position: -1
-      recv_type: 84
-      scope: 15
-      signature_str: 87
-    callee:
-      name: 22
-      pkg: 2
-      position: 81
-      recv_type: 10
-      scope: 15
-      signature_str: 25
-    position: 81
-    callee_var_name: user
-    callee_recv_var_name: age
-    chain_root: user
-  - caller:
-      name: 80
-      pkg: 57
-      position: -1
-      recv_type: 84
-      scope: 15
-      signature_str: 87
-    callee:
-      name: 66
-      pkg: 64
-      position: 65
+      pkg: 7
+      position: 8
       recv_type: -1
-      scope: 15
-      signature_str: 67
-    position: 65
+      scope: 49
+      signature_str: 10
+    position: 8
     args:
-      - kind: 54
+      - kind: 2
         name: -1
-        value: 55
+        value: 3
         raw: -1
         pkg: -1
         type: -1
         position: -1
         resolved_type: -1
         generic_type_name: -1
-      - kind: 8
+      - kind: 2
         name: -1
-        value: -1
-        x:
-          kind: 0
-          name: 56
-          value: -1
-          raw: -1
-          pkg: 57
-          type: 58
-          position: 59
-          resolved_type: -1
-          generic_type_name: -1
-        sel:
-          kind: 0
-          name: 60
-          value: -1
-          raw: -1
-          pkg: 57
-          type: 6
-          position: 61
-          resolved_type: -1
-          generic_type_name: -1
-        raw: -1
-        pkg: 57
-        type: 6
-        position: 59
-        resolved_type: -1
-        generic_type_name: -1
-      - kind: 0
-        name: 36
-        value: -1
-        raw: -1
-        pkg: 57
-        type: 6
-        position: 62
-        resolved_type: -1
-        generic_type_name: -1
-      - kind: 0
-        name: 40
-        value: -1
-        raw: -1
-        pkg: 57
-        type: 20
-        position: 63
-        resolved_type: -1
-        generic_type_name: -1
-    param_arg_map:
-      a:
-        kind: 8
-        name: -1
-        value: -1
-        x:
-          kind: 0
-          name: 56
-          value: -1
-          raw: -1
-          pkg: 57
-          type: 58
-          position: 59
-          resolved_type: -1
-          generic_type_name: -1
-        sel:
-          kind: 0
-          name: 60
-          value: -1
-          raw: -1
-          pkg: 57
-          type: 6
-          position: 61
-          resolved_type: -1
-          generic_type_name: -1
-        raw: -1
-        pkg: 57
-        type: 6
-        position: 59
-        resolved_type: -1
-        generic_type_name: -1
-      format:
-        kind: 54
-        name: -1
-        value: 55
-        raw: -1
-        pkg: -1
-        type: -1
-        position: -1
-        resolved_type: -1
-        generic_type_name: -1
-  - caller:
-      name: 114
-      pkg: 112
-      position: -1
-      recv_type: -1
-      scope: 79
-      signature_str: 128
-    callee:
-      name: 46
-      pkg: 2
-      position: 109
-      recv_type: -1
-      scope: 15
-      signature_str: 110
-    position: 109
-    args:
-      - kind: 54
-        name: -1
-        value: 107
-        raw: -1
-        pkg: -1
-        type: -1
-        position: -1
-        resolved_type: -1
-        generic_type_name: -1
-      - kind: 54
-        name: -1
-        value: 108
+        value: 4
         raw: -1
         pkg: -1
         type: -1
@@ -2473,58 +2324,58 @@ call_graph:
         generic_type_name: -1
     assignments:
       user:
-        - variable_name: 74
-          pkg: 112
-          concrete_type: 3
-          position: 113
-          scope: 79
+        - variable_name: 15
+          pkg: 16
+          concrete_type: 14
+          position: 17
+          scope: 18
           value:
-            kind: 69
+            kind: 13
             name: -1
             value: -1
             fun:
-              kind: 8
+              kind: 12
               name: -1
               value: -1
               x:
-                kind: 0
-                name: 70
+                kind: 5
+                name: 6
                 value: -1
                 raw: -1
-                pkg: 2
+                pkg: 7
                 type: -1
-                position: 109
+                position: 8
                 resolved_type: -1
                 generic_type_name: -1
               sel:
-                kind: 0
-                name: 46
+                kind: 5
+                name: 9
                 value: -1
                 raw: -1
-                pkg: 2
-                type: 110
-                position: 111
+                pkg: 7
+                type: 10
+                position: 11
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
-              pkg: 2
-              type: 110
-              position: 109
+              pkg: 7
+              type: 10
+              position: 8
               resolved_type: -1
               generic_type_name: -1
             args:
-              - kind: 54
+              - kind: 2
                 name: -1
-                value: 107
+                value: 3
                 raw: -1
                 pkg: -1
                 type: -1
                 position: -1
                 resolved_type: -1
                 generic_type_name: -1
-              - kind: 54
+              - kind: 2
                 name: -1
-                value: 108
+                value: 4
                 raw: -1
                 pkg: -1
                 type: -1
@@ -2533,28 +2384,28 @@ call_graph:
                 generic_type_name: -1
             raw: -1
             pkg: -1
-            type: 3
-            position: 109
+            type: 14
+            position: 8
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 0
-            name: 74
+            kind: 5
+            name: 15
             value: -1
             raw: -1
-            pkg: 112
-            type: 3
-            position: 113
+            pkg: 16
+            type: 14
+            position: 17
             resolved_type: -1
             generic_type_name: -1
-          func: 114
+          func: 19
           callee_func: NewUser
           callee_pkg: multipackage/models
     param_arg_map:
       age:
-        kind: 54
+        kind: 2
         name: -1
-        value: 108
+        value: 4
         raw: -1
         pkg: -1
         type: -1
@@ -2562,9 +2413,9 @@ call_graph:
         resolved_type: -1
         generic_type_name: -1
       name:
-        kind: 54
+        kind: 2
         name: -1
-        value: 107
+        value: 3
         raw: -1
         pkg: -1
         type: -1
@@ -2573,372 +2424,521 @@ call_graph:
         generic_type_name: -1
     callee_recv_var_name: user
   - caller:
-      name: 114
-      pkg: 112
+      name: 19
+      pkg: 16
       position: -1
       recv_type: -1
-      scope: 79
-      signature_str: 128
+      scope: 18
+      signature_str: 39
     callee:
-      name: 101
-      pkg: 57
-      position: 116
+      name: 23
+      pkg: 21
+      position: 22
       recv_type: -1
-      scope: 15
-      signature_str: 117
-    position: 116
+      scope: 49
+      signature_str: 24
+    position: 22
     assignments:
       service:
-        - variable_name: 119
-          pkg: 112
-          concrete_type: 58
-          position: 120
-          scope: 79
+        - variable_name: 27
+          pkg: 16
+          concrete_type: 26
+          position: 28
+          scope: 18
           value:
-            kind: 69
+            kind: 13
             name: -1
             value: -1
             fun:
-              kind: 8
+              kind: 12
               name: -1
               value: -1
               x:
-                kind: 0
-                name: 115
+                kind: 5
+                name: 20
                 value: -1
                 raw: -1
-                pkg: 57
+                pkg: 21
                 type: -1
-                position: 116
+                position: 22
                 resolved_type: -1
                 generic_type_name: -1
               sel:
-                kind: 0
-                name: 101
+                kind: 5
+                name: 23
                 value: -1
                 raw: -1
-                pkg: 57
-                type: 117
-                position: 118
+                pkg: 21
+                type: 24
+                position: 25
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
-              pkg: 57
-              type: 117
-              position: 116
+              pkg: 21
+              type: 24
+              position: 22
               resolved_type: -1
               generic_type_name: -1
             raw: -1
             pkg: -1
-            type: 58
-            position: 116
+            type: 26
+            position: 22
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 0
-            name: 119
+            kind: 5
+            name: 27
             value: -1
             raw: -1
-            pkg: 112
-            type: 58
-            position: 120
+            pkg: 16
+            type: 26
+            position: 28
             resolved_type: -1
             generic_type_name: -1
-          func: 114
+          func: 19
           callee_func: NewUserService
           callee_pkg: multipackage/services
     callee_recv_var_name: service
   - caller:
-      name: 114
-      pkg: 112
+      name: 19
+      pkg: 16
       position: -1
       recv_type: -1
-      scope: 79
-      signature_str: 128
+      scope: 18
+      signature_str: 39
     callee:
-      name: 80
-      pkg: 57
-      position: 122
-      recv_type: 84
-      scope: 15
-      signature_str: 123
-    position: 122
+      name: 31
+      pkg: 21
+      position: 30
+      recv_type: 108
+      scope: 49
+      signature_str: 32
+    position: 30
     args:
-      - kind: 0
-        name: 74
+      - kind: 5
+        name: 15
         value: -1
         raw: -1
-        pkg: 112
-        type: 3
-        position: 121
+        pkg: 16
+        type: 14
+        position: 29
         resolved_type: -1
         generic_type_name: -1
     assignments:
       age:
-        - variable_name: 40
-          pkg: 57
-          concrete_type: 20
-          position: 83
-          scope: 79
+        - variable_name: 74
+          pkg: 21
+          concrete_type: 54
+          position: 107
+          scope: 18
           value:
-            kind: 69
+            kind: 13
             name: -1
             value: -1
             fun:
-              kind: 8
+              kind: 12
               name: -1
               value: -1
               x:
-                kind: 0
-                name: 74
+                kind: 5
+                name: 15
                 value: -1
                 raw: -1
-                pkg: 57
-                type: 3
-                position: 81
+                pkg: 21
+                type: 14
+                position: 105
                 resolved_type: -1
                 generic_type_name: -1
               sel:
-                kind: 0
-                name: 22
+                kind: 5
+                name: 56
                 value: -1
                 raw: -1
-                pkg: 2
-                type: 25
-                position: 82
+                pkg: 7
+                type: 59
+                position: 106
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
-              pkg: 2
-              type: 25
-              position: 81
+              pkg: 7
+              type: 59
+              position: 105
               resolved_type: -1
               generic_type_name: -1
               receiver_type:
-                kind: 0
-                name: 26
+                kind: 5
+                name: 60
                 value: -1
                 raw: -1
-                pkg: 2
-                type: 26
+                pkg: 7
+                type: 60
                 position: -1
                 resolved_type: -1
                 generic_type_name: -1
             raw: -1
             pkg: -1
-            type: 20
-            position: 81
+            type: 54
+            position: 105
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 0
-            name: 40
+            kind: 5
+            name: 74
             value: -1
             raw: -1
-            pkg: 57
-            type: 20
-            position: 83
+            pkg: 21
+            type: 54
+            position: 107
             resolved_type: -1
             generic_type_name: -1
-          func: 80
+          func: 31
           callee_func: GetAge
           callee_pkg: multipackage/models
       name:
-        - variable_name: 36
-          pkg: 57
-          concrete_type: 6
-          position: 78
-          scope: 79
+        - variable_name: 70
+          pkg: 21
+          concrete_type: 35
+          position: 104
+          scope: 18
           value:
-            kind: 69
+            kind: 13
             name: -1
             value: -1
             fun:
-              kind: 8
+              kind: 12
               name: -1
               value: -1
               x:
-                kind: 0
-                name: 74
+                kind: 5
+                name: 15
                 value: -1
                 raw: -1
-                pkg: 57
-                type: 3
-                position: 76
+                pkg: 21
+                type: 14
+                position: 102
                 resolved_type: -1
                 generic_type_name: -1
               sel:
-                kind: 0
-                name: 9
+                kind: 5
+                name: 45
                 value: -1
                 raw: -1
-                pkg: 2
-                type: 17
-                position: 77
+                pkg: 7
+                type: 51
+                position: 103
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
-              pkg: 2
-              type: 17
-              position: 76
+              pkg: 7
+              type: 51
+              position: 102
               resolved_type: -1
               generic_type_name: -1
               receiver_type:
-                kind: 0
-                name: 26
+                kind: 5
+                name: 60
                 value: -1
                 raw: -1
-                pkg: 2
-                type: 26
+                pkg: 7
+                type: 60
                 position: -1
                 resolved_type: -1
                 generic_type_name: -1
             raw: -1
             pkg: -1
-            type: 6
-            position: 76
+            type: 35
+            position: 102
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 0
-            name: 36
+            kind: 5
+            name: 70
             value: -1
             raw: -1
-            pkg: 57
-            type: 6
-            position: 78
+            pkg: 21
+            type: 35
+            position: 104
             resolved_type: -1
             generic_type_name: -1
-          func: 80
+          func: 31
           callee_func: GetName
           callee_pkg: multipackage/models
       result:
-        - variable_name: 125
-          pkg: 112
-          concrete_type: 6
-          position: 126
-          scope: 79
+        - variable_name: 36
+          pkg: 16
+          concrete_type: 35
+          position: 37
+          scope: 18
           value:
-            kind: 69
+            kind: 13
             name: -1
             value: -1
             fun:
-              kind: 8
+              kind: 12
               name: -1
               value: -1
               x:
-                kind: 0
-                name: 119
+                kind: 5
+                name: 27
                 value: -1
                 raw: -1
-                pkg: 112
-                type: 58
-                position: 122
+                pkg: 16
+                type: 26
+                position: 30
                 resolved_type: -1
                 generic_type_name: -1
               sel:
-                kind: 0
-                name: 80
+                kind: 5
+                name: 31
                 value: -1
                 raw: -1
-                pkg: 57
-                type: 123
-                position: 124
+                pkg: 21
+                type: 32
+                position: 33
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
-              pkg: 57
-              type: 123
-              position: 122
+              pkg: 21
+              type: 32
+              position: 30
               resolved_type: -1
               generic_type_name: -1
               receiver_type:
-                kind: 0
-                name: 96
+                kind: 5
+                name: 34
                 value: -1
                 raw: -1
-                pkg: 57
-                type: 96
+                pkg: 21
+                type: 34
                 position: -1
                 resolved_type: -1
                 generic_type_name: -1
             args:
-              - kind: 0
-                name: 74
+              - kind: 5
+                name: 15
                 value: -1
                 raw: -1
-                pkg: 112
-                type: 3
-                position: 121
+                pkg: 16
+                type: 14
+                position: 29
                 resolved_type: -1
                 generic_type_name: -1
             raw: -1
             pkg: -1
-            type: 6
-            position: 122
+            type: 35
+            position: 30
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 0
-            name: 125
+            kind: 5
+            name: 36
             value: -1
             raw: -1
-            pkg: 112
-            type: 6
-            position: 126
+            pkg: 16
+            type: 35
+            position: 37
             resolved_type: -1
             generic_type_name: -1
-          func: 114
+          func: 19
           callee_func: ProcessUser
           callee_pkg: multipackage/services
     param_arg_map:
       user:
-        kind: 0
-        name: 74
+        kind: 5
+        name: 15
         value: -1
         raw: -1
-        pkg: 112
-        type: 3
-        position: 121
+        pkg: 16
+        type: 14
+        position: 29
         resolved_type: -1
         generic_type_name: -1
     callee_var_name: service
     callee_recv_var_name: result
     chain_root: service
   - caller:
-      name: 114
-      pkg: 112
+      name: 19
+      pkg: 16
       position: -1
       recv_type: -1
-      scope: 79
-      signature_str: 128
+      scope: 18
+      signature_str: 39
     callee:
       name: 176
-      pkg: 64
+      pkg: 40
       position: 175
       recv_type: -1
-      scope: 15
+      scope: 49
       signature_str: 177
     position: 175
     args:
-      - kind: 0
-        name: 125
+      - kind: 5
+        name: 36
         value: -1
         raw: -1
-        pkg: 112
-        type: 6
+        pkg: 16
+        type: 35
         position: 174
         resolved_type: -1
         generic_type_name: -1
     param_arg_map:
       a:
-        kind: 0
-        name: 125
+        kind: 5
+        name: 36
         value: -1
         raw: -1
-        pkg: 112
-        type: 6
+        pkg: 16
+        type: 35
         position: 174
+        resolved_type: -1
+        generic_type_name: -1
+  - caller:
+      name: 31
+      pkg: 21
+      position: -1
+      recv_type: 108
+      scope: 49
+      signature_str: 111
+    callee:
+      name: 45
+      pkg: 7
+      position: 102
+      recv_type: 46
+      scope: 49
+      signature_str: 51
+    position: 102
+    callee_var_name: user
+    callee_recv_var_name: name
+    chain_root: user
+  - caller:
+      name: 31
+      pkg: 21
+      position: -1
+      recv_type: 108
+      scope: 49
+      signature_str: 111
+    callee:
+      name: 56
+      pkg: 7
+      position: 105
+      recv_type: 46
+      scope: 49
+      signature_str: 59
+    position: 105
+    callee_var_name: user
+    callee_recv_var_name: age
+    chain_root: user
+  - caller:
+      name: 31
+      pkg: 21
+      position: -1
+      recv_type: 108
+      scope: 49
+      signature_str: 111
+    callee:
+      name: 95
+      pkg: 40
+      position: 94
+      recv_type: -1
+      scope: 49
+      signature_str: 96
+    position: 94
+    args:
+      - kind: 2
+        name: -1
+        value: 87
+        raw: -1
+        pkg: -1
+        type: -1
+        position: -1
+        resolved_type: -1
+        generic_type_name: -1
+      - kind: 12
+        name: -1
+        value: -1
+        x:
+          kind: 5
+          name: 88
+          value: -1
+          raw: -1
+          pkg: 21
+          type: 26
+          position: 89
+          resolved_type: -1
+          generic_type_name: -1
+        sel:
+          kind: 5
+          name: 90
+          value: -1
+          raw: -1
+          pkg: 21
+          type: 35
+          position: 91
+          resolved_type: -1
+          generic_type_name: -1
+        raw: -1
+        pkg: 21
+        type: 35
+        position: 89
+        resolved_type: -1
+        generic_type_name: -1
+      - kind: 5
+        name: 70
+        value: -1
+        raw: -1
+        pkg: 21
+        type: 35
+        position: 92
+        resolved_type: -1
+        generic_type_name: -1
+      - kind: 5
+        name: 74
+        value: -1
+        raw: -1
+        pkg: 21
+        type: 54
+        position: 93
+        resolved_type: -1
+        generic_type_name: -1
+    param_arg_map:
+      a:
+        kind: 12
+        name: -1
+        value: -1
+        x:
+          kind: 5
+          name: 88
+          value: -1
+          raw: -1
+          pkg: 21
+          type: 26
+          position: 89
+          resolved_type: -1
+          generic_type_name: -1
+        sel:
+          kind: 5
+          name: 90
+          value: -1
+          raw: -1
+          pkg: 21
+          type: 35
+          position: 91
+          resolved_type: -1
+          generic_type_name: -1
+        raw: -1
+        pkg: 21
+        type: 35
+        position: 89
+        resolved_type: -1
+        generic_type_name: -1
+      format:
+        kind: 2
+        name: -1
+        value: 87
+        raw: -1
+        pkg: -1
+        type: -1
+        position: -1
         resolved_type: -1
         generic_type_name: -1
   - caller:
@@ -2946,26 +2946,26 @@ call_graph:
       pkg: 132
       position: -1
       recv_type: -1
-      scope: 15
+      scope: 49
       signature_str: 146
     callee:
       name: 140
       pkg: 134
       position: 139
       recv_type: -1
-      scope: 15
+      scope: 49
       signature_str: 137
     position: 139
     args:
-      - kind: 69
+      - kind: 13
         name: -1
         value: -1
         fun:
-          kind: 8
+          kind: 12
           name: -1
           value: -1
           x:
-            kind: 0
+            kind: 5
             name: 134
             value: -1
             raw: -1
@@ -2975,7 +2975,7 @@ call_graph:
             resolved_type: -1
             generic_type_name: -1
           sel:
-            kind: 0
+            kind: 5
             name: 136
             value: -1
             raw: -1
@@ -2991,32 +2991,32 @@ call_graph:
           resolved_type: -1
           generic_type_name: -1
         args:
-          - kind: 0
+          - kind: 5
             name: 131
             value: -1
             raw: -1
             pkg: 132
-            type: 6
+            type: 35
             position: 133
             resolved_type: -1
             generic_type_name: -1
         raw: -1
         pkg: -1
-        type: 6
+        type: 35
         position: 135
         resolved_type: -1
         generic_type_name: -1
     param_arg_map:
       s:
-        kind: 69
+        kind: 13
         name: -1
         value: -1
         fun:
-          kind: 8
+          kind: 12
           name: -1
           value: -1
           x:
-            kind: 0
+            kind: 5
             name: 134
             value: -1
             raw: -1
@@ -3026,7 +3026,7 @@ call_graph:
             resolved_type: -1
             generic_type_name: -1
           sel:
-            kind: 0
+            kind: 5
             name: 136
             value: -1
             raw: -1
@@ -3042,18 +3042,18 @@ call_graph:
           resolved_type: -1
           generic_type_name: -1
         args:
-          - kind: 0
+          - kind: 5
             name: 131
             value: -1
             raw: -1
             pkg: 132
-            type: 6
+            type: 35
             position: 133
             resolved_type: -1
             generic_type_name: -1
         raw: -1
         pkg: -1
-        type: 6
+        type: 35
         position: 135
         resolved_type: -1
         generic_type_name: -1
@@ -3062,34 +3062,34 @@ call_graph:
       pkg: 132
       position: -1
       recv_type: -1
-      scope: 15
+      scope: 49
       signature_str: 146
     callee:
       name: 136
       pkg: 134
       position: 135
       recv_type: -1
-      scope: 15
+      scope: 49
       signature_str: 137
     position: 135
     args:
-      - kind: 0
+      - kind: 5
         name: 131
         value: -1
         raw: -1
         pkg: 132
-        type: 6
+        type: 35
         position: 133
         resolved_type: -1
         generic_type_name: -1
     param_arg_map:
       s:
-        kind: 0
+        kind: 5
         name: 131
         value: -1
         raw: -1
         pkg: 132
-        type: 6
+        type: 35
         position: 133
         resolved_type: -1
         generic_type_name: -1


### PR DESCRIPTION
Follow-up to #97 (deterministic generation), which unblocked this. Implements gap-analysis item 3.2 — all three parts combined.

## Problem

The six YAMLs under `internal/spec/tests/` were dev-inspection artifacts stuck in the worst of both worlds:

- **Tracked in git but also listed in `.gitignore`**, so every `go test ./internal/metadata/` run dirtied the working tree — the coverage workflow literally ran `git restore internal/spec/tests/` to cope.
- **Rewritten unconditionally on every test run** with machine-specific temp paths (`claude-501/…`, `/var/folders/…/T/…`) because the path sanitizer was a lossy component-name heuristic (its random-suffix detector never matched anything containing a digit).
- **Asserted nothing** — the test compared in-memory structs; the files were write-only output.

## Changes

- `TestGenerateMetadata` now **byte-compares** the sanitized serialized metadata against `internal/spec/tests/<name>.yaml` and fails with a first-diff report on mismatch. The files are only written when run with `-update`:
  ```
  go test ./internal/metadata/ -run TestGenerateMetadata -update
  ```
- Sanitization strips the **exact per-test temp root** (including the macOS `/private` symlink-resolved form) before falling back to the old heuristic, so fixtures are machine-independent (`main/test.go:9:2` instead of `claude-501/001/main/test.go:9:2`).
- Goldens regenerated once with `-update`: no machine-specific strings remain (checked for `/Users/`, `/var/folders`, `/private/`, temp IDs).
- Removed the `internal/spec/tests` entry from `.gitignore` and the `git restore` workaround from `coverage.yml`.

## Verification

- Compare mode passes with `-count=3` and leaves the tree clean.
- Full `go test ./...` green; `gofmt -s`/`go vet` clean.
- Grep confirms zero machine-specific paths in the regenerated goldens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Test metadata validation now compares against deterministic golden fixtures, with an optional update mode to regenerate expectations.
* **Bug Fixes**
  * Improved metadata generation stability by making callee AST/file resolution deterministic and receiver-aware.
  * Normalized test source-location path representations and updated YAML fixtures accordingly.
* **Chores**
  * Adjusted coverage automation to avoid unnecessary working-tree resets before badge updates.
  * Updated ignore rules to exclude a generated directory.
  * Enforced LF-only line endings for spec YAML fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->