### PR TITLE
Remove report card due to retire

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # APISpec: Generate OpenAPI from Go code
 
 [![Coverage](https://img.shields.io/badge/coverage-70.1%25-yellowgreen.svg)](https://github.com/ehabterra/apispec)
-[![Go Report Card](https://goreportcard.com/badge/github.com/ehabterra/apispec)](https://goreportcard.com/report/github.com/ehabterra/apispec)
 [![Go Version](https://img.shields.io/badge/go-1.26+-00ADD8?style=flat&logo=go)](https://go.dev/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/ehabterra/apispec/blob/main/LICENSE)
 [![GitHub Actions](https://img.shields.io/github/actions/workflow/status/ehabterra/apispec/ci.yml?branch=main&label=CI&logo=github)](https://github.com/ehabterra/apispec/actions/workflows/ci.yml)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the Go Report Card badge from the top of the README, leaving the Coverage badge as the primary badge displayed there.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->