### PR TITLE
test: wire 11 orphaned testdata fixtures into go test

### DIFF
--- a/docs/GAP_ANALYSIS.md
+++ b/docs/GAP_ANALYSIS.md
@@ -1,0 +1,94 @@
+# apispec — What's Important to Cover (Gap Analysis for Discussion)
+
+*Generated 2026-07-07 from a full-repo sweep: architecture map, TODO/limitation hunt, test-coverage audit, and GitHub issue/PR history. For discussion — priorities are proposals, not decisions.*
+
+## TL;DR — proposed priorities
+
+| # | Item | Why it matters | Effort (guess) |
+|---|------|----------------|----------------|
+| 1 | **Deterministic output** (string pool, call-graph edge order, fiber/generic/operationId flips) | Blocks reliable golden testing, clean diffs, reproducible CI | Medium |
+| 2 | ~~**Wire existing `testdata/` scenarios into `go test`**~~ ✅ DONE 2026-07-08 — all 11 orphaned fixtures now covered (see §3.1) | Regressions in whole frameworks currently only caught by manual `compare-spec.sh` | Low–Medium |
+| 3 | **Fix `internal/spec/tests/*.yaml` fixture hygiene** (tracked-but-gitignored, mutated by every test run, embed absolute temp paths) | Constant dirty-tree noise; non-portable; hides real changes | Low |
+| 4 | **Mux path params → handler params** | Only framework in the support matrix with a hole in a core column | Medium |
+| 5 | **Generic types (parametric structs)** | README-declared partial; generics are mainstream Go now | High |
+| 6 | **Interface-typed param resolution** | README-declared gap + `docs/INTERFACE_RESOLUTION.md` future-work list | High |
+| 7 | **Robustness regression fixtures for large/cyclic projects** (closed issues #10, #14, #20) | Worst historical failures (hang, stack overflow, truncated output) have no regression tests | Medium |
+
+---
+
+## 1. Correctness & determinism (highest leverage)
+
+### 1.1 Nondeterministic spec/metadata output — ✅ FIXED 2026-07-07
+
+> Status: root causes were unsorted map iteration (string-pool interning order in `GenerateMetadataWithLogger`, `analyzeInterfaceImplementations` append order, raw-`token.Pos` anon-struct keys, `detectFrameworkType` first-match-wins, `generateSchemas` inline-vs-$ref order, first-match-wins package lookups). Guarded by `TestGenerateMetadataDeterministic` and `TestGenerateDeterministic`. Historical fiber/generic flips verified gone across 8 CLI runs.
+- Observed on this branch: `internal/spec/tests/multipackage.yaml` diff (466 lines) is **pure reordering** — `string_pool` entries and call-graph `caller/callee` blocks shuffle between runs with identical content. Same for `example.yaml` type ordering.
+- Known flips (from prior sessions): fiber responses, generic response resolution, operationId assignment vary between runs.
+- Coverage percentages also fluctuate ±1–2% between identical runs — another symptom of order-dependent traversal.
+- **Impact:** golden-file testing (item 2) is impractical until this is fixed; spec diffs between releases are noisy; users see churn in committed `openapi.yaml` files.
+- **Direction:** sort at serialization boundaries (string pool, edges, paths, schemas) rather than chasing map-iteration order at every site. PR #93 (stop re-sorting tracker maps) and #85 (generic determinism) already started this — finish the sweep.
+
+### 1.2 Silent degradations worth surfacing or fixing
+- `internal/spec/extractor.go:515` — speculative middleware (`auth(h)`) using an **unknown auth library is silently ignored** — no warning, no diagnostic. Contradicts the unresolved-security diagnostics philosophy used elsewhere; should at least emit a diagnostic.
+- `internal/metadata/metadata.go:1598` — `assignment.ReturnIndex = 0` hardcoded: multi-return assignments always bind the first return value. Wrong tracing for `h, err := factory()` style code paths.
+- `internal/spec/tracker.go:1213` — functional-options parameter tracing uses a self-described "confusing, may not handle all cases" reverse-link workaround (relates to closed issue #38).
+- Non-string map keys silently fall back to bare `object` (`schema_mapper.go:84`, `mapper.go:2030`) — fine as behavior, but could warrant a diagnostic.
+- Many bare `object` fallbacks in `mapper.go` when a type can't be resolved — the insight report catches some of these; consider making "unresolved → object" count a first-class quality metric.
+
+## 2. Declared feature gaps (README §Partial/Not-yet + docs)
+
+Ordered by proposed value:
+
+1. **Gorilla Mux path params** detected but not wired into handler params (`config_mux.go:88`, README:231). Only remaining hole in the framework support matrix.
+2. **Generic types** (parametric structs) — partial. Function generics work; `Page[T]`-style response envelopes are common in real APIs.
+3. **Interface-typed parameters** not resolved to concrete types. `docs/INTERFACE_RESOLUTION.md` lists the future work: automatic discovery, cross-package resolution, generic interfaces.
+4. **Handler-factory pattern, part 2** — request-body-via-wrapper still pending (part 1, closure-returning routes, is done).
+5. **Router passed as function parameter** (not via Mount) isn't traversed — known fiber `/products` gap; deferred feature.
+6. **`dive` validator tag** (array-element validation) — README-declared "planned".
+7. **Same path + same status, different schemas** — not supported (would need `oneOf` merge).
+8. **HTTP method chosen via switch/if** around `net/http` Handle — not detected.
+9. Conditional/dynamic runtime route registration — explicitly out of scope; keep it documented rather than attempt it.
+
+Cross-cutting principle (worth restating in CONTRIBUTING or docs): **auth/security detection must stay framework-agnostic and config-driven** — every new detection feature should cover all six frameworks and all wiring styles (router-level, group, per-route, wrapper, var-assigned), not just the framework that prompted it.
+
+## 3. Testing gaps
+
+### 3.1 Orphaned testdata scenarios (cheap, high-value) — ✅ DONE 2026-07-08
+
+> Status: the 11 previously-untested fixtures are now wired into `go test`. `generator/testdata_frameworks_test.go` (`TestTestdata_Frameworks`) covers `chi`, `fiber`, `gin`, `mux`, `generic` — structural assertions (expected routes + methods present, no dangling `$ref`, no unresolved placeholders), loading each fixture's committed `used-config.yaml` when present so it matches the `compare-spec.sh` snapshot. `generator/testdata_auth_test.go` (`TestTestdata_AuthPresets`) covers the 6 auth fixtures (`auth_chi_with`, `auth_echo_group`, `auth_fiber_group`, `auth_gin_perroute`, `auth_mux_subrouter`, `auth_nethttp_wrap`) — each asserts the golang-jwt import auto-applies `bearerAuth` to the guarded route and leaves the sibling open route untouched, one row per framework wiring style (route/subtree/per-route/router/wrapper scope).
+
+Original finding (kept for context): 27 scenario dirs existed under `testdata/`, but automated tests only exercised ~14. **No `go test` references at all** for the 11 dirs above; they were only reachable via the manual `scripts/compare-spec.sh` flow. The structural-assertion style already used in `generator/testdata_smoke_test.go` (paths present, no dangling `$ref`, no unresolved placeholders) was the right template — now extended over these dirs.
+
+### 3.2 Fixture hygiene: `internal/spec/tests/*.yaml`
+These are not golden files — `metadata_test.go:802` *writes* them on every run as dev-inspection artifacts. They're tracked in git but also listed in `.gitignore`, so every `go test` run dirties the tree (CI's coverage workflow literally runs `git restore internal/spec/tests/` to cope). They also embed the absolute temp path of the machine that last ran tests. Options: (a) `git rm --cached` them and keep them purely local, (b) write them to `t.TempDir()`, or (c) sanitize paths + sort output and promote them to real golden files once 1.1 lands.
+
+### 3.3 Coverage cold spots
+- `cmd/apispecui` — **zero tests** for 1,845 lines (config editor, preview, diagram endpoints). Recent feature work (#91, #75/#76) keeps landing here untested. Even handler-level HTTP tests would help.
+- `internal/engine` 58.3% — the orchestrator; package filtering/framework-dependency logic had a past silent-ignore bug (`engine.go:298`), which argues for more filter tests.
+- `internal/metadata` 64.1% — the AST layer, second-largest package.
+- `internal/spec/tracker_test.go:1236,1360` — assertion-light ("verify the code path exists") tests on the most complex file in the repo.
+
+### 3.4 CI gates
+PRs get build (3 OSes) + `go test -race` + lint/vet/gofmt — good. But the only coverage threshold (45%, in `scripts/update-coverage-badge.sh`) runs **post-merge on main** as part of the badge job. Consider running the same library-scoped check as a PR gate, and raising the floor toward the actual ~70%.
+
+## 4. Robustness (lessons from closed issues)
+
+All 8 historical issues are closed and there are zero open issues/PRs, but the worst failure modes have no regression fixtures:
+
+- **#10 stack overflow** (cyclic struct → unbounded recursion in `generateStructSchema`) and **#14 truncated output** — same 12-package project. Add a fixture with self-referential / mutually-recursive types and a large synthetic call graph.
+- **#20 hang on scan** (Echo + swaggo, 23 endpoints, limits set) — the tracker's tree expansion is exponential in dense graphs; recursion is stack-counted now, but there's no test asserting bounded runtime on a dense-graph fixture. A timeout-guarded stress test would lock in the fix.
+- **#34 debuggability** — a user couldn't tell *why* routes were missed in a real project. The insight report and diagnostics exist; a documented "my route is missing — how to debug" section (using `--write-metadata`, the diagram, insight output) would close the loop.
+
+## 5. Housekeeping (quick wins)
+
+- Delete `README.md.bak` (stale 33k copy).
+- Remove committed root-level artifacts: `coverage*.out/txt/html`, `profiles*/`, and decide the fate of `playground_optimized.go` (0% coverage, gitignore-patterned but present).
+- Resolve the tracked-vs-gitignored contradiction for `internal/spec/tests/` (see 3.2).
+- `docs/AUTH_DETECTION_DESIGN.md:319` says a phase is "not yet called from traversal" while marking it DONE below — reconcile the doc.
+- Verify the package READMEs linked from the main README (`cmd/apispec/README.md`, `internal/spec/README.md`, etc.) actually exist.
+
+## 6. Suggested sequencing
+
+1. **Now (this branch / next):** finish determinism (1.1) — it unblocks everything test-shaped; fixture hygiene (3.2) rides along.
+2. **Next:** ~~wire orphaned testdata scenarios into smoke tests (3.1)~~ ✅ DONE 2026-07-08 + robustness fixtures (4, still open) — locks in current behavior before feature work.
+3. **Then features by value:** mux path params → generic types → interface resolution → handler-factory part 2 → router-as-param → `dive`.
+4. **Continuous:** apispecui test baseline, PR-level coverage gate, housekeeping.

--- a/generator/testdata_auth_test.go
+++ b/generator/testdata_auth_test.go
@@ -1,0 +1,161 @@
+package generator
+
+import (
+	"testing"
+
+	intspec "github.com/ehabterra/apispec/internal/spec"
+	"github.com/ehabterra/apispec/spec"
+)
+
+// opFor returns the Operation for an uppercase HTTP method on a PathItem, or
+// nil if that method is not declared. Keeps the auth table below able to name
+// its method as a plain string.
+func opFor(item intspec.PathItem, method string) *intspec.Operation {
+	switch method {
+	case "GET":
+		return item.Get
+	case "POST":
+		return item.Post
+	case "PUT":
+		return item.Put
+	case "DELETE":
+		return item.Delete
+	case "PATCH":
+		return item.Patch
+	case "OPTIONS":
+		return item.Options
+	case "HEAD":
+		return item.Head
+	default:
+		return nil
+	}
+}
+
+// hasSecurityScheme reports whether reqs contains a requirement naming scheme.
+func hasSecurityScheme(reqs *[]spec.SecurityRequirement, scheme string) bool {
+	if reqs == nil {
+		return false
+	}
+	for _, r := range *reqs {
+		if _, ok := r[scheme]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// TestTestdata_AuthPresets locks in the built-in auth/security presets across
+// every framework's untested wiring style. Each fixture imports golang-jwt, so
+// the engine's import detector (ApplySecurityPresets) must attach bearerAuth to
+// the guarded route(s) and leave the sibling open route untouched. The route +
+// scheme expectations mirror each fixture's committed openapi-7.53.yaml snapshot
+// that scripts/compare-spec.sh regenerates; this promotes those snapshots into
+// automated coverage.
+//
+// The middleware-reach dimension differs per fixture and is the point of each:
+//   - auth_chi_with     chi r.With(mw).Get(...)   — route scope (chained only)
+//   - auth_echo_group   echo e.Group("/api", mw)  — subtree scope
+//   - auth_fiber_group  fiber app.Group("/api",mw)— subtree scope
+//   - auth_gin_perroute gin r.GET(path, mw, h)    — per-route middleware
+//   - auth_mux_subrouter gorilla sub.Use(mw)      — subrouter (router) scope
+//   - auth_nethttp_wrap  mux.Handle(p, auth(h))   — handler-wrapper scope
+func TestTestdata_AuthPresets(t *testing.T) {
+	cases := []struct {
+		name      string
+		cfg       func() *spec.APISpecConfig
+		protected struct{ method, path string }
+		open      struct{ method, path string }
+	}{
+		{
+			name:      "auth_chi_with",
+			cfg:       spec.DefaultChiConfig,
+			protected: struct{ method, path string }{"GET", "/users/{id}"},
+			open:      struct{ method, path string }{"GET", "/health"},
+		},
+		{
+			name:      "auth_echo_group",
+			cfg:       spec.DefaultEchoConfig,
+			protected: struct{ method, path string }{"GET", "/api/me"},
+			open:      struct{ method, path string }{"GET", "/health"},
+		},
+		{
+			name:      "auth_fiber_group",
+			cfg:       spec.DefaultFiberConfig,
+			protected: struct{ method, path string }{"GET", "/api/me"},
+			open:      struct{ method, path string }{"GET", "/health"},
+		},
+		{
+			name:      "auth_gin_perroute",
+			cfg:       spec.DefaultGinConfig,
+			protected: struct{ method, path string }{"GET", "/users/{id}"},
+			open:      struct{ method, path string }{"GET", "/health"},
+		},
+		{
+			name:      "auth_mux_subrouter",
+			cfg:       spec.DefaultMuxConfig,
+			protected: struct{ method, path string }{"POST", "/api/me"},
+			open:      struct{ method, path string }{"POST", "/health"},
+		},
+		{
+			name:      "auth_nethttp_wrap",
+			cfg:       spec.DefaultHTTPConfig,
+			protected: struct{ method, path string }{"GET", "/users/{id}"},
+			open:      struct{ method, path string }{"GET", "/health"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := loadTestdata(t, tc.name, tc.cfg())
+			noDanglingRefs(t, out)
+
+			// Protected route: present and carrying bearerAuth.
+			pItem, ok := out.Paths[tc.protected.path]
+			if !ok {
+				t.Fatalf("%s %s missing; have %v", tc.protected.method, tc.protected.path, mapPathKeys(out.Paths))
+			}
+			pOp := opFor(pItem, tc.protected.method)
+			if pOp == nil {
+				t.Fatalf("%s %s: no %s operation", tc.protected.method, tc.protected.path, tc.protected.method)
+			}
+			if !hasSecurityScheme(pOp.Security, "bearerAuth") {
+				t.Errorf("%s %s: expected bearerAuth, got security=%v",
+					tc.protected.method, tc.protected.path, pOp.Security)
+			}
+
+			// Open sibling: present but with no security requirement.
+			oItem, ok := out.Paths[tc.open.path]
+			if !ok {
+				t.Fatalf("%s %s missing; have %v", tc.open.method, tc.open.path, mapPathKeys(out.Paths))
+			}
+			oOp := opFor(oItem, tc.open.method)
+			if oOp == nil {
+				t.Fatalf("%s %s: no %s operation", tc.open.method, tc.open.path, tc.open.method)
+			}
+			if oOp.Security != nil {
+				t.Errorf("%s %s: expected no security (sibling of guarded route), got %v",
+					tc.open.method, tc.open.path, *oOp.Security)
+			}
+
+			// The bearerAuth scheme must be catalogued in components.
+			if out.Components == nil || out.Components.SecuritySchemes == nil {
+				t.Fatal("expected components.securitySchemes to be populated")
+			}
+			if _, ok := out.Components.SecuritySchemes["bearerAuth"]; !ok {
+				t.Errorf("bearerAuth scheme missing from components; have %v",
+					securitySchemeKeys(out))
+			}
+		})
+	}
+}
+
+func securitySchemeKeys(out *spec.OpenAPISpec) []string {
+	if out.Components == nil {
+		return nil
+	}
+	keys := make([]string, 0, len(out.Components.SecuritySchemes))
+	for k := range out.Components.SecuritySchemes {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/generator/testdata_frameworks_test.go
+++ b/generator/testdata_frameworks_test.go
@@ -1,0 +1,129 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ehabterra/apispec/spec"
+)
+
+// loadTestdataWithFixtureConfig generates the spec for a fixture using its
+// committed used-config.yaml when one exists (the exact config
+// scripts/compare-spec.sh feeds the CLI), falling back to the supplied default
+// framework config otherwise. This keeps these smoke tests faithful to the
+// snapshots they mirror.
+func loadTestdataWithFixtureConfig(t *testing.T, name string, fallback *spec.APISpecConfig) *spec.OpenAPISpec {
+	t.Helper()
+	dir := filepath.Join("..", "testdata", name)
+
+	cfg := fallback
+	cfgPath := filepath.Join(dir, "used-config.yaml")
+	if _, err := os.Stat(cfgPath); err == nil {
+		loaded, lerr := spec.LoadAPISpecConfig(cfgPath)
+		if lerr != nil {
+			t.Fatalf("LoadAPISpecConfig(%s): %v", cfgPath, lerr)
+		}
+		cfg = loaded
+	}
+
+	out, err := NewGenerator(cfg).GenerateFromDirectory(dir)
+	if err != nil {
+		t.Fatalf("GenerateFromDirectory(%s): %v", dir, err)
+	}
+	if out == nil || out.Paths == nil {
+		t.Fatalf("nil spec or paths for %s", name)
+	}
+	return out
+}
+
+// TestTestdata_Frameworks is a structural smoke test over the top-level
+// per-framework fixtures that previously had no automated coverage — they were
+// only reachable through the manual scripts/compare-spec.sh flow. Each fixture's
+// expected routes mirror its committed openapi-7.53.yaml snapshot. The
+// assertions are deliberately structural (paths present, methods present, no
+// dangling $refs, no unresolved-type placeholders) so ordinary schema evolution
+// doesn't churn them, but a whole framework silently dropping routes fails loud.
+func TestTestdata_Frameworks(t *testing.T) {
+	type route struct {
+		path    string
+		methods []string
+	}
+	cases := []struct {
+		name     string
+		fallback *spec.APISpecConfig
+		routes   []route
+	}{
+		{
+			name:     "chi",
+			fallback: spec.DefaultChiConfig(),
+			routes: []route{
+				{"/payment/payment/process", []string{"POST"}},
+				{"/payment/stripe/pk", []string{"GET"}},
+				{"/products/", []string{"GET", "POST"}},
+				{"/products/{id}", []string{"GET"}},
+				{"/users/", []string{"GET", "POST"}},
+				{"/users/{id}", []string{"GET"}},
+			},
+		},
+		{
+			name:     "fiber",
+			fallback: spec.DefaultFiberConfig(),
+			routes: []route{
+				{"/api/info", []string{"GET"}},
+				{"/health", []string{"GET"}},
+				{"/products/", []string{"GET", "POST"}},
+				{"/products/{id}", []string{"GET"}},
+				{"/users/", []string{"GET", "POST"}},
+				{"/users/{id}", []string{"GET", "PUT", "DELETE"}},
+			},
+		},
+		{
+			name:     "gin",
+			fallback: spec.DefaultGinConfig(),
+			routes: []route{
+				{"/users/", []string{"GET", "POST"}},
+				{"/users/{id}", []string{"GET", "PUT", "DELETE"}},
+			},
+		},
+		{
+			name:     "mux",
+			fallback: spec.DefaultMuxConfig(),
+			routes: []route{
+				{"/api/v1/health", []string{"GET"}},
+				{"/users", []string{"GET", "POST"}},
+				{"/users/{id}", []string{"GET", "PUT", "DELETE"}},
+			},
+		},
+		{
+			name:     "generic",
+			fallback: spec.DefaultHTTPConfig(),
+			routes: []route{
+				{"/api/email/send", []string{"POST"}},
+				{"/api/users", []string{"POST"}},
+				{"/api/users/list", []string{"POST"}},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := loadTestdataWithFixtureConfig(t, tc.name, tc.fallback)
+			noDanglingRefs(t, out)
+			noUnresolvedPlaceholders(t, out)
+
+			for _, r := range tc.routes {
+				item, ok := out.Paths[r.path]
+				if !ok {
+					t.Errorf("path %q missing; have %v", r.path, mapPathKeys(out.Paths))
+					continue
+				}
+				for _, m := range r.methods {
+					if opFor(item, m) == nil {
+						t.Errorf("%s %s: expected %s operation, missing", m, r.path, m)
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Wires the 11 `testdata/` scenarios that had **no `go test` coverage** into automated structural smoke tests. Previously these fixtures were only reachable through the manual `scripts/compare-spec.sh` flow, so a whole framework silently dropping routes — or an auth preset breaking — could pass CI. Closes gap-analysis item **3.1**.

## Tests added

**`generator/testdata_frameworks_test.go`** — `TestTestdata_Frameworks` covers `chi`, `fiber`, `gin`, `mux`, `generic`. Structural assertions only (expected routes + methods present, no dangling `$ref`, no unresolved-type placeholders), so ordinary schema evolution won't churn them but a dropped route fails loud. Loads each fixture's committed `used-config.yaml` when present (chi/fiber/gin/generic) to match exactly how `compare-spec.sh` generates the snapshot; falls back to the default framework config otherwise (mux).

**`generator/testdata_auth_test.go`** — `TestTestdata_AuthPresets` covers the 6 previously-untested auth fixtures. Each asserts the golang-jwt import auto-applies `bearerAuth` (via the engine's `ApplySecurityPresets` import detector) to the guarded route and leaves the sibling open route untouched — one table row per distinct middleware-reach wiring style:

| Fixture | Framework wiring | Scope |
|---|---|---|
| `auth_chi_with` | `r.With(mw).Get(...)` | route (chained only) |
| `auth_echo_group` | `e.Group("/api", mw)` | subtree |
| `auth_fiber_group` | `app.Group("/api", mw)` | subtree |
| `auth_gin_perroute` | `r.GET(path, mw, h)` | per-route |
| `auth_mux_subrouter` | `sub.Use(mw)` | subrouter (router) |
| `auth_nethttp_wrap` | `mux.Handle(p, auth(h))` | handler-wrapper |

Expectations mirror each fixture's committed `openapi-7.53.yaml` snapshot, promoting those snapshots into real coverage.

## Verification

- `TestTestdata_Frameworks` — 5/5 subtests pass
- `TestTestdata_AuthPresets` — 6/6 subtests pass
- Full `go test ./generator/` passes; `go vet` and `gofmt` clean

Also marks item 3.1 done in `docs/GAP_ANALYSIS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)