### PR TITLE
feat(mux): wire gorilla/mux path params into handler parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ See [`cmd/apidiag/README.md`](cmd/apidiag/README.md) for full documentation and 
 | **Echo**          | ✅               | ✅          | ✅                | ✅           | ✅        | ✅   |
 | **Chi**           | ✅               | ✅          | ✅ (incl. `render`) | ✅         | ✅        | ✅   |
 | **Fiber**         | ✅               | ✅          | ✅                | ✅           | ✅        | ✅   |
-| **Gorilla Mux**   | ✅               | ✅ (`mux.Vars(r)["id"]`) | ✅ (`PathPrefix`, `Subrouter`) | ✅ | ✅ | ✅ |
+| **Gorilla Mux**   | ✅               | ✅ (`mux.Vars(r)["id"]`, incl. helper-wrapped & `{id:regex}` → `pattern`) | ✅ (`PathPrefix`, `Subrouter`) | ✅ | ✅ | ✅ |
 | **`net/http`**    | ✅ (`HandleFunc`, `Handle`; Go 1.22 method-aware patterns) | ✅ (`{id}` wildcards + `r.PathValue`) | basic | ✅ | ✅ | ✅ |
 
 Conditional registration (dynamic routes built at runtime) is generally not supported.

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ See [`cmd/apidiag/README.md`](cmd/apidiag/README.md) for full documentation and 
 | **Echo**          | ✅               | ✅          | ✅                | ✅           | ✅        | ✅   |
 | **Chi**           | ✅               | ✅          | ✅ (incl. `render`) | ✅         | ✅        | ✅   |
 | **Fiber**         | ✅               | ✅          | ✅                | ✅           | ✅        | ✅   |
-| **Gorilla Mux**   | ✅               | ✅ *(detected, not yet wired into handler params)* | ✅ (`PathPrefix`, `Subrouter`) | ✅ | ✅ | ✅ |
+| **Gorilla Mux**   | ✅               | ✅ (`mux.Vars(r)["id"]`) | ✅ (`PathPrefix`, `Subrouter`) | ✅ | ✅ | ✅ |
 | **`net/http`**    | ✅ (`HandleFunc`, `Handle`; Go 1.22 method-aware patterns) | ✅ (`{id}` wildcards + `r.PathValue`) | basic | ✅ | ✅ | ✅ |
 
 Conditional registration (dynamic routes built at runtime) is generally not supported.

--- a/docs/GAP_ANALYSIS.md
+++ b/docs/GAP_ANALYSIS.md
@@ -58,7 +58,8 @@ Cross-cutting principle (worth restating in CONTRIBUTING or docs): **auth/securi
 >
 > Two follow-on fixes landed with it:
 > - **Regex-constrained params** (`{id:[0-9]+}`, mux/chi): `convertPathToOpenAPI` now strips the regex to `{id}` (OpenAPI paths can't carry a regex — previously the param was dropped entirely and the path was invalid) and surfaces the constraint as a schema `pattern`.
-> - Guarded by `TestTestdata_MuxPathParams` (direct) and `TestTestdata_MuxAdvancedPathParams` (regex + helper indirection + unread-placeholder-stays-warned). Other frameworks' path params verified unchanged; no golden drift.
+> - **Key-mismatch diagnostic**: reachability wires `{id}` clean whenever the handler *reaches* `mux.Vars`, but it can't tell whether the code reads the *right* key. `recordPathVarKeyMismatches` recovers the literal keys actually read — via the assignment tracker (`vars := mux.Vars(r); vars["id"]`, tagged `CalleeFunc`/`CalleePkg`) and inline `mux.Vars(r)["id"]` — and reports any key with no matching placeholder (e.g. `mux.Vars(r)["userId"]` on `/users/{id}`, an always-empty read). Surfaced as a `[path-params]` CLI warning and programmatically via `Engine.GetPathParamMismatches()` / `Generator.PathParamMismatches()` (for the UI). Dynamic keys and keys passed into helpers aren't recovered — the diagnostic errs toward zero false positives.
+> - Guarded by `TestTestdata_MuxPathParams` (direct), `TestTestdata_MuxAdvancedPathParams` (regex + helper indirection + unread-placeholder-stays-warned), and `TestTestdata_MuxPathParamKeyMismatch` (typo key). Other frameworks' path params verified unchanged; no golden drift.
 
 ## 3. Testing gaps
 

--- a/docs/GAP_ANALYSIS.md
+++ b/docs/GAP_ANALYSIS.md
@@ -54,7 +54,11 @@ Cross-cutting principle (worth restating in CONTRIBUTING or docs): **auth/securi
 
 > The support matrix is now fully green. Root cause: mux exposes path vars as a **map** (`vars := mux.Vars(r); id := vars["id"]`), so the name is a map key, not a call argument — the arg-index `ParamPattern` mechanism (which works for `chi.URLParam(r,"id")`, `c.Param("id")`, `r.PathValue("id")`) couldn't reach it. Two visible symptoms: a bogus `net/http.Request` path param (the `Vars` call's request arg misread as a name) and the real `{id}` left flagged *"present in path but not found in the code"*.
 >
-> Fix (config-driven, keeps the engine framework-agnostic): added a `ParamPattern.NameFromMapKey` flag and set it on mux's `Vars` pattern; when the accessor matches within a route's subtree, `extractMapKeyParams` emits one clean path parameter per `{placeholder}` in the route path (names are authoritative from the path template, which is robust to every access form — assignment, blank `_ =`, or inline `store.Delete(vars["id"])`). Routes whose handler never calls `Vars` still fall through to the warned synthesis, matching chi/gin/etc. Guarded by `TestTestdata_MuxPathParams`; other frameworks' path params verified unchanged.
+> Fix (config-driven, keeps the engine framework-agnostic): added a `ParamPattern.NameFromMapKey` flag and set it on mux's `Vars` pattern. Per route, `completeMapKeyPathParams` emits one clean path parameter per `{placeholder}` in the route path **when the handler reaches the accessor** — determined by call-graph reachability (`handlerReachesAccessor`, bounded depth), so direct, inline (`mux.Vars(r)["id"]`), and **helper-wrapped** access (`id := readParam(r, "id")` where `readParam` wraps `mux.Vars`) all resolve. Names are authoritative from the path template (robust to every access form — assignment, blank `_ =`, inline call arg, dynamic key in a helper). Routes whose handler never reaches `Vars` still fall through to the warned synthesis, matching chi/gin/etc.
+>
+> Two follow-on fixes landed with it:
+> - **Regex-constrained params** (`{id:[0-9]+}`, mux/chi): `convertPathToOpenAPI` now strips the regex to `{id}` (OpenAPI paths can't carry a regex — previously the param was dropped entirely and the path was invalid) and surfaces the constraint as a schema `pattern`.
+> - Guarded by `TestTestdata_MuxPathParams` (direct) and `TestTestdata_MuxAdvancedPathParams` (regex + helper indirection + unread-placeholder-stays-warned). Other frameworks' path params verified unchanged; no golden drift.
 
 ## 3. Testing gaps
 

--- a/docs/GAP_ANALYSIS.md
+++ b/docs/GAP_ANALYSIS.md
@@ -9,7 +9,7 @@
 | 1 | **Deterministic output** (string pool, call-graph edge order, fiber/generic/operationId flips) | Blocks reliable golden testing, clean diffs, reproducible CI | Medium |
 | 2 | ~~**Wire existing `testdata/` scenarios into `go test`**~~ ✅ DONE 2026-07-08 — all 11 orphaned fixtures now covered (see §3.1) | Regressions in whole frameworks currently only caught by manual `compare-spec.sh` | Low–Medium |
 | 3 | **Fix `internal/spec/tests/*.yaml` fixture hygiene** (tracked-but-gitignored, mutated by every test run, embed absolute temp paths) | Constant dirty-tree noise; non-portable; hides real changes | Low |
-| 4 | **Mux path params → handler params** | Only framework in the support matrix with a hole in a core column | Medium |
+| 4 | ~~**Mux path params → handler params**~~ ✅ DONE 2026-07-08 — `mux.Vars(r)["id"]` now wired (see §2.1) | Only framework in the support matrix with a hole in a core column | Medium |
 | 5 | **Generic types (parametric structs)** | README-declared partial; generics are mainstream Go now | High |
 | 6 | **Interface-typed param resolution** | README-declared gap + `docs/INTERFACE_RESOLUTION.md` future-work list | High |
 | 7 | ~~**Robustness regression fixtures for large/cyclic projects**~~ ✅ DONE 2026-07-08 — #10/#14 (recursive_types) + #20 (dense_graph) fixtures added; one open limitation noted (see §4) | Worst historical failures (hang, stack overflow, truncated output) have no regression tests | Medium |
@@ -38,7 +38,7 @@
 
 Ordered by proposed value:
 
-1. **Gorilla Mux path params** detected but not wired into handler params (`config_mux.go:88`, README:231). Only remaining hole in the framework support matrix.
+1. ~~**Gorilla Mux path params** detected but not wired into handler params~~ ✅ **DONE 2026-07-08** (§2.1 below).
 2. **Generic types** (parametric structs) — partial. Function generics work; `Page[T]`-style response envelopes are common in real APIs.
 3. **Interface-typed parameters** not resolved to concrete types. `docs/INTERFACE_RESOLUTION.md` lists the future work: automatic discovery, cross-package resolution, generic interfaces.
 4. **Handler-factory pattern, part 2** — request-body-via-wrapper still pending (part 1, closure-returning routes, is done).
@@ -49,6 +49,12 @@ Ordered by proposed value:
 9. Conditional/dynamic runtime route registration — explicitly out of scope; keep it documented rather than attempt it.
 
 Cross-cutting principle (worth restating in CONTRIBUTING or docs): **auth/security detection must stay framework-agnostic and config-driven** — every new detection feature should cover all six frameworks and all wiring styles (router-level, group, per-route, wrapper, var-assigned), not just the framework that prompted it.
+
+### 2.1 Gorilla Mux path params — ✅ DONE 2026-07-08
+
+> The support matrix is now fully green. Root cause: mux exposes path vars as a **map** (`vars := mux.Vars(r); id := vars["id"]`), so the name is a map key, not a call argument — the arg-index `ParamPattern` mechanism (which works for `chi.URLParam(r,"id")`, `c.Param("id")`, `r.PathValue("id")`) couldn't reach it. Two visible symptoms: a bogus `net/http.Request` path param (the `Vars` call's request arg misread as a name) and the real `{id}` left flagged *"present in path but not found in the code"*.
+>
+> Fix (config-driven, keeps the engine framework-agnostic): added a `ParamPattern.NameFromMapKey` flag and set it on mux's `Vars` pattern; when the accessor matches within a route's subtree, `extractMapKeyParams` emits one clean path parameter per `{placeholder}` in the route path (names are authoritative from the path template, which is robust to every access form — assignment, blank `_ =`, or inline `store.Delete(vars["id"])`). Routes whose handler never calls `Vars` still fall through to the warned synthesis, matching chi/gin/etc. Guarded by `TestTestdata_MuxPathParams`; other frameworks' path params verified unchanged.
 
 ## 3. Testing gaps
 

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/ehabterra/apispec/internal/engine"
+	intspec "github.com/ehabterra/apispec/internal/spec"
 	"github.com/ehabterra/apispec/spec"
 )
 
@@ -48,6 +49,18 @@ func (g *Generator) GenerateFromDirectory(dir string) (*spec.OpenAPISpec, error)
 
 	// Create a new engine instance for this generation
 	genEngine := engine.NewEngine(engineConfig)
+	g.engine = genEngine
 
 	return genEngine.GenerateOpenAPI()
+}
+
+// PathParamMismatches returns map-key path-variable reads (e.g.
+// mux.Vars(r)["userId"]) from the most recent GenerateFromDirectory whose key
+// matches no route placeholder — a likely typo. Empty when none or before any
+// generation.
+func (g *Generator) PathParamMismatches() []intspec.PathParamMismatch {
+	if g.engine == nil {
+		return nil
+	}
+	return g.engine.GetPathParamMismatches()
 }

--- a/generator/testdata_frameworks_test.go
+++ b/generator/testdata_frameworks_test.go
@@ -181,3 +181,62 @@ func TestTestdata_MuxPathParams(t *testing.T) {
 		}
 	}
 }
+
+// TestTestdata_MuxAdvancedPathParams locks in the harder gorilla/mux path-param
+// cases beyond the direct `mux.Vars(r)["id"]` idiom:
+//   - /products/{sku:[a-z0-9-]+}: the regex constraint is stripped from the
+//     OpenAPI path ({sku}) and surfaced as a schema pattern; param is clean.
+//   - /orders/{id}: the handler reads the var through a helper (pathVar wraps
+//     mux.Vars), resolved via call-graph reachability; param is clean.
+//   - /items/{id}: the handler never reads the var, so it stays warned.
+func TestTestdata_MuxAdvancedPathParams(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "mux_path_params", spec.DefaultMuxConfig())
+
+	pathParam := func(t *testing.T, path string) *intspec.Parameter {
+		t.Helper()
+		item, ok := out.Paths[path]
+		if !ok {
+			t.Fatalf("%s missing; have %v", path, mapPathKeys(out.Paths))
+		}
+		if item.Get == nil {
+			t.Fatalf("GET %s missing", path)
+		}
+		var found []intspec.Parameter
+		for _, p := range item.Get.Parameters {
+			if p.In == "path" {
+				found = append(found, p)
+			}
+		}
+		if len(found) != 1 {
+			t.Fatalf("GET %s: want 1 path param, got %d: %+v", path, len(found), found)
+		}
+		return &found[0]
+	}
+
+	isWarned := func(p *intspec.Parameter) bool {
+		_, ok := p.Extensions["x-warning"]
+		return ok
+	}
+
+	// Regex-constrained param: path normalized, pattern captured, clean.
+	if _, ok := out.Paths["/products/{sku:[a-z0-9-]+}"]; ok {
+		t.Errorf("regex constraint leaked into the OpenAPI path; want /products/{sku}")
+	}
+	sku := pathParam(t, "/products/{sku}")
+	if sku.Name != "sku" || isWarned(sku) {
+		t.Errorf("/products/{sku}: want clean 'sku', got name=%q warned=%v", sku.Name, isWarned(sku))
+	}
+	if sku.Schema == nil || sku.Schema.Pattern != "[a-z0-9-]+" {
+		t.Errorf("/products/{sku}: want schema.pattern=[a-z0-9-]+, got %+v", sku.Schema)
+	}
+
+	// Helper indirection: clean via call-graph reachability.
+	if id := pathParam(t, "/orders/{id}"); id.Name != "id" || isWarned(id) {
+		t.Errorf("/orders/{id}: want clean 'id' (helper-wrapped mux.Vars), got name=%q warned=%v", id.Name, isWarned(id))
+	}
+
+	// Unread placeholder: stays warned.
+	if id := pathParam(t, "/items/{id}"); !isWarned(id) {
+		t.Errorf("/items/{id}: want warned (handler never reads the var), got clean")
+	}
+}

--- a/generator/testdata_frameworks_test.go
+++ b/generator/testdata_frameworks_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	intspec "github.com/ehabterra/apispec/internal/spec"
 	"github.com/ehabterra/apispec/spec"
 )
 
@@ -125,5 +126,58 @@ func TestTestdata_Frameworks(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestTestdata_MuxPathParams locks in gorilla/mux path-parameter wiring.
+// Mux exposes path vars as a map (`mux.Vars(r)["id"]`), so the parameter name
+// is a map key rather than a call argument. This previously produced a bogus
+// `net/http.Request` parameter (the Vars call's request arg misread as a name)
+// and left the real `{id}` flagged "present in path but not found in the code".
+// After the fix every /users/{id} operation must carry exactly one clean path
+// parameter named `id` (string, required) with no warning and no bogus entry.
+func TestTestdata_MuxPathParams(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "mux", spec.DefaultMuxConfig())
+
+	item, ok := out.Paths["/users/{id}"]
+	if !ok {
+		t.Fatalf("/users/{id} missing; have %v", mapPathKeys(out.Paths))
+	}
+
+	for _, tc := range []struct {
+		method string
+		op     *intspec.Operation
+	}{
+		{"GET", item.Get},
+		{"PUT", item.Put},
+		{"DELETE", item.Delete},
+	} {
+		if tc.op == nil {
+			t.Errorf("%s /users/{id} missing", tc.method)
+			continue
+		}
+		pathParams := make([]intspec.Parameter, 0, len(tc.op.Parameters))
+		for _, p := range tc.op.Parameters {
+			if p.In == "path" {
+				pathParams = append(pathParams, p)
+			}
+		}
+		if len(pathParams) != 1 {
+			t.Errorf("%s /users/{id}: want exactly 1 path param, got %d: %+v", tc.method, len(pathParams), pathParams)
+			continue
+		}
+		p := pathParams[0]
+		if p.Name != "id" {
+			t.Errorf("%s /users/{id}: path param name = %q, want \"id\" (no bogus request param)", tc.method, p.Name)
+		}
+		if !p.Required {
+			t.Errorf("%s /users/{id}: path param should be required", tc.method)
+		}
+		if p.Schema == nil || p.Schema.Type != "string" {
+			t.Errorf("%s /users/{id}: path param schema = %+v, want {type: string}", tc.method, p.Schema)
+		}
+		if _, warned := p.Extensions["x-warning"]; warned {
+			t.Errorf("%s /users/{id}: path param carries an x-warning; the handler reads it via mux.Vars so it should be clean", tc.method)
+		}
 	}
 }

--- a/generator/testdata_frameworks_test.go
+++ b/generator/testdata_frameworks_test.go
@@ -3,6 +3,7 @@ package generator
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	intspec "github.com/ehabterra/apispec/internal/spec"
@@ -238,5 +239,37 @@ func TestTestdata_MuxAdvancedPathParams(t *testing.T) {
 	// Unread placeholder: stays warned.
 	if id := pathParam(t, "/items/{id}"); !isWarned(id) {
 		t.Errorf("/items/{id}: want warned (handler never reads the var), got clean")
+	}
+}
+
+// TestTestdata_MuxPathParamKeyMismatch checks the map-key diagnostic: the fixture's
+// getTag handler reads mux.Vars(r)["tag"] on a /tags/{id} route — a typo the read
+// will silently return empty for. Reachability alone can't catch it (the handler
+// does reach mux.Vars, so {id} wires clean), but recovering the actual key does.
+// Every other route in the fixture reads a key that matches its placeholder, so
+// exactly one mismatch must be reported.
+func TestTestdata_MuxPathParamKeyMismatch(t *testing.T) {
+	dir := filepath.Join("..", "testdata", "mux_path_params")
+	g := NewGenerator(spec.DefaultMuxConfig())
+	if _, err := g.GenerateFromDirectory(dir); err != nil {
+		t.Fatalf("GenerateFromDirectory: %v", err)
+	}
+
+	got := g.PathParamMismatches()
+	if len(got) != 1 {
+		t.Fatalf("want exactly 1 path-param mismatch, got %d: %+v", len(got), got)
+	}
+	m := got[0]
+	if m.Key != "tag" {
+		t.Errorf("mismatch key = %q, want \"tag\"", m.Key)
+	}
+	if m.Path != "/tags/{id}" {
+		t.Errorf("mismatch path = %q, want \"/tags/{id}\"", m.Path)
+	}
+	if m.Method != "GET" {
+		t.Errorf("mismatch method = %q, want \"GET\"", m.Method)
+	}
+	if !strings.HasSuffix(m.Handler, "getTag") {
+		t.Errorf("mismatch handler = %q, want it to name getTag", m.Handler)
 	}
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -225,6 +225,10 @@ type Engine struct {
 	// generation that matched no SecurityMapping. Surfaced to callers (the UI)
 	// so the user can map it to a scheme.
 	unresolvedSecurity []intspec.MiddlewareRef
+
+	// pathParamMismatches lists map-key path-variable reads (mux.Vars(r)["x"])
+	// whose key matches no route placeholder, gathered during the last generation.
+	pathParamMismatches []intspec.PathParamMismatch
 }
 
 // SkippedPackage is a package excluded from analysis due to compile/type
@@ -598,6 +602,7 @@ func (e *Engine) GenerateOpenAPI() (*spec.OpenAPISpec, error) {
 	}
 	if secDiag != nil {
 		e.unresolvedSecurity = secDiag.UnresolvedMiddleware
+		e.pathParamMismatches = secDiag.PathParamMismatches
 	}
 	e.reportPhase(fmt.Sprintf("spec mapped (%d paths)", len(openAPISpec.Paths)), time.Since(tSpec))
 
@@ -950,6 +955,13 @@ func (e *Engine) GetMetadata() *metadata.Metadata {
 // generation that matched no SecurityMapping (deduped). Empty when none.
 func (e *Engine) GetUnresolvedSecurity() []intspec.MiddlewareRef {
 	return e.unresolvedSecurity
+}
+
+// GetPathParamMismatches returns map-key path-variable reads (e.g.
+// mux.Vars(r)["userId"]) from the most recent generation whose key matches no
+// route placeholder — a likely typo. Empty when none.
+func (e *Engine) GetPathParamMismatches() []intspec.PathParamMismatch {
+	return e.pathParamMismatches
 }
 
 // SkippedPackages returns the in-module packages excluded from the most recent

--- a/internal/spec/config.go
+++ b/internal/spec/config.go
@@ -200,6 +200,13 @@ type ParamPattern struct {
 	TypeFromArg bool `yaml:"typeFromArg,omitempty" json:"typeFromArg,omitempty"` // Extract type from argument
 	Deref       bool `yaml:"deref,omitempty" json:"deref,omitempty"`             // Dereference pointer types
 
+	// NameFromMapKey extracts parameter names from the string-literal keys used
+	// to index this call's map result inside the handler, rather than from a
+	// call argument. This is the gorilla/mux idiom `mux.Vars(r)["id"]`, where
+	// the parameter name is a map key, not an argument. Only keys that also
+	// appear as `{placeholder}` segments in the route path are emitted.
+	NameFromMapKey bool `yaml:"nameFromMapKey,omitempty" json:"nameFromMapKey,omitempty"`
+
 	// Package/type filtering
 	CallerPkgPatterns      []string `yaml:"callerPkgPatterns,omitempty" json:"callerPkgPatterns,omitempty"`
 	CallerRecvTypePatterns []string `yaml:"callerRecvTypePatterns,omitempty" json:"callerRecvTypePatterns,omitempty"`

--- a/internal/spec/config_mux.go
+++ b/internal/spec/config_mux.go
@@ -85,12 +85,17 @@ func DefaultMuxConfig() *APISpecConfig {
 				jsonMarshalPattern(),
 				jsonEncodePattern(".*json(iter)?\\.\\*?Encoder"),
 			),
-			ParamPatterns: []ParamPattern{ // @note: mux does not have a ParamPattern and it's not supported in this version
+			ParamPatterns: []ParamPattern{
+				// gorilla/mux exposes path variables as a map: `mux.Vars(r)["id"]`.
+				// The parameter name is a map key, not a call argument, so names
+				// are recovered from the string-literal index keys used on the
+				// Vars(...) result (intersected with the route's `{placeholder}`
+				// segments).
 				{
-					CallRegex:     `^Vars$`,
-					ParamIn:       "path",
-					ParamArgIndex: 0,
-					RecvTypeRegex: `^github\.com/gorilla/mux$`,
+					CallRegex:      `^Vars$`,
+					ParamIn:        "path",
+					NameFromMapKey: true,
+					RecvTypeRegex:  `^github\.com/gorilla/mux$`,
 				},
 			},
 			SecurityPatterns: muxSecurityPatterns(),

--- a/internal/spec/dynamic_path_params_test.go
+++ b/internal/spec/dynamic_path_params_test.go
@@ -51,7 +51,7 @@ func TestAppendDynamicParamRefs_AddsAndDedupes(t *testing.T) {
 // $ref and an x-warning inline param for every dynamic placeholder.
 func TestEnsureAllPathParams_RecognisesRef(t *testing.T) {
 	params := []Parameter{{Ref: "#/components/parameters/MountPointParam"}}
-	got := ensureAllPathParams("/{mountPoint}/{id}", params)
+	got := ensureAllPathParams("/{mountPoint}/{id}", params, nil)
 
 	// Expect: original $ref kept, plus one inline for {id}. No duplicate for mountPoint.
 	if len(got) != 2 {

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -735,6 +735,10 @@ func (e *Extractor) handleRouteNode(node TrackerNodeInterface, routeInfo *RouteI
 	visitedEdges := make(map[string]bool)
 	e.extractRouteChildren(node, routeInfo, mountTags, routes, visitedEdges)
 
+	// Add map-key path params (mux.Vars) for placeholders the handler reads via
+	// the accessor — including through helper wrappers the subtree walk misses.
+	e.completeMapKeyPathParams(routeInfo)
+
 	// Apply overrides
 	e.overrideApplier.ApplyOverrides(routeInfo)
 
@@ -1001,8 +1005,13 @@ func (e *Extractor) extractParamsFromNode(node TrackerNodeInterface, route *Rout
 		if !matcher.MatchNode(node) {
 			continue
 		}
+		// Map-key accessors (mux.Vars) carry the parameter name as a map key,
+		// not a call argument, so nothing is extracted from the node itself.
+		// Their path params are added once per route in completeMapKeyPathParams,
+		// which handles direct, inline, and helper-wrapped access uniformly via
+		// call-graph reachability.
 		if impl, ok := matcher.(*ParamPatternMatcherImpl); ok && impl.pattern.NameFromMapKey {
-			return e.extractMapKeyParams(node, route, impl.pattern)
+			return nil
 		}
 		if param := matcher.ExtractParam(node, route); param != nil {
 			return []Parameter{*param}
@@ -1012,50 +1021,165 @@ func (e *Extractor) extractParamsFromNode(node TrackerNodeInterface, route *Rout
 	return nil
 }
 
-// extractMapKeyParams recovers path parameters for frameworks whose path-var
+// completeMapKeyPathParams adds path parameters for frameworks whose path-var
 // accessor returns a map indexed by name — the gorilla/mux idiom
-// `mux.Vars(r)["id"]` — rather than taking the name as a call argument.
+// `mux.Vars(r)["id"]`. The name is a map key, not a call argument, so it can't
+// be pulled from the accessor call; instead, if the route's handler reaches the
+// accessor anywhere in its call graph (directly, inline, or through a helper
+// like `id := readParam(r, "id")`), the handler reads request path variables,
+// and every `{placeholder}` in the route path is a genuine path parameter.
 //
-// Reaching this function means the accessor call (e.g. mux.Vars) matched within
-// this route's subtree, i.e. the handler (or a helper it calls) reads request
-// path variables. Every `{placeholder}` in the route path is a path parameter
-// by definition, so we emit one clean parameter per placeholder. Taking the
-// names from the path template (rather than from the specific index keys) makes
-// this robust to every access form — `id := vars["id"]`, `_ = vars["id"]`, or an
-// inline `store.Delete(vars["id"])` — none of which are uniformly recoverable
-// from the metadata. Routes whose handler never calls the accessor don't reach
-// here, so their placeholders still fall through to ensureAllPathParams and keep
-// the "present in path but not found in the code" warning, matching how the
-// other frameworks behave.
-func (e *Extractor) extractMapKeyParams(_ TrackerNodeInterface, route *RouteInfo, pattern ParamPattern) []Parameter {
-	if route == nil {
-		return nil
+// Names come from the path template (authoritative for path params), which is
+// robust to every access form — assignment, blank `_ =`, inline call arg, or a
+// dynamic key inside a helper — none of which are uniformly recoverable from the
+// metadata. Routes whose handler never reaches the accessor are left untouched,
+// so their placeholders still fall through to ensureAllPathParams and keep the
+// "present in path but not found in the code" warning, matching the other
+// frameworks.
+func (e *Extractor) completeMapKeyPathParams(route *RouteInfo) {
+	if route == nil || route.Metadata == nil {
+		return
 	}
+	var accessor *ParamPattern
+	for i := range e.cfg.Framework.ParamPatterns {
+		if e.cfg.Framework.ParamPatterns[i].NameFromMapKey {
+			accessor = &e.cfg.Framework.ParamPatterns[i]
+			break
+		}
+	}
+	if accessor == nil {
+		return
+	}
+
 	placeholders := pathPlaceholders(route.Path)
 	if len(placeholders) == 0 {
-		return nil
+		return
 	}
-	params := make([]Parameter, 0, len(placeholders))
+	covered := make(map[string]bool)
+	for _, p := range route.Params {
+		if p.In == "path" {
+			covered[p.Name] = true
+		}
+	}
+	missing := false
 	for _, name := range placeholders {
-		params = append(params, Parameter{
+		if !covered[name] {
+			missing = true
+			break
+		}
+	}
+	if !missing {
+		return
+	}
+
+	if !e.handlerReachesAccessor(route, *accessor) {
+		return
+	}
+
+	patterns := pathParamPatterns(route.Path)
+	for _, name := range placeholders {
+		if covered[name] {
+			continue
+		}
+		schema := &Schema{Type: "string"}
+		if pat := patterns[name]; pat != "" {
+			schema.Pattern = pat
+		}
+		route.Params = append(route.Params, Parameter{
 			Name:     name,
-			In:       pattern.ParamIn,
-			Required: pattern.ParamIn == "path",
-			Schema:   &Schema{Type: "string"},
+			In:       accessor.ParamIn,
+			Required: accessor.ParamIn == "path",
+			Schema:   schema,
 		})
 	}
-	return params
 }
 
-// pathPlaceholders returns the `{name}` placeholder names in a route path, in
-// order of appearance.
-func pathPlaceholders(path string) []string {
-	re := mustCachedRegex(`\{([a-zA-Z_][a-zA-Z0-9_]*)\}`)
-	matches := re.FindAllStringSubmatch(path, -1)
-	names := make([]string, 0, len(matches))
-	for _, m := range matches {
-		names = append(names, m[1])
+// handlerReachesAccessor reports whether the route's handler transitively calls
+// the map-key accessor described by pattern, following the call graph through
+// helper functions up to maxWrapperLookThroughDepth. Seeds are the handler
+// function's call-graph base IDs (matched by name + package), so it works
+// regardless of the exact key format.
+func (e *Extractor) handlerReachesAccessor(route *RouteInfo, pattern ParamPattern) bool {
+	meta := route.Metadata
+	if meta == nil || route.Function == "" {
+		return false
 	}
+	// route.Function is package-qualified ("pkg/path.Handler"); call-graph
+	// caller names are bare ("Handler"), so strip the package prefix to match.
+	bareFunc := route.Function
+	if route.Package != "" {
+		bareFunc = strings.TrimPrefix(route.Function, route.Package+".")
+	}
+	visited := make(map[string]bool)
+	for i := range meta.CallGraph {
+		edge := &meta.CallGraph[i]
+		if getString(meta, edge.Caller.Name) != bareFunc {
+			continue
+		}
+		if route.Package != "" && getString(meta, edge.Caller.Pkg) != route.Package {
+			continue
+		}
+		if e.reachesAccessor(meta, edge.Caller.BaseID(), pattern, visited, 0) {
+			return true
+		}
+	}
+	return false
+}
+
+// reachesAccessor walks meta.Callers from a function base ID, returning true if
+// any transitively-reachable call edge matches the accessor pattern.
+func (e *Extractor) reachesAccessor(meta *metadata.Metadata, key string, pattern ParamPattern, visited map[string]bool, depth int) bool {
+	if key == "" || visited[key] || depth > maxWrapperLookThroughDepth {
+		return false
+	}
+	visited[key] = true
+	for _, edge := range meta.Callers[key] {
+		if edgeMatchesAccessor(meta, edge, pattern) {
+			return true
+		}
+		if e.reachesAccessor(meta, edge.Callee.BaseID(), pattern, visited, depth+1) {
+			return true
+		}
+	}
+	return false
+}
+
+// edgeMatchesAccessor reports whether a call edge's callee matches a param
+// pattern's accessor identity (call-name regex + fully-qualified receiver/pkg
+// regex), mirroring ParamPatternMatcherImpl.MatchNode.
+func edgeMatchesAccessor(meta *metadata.Metadata, edge *metadata.CallGraphEdge, pattern ParamPattern) bool {
+	callName := getString(meta, edge.Callee.Name)
+	recvType := getString(meta, edge.Callee.RecvType)
+	recvPkg := getString(meta, edge.Callee.Pkg)
+	fq := recvPkg
+	if fq != "" && recvType != "" {
+		fq += "." + recvType
+	} else if recvType != "" {
+		fq = recvType
+	}
+	if pattern.CallRegex != "" {
+		if re, err := cachedRegex(pattern.CallRegex); err != nil || !re.MatchString(callName) {
+			return false
+		}
+	}
+	if pattern.RecvTypeRegex != "" {
+		if re, err := cachedRegex(pattern.RecvTypeRegex); err != nil || !re.MatchString(fq) {
+			return false
+		}
+	}
+	return true
+}
+
+// pathPlaceholders returns the placeholder names in a route path, in order of
+// appearance. It handles both plain `{name}` and constrained `{name:pattern}`
+// (mux/chi) placeholders.
+func pathPlaceholders(path string) []string {
+	var names []string
+	forEachPathParam(path, func(name, _ string) {
+		if name != "" {
+			names = append(names, name)
+		}
+	})
 	return names
 }
 

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -2,6 +2,8 @@ package spec
 
 import (
 	"fmt"
+	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -113,6 +115,12 @@ type Extractor struct {
 	securityUnresolved    []MiddlewareRef
 	securityUnresolvedSet map[string]struct{}
 
+	// pathParamMismatches collects handlers that read a map-key path variable
+	// (e.g. mux.Vars(r)["userId"]) whose key is not declared as a `{placeholder}`
+	// in the route path — a likely typo, since the read will always be empty.
+	pathParamMismatches  []PathParamMismatch
+	pathParamMismatchSet map[string]struct{}
+
 	// parentFnIndex maps a function's BaseID to call edges made inside func
 	// literals lexically nested in it (keyed by ParentFunction). Lets wrapper
 	// look-through reach a library call that lives in the closure a middleware
@@ -187,7 +195,15 @@ func (e *Extractor) ExtractRoutes() []*RouteInfo {
 	for _, root := range e.tree.GetRoots() {
 		e.traverseForRoutes(root, "", nil, nil, nil, &routes)
 	}
-	return dropSubsumedMountPrefixes(routes)
+	routes = dropSubsumedMountPrefixes(routes)
+
+	// Diagnose map-key path-variable reads whose key matches no path placeholder.
+	// Done over the finalised route set so method/path are settled (handleRouteNode
+	// runs on transient, pre-dedup route objects).
+	for _, r := range routes {
+		e.recordPathVarKeyMismatches(r)
+	}
+	return routes
 }
 
 // dropSubsumedMountPrefixes removes spurious partially-mounted duplicates of a
@@ -1092,6 +1108,201 @@ func (e *Extractor) completeMapKeyPathParams(route *RouteInfo) {
 			Schema:   schema,
 		})
 	}
+}
+
+// PathParamMismatch records a handler reading a map-key path variable whose key
+// has no matching `{placeholder}` in the route path — surfaced as a diagnostic.
+type PathParamMismatch struct {
+	Method  string // HTTP method
+	Path    string // OpenAPI path (regex constraints stripped)
+	Handler string // handler function (package-qualified)
+	Key     string // key read in code, e.g. mux.Vars(r)["userId"]
+}
+
+// PathParamMismatches returns the map-key path-variable diagnostics gathered
+// during extraction (keys read in code that no route placeholder declares).
+func (e *Extractor) PathParamMismatches() []PathParamMismatch {
+	return e.pathParamMismatches
+}
+
+// recordPathVarKeyMismatches recovers the literal keys the handler reads through
+// the map-key accessor (mux.Vars) and records a diagnostic for any key that is
+// not a `{placeholder}` in the route path. The recovery uses the assignment
+// tracker: a variable assigned from the accessor (`vars := mux.Vars(r)`, tagged
+// with CalleeFunc/CalleePkg on the assignment) is "accessor-derived", and any
+// `accessorVar["key"]` or inline `mux.Vars(r)["key"]` index yields that key.
+func (e *Extractor) recordPathVarKeyMismatches(route *RouteInfo) {
+	if route == nil || route.Metadata == nil || route.Function == "" {
+		return
+	}
+	accessor := e.mapKeyAccessor()
+	if accessor == nil {
+		return
+	}
+	keys := e.recoverAccessorKeys(route, *accessor)
+	if len(keys) == 0 {
+		return
+	}
+	placeholders := make(map[string]bool)
+	for _, n := range pathPlaceholders(route.Path) {
+		placeholders[n] = true
+	}
+	// Sorted iteration keeps the diagnostics list deterministic.
+	names := make([]string, 0, len(keys))
+	for k := range keys {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	for _, key := range names {
+		if placeholders[key] {
+			continue
+		}
+		openAPIPath := convertPathToOpenAPI(joinPaths(route.MountPath, route.Path))
+		dedup := route.Method + " " + openAPIPath + " " + key
+		if e.pathParamMismatchSet == nil {
+			e.pathParamMismatchSet = make(map[string]struct{})
+		}
+		if _, ok := e.pathParamMismatchSet[dedup]; ok {
+			continue
+		}
+		e.pathParamMismatchSet[dedup] = struct{}{}
+		e.pathParamMismatches = append(e.pathParamMismatches, PathParamMismatch{
+			Method:  route.Method,
+			Path:    openAPIPath,
+			Handler: route.Function,
+			Key:     key,
+		})
+	}
+}
+
+// mapKeyAccessor returns the first configured NameFromMapKey param pattern, or
+// nil when the framework has none (only gorilla/mux does by default).
+func (e *Extractor) mapKeyAccessor() *ParamPattern {
+	for i := range e.cfg.Framework.ParamPatterns {
+		if e.cfg.Framework.ParamPatterns[i].NameFromMapKey {
+			return &e.cfg.Framework.ParamPatterns[i]
+		}
+	}
+	return nil
+}
+
+// recoverAccessorKeys returns the set of literal keys the route's handler reads
+// through the map-key accessor (direct `vars["id"]` on an accessor-derived
+// variable, or inline `mux.Vars(r)["id"]`). Dynamic keys and keys passed into
+// helpers are not recovered — the diagnostic errs toward no false positives.
+func (e *Extractor) recoverAccessorKeys(route *RouteInfo, accessor ParamPattern) map[string]struct{} {
+	meta := route.Metadata
+	bareFunc := route.Function
+	if route.Package != "" {
+		bareFunc = strings.TrimPrefix(route.Function, route.Package+".")
+	}
+	fn := findFunctionByName(meta, route.Package, bareFunc)
+	if fn == nil {
+		return nil
+	}
+
+	callRe, err1 := cachedRegex(accessor.CallRegex)
+	recvRe, err2 := cachedRegex(accessor.RecvTypeRegex)
+	if (accessor.CallRegex != "" && err1 != nil) || (accessor.RecvTypeRegex != "" && err2 != nil) {
+		return nil
+	}
+
+	// Variables assigned directly from the accessor call (vars := mux.Vars(r)).
+	accessorVars := make(map[string]bool)
+	for name, asgns := range fn.AssignmentMap {
+		for i := range asgns {
+			a := &asgns[i]
+			if (callRe == nil || callRe.MatchString(a.CalleeFunc)) &&
+				(recvRe == nil || recvRe.MatchString(a.CalleePkg)) &&
+				a.CalleeFunc != "" {
+				accessorVars[name] = true
+			}
+		}
+	}
+
+	keys := make(map[string]struct{})
+	for _, asgns := range fn.AssignmentMap {
+		for i := range asgns {
+			collectAccessorKeys(&asgns[i].Value, accessorVars, callRe, recvRe, keys)
+		}
+	}
+	return keys
+}
+
+// collectAccessorKeys walks an expression tree, recording the literal key of any
+// `X["key"]` index where X is an accessor-derived variable or an inline accessor
+// call. Recurses so nested expressions (`"John " + vars["id"]`) are covered.
+func collectAccessorKeys(arg *metadata.CallArgument, accessorVars map[string]bool, callRe, recvRe *regexp.Regexp, out map[string]struct{}) {
+	if arg == nil {
+		return
+	}
+	if arg.GetKind() == metadata.KindIndex && arg.Fun != nil && arg.Fun.GetKind() == metadata.KindLiteral && arg.X != nil {
+		derived := false
+		switch {
+		case arg.X.GetKind() == metadata.KindIdent && accessorVars[arg.X.GetName()]:
+			derived = true
+		case isAccessorCall(arg.X, callRe, recvRe):
+			derived = true
+		}
+		if derived {
+			if key := strings.Trim(arg.Fun.GetValue(), "\"`"); key != "" {
+				out[key] = struct{}{}
+			}
+		}
+	}
+	collectAccessorKeys(arg.X, accessorVars, callRe, recvRe, out)
+	collectAccessorKeys(arg.Fun, accessorVars, callRe, recvRe, out)
+	collectAccessorKeys(arg.Sel, accessorVars, callRe, recvRe, out)
+	for i := range arg.Args {
+		collectAccessorKeys(arg.Args[i], accessorVars, callRe, recvRe, out)
+	}
+}
+
+// isAccessorCall reports whether a call-argument is a call to the accessor
+// (e.g. `mux.Vars(r)`), matching the call name and receiver/package regexes.
+func isAccessorCall(x *metadata.CallArgument, callRe, recvRe *regexp.Regexp) bool {
+	if x == nil || x.GetKind() != metadata.KindCall || x.Fun == nil {
+		return false
+	}
+	fun := x.Fun
+	name := fun.GetName()
+	pkg := fun.GetPkg()
+	if fun.GetKind() == metadata.KindSelector && fun.Sel != nil {
+		name = fun.Sel.GetName()
+		if pkg == "" {
+			pkg = fun.Sel.GetPkg()
+		}
+	}
+	if callRe != nil && !callRe.MatchString(name) {
+		return false
+	}
+	if recvRe != nil && !recvRe.MatchString(pkg) {
+		return false
+	}
+	return true
+}
+
+// findFunctionByName locates a function by package and (bare) name, preferring
+// the named package and falling back to any package declaring the name.
+func findFunctionByName(meta *metadata.Metadata, pkg, name string) *metadata.Function {
+	if meta == nil || name == "" {
+		return nil
+	}
+	if p, ok := meta.Packages[pkg]; ok {
+		for _, file := range p.Files {
+			if fn, ok := file.Functions[name]; ok {
+				return fn
+			}
+		}
+	}
+	for _, p := range meta.Packages {
+		for _, file := range p.Files {
+			if fn, ok := file.Functions[name]; ok {
+				return fn
+			}
+		}
+	}
+	return nil
 }
 
 // handlerReachesAccessor reports whether the route's handler transitively calls

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -1295,8 +1295,17 @@ func findFunctionByName(meta *metadata.Metadata, pkg, name string) *metadata.Fun
 			}
 		}
 	}
-	for _, p := range meta.Packages {
-		for _, file := range p.Files {
+	// Fallback: any package declaring the name. Sort package keys so that when
+	// several packages declare the same bare name the result is stable across
+	// runs (map iteration order is random). Function names are unique within a
+	// package, so the inner file order doesn't affect the result.
+	pkgNames := make([]string, 0, len(meta.Packages))
+	for p := range meta.Packages {
+		pkgNames = append(pkgNames, p)
+	}
+	sort.Strings(pkgNames)
+	for _, p := range pkgNames {
+		for _, file := range meta.Packages[p].Files {
 			if fn, ok := file.Functions[name]; ok {
 				return fn
 			}

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -859,18 +859,14 @@ func (e *Extractor) extractRouteChildren(routeNode TrackerNodeInterface, route *
 		}
 
 		// Extract parameters
-		if param := e.extractParamFromNode(child, route); param != nil {
-			route.Params = append(route.Params, *param)
-		}
+		route.Params = append(route.Params, e.extractParamsFromNode(child, route)...)
 
 		// Recursive extraction
 		e.extractRouteChildren(child, route, mountTags, routes, visitedEdges)
 	}
 
 	// Extract parameters from the route node itself
-	if param := e.extractParamFromNode(routeNode, route); param != nil {
-		route.Params = append(route.Params, *param)
-	}
+	route.Params = append(route.Params, e.extractParamsFromNode(routeNode, route)...)
 }
 
 // preferRequestInfo chooses the more specific of two request bodies for the
@@ -996,14 +992,71 @@ func (e *Extractor) extractResponseFromNode(node TrackerNodeInterface, route *Ro
 	return nil
 }
 
-// extractParamFromNode extracts parameter information from a node
-func (e *Extractor) extractParamFromNode(node TrackerNodeInterface, route *RouteInfo) *Parameter {
+// extractParamsFromNode extracts parameter information from a node. Most
+// patterns yield at most one parameter (returned as a single-element slice),
+// but map-key patterns (gorilla/mux's `Vars(r)["id"]`) can yield several,
+// one per indexed key that matches a path placeholder.
+func (e *Extractor) extractParamsFromNode(node TrackerNodeInterface, route *RouteInfo) []Parameter {
 	for _, matcher := range e.paramMatchers {
-		if matcher.MatchNode(node) {
-			return matcher.ExtractParam(node, route)
+		if !matcher.MatchNode(node) {
+			continue
 		}
+		if impl, ok := matcher.(*ParamPatternMatcherImpl); ok && impl.pattern.NameFromMapKey {
+			return e.extractMapKeyParams(node, route, impl.pattern)
+		}
+		if param := matcher.ExtractParam(node, route); param != nil {
+			return []Parameter{*param}
+		}
+		return nil
 	}
 	return nil
+}
+
+// extractMapKeyParams recovers path parameters for frameworks whose path-var
+// accessor returns a map indexed by name — the gorilla/mux idiom
+// `mux.Vars(r)["id"]` — rather than taking the name as a call argument.
+//
+// Reaching this function means the accessor call (e.g. mux.Vars) matched within
+// this route's subtree, i.e. the handler (or a helper it calls) reads request
+// path variables. Every `{placeholder}` in the route path is a path parameter
+// by definition, so we emit one clean parameter per placeholder. Taking the
+// names from the path template (rather than from the specific index keys) makes
+// this robust to every access form — `id := vars["id"]`, `_ = vars["id"]`, or an
+// inline `store.Delete(vars["id"])` — none of which are uniformly recoverable
+// from the metadata. Routes whose handler never calls the accessor don't reach
+// here, so their placeholders still fall through to ensureAllPathParams and keep
+// the "present in path but not found in the code" warning, matching how the
+// other frameworks behave.
+func (e *Extractor) extractMapKeyParams(_ TrackerNodeInterface, route *RouteInfo, pattern ParamPattern) []Parameter {
+	if route == nil {
+		return nil
+	}
+	placeholders := pathPlaceholders(route.Path)
+	if len(placeholders) == 0 {
+		return nil
+	}
+	params := make([]Parameter, 0, len(placeholders))
+	for _, name := range placeholders {
+		params = append(params, Parameter{
+			Name:     name,
+			In:       pattern.ParamIn,
+			Required: pattern.ParamIn == "path",
+			Schema:   &Schema{Type: "string"},
+		})
+	}
+	return params
+}
+
+// pathPlaceholders returns the `{name}` placeholder names in a route path, in
+// order of appearance.
+func pathPlaceholders(path string) []string {
+	re := mustCachedRegex(`\{([a-zA-Z_][a-zA-Z0-9_]*)\}`)
+	matches := re.FindAllStringSubmatch(path, -1)
+	names := make([]string, 0, len(matches))
+	for _, m := range matches {
+		names = append(names, m[1])
+	}
+	return names
 }
 
 // joinPaths joins two URL paths cleanly

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -100,11 +100,16 @@ func DefaultAPISpecConfig() *APISpecConfig {
 	return &APISpecConfig{}
 }
 
-// SecurityDiagnostics carries non-fatal findings from security extraction.
+// SecurityDiagnostics carries non-fatal findings from extraction.
 type SecurityDiagnostics struct {
 	// UnresolvedMiddleware lists detected auth middleware that matched no
 	// SecurityMapping (deduped). The UI uses this to offer interactive mapping.
 	UnresolvedMiddleware []MiddlewareRef
+
+	// PathParamMismatches lists handlers that read a map-key path variable
+	// (mux.Vars(r)["userId"]) whose key matches no route placeholder — a likely
+	// typo, since the read is always empty.
+	PathParamMismatches []PathParamMismatch
 }
 
 // MapMetadataToOpenAPI maps metadata to OpenAPI specification.
@@ -134,6 +139,15 @@ func MapMetadataToOpenAPIWithDiagnostics(tree TrackerTreeInterface, cfg *APISpec
 		}
 		log.Printf("[security] %d auth middleware not mapped to a security scheme "+
 			"(add securityMappings to resolve): %s", len(unresolved), strings.Join(names, ", "))
+	}
+
+	// Warn about handlers that read a path variable by a key with no matching
+	// path placeholder (e.g. mux.Vars(r)["userId"] on a /users/{id} route) — a
+	// likely typo, since the read is always empty.
+	for _, m := range extractor.PathParamMismatches() {
+		log.Printf("[path-params] %s %s: handler %s reads path variable %q, "+
+			"but the path declares no such parameter (did you mean a different key or path segment?)",
+			m.Method, m.Path, m.Handler, m.Key)
 	}
 
 	// Build paths
@@ -185,7 +199,10 @@ func MapMetadataToOpenAPIWithDiagnostics(tree TrackerTreeInterface, cfg *APISpec
 		spec.Components.SecuritySchemes = schemes
 	}
 
-	diag := &SecurityDiagnostics{UnresolvedMiddleware: extractor.UnresolvedSecurity()}
+	diag := &SecurityDiagnostics{
+		UnresolvedMiddleware: extractor.UnresolvedSecurity(),
+		PathParamMismatches:  extractor.PathParamMismatches(),
+	}
 	return spec, diag, nil
 }
 

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -238,7 +238,8 @@ func buildPathsFromRoutes(routes []*RouteInfo) map[string]PathItem {
 
 	for _, route := range routes {
 		// Convert path to OpenAPI format
-		openAPIPath := convertPathToOpenAPI(joinPaths(route.MountPath, route.Path))
+		rawPath := joinPaths(route.MountPath, route.Path)
+		openAPIPath := convertPathToOpenAPI(rawPath)
 
 		// Get or create path item
 		pathItem, exists := paths[openAPIPath]
@@ -281,7 +282,7 @@ func buildPathsFromRoutes(routes []*RouteInfo) map[string]PathItem {
 		// fresh declaration. The matching {name} in the path is then
 		// considered "covered" by ensureAllPathParams below.
 		operation.Parameters = appendDynamicParamRefs(operation.Parameters, route.DynamicParams)
-		operation.Parameters = ensureAllPathParams(openAPIPath, operation.Parameters)
+		operation.Parameters = ensureAllPathParams(openAPIPath, operation.Parameters, pathParamPatterns(rawPath))
 
 		// Add responses
 		operation.Responses = buildResponses(route.Response)
@@ -304,8 +305,11 @@ func buildPathsFromRoutes(routes []*RouteInfo) map[string]PathItem {
 	return paths
 }
 
-// ensureAllPathParams ensures all path parameters in the path are present in the parameters slice
-func ensureAllPathParams(openAPIPath string, params []Parameter) []Parameter {
+// ensureAllPathParams ensures all path parameters in the path are present in
+// the parameters slice. openAPIPath is already normalised (regex constraints
+// stripped); patterns carries any `{name:pattern}` constraints recovered from
+// the raw path so synthesized params still surface them as a schema pattern.
+func ensureAllPathParams(openAPIPath string, params []Parameter, patterns map[string]string) []Parameter {
 	paramMap := make(map[string]bool)
 	for _, p := range params {
 		if p.In == "path" {
@@ -326,11 +330,15 @@ func ensureAllPathParams(openAPIPath string, params []Parameter) []Parameter {
 		name := match[1]
 		if !paramMap[name] {
 			// Add default path parameter with warning extension
+			schema := &Schema{Type: "string"}
+			if pat := patterns[name]; pat != "" {
+				schema.Pattern = pat
+			}
 			params = append(params, Parameter{
 				Name:     name,
 				In:       "path",
 				Required: true,
-				Schema:   &Schema{Type: "string"},
+				Schema:   schema,
 				Extensions: map[string]any{
 					"x-warning": "This parameter is present in the path but not found in the code.",
 				},
@@ -586,7 +594,13 @@ func setOperationOnPathItem(item *PathItem, method string, op *Operation) {
 
 // convertPathToOpenAPI converts a Go path to OpenAPI format
 func convertPathToOpenAPI(path string) string {
-	// Regular expression to match :param format
+	// Strip regex constraints from `{name:pattern}` placeholders (gorilla/mux
+	// and chi allow them, e.g. `/users/{id:[0-9]+}`). OpenAPI path templates
+	// cannot carry a regex, so the constraint is removed here and surfaced
+	// separately as a schema `pattern` on the parameter.
+	path = stripParamPatterns(path)
+
+	// Convert :param (gin/echo) -> {param}.
 	// This matches a colon followed by one or more word characters (letters, digits, underscore)
 	re := mustCachedRegex(`:([a-zA-Z_][a-zA-Z0-9_]*)`)
 
@@ -594,6 +608,93 @@ func convertPathToOpenAPI(path string) string {
 	result := re.ReplaceAllString(path, "{$1}")
 
 	return result
+}
+
+// forEachPathParam scans a URL path and invokes fn once per `{...}` placeholder
+// with its name and optional regex pattern (the substring after the first ':').
+// Braces are matched with depth counting so patterns that themselves contain
+// braces — mux's `{id:[0-9]{3}}` — parse correctly. A malformed (unbalanced)
+// placeholder stops the scan.
+func forEachPathParam(path string, fn func(name, pattern string)) {
+	for i := 0; i < len(path); i++ {
+		if path[i] != '{' {
+			continue
+		}
+		depth, j := 1, i+1
+		for ; j < len(path) && depth > 0; j++ {
+			switch path[j] {
+			case '{':
+				depth++
+			case '}':
+				depth--
+			}
+		}
+		if depth != 0 {
+			return // unbalanced — give up rather than emit garbage
+		}
+		inner := path[i+1 : j-1]
+		name, pattern := inner, ""
+		if c := strings.IndexByte(inner, ':'); c >= 0 {
+			name, pattern = inner[:c], inner[c+1:]
+		}
+		fn(name, pattern)
+		i = j - 1
+	}
+}
+
+// stripParamPatterns rewrites `{name:pattern}` placeholders to `{name}`, leaving
+// plain `{name}` and ordinary text untouched.
+func stripParamPatterns(path string) string {
+	if !strings.ContainsRune(path, '{') {
+		return path
+	}
+	var b strings.Builder
+	b.Grow(len(path))
+	for i := 0; i < len(path); i++ {
+		if path[i] != '{' {
+			b.WriteByte(path[i])
+			continue
+		}
+		depth, j := 1, i+1
+		for ; j < len(path) && depth > 0; j++ {
+			switch path[j] {
+			case '{':
+				depth++
+			case '}':
+				depth--
+			}
+		}
+		if depth != 0 {
+			b.WriteString(path[i:]) // unbalanced — copy the remainder verbatim
+			return b.String()
+		}
+		inner := path[i+1 : j-1]
+		name := inner
+		if c := strings.IndexByte(inner, ':'); c >= 0 {
+			name = inner[:c]
+		}
+		b.WriteByte('{')
+		b.WriteString(name)
+		b.WriteByte('}')
+		i = j - 1
+	}
+	return b.String()
+}
+
+// pathParamPatterns returns the name->regex-pattern map for the constrained
+// `{name:pattern}` placeholders in a path (unconstrained `{name}` are omitted).
+func pathParamPatterns(path string) map[string]string {
+	var out map[string]string
+	forEachPathParam(path, func(name, pattern string) {
+		if name == "" || pattern == "" {
+			return
+		}
+		if out == nil {
+			out = map[string]string{}
+		}
+		out[name] = pattern
+	})
+	return out
 }
 
 // generateComponentSchemas generates component schemas from metadata

--- a/internal/spec/mapper_comprehensive_test.go
+++ b/internal/spec/mapper_comprehensive_test.go
@@ -617,6 +617,7 @@ func TestEnsureAllPathParams_Comprehensive(t *testing.T) {
 		name     string
 		path     string
 		params   []Parameter
+		patterns map[string]string
 		expected int // expected number of parameters
 	}{
 		{
@@ -624,6 +625,13 @@ func TestEnsureAllPathParams_Comprehensive(t *testing.T) {
 			path:     "/users",
 			params:   []Parameter{},
 			expected: 0,
+		},
+		{
+			name:     "missing_path_param_with_pattern",
+			path:     "/users/{id}",
+			params:   []Parameter{},
+			patterns: map[string]string{"id": "[0-9]+"},
+			expected: 1,
 		},
 		{
 			name:     "missing_path_param",
@@ -659,7 +667,7 @@ func TestEnsureAllPathParams_Comprehensive(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := ensureAllPathParams(tt.path, tt.params, nil)
+			result := ensureAllPathParams(tt.path, tt.params, tt.patterns)
 			if len(result) != tt.expected {
 				t.Errorf("Expected %d parameters, got %d", tt.expected, len(result))
 			}
@@ -669,6 +677,12 @@ func TestEnsureAllPathParams_Comprehensive(t *testing.T) {
 			for _, p := range result {
 				if p.In == "path" {
 					pathParams[p.Name] = true
+				}
+				// A constrained placeholder must carry its pattern on the schema.
+				if p.In == "path" && tt.patterns[p.Name] != "" {
+					if p.Schema == nil || p.Schema.Pattern != tt.patterns[p.Name] {
+						t.Errorf("param %q: expected schema.pattern %q, got %+v", p.Name, tt.patterns[p.Name], p.Schema)
+					}
 				}
 			}
 

--- a/internal/spec/mapper_comprehensive_test.go
+++ b/internal/spec/mapper_comprehensive_test.go
@@ -659,7 +659,7 @@ func TestEnsureAllPathParams_Comprehensive(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := ensureAllPathParams(tt.path, tt.params)
+			result := ensureAllPathParams(tt.path, tt.params, nil)
 			if len(result) != tt.expected {
 				t.Errorf("Expected %d parameters, got %d", tt.expected, len(result))
 			}

--- a/testdata/mux_path_params/go.mod
+++ b/testdata/mux_path_params/go.mod
@@ -1,0 +1,5 @@
+module testdata/mux_path_params
+
+go 1.21
+
+require github.com/gorilla/mux v1.8.1

--- a/testdata/mux_path_params/go.sum
+++ b/testdata/mux_path_params/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=

--- a/testdata/mux_path_params/main.go
+++ b/testdata/mux_path_params/main.go
@@ -1,0 +1,53 @@
+// Package main exercises gorilla/mux path-parameter wiring beyond the direct
+// `vars := mux.Vars(r); vars["id"]` idiom:
+//
+//   - regex-constrained params `{sku:[a-z0-9-]+}` (OpenAPI path must drop the
+//     regex to `{sku}` and surface it as a schema pattern);
+//   - helper indirection, where the handler reads the var through a wrapper
+//     (`pathVar(r, "id")`) that itself calls mux.Vars — resolved via call-graph
+//     reachability, not the tracker subtree;
+//   - a placeholder the handler never reads, which must stay warned.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+type Product struct {
+	SKU  string `json:"sku"`
+	Name string `json:"name"`
+}
+
+// pathVar wraps mux.Vars behind a helper with a parameter key — the indirection
+// that call-graph reachability must see through.
+func pathVar(r *http.Request, key string) string {
+	return mux.Vars(r)[key]
+}
+
+// getProduct reads a regex-constrained param directly.
+func getProduct(w http.ResponseWriter, r *http.Request) {
+	sku := mux.Vars(r)["sku"]
+	_ = json.NewEncoder(w).Encode(Product{SKU: sku})
+}
+
+// getOrder reads the param through the pathVar helper.
+func getOrder(w http.ResponseWriter, r *http.Request) {
+	id := pathVar(r, "id")
+	_ = json.NewEncoder(w).Encode(map[string]string{"id": id})
+}
+
+// getItem never reads the path var, so its {id} stays warned.
+func getItem(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode(map[string]string{"ok": "true"})
+}
+
+func main() {
+	r := mux.NewRouter()
+	r.HandleFunc("/products/{sku:[a-z0-9-]+}", getProduct).Methods("GET")
+	r.HandleFunc("/orders/{id}", getOrder).Methods("GET")
+	r.HandleFunc("/items/{id}", getItem).Methods("GET")
+	_ = http.ListenAndServe(":8080", r)
+}

--- a/testdata/mux_path_params/main.go
+++ b/testdata/mux_path_params/main.go
@@ -44,10 +44,21 @@ func getItem(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(map[string]string{"ok": "true"})
 }
 
+// getTag has a key typo: the route declares {id} but the handler reads "tag" —
+// so the read is always empty. Reachability alone can't catch this (the handler
+// does reach mux.Vars), but recovering the actual key does: it surfaces a
+// path-param mismatch diagnostic.
+func getTag(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	tag := vars["tag"]
+	_ = json.NewEncoder(w).Encode(map[string]string{"tag": tag})
+}
+
 func main() {
 	r := mux.NewRouter()
 	r.HandleFunc("/products/{sku:[a-z0-9-]+}", getProduct).Methods("GET")
 	r.HandleFunc("/orders/{id}", getOrder).Methods("GET")
 	r.HandleFunc("/items/{id}", getItem).Methods("GET")
+	r.HandleFunc("/tags/{id}", getTag).Methods("GET")
 	_ = http.ListenAndServe(":8080", r)
 }


### PR DESCRIPTION
## What

Closes the last hole in the framework support matrix — **Gorilla Mux path params** — covers the harder access patterns, and adds a diagnostic for path-variable key typos.

## The problem

Mux exposes path vars as a **map** (`vars := mux.Vars(r); id := vars["id"]`), so the parameter *name* is a map key, not a call argument. The generic arg-index `ParamPattern` mechanism (chi/gin/echo/net-http) can't reach it, so mux `/users/{id}` came out with a bogus `net/http.Request` param **and** the real `{id}` flagged *"present in path but not found in the code"*.

## The fix (config-driven, engine stays framework-agnostic)

- Added `ParamPattern.NameFromMapKey` and set it on mux's `Vars` pattern (replacing the broken `ParamArgIndex: 0`).
- Path params are added **per route** by `completeMapKeyPathParams`, emitting one clean param per `{placeholder}` **iff the handler reaches the accessor** — determined by **call-graph reachability** (`handlerReachesAccessor`, bounded depth). This uniformly covers:
  - **direct** — `vars := mux.Vars(r); vars["id"]`
  - **inline** — `mux.Vars(r)["id"]`
  - **helper-wrapped** — `id := readParam(r, "id")` where `readParam` wraps `mux.Vars` (the tracker subtree misses this; the call graph doesn't)
- Names come from the **path template** (authoritative for path params), robust to every access form — assignment, blank `_ =`, inline call arg, or a dynamic key inside a helper.
- Routes whose handler never reaches `Vars` still fall through to the warned synthesis — parity with chi/gin/echo/fiber.

### Companion fix — regex-constrained params

`{id:[0-9]+}` (mux & chi) previously passed through as `/users/{id:[0-9]+}` — **invalid OpenAPI**, and the param was dropped entirely. Now `convertPathToOpenAPI` strips the regex to `{id}` (balanced-brace scan, handles `{id:[0-9]{3}}`) and surfaces the constraint as a schema `pattern`. `ensureAllPathParams` threads a name→pattern map so even warned synthesis carries it.

### Companion fix — path-variable key-mismatch diagnostic

Reachability wires `{id}` clean whenever the handler *reaches* `mux.Vars`, but it can't tell whether the code reads the **right** key. `mux.Vars(r)["userId"]` on a `/users/{id}` route wires `{id}` clean yet the read is always empty — a silent bug.

`recordPathVarKeyMismatches` recovers the literal keys actually read — via the **assignment tracker** (a var tagged `CalleeFunc`/`CalleePkg` matching the accessor is "accessor-derived": `vars := mux.Vars(r)`, then `collectAccessorKeys` walks assignment RHS trees for `X["lit"]`) and inline `mux.Vars(r)["id"]` — and reports any key with no matching placeholder. Run once over the **finalised** route set at the end of `ExtractRoutes` (not in `handleRouteNode`, which runs on transient pre-dedup routes and would emit phantom methods). Dynamic keys and keys passed into helpers aren't recovered, so the diagnostic has **zero false positives**.

Surfaced as a `[path-params]` CLI warning and programmatically via `Engine.GetPathParamMismatches()` / `Generator.PathParamMismatches()` (for the UI).

## Verification

- `TestTestdata_MuxPathParams` — `/users/{id}` GET/PUT/DELETE each carry exactly one clean `id` param, no warning, no bogus entry.
- `TestTestdata_MuxAdvancedPathParams` (fixture `testdata/mux_path_params`) — regex param → `{sku}` + `pattern`; helper-wrapped → clean; unread placeholder → stays warned.
- `TestTestdata_MuxPathParamKeyMismatch` — fixture `getTag` reads `mux.Vars(r)["tag"]` on `/tags/{id}` (wires clean via reachability); exactly one mismatch is reported for the wrong key.
- gin / echo / fiber / chi / net-http path params spot-checked **unchanged**.
- Full `go test ./...` passes; `-race` clean; `go vet` + `gofmt` clean; diagnostic order deterministic; no golden-fixture drift.
- README matrix cell flipped to ✅; gap-analysis §2.1 updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)