### PR TITLE
feat: split r.Method-dispatch handlers into per-method operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ APISpec aims for practical coverage of real-world Go services. A quick survey of
 - CGO packages can be skipped to avoid build errors.
 - Dependency-injected route groups.
 - Go 1.22 `net/http.ServeMux` method-aware routing — patterns that carry the verb on the registration (`mux.HandleFunc("GET /users/{id}", getUser)`) are split into method + path, `{id}` wildcards become path parameters, and `r.PathValue("id")` is recognised as a path parameter. ServeMux-only syntax (`{path...}` trailing wildcards, the `{$}` end-of-path anchor) is normalised to OpenAPI templating. See `testdata/servemux/`.
+- Method dispatch in the handler — a single handler registered without a verb (`http.HandleFunc("/users", h)`) that branches on `r.Method` (`switch r.Method { case http.MethodGet: … }` or an `if r.Method == …` chain) is split into one operation per HTTP method, with each branch's request body and responses attributed to its own method (by source position) and unique operationIds. `http.MethodXxx` constants, plain `"GET"` literals, and multi-method cases (`case http.MethodGet, http.MethodHead:`) all resolve. See `testdata/method_switch/`. *Not yet:* two branches returning the same status code with different bodies (the shared status slot keeps one), and dispatch inside a receiver-method handler.
 - Handler factories — a route registered as a *call* that returns the framework's handler type (`g.POST("/users", h.Create())` where `Create() echo.HandlerFunc { return func(c) {…} }`), including when the handler is dispatched through an interface whose implementation lives in a different package.
 - Function-local named types used as request/response bodies (`type Login struct{…}` declared inside a handler) — captured from the function body and emitted as real component schemas rather than dangling `$ref`s.
 - Request bodies bound through a custom wrapper (`util.ReadRequest(c, &dto)` → `ctx.Bind(dto)`) — the concrete type is traced through the wrapper's parameters.
@@ -272,7 +273,6 @@ APISpec aims for practical coverage of real-world Go services. A quick survey of
 - Interface-typed function parameters — not fully resolved to concrete types.
 - Same path + same status code with different schemas — not yet supported.
 - Receiver/parent type tracing is limited; `Decode` on non-body targets may be misclassified (see [Request body source disambiguation](#request-body-source-disambiguation)).
-- HTTP methods set via switch/if around `net/http.Handle`/`HandleFunc` — not detected.
 - `dive` validator tag (array-element validation) — planned.
 
 ### Selected capability highlights

--- a/generator/testdata_frameworks_test.go
+++ b/generator/testdata_frameworks_test.go
@@ -119,6 +119,15 @@ func TestTestdata_Frameworks(t *testing.T) {
 				{"/create", []string{"POST"}},
 			},
 		},
+		{
+			name:     "method_switch",
+			fallback: spec.DefaultHTTPConfig(),
+			routes: []route{
+				{"/users", []string{"GET", "POST"}},
+				{"/item", []string{"GET", "DELETE"}},
+				{"/ping", []string{"GET", "HEAD"}},
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/generator/testdata_method_switch_test.go
+++ b/generator/testdata_method_switch_test.go
@@ -1,0 +1,79 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/spec"
+)
+
+// TestTestdata_MethodSwitch locks in control-flow method dispatch: a single
+// net/http handler registered without a verb that branches on r.Method (via a
+// switch or an if/else-if chain) must split into one operation per HTTP method,
+// with each branch's request/response attributed to its own method and unique
+// operationIds across the split.
+func TestTestdata_MethodSwitch(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "method_switch", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+
+	// Expected method set per path (the core win: no more single default POST).
+	want := map[string][]string{
+		"/users": {"GET", "POST"},
+		"/item":  {"GET", "DELETE"},
+		"/ping":  {"GET", "HEAD"},
+	}
+	for path, methods := range want {
+		item, ok := out.Paths[path]
+		if !ok {
+			t.Errorf("path %q missing; have %v", path, mapPathKeys(out.Paths))
+			continue
+		}
+		for _, m := range methods {
+			if opFor(item, m) == nil {
+				t.Errorf("%s %s: expected operation, missing", m, path)
+			}
+		}
+		// The default POST must be gone where the handler doesn't serve POST.
+		if path == "/item" && opFor(item, "POST") != nil {
+			t.Errorf("%s should not carry a POST operation", path)
+		}
+		if path == "/ping" && opFor(item, "POST") != nil {
+			t.Errorf("%s should not carry a POST operation", path)
+		}
+	}
+
+	// Per-branch attribution: POST /users carries the request body; GET does not.
+	users := out.Paths["/users"]
+	if post := opFor(users, "POST"); post == nil || post.RequestBody == nil {
+		t.Errorf("POST /users should carry a request body (CreateUserRequest)")
+	}
+	if get := opFor(users, "GET"); get == nil || get.RequestBody != nil {
+		t.Errorf("GET /users should not carry a request body, got %+v", get)
+	}
+
+	// DELETE /item is bodyless (204): it must not carry a GET-style user body.
+	item := out.Paths["/item"]
+	if del := opFor(item, "DELETE"); del != nil {
+		for status := range del.Responses {
+			if status == "200" {
+				t.Errorf("DELETE /item should not carry a 200 body response")
+			}
+		}
+	}
+
+	// operationIds are unique across the split (method-suffixed).
+	seen := map[string]bool{}
+	for _, path := range []string{"/users", "/item", "/ping"} {
+		for _, m := range []string{"GET", "POST", "PUT", "DELETE", "HEAD"} {
+			if op := opFor(out.Paths[path], m); op != nil {
+				id := op.OperationID
+				if id == "" {
+					t.Errorf("%s %s: empty operationId", m, path)
+				}
+				if seen[id] {
+					t.Errorf("duplicate operationId %q across the method split", id)
+				}
+				seen[id] = true
+			}
+		}
+	}
+}

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -1472,15 +1472,16 @@ func processFunctions(file *ast.File, info *types.Info, pkgName string, fset *to
 		})
 
 		f.Functions[fn.Name.Name] = &Function{
-			Name:          metadata.StringPool.Get(fn.Name.Name),
-			Pkg:           metadata.StringPool.Get(pkgName),
-			Signature:     *ExprToCallArgument(fn.Type, info, pkgName, fset, metadata),
-			Position:      metadata.StringPool.Get(getFuncPosition(fn, fset)),
-			Scope:         metadata.StringPool.Get(getScope(fn.Name.Name)),
-			Comments:      metadata.StringPool.Get(comments),
-			TypeParams:    typeParams,
-			ReturnVars:    returnVars,
-			AssignmentMap: assignmentsInFunc,
+			Name:           metadata.StringPool.Get(fn.Name.Name),
+			Pkg:            metadata.StringPool.Get(pkgName),
+			Signature:      *ExprToCallArgument(fn.Type, info, pkgName, fset, metadata),
+			Position:       metadata.StringPool.Get(getFuncPosition(fn, fset)),
+			Scope:          metadata.StringPool.Get(getScope(fn.Name.Name)),
+			Comments:       metadata.StringPool.Get(comments),
+			TypeParams:     typeParams,
+			ReturnVars:     returnVars,
+			AssignmentMap:  assignmentsInFunc,
+			MethodDispatch: detectMethodDispatch(fn.Body, info, fset),
 		}
 
 		f.Functions[fn.Name.Name].SignatureStr = metadata.StringPool.Get(CallArgToString(&f.Functions[fn.Name.Name].Signature))

--- a/internal/metadata/method_dispatch.go
+++ b/internal/metadata/method_dispatch.go
@@ -1,0 +1,141 @@
+package metadata
+
+import (
+	"go/ast"
+	"go/constant"
+	"go/token"
+	"go/types"
+	"strings"
+)
+
+// httpMethodVerbs is the set of HTTP verbs a method-dispatch branch may name.
+var httpMethodVerbs = map[string]bool{
+	"GET": true, "POST": true, "PUT": true, "DELETE": true,
+	"PATCH": true, "HEAD": true, "OPTIONS": true, "CONNECT": true, "TRACE": true,
+}
+
+// detectMethodDispatch finds control-flow dispatch on `r.Method` inside a
+// handler body — a `switch r.Method { case http.MethodGet: … }` or an
+// `if r.Method == http.MethodGet { … } else if … ` chain — and returns one
+// MethodBranch per arm (the HTTP method(s) it handles and its source line
+// range). Returns nil when the body doesn't dispatch on the request method, so
+// ordinary handlers carry no MethodDispatch.
+//
+// Method values are resolved through the type checker's constant value
+// (`info.Types[expr].Value`), so `http.MethodGet`, a bare `"GET"` literal, and
+// a project-local `const MyGet = "GET"` all resolve uniformly. The request
+// operand is identified by type (`*net/http.Request`), not by parameter name,
+// so it is robust to any naming.
+func detectMethodDispatch(body *ast.BlockStmt, info *types.Info, fset *token.FileSet) []MethodBranch {
+	if body == nil || info == nil || fset == nil {
+		return nil
+	}
+	var branches []MethodBranch
+	ast.Inspect(body, func(n ast.Node) bool {
+		switch stmt := n.(type) {
+		case *ast.SwitchStmt:
+			if !isRequestMethodExpr(stmt.Tag, info) {
+				return true
+			}
+			for _, clause := range stmt.Body.List {
+				cc, ok := clause.(*ast.CaseClause)
+				if !ok || len(cc.List) == 0 {
+					continue // the `default:` arm names no method
+				}
+				methods := caseMethodVerbs(cc.List, info)
+				if len(methods) == 0 {
+					continue
+				}
+				branches = append(branches, MethodBranch{
+					Methods:   methods,
+					StartLine: fset.Position(cc.Pos()).Line,
+					EndLine:   fset.Position(cc.End()).Line,
+				})
+			}
+			return false // switch handled; nested method-switches are not expected
+		case *ast.IfStmt:
+			if arms, ok := methodIfBranches(stmt, info, fset); ok {
+				branches = append(branches, arms...)
+				return false // the whole if/else-if chain is consumed here
+			}
+		}
+		return true
+	})
+	return branches
+}
+
+// isRequestMethodExpr reports whether expr is `<request>.Method` where
+// <request> is typed `*net/http.Request`.
+func isRequestMethodExpr(expr ast.Expr, info *types.Info) bool {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok || sel.Sel == nil || sel.Sel.Name != "Method" {
+		return false
+	}
+	t := info.TypeOf(sel.X)
+	return t != nil && t.String() == "*net/http.Request"
+}
+
+// caseMethodVerbs resolves the expressions of a `case` clause to HTTP verbs
+// (a single clause may list several: `case http.MethodGet, http.MethodHead:`).
+func caseMethodVerbs(exprs []ast.Expr, info *types.Info) []string {
+	var out []string
+	for _, e := range exprs {
+		if v := constMethodVerb(e, info); v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// constMethodVerb returns the upper-cased HTTP verb an expression constant-folds
+// to, or "" if it is not a constant string naming a known method.
+func constMethodVerb(e ast.Expr, info *types.Info) string {
+	tv, ok := info.Types[e]
+	if !ok || tv.Value == nil || tv.Value.Kind() != constant.String {
+		return ""
+	}
+	v := strings.ToUpper(constant.StringVal(tv.Value))
+	if httpMethodVerbs[v] {
+		return v
+	}
+	return ""
+}
+
+// methodIfBranches walks an `if r.Method == X { … } else if r.Method == Y { … }`
+// chain, returning one MethodBranch per matching arm. ok is false when the head
+// `if` does not compare the request method (so the caller keeps descending).
+func methodIfBranches(ifStmt *ast.IfStmt, info *types.Info, fset *token.FileSet) (arms []MethodBranch, ok bool) {
+	for cur := ifStmt; cur != nil; {
+		if verb := ifMethodEqVerb(cur.Cond, info); verb != "" && cur.Body != nil {
+			ok = true
+			arms = append(arms, MethodBranch{
+				Methods:   []string{verb},
+				StartLine: fset.Position(cur.Body.Pos()).Line,
+				EndLine:   fset.Position(cur.Body.End()).Line,
+			})
+		}
+		if elseIf, isIf := cur.Else.(*ast.IfStmt); isIf {
+			cur = elseIf
+		} else {
+			cur = nil
+		}
+	}
+	return arms, ok
+}
+
+// ifMethodEqVerb returns the verb when cond is `r.Method == <method>` (in either
+// operand order), else "".
+func ifMethodEqVerb(cond ast.Expr, info *types.Info) string {
+	be, ok := cond.(*ast.BinaryExpr)
+	if !ok || be.Op != token.EQL {
+		return ""
+	}
+	switch {
+	case isRequestMethodExpr(be.X, info):
+		return constMethodVerb(be.Y, info)
+	case isRequestMethodExpr(be.Y, info):
+		return constMethodVerb(be.X, info)
+	default:
+		return ""
+	}
+}

--- a/internal/metadata/method_dispatch_test.go
+++ b/internal/metadata/method_dispatch_test.go
@@ -1,0 +1,200 @@
+package metadata
+
+import (
+	"go/ast"
+	"go/importer"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// typeCheckHandler parses and type-checks a snippet (which must declare a
+// handler named `h`) and returns its body, the types.Info, and the fileset —
+// everything detectMethodDispatch needs.
+func typeCheckHandler(t *testing.T, body string) (*ast.BlockStmt, *types.Info, *token.FileSet) {
+	t.Helper()
+	src := "package p\n\nimport \"net/http\"\n\nfunc h(w http.ResponseWriter, r *http.Request) {\n" + body + "\n}\n"
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "h.go", src, 0)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	info := &types.Info{
+		Types: map[ast.Expr]types.TypeAndValue{},
+		Defs:  map[*ast.Ident]types.Object{},
+		Uses:  map[*ast.Ident]types.Object{},
+	}
+	conf := types.Config{Importer: importer.Default()}
+	if _, err := conf.Check("p", fset, []*ast.File{file}, info); err != nil {
+		t.Fatalf("typecheck: %v", err)
+	}
+	for _, d := range file.Decls {
+		if fn, ok := d.(*ast.FuncDecl); ok && fn.Name.Name == "h" {
+			return fn.Body, info, fset
+		}
+	}
+	t.Fatal("handler h not found")
+	return nil, nil, nil
+}
+
+// methodsOf flattens a branch list to a sorted, comma-joined method string for
+// order-independent comparison.
+func methodsOf(branches []MethodBranch) string {
+	var all []string
+	for _, b := range branches {
+		all = append(all, strings.Join(b.Methods, "+"))
+	}
+	sort.Strings(all)
+	return strings.Join(all, ",")
+}
+
+func TestDetectMethodDispatch(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string // methodsOf() of the result; "" means no dispatch
+	}{
+		{
+			name: "switch with GET and POST",
+			body: `switch r.Method {
+			case http.MethodGet:
+				_ = w
+			case http.MethodPost:
+				_ = r
+			default:
+				_ = w
+			}`,
+			want: "GET,POST",
+		},
+		{
+			name: "if/else-if chain GET and DELETE",
+			body: `if r.Method == http.MethodGet {
+				_ = w
+			} else if r.Method == http.MethodDelete {
+				_ = r
+			}`,
+			want: "DELETE,GET",
+		},
+		{
+			name: "multi-method case GET,HEAD",
+			body: `switch r.Method {
+			case http.MethodGet, http.MethodHead:
+				_ = w
+			}`,
+			want: "GET+HEAD",
+		},
+		{
+			name: "string literal case",
+			body: `switch r.Method {
+			case "GET":
+				_ = w
+			case "put":
+				_ = r
+			}`,
+			want: "GET,PUT",
+		},
+		{
+			name: "reversed if comparison (const == r.Method)",
+			body: `if http.MethodPatch == r.Method {
+				_ = w
+			}`,
+			want: "PATCH",
+		},
+		{
+			name: "no dispatch — plain handler",
+			body: `_ = w
+			_ = r`,
+			want: "",
+		},
+		{
+			name: "switch on something else is ignored",
+			body: `switch r.URL.Path {
+			case "/a":
+				_ = w
+			}`,
+			want: "",
+		},
+		{
+			name: "default-only switch names no method",
+			body: `switch r.Method {
+			default:
+				_ = w
+			}`,
+			want: "",
+		},
+		{
+			name: "case string that is not a known verb is skipped",
+			body: `switch r.Method {
+			case "BOGUS":
+				_ = w
+			case http.MethodGet:
+				_ = r
+			}`,
+			want: "GET",
+		},
+		{
+			name: "non-constant case expression is skipped",
+			body: `x := "GET"
+			switch r.Method {
+			case x:
+				_ = w
+			}`,
+			want: "",
+		},
+		{
+			name: "!= comparison is not a dispatch",
+			body: `if r.Method != http.MethodGet {
+				_ = w
+			}`,
+			want: "",
+		},
+		{
+			name: "non-method if is ignored",
+			body: `if r.URL.Path == "/x" {
+				_ = w
+			}`,
+			want: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, info, fset := typeCheckHandler(t, tc.body)
+			got := methodsOf(detectMethodDispatch(body, info, fset))
+			if got != tc.want {
+				t.Errorf("detectMethodDispatch methods = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDetectMethodDispatch_LineRanges(t *testing.T) {
+	body, info, fset := typeCheckHandler(t, `switch r.Method {
+	case http.MethodGet:
+		_ = w
+	case http.MethodPost:
+		_ = r
+	}`)
+	branches := detectMethodDispatch(body, info, fset)
+	if len(branches) != 2 {
+		t.Fatalf("want 2 branches, got %d", len(branches))
+	}
+	for _, b := range branches {
+		if b.StartLine <= 0 || b.EndLine < b.StartLine {
+			t.Errorf("branch %v has invalid line range [%d,%d]", b.Methods, b.StartLine, b.EndLine)
+		}
+	}
+	// The two case ranges must not overlap (each verb owns distinct lines).
+	if branches[0].EndLine >= branches[1].StartLine {
+		t.Errorf("case ranges overlap: %+v", branches)
+	}
+}
+
+func TestDetectMethodDispatch_NilSafety(t *testing.T) {
+	if got := detectMethodDispatch(nil, nil, nil); got != nil {
+		t.Errorf("nil inputs should yield nil, got %v", got)
+	}
+}

--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -499,6 +499,21 @@ type Function struct {
 
 	// map of variable name to all assignments (for alias/reassignment tracking)
 	AssignmentMap map[string][]Assignment `yaml:"assignments,omitempty"`
+
+	// MethodDispatch records the arms of an `r.Method` control-flow dispatch
+	// (a `switch r.Method` or an `if r.Method == …` chain) inside the function
+	// body, so a net/http handler that branches on the verb can be split into
+	// one operation per HTTP method. Empty for handlers that don't dispatch.
+	MethodDispatch []MethodBranch `yaml:"method_dispatch,omitempty"`
+}
+
+// MethodBranch is one arm of an `r.Method` dispatch: the HTTP method(s) it
+// handles and the source line range of its body, used to attribute each
+// branch's request/response to the right operation.
+type MethodBranch struct {
+	Methods   []string `yaml:"methods,omitempty"`    // e.g. ["GET"] or ["GET","HEAD"]
+	StartLine int      `yaml:"start_line,omitempty"` // first line of the branch body (inclusive)
+	EndLine   int      `yaml:"end_line,omitempty"`   // last line of the branch body (inclusive)
 }
 
 // Variable represents a variable

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -30,6 +30,11 @@ type RouteInfo struct {
 	Response  map[string]*ResponseInfo
 	Params    []Parameter
 
+	// OperationIDSuffix disambiguates the operationId when one handler yields
+	// several operations (e.g. an r.Method dispatch split into GET/POST). Empty
+	// for ordinary routes. Appended as "_<suffix>" to the computed operationId.
+	OperationIDSuffix string
+
 	UsedTypes map[string]*Schema
 	Metadata  *metadata.Metadata
 
@@ -82,6 +87,11 @@ type RequestInfo struct {
 	ContentType string
 	BodyType    string
 	Schema      *Schema
+
+	// File and Line locate the call site that produced this request body, used
+	// to attribute it to an r.Method dispatch branch (see splitMethodDispatchRoutes).
+	File string
+	Line int
 }
 
 // ResponseInfo represents response information
@@ -90,6 +100,11 @@ type ResponseInfo struct {
 	ContentType string
 	BodyType    string
 	Schema      *Schema
+
+	// File and Line locate the call site that produced this response, used to
+	// attribute it to an r.Method dispatch branch (see splitMethodDispatchRoutes).
+	File string
+	Line int
 }
 
 // Extractor provides a cleaner, more modular approach to extraction
@@ -227,6 +242,10 @@ func (e *Extractor) ExtractRoutes() []*RouteInfo {
 		e.traverseForRoutes(root, "", nil, nil, nil, &routes)
 	}
 	routes = dropSubsumedMountPrefixes(routes)
+
+	// Split handlers that dispatch on r.Method (switch/if) into one route per
+	// HTTP method, before the per-route diagnostics below run on the settled set.
+	routes = splitMethodDispatchRoutes(routes)
 
 	// Diagnose map-key path-variable reads whose key matches no path placeholder.
 	// Done over the finalised route set so method/path are settled (handleRouteNode
@@ -967,6 +986,11 @@ func (e *Extractor) extractRouteChildren(routeNode TrackerNodeInterface, route *
 		// a later generic `object` — which happens when one path resolves the
 		// type through a binding wrapper and another doesn't.
 		if req := e.extractRequestFromNode(child, route); req != nil {
+			// Record the call site so a method-dispatch handler can attribute
+			// this request body to the right verb branch by line range.
+			if f, l, _ := calleePosition(child); req.File == "" {
+				req.File, req.Line = f, l
+			}
 			route.Request = preferRequestInfo(route.Request, req)
 		}
 
@@ -1091,6 +1115,9 @@ func (e *Extractor) pairAndFillResponses(route *RouteInfo, candidates []response
 				continue
 			}
 			seen[dedupeKey] = true
+			// Carry the call-site position so a method-dispatch handler can
+			// attribute this response to the right verb branch by line range.
+			resp.File, resp.Line = file, line
 			frags = append(frags, fragment{resp: resp, chain: cand.chain, caller: caller, file: file, line: line, col: col})
 		}
 	}

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -35,6 +35,13 @@ type RouteInfo struct {
 	// for ordinary routes. Appended as "_<suffix>" to the computed operationId.
 	OperationIDSuffix string
 
+	// MethodExplicit is true when Method was resolved from the registration
+	// (a verb-carrying call/arg/path, e.g. router.GET or "GET /x"), and false
+	// when it fell back to the default. Only verb-less routes are eligible for
+	// r.Method-dispatch splitting — a router that registers a concrete verb
+	// won't dispatch the other verbs to the handler.
+	MethodExplicit bool
+
 	UsedTypes map[string]*Schema
 	Metadata  *metadata.Metadata
 

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -271,8 +271,12 @@ func buildPathsFromRoutes(routes []*RouteInfo) map[string]PathItem {
 		}
 
 		// Create operation
+		operationID := pkg + strings.Replace(strings.Replace(route.Function, TypeSep, ".", 1), pkg, "", 1)
+		if route.OperationIDSuffix != "" {
+			operationID += "_" + route.OperationIDSuffix
+		}
 		operation := &Operation{
-			OperationID: pkg + strings.Replace(strings.Replace(route.Function, TypeSep, ".", 1), pkg, "", 1),
+			OperationID: operationID,
 			Summary:     route.Summary,
 			Tags:        route.Tags,
 		}

--- a/internal/spec/method_dispatch.go
+++ b/internal/spec/method_dispatch.go
@@ -40,6 +40,12 @@ func methodDispatchFor(route *RouteInfo) ([]metadata.MethodBranch, string) {
 	if meta == nil || route.Function == "" {
 		return nil, ""
 	}
+	// A route registered with a concrete verb (router.GET, "POST /x", …) only
+	// receives that verb, so its handler's incidental r.Method branches are dead
+	// for this route — never split it. Only verb-less registrations dispatch.
+	if route.MethodExplicit {
+		return nil, ""
+	}
 	bare := route.Function
 	if route.Package != "" {
 		bare = strings.TrimPrefix(route.Function, route.Package+".")

--- a/internal/spec/method_dispatch.go
+++ b/internal/spec/method_dispatch.go
@@ -1,0 +1,132 @@
+package spec
+
+import (
+	"strings"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// splitMethodDispatchRoutes expands each route whose handler dispatches on
+// r.Method (a `switch r.Method` or `if r.Method == …` chain — recorded as
+// metadata.Function.MethodDispatch) into one route per HTTP method, attributing
+// each verb branch's request and responses to its own operation. Routes whose
+// handler does not dispatch pass through unchanged.
+//
+// Attribution is by source position: a request/response located inside the
+// handler is assigned to the branch whose line range contains it; one located
+// outside the handler (a shared helper in another file, or with no recoverable
+// position) is attached to every method, and one located inside the handler but
+// outside every verb branch (e.g. the `default:` arm's 405) is dropped. Two
+// branches that return the *same* status with different bodies are a known
+// limitation — the earlier status-slot pairing keeps one, so they don't split.
+func splitMethodDispatchRoutes(routes []*RouteInfo) []*RouteInfo {
+	out := make([]*RouteInfo, 0, len(routes))
+	for _, route := range routes {
+		branches, handlerFile := methodDispatchFor(route)
+		if len(branches) == 0 {
+			out = append(out, route)
+			continue
+		}
+		out = append(out, splitRouteByMethodBranches(route, branches, handlerFile)...)
+	}
+	return out
+}
+
+// methodDispatchFor returns the handler's r.Method dispatch branches and the
+// source file the handler is defined in (for same-file position scoping), or
+// nil when the route's handler doesn't dispatch on the method.
+func methodDispatchFor(route *RouteInfo) ([]metadata.MethodBranch, string) {
+	meta := route.Metadata
+	if meta == nil || route.Function == "" {
+		return nil, ""
+	}
+	bare := route.Function
+	if route.Package != "" {
+		bare = strings.TrimPrefix(route.Function, route.Package+".")
+	}
+	fn := findFunctionByName(meta, route.Package, bare)
+	if fn == nil || len(fn.MethodDispatch) == 0 {
+		return nil, ""
+	}
+	return fn.MethodDispatch, fileOfPosition(meta.StringPool.GetString(fn.Position))
+}
+
+// splitRouteByMethodBranches builds one RouteInfo per HTTP method named across
+// the dispatch branches, with request/response scoped to that method.
+func splitRouteByMethodBranches(route *RouteInfo, branches []metadata.MethodBranch, handlerFile string) []*RouteInfo {
+	type lineRange struct{ start, end int }
+	ranges := map[string][]lineRange{}
+	var order []string
+	for _, b := range branches {
+		for _, m := range b.Methods {
+			if _, seen := ranges[m]; !seen {
+				order = append(order, m)
+			}
+			ranges[m] = append(ranges[m], lineRange{b.StartLine, b.EndLine})
+		}
+	}
+	if len(order) == 0 {
+		return []*RouteInfo{route}
+	}
+
+	// insideHandler reports whether a call site sits in the handler's own file
+	// (so its line can be compared against the branch ranges).
+	insideHandler := func(file string, line int) bool {
+		return handlerFile != "" && line > 0 && file == handlerFile
+	}
+	inRanges := func(rs []lineRange, line int) bool {
+		for _, r := range rs {
+			if line >= r.start && line <= r.end {
+				return true
+			}
+		}
+		return false
+	}
+	// belongsTo reports whether a call site at (file,line) belongs to method m:
+	// either it's outside the handler (shared → every method) or it falls in one
+	// of m's branch ranges. A site inside the handler but in no branch (default
+	// arm) belongs to no method.
+	belongsTo := func(rs []lineRange, file string, line int) bool {
+		if !insideHandler(file, line) {
+			return true
+		}
+		return inRanges(rs, line)
+	}
+
+	result := make([]*RouteInfo, 0, len(order))
+	for _, m := range order {
+		rs := ranges[m]
+		nr := *route // shallow copy; per-method Method/Request/Response below
+		nr.Method = m
+		nr.OperationIDSuffix = m // keep operationIds unique across the split
+		nr.Response = map[string]*ResponseInfo{}
+		nr.Request = nil
+
+		for slot, resp := range route.Response {
+			if resp != nil && belongsTo(rs, resp.File, resp.Line) {
+				nr.Response[slot] = resp
+			}
+		}
+		if route.Request != nil && belongsTo(rs, route.Request.File, route.Request.Line) {
+			nr.Request = route.Request
+		}
+		result = append(result, &nr)
+	}
+	return result
+}
+
+// fileOfPosition returns the file portion of a "file:line:col" position string,
+// tolerating a Windows drive-letter colon (only the trailing :line:col is
+// stripped).
+func fileOfPosition(pos string) string {
+	lastColon := strings.LastIndexByte(pos, ':')
+	if lastColon < 0 {
+		return pos
+	}
+	rest := pos[:lastColon]
+	midColon := strings.LastIndexByte(rest, ':')
+	if midColon < 0 {
+		return rest
+	}
+	return rest[:midColon]
+}

--- a/internal/spec/method_dispatch_test.go
+++ b/internal/spec/method_dispatch_test.go
@@ -1,0 +1,187 @@
+package spec
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+func TestFileOfPosition(t *testing.T) {
+	cases := map[string]string{
+		"/a/b/x.go:10:5":  "/a/b/x.go",
+		"x.go:1:2":        "x.go",
+		`C:\a\x.go:10:20`: `C:\a\x.go`, // Windows drive colon preserved
+		"nocolon":         "nocolon",
+		"only:1":          "only", // one colon: strips the trailing segment
+	}
+	for in, want := range cases {
+		if got := fileOfPosition(in); got != want {
+			t.Errorf("fileOfPosition(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// resp is a small helper to build a positioned response.
+func resp(status int, file string, line int) *ResponseInfo {
+	return &ResponseInfo{StatusCode: status, BodyType: "T", File: file, Line: line}
+}
+
+func TestSplitRouteByMethodBranches_Scoping(t *testing.T) {
+	const handlerFile = "handler.go"
+	branches := []metadata.MethodBranch{
+		{Methods: []string{"GET"}, StartLine: 10, EndLine: 12},
+		{Methods: []string{"POST"}, StartLine: 13, EndLine: 18},
+	}
+	route := &RouteInfo{
+		Path:     "/users",
+		Method:   "POST",
+		Function: "pkg.usersHandler",
+		Package:  "pkg",
+		Response: map[string]*ResponseInfo{
+			"200": resp(200, handlerFile, 11), // inside GET branch
+			"201": resp(201, handlerFile, 15), // inside POST branch
+			"405": resp(405, handlerFile, 20), // inside handler, no branch (default arm) -> dropped
+			"500": resp(500, "helper.go", 3),  // other file (shared helper) -> all methods
+		},
+		Request: &RequestInfo{BodyType: "CreateReq", File: handlerFile, Line: 14}, // POST branch
+	}
+
+	got := splitRouteByMethodBranches(route, branches, handlerFile)
+	if len(got) != 2 {
+		t.Fatalf("want 2 method routes, got %d", len(got))
+	}
+	byMethod := map[string]*RouteInfo{}
+	for _, r := range got {
+		byMethod[r.Method] = r
+	}
+
+	get, post := byMethod["GET"], byMethod["POST"]
+	if get == nil || post == nil {
+		t.Fatalf("missing method route(s): %+v", byMethod)
+	}
+
+	statuses := func(r *RouteInfo) []string {
+		var s []string
+		for slot := range r.Response {
+			s = append(s, slot)
+		}
+		sort.Strings(s)
+		return s
+	}
+
+	// GET: its own 200 + the shared 500; NOT the POST 201, NOT the default 405.
+	if want := []string{"200", "500"}; !equalStrs(statuses(get), want) {
+		t.Errorf("GET statuses = %v, want %v", statuses(get), want)
+	}
+	if get.Request != nil {
+		t.Errorf("GET should have no request body (Decode is in POST branch), got %+v", get.Request)
+	}
+	// POST: its own 201 + shared 500 + the request body; NOT GET's 200, NOT 405.
+	if want := []string{"201", "500"}; !equalStrs(statuses(post), want) {
+		t.Errorf("POST statuses = %v, want %v", statuses(post), want)
+	}
+	if post.Request == nil {
+		t.Errorf("POST should carry the request body")
+	}
+	// operationId suffixes keep the split unique.
+	if get.OperationIDSuffix != "GET" || post.OperationIDSuffix != "POST" {
+		t.Errorf("operationId suffixes = %q/%q, want GET/POST", get.OperationIDSuffix, post.OperationIDSuffix)
+	}
+}
+
+func TestSplitRouteByMethodBranches_MultiMethodBranch(t *testing.T) {
+	branches := []metadata.MethodBranch{
+		{Methods: []string{"GET", "HEAD"}, StartLine: 5, EndLine: 6},
+	}
+	route := &RouteInfo{
+		Method:   "POST",
+		Function: "pkg.ping",
+		Response: map[string]*ResponseInfo{"200": resp(200, "h.go", 6)},
+	}
+	got := splitRouteByMethodBranches(route, branches, "h.go")
+	if len(got) != 2 {
+		t.Fatalf("want GET+HEAD = 2 routes, got %d", len(got))
+	}
+	for _, r := range got {
+		if r.Method != "GET" && r.Method != "HEAD" {
+			t.Errorf("unexpected method %q", r.Method)
+		}
+		if _, ok := r.Response["200"]; !ok {
+			t.Errorf("%s missing the shared 200 response", r.Method)
+		}
+	}
+}
+
+// TestSplitMethodDispatchRoutes_SplitsDispatchHandler drives the full split
+// path via real (hand-built) metadata: a handler whose Function carries a
+// MethodDispatch is expanded into one route per method with scoped responses.
+func TestSplitMethodDispatchRoutes_SplitsDispatchHandler(t *testing.T) {
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	meta.Packages = map[string]*metadata.Package{
+		"pkg": {Files: map[string]*metadata.File{
+			"h.go": {Functions: map[string]*metadata.Function{
+				"usersHandler": {
+					Position: meta.StringPool.Get("h.go:1:1"),
+					MethodDispatch: []metadata.MethodBranch{
+						{Methods: []string{"GET"}, StartLine: 2, EndLine: 3},
+						{Methods: []string{"POST"}, StartLine: 4, EndLine: 6},
+					},
+				},
+			}},
+		}},
+	}
+	route := &RouteInfo{
+		Path: "/users", Method: "POST",
+		Function: "pkg.usersHandler", Package: "pkg",
+		Metadata: meta,
+		Response: map[string]*ResponseInfo{
+			"200": resp(200, "h.go", 2), // GET branch
+			"201": resp(201, "h.go", 5), // POST branch
+		},
+	}
+	got := splitMethodDispatchRoutes([]*RouteInfo{route})
+	if len(got) != 2 {
+		t.Fatalf("want 2 routes after split, got %d", len(got))
+	}
+	byMethod := map[string]*RouteInfo{}
+	for _, r := range got {
+		byMethod[r.Method] = r
+	}
+	if byMethod["GET"] == nil || byMethod["POST"] == nil {
+		t.Fatalf("want GET and POST routes, got %v", byMethod)
+	}
+	if _, ok := byMethod["GET"].Response["200"]; !ok {
+		t.Errorf("GET should own the 200 response")
+	}
+	if _, ok := byMethod["POST"].Response["201"]; !ok {
+		t.Errorf("POST should own the 201 response")
+	}
+	if _, ok := byMethod["GET"].Response["201"]; ok {
+		t.Errorf("GET should not carry the POST-branch 201")
+	}
+}
+
+// splitMethodDispatchRoutes must pass through routes whose handler has no
+// dispatch (or no resolvable metadata) unchanged.
+func TestSplitMethodDispatchRoutes_PassThrough(t *testing.T) {
+	routes := []*RouteInfo{
+		{Path: "/a", Method: "GET", Function: "pkg.plain"}, // nil Metadata -> not dispatch
+	}
+	got := splitMethodDispatchRoutes(routes)
+	if len(got) != 1 || got[0] != routes[0] {
+		t.Errorf("non-dispatch route should pass through unchanged, got %+v", got)
+	}
+}
+
+func equalStrs(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/spec/method_dispatch_test.go
+++ b/internal/spec/method_dispatch_test.go
@@ -162,6 +162,35 @@ func TestSplitMethodDispatchRoutes_SplitsDispatchHandler(t *testing.T) {
 	}
 }
 
+// TestSplitMethodDispatchRoutes_SkipsExplicitMethod verifies that a route
+// registered with a concrete verb (MethodExplicit) is NOT split even when its
+// handler happens to branch on r.Method — the router only routes that one verb
+// to the handler.
+func TestSplitMethodDispatchRoutes_SkipsExplicitMethod(t *testing.T) {
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	meta.Packages = map[string]*metadata.Package{
+		"pkg": {Files: map[string]*metadata.File{
+			"h.go": {Functions: map[string]*metadata.Function{
+				"h": {
+					Position: meta.StringPool.Get("h.go:1:1"),
+					MethodDispatch: []metadata.MethodBranch{
+						{Methods: []string{"GET"}, StartLine: 2, EndLine: 3},
+						{Methods: []string{"POST"}, StartLine: 4, EndLine: 6},
+					},
+				},
+			}},
+		}},
+	}
+	route := &RouteInfo{
+		Path: "/x", Method: "GET", MethodExplicit: true, // e.g. router.GET("/x", h)
+		Function: "pkg.h", Package: "pkg", Metadata: meta,
+	}
+	got := splitMethodDispatchRoutes([]*RouteInfo{route})
+	if len(got) != 1 || got[0].Method != "GET" {
+		t.Errorf("explicit-method route must not split; got %d routes %+v", len(got), got)
+	}
+}
+
 // splitMethodDispatchRoutes must pass through routes whose handler has no
 // dispatch (or no resolvable metadata) unchanged.
 func TestSplitMethodDispatchRoutes_PassThrough(t *testing.T) {

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -246,6 +246,7 @@ func (r *RoutePatternMatcherImpl) extractRouteDetails(node TrackerNodeInterface,
 	if r.pattern.MethodFromCall {
 		funcName := r.contextProvider.GetString(edge.Callee.Name)
 		routeInfo.Method = r.extractMethodFromFunctionNameWithConfig(funcName, r.pattern.MethodExtraction)
+		routeInfo.MethodExplicit = true
 		found = true
 	} else if r.pattern.MethodFromHandler && r.pattern.HandlerFromArg && len(edge.Args) > r.pattern.HandlerArgIndex {
 		// Extract method from handler function name
@@ -253,6 +254,7 @@ func (r *RoutePatternMatcherImpl) extractRouteDetails(node TrackerNodeInterface,
 		handlerName := r.contextProvider.GetArgumentInfo(handlerArg)
 		if handlerName != "" {
 			routeInfo.Method = r.extractMethodFromFunctionNameWithConfig(handlerName, r.pattern.MethodExtraction)
+			routeInfo.MethodExplicit = true
 			found = true
 		}
 	} else if r.pattern.MethodArgIndex >= 0 && len(edge.Args) > r.pattern.MethodArgIndex {
@@ -267,6 +269,7 @@ func (r *RoutePatternMatcherImpl) extractRouteDetails(node TrackerNodeInterface,
 			// Check if it's a valid HTTP method
 			if r.isValidHTTPMethod(cleanMethod) {
 				routeInfo.Method = strings.ToUpper(cleanMethod)
+				routeInfo.MethodExplicit = true
 				found = true
 			} else {
 				// If not a valid method, try to extract from argument info
@@ -275,6 +278,7 @@ func (r *RoutePatternMatcherImpl) extractRouteDetails(node TrackerNodeInterface,
 					cleanArgInfo := strings.Trim(argInfo, "\"'")
 					if r.isValidHTTPMethod(cleanArgInfo) {
 						routeInfo.Method = strings.ToUpper(cleanArgInfo)
+						routeInfo.MethodExplicit = true
 						found = true
 					}
 				}
@@ -284,6 +288,7 @@ func (r *RoutePatternMatcherImpl) extractRouteDetails(node TrackerNodeInterface,
 		// If we still don't have a method, try to infer from context (if enabled)
 		if routeInfo.Method == "" && r.pattern.MethodExtraction != nil && r.pattern.MethodExtraction.InferFromContext {
 			routeInfo.Method = r.inferMethodFromContext(node, edge)
+			routeInfo.MethodExplicit = true
 			found = true
 		}
 	}
@@ -297,6 +302,7 @@ func (r *RoutePatternMatcherImpl) extractRouteDetails(node TrackerNodeInterface,
 		if r.pattern.MethodFromPath {
 			if method, rest := splitMethodFromPath(path); method != "" {
 				routeInfo.Method = method
+				routeInfo.MethodExplicit = true
 				path = rest
 			}
 			path = normalizeServeMuxPath(path)

--- a/testdata/method_switch/go.mod
+++ b/testdata/method_switch/go.mod
@@ -1,0 +1,3 @@
+module github.com/ehabterra/apispec/testdata/method_switch
+
+go 1.22

--- a/testdata/method_switch/main.go
+++ b/testdata/method_switch/main.go
@@ -1,0 +1,61 @@
+// Package main exercises control-flow method dispatch: a single net/http
+// handler registered without a verb that branches on r.Method (via switch or
+// if) must split into one OpenAPI operation per HTTP method, with each branch's
+// request/response attributed to its own method.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type User struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+type CreateUserRequest struct {
+	Name string `json:"name"`
+}
+
+// usersHandler dispatches on r.Method with a switch: GET lists users, POST
+// creates one (with a request body and a 201), and default rejects.
+func usersHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		json.NewEncoder(w).Encode([]User{})
+	case http.MethodPost:
+		var req CreateUserRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(User{})
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+// itemHandler dispatches on r.Method with an if/else-if chain: GET returns a
+// user, DELETE returns 204 No Content.
+func itemHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodGet {
+		json.NewEncoder(w).Encode(User{})
+	} else if r.Method == http.MethodDelete {
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// pingHandler uses a single case that lists multiple methods; both GET and HEAD
+// map to the same 200 branch.
+func pingHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet, http.MethodHead:
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+func main() {
+	http.HandleFunc("/users", usersHandler)
+	http.HandleFunc("/item", itemHandler)
+	http.HandleFunc("/ping", pingHandler)
+	http.ListenAndServe(":8080", nil)
+}


### PR DESCRIPTION
## What

A single `net/http` handler registered without a verb (`http.HandleFunc("/users", h)`) that branches on `r.Method` — via `switch r.Method { case http.MethodGet: … }` or an `if r.Method == … else if …` chain — was collapsed to a single default `POST` operation. It now **splits into one OpenAPI operation per HTTP method**, with each branch's request body and responses attributed to its own method.

Closes the "HTTP methods set via switch/if around `net/http.Handle`/`HandleFunc` — not detected" gap.

### Example

```go
func usersHandler(w http.ResponseWriter, r *http.Request) {
    switch r.Method {
    case http.MethodGet:
        json.NewEncoder(w).Encode([]User{})
    case http.MethodPost:
        var req CreateUserRequest
        _ = json.NewDecoder(r.Body).Decode(&req)
        w.WriteHeader(http.StatusCreated)
        json.NewEncoder(w).Encode(User{})
    }
}
http.HandleFunc("/users", usersHandler)
```

**Before:** `POST /users` only. **After:** `GET /users` (array of `User`) **and** `POST /users` (`CreateUserRequest` body → `201 User`).

## How

- **`internal/metadata/method_dispatch.go`** — a targeted AST detector records one `MethodBranch{methods, line-range}` per arm. Verbs resolve through the type checker's constant value (`info.Types[expr].Value`), so `http.MethodGet`, a bare `"GET"` literal, and a project-local const all fold uniformly; the request operand is identified by type (`*net/http.Request`), robust to naming. Recorded on `metadata.Function.MethodDispatch` (`omitempty` — non-dispatch handlers carry nothing, so no golden drift).
- **`internal/spec/method_dispatch.go`** — after route extraction, a handler with `MethodDispatch` is expanded into one route per verb. Request/response are scoped to a branch by **source-position containment** (`ResponseInfo`/`RequestInfo` now carry `File`+`Line`): a call inside the handler goes to the branch that contains it; one in another file (shared helper) or unlocated goes to every method; one inside the handler but outside every branch (the `default:` arm) is dropped. operationIds stay unique via a method suffix.

This is a deliberately **narrow, targeted** mechanism (an AST pattern-detector + line-range scoping), not a general control-flow graph — so it can be superseded cleanly if a broader CFG lands.

## Tests & coverage

- `testdata/method_switch/` + `TestTestdata_MethodSwitch` — per-method operations, per-branch request/response attribution, unique operationIds, bodyless `DELETE`.
- Detector unit tests: switch / if-chain / multi-method case / string literals / reversed comparison / `!=` / non-dispatch / nil / line ranges.
- Split unit tests: scoping / cross-file-shared / default-arm drop / multi-method / full-split via metadata / pass-through.
- Structural row in `TestTestdata_Frameworks`.
- New code **90–100%** covered. Full suite passes; `golangci-lint` clean; deterministic.

## Known limitations (intentionally narrow)

- Two branches returning the **same status code** with different bodies — the shared status slot keeps one.
- Dispatch inside a **receiver-method** handler (`func (h *H) ServeHTTP(w, r)`) — only top-level function handlers are split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Go HTTP handlers that branch on `r.Method` are now recognized and represented as separate OpenAPI operations for each supported HTTP method.
  - Request bodies and responses are attributed to the appropriate method-specific operation.
  - Generated operation IDs remain unique across split operations.

- **Documentation**
  - Updated Go language support documentation to describe HTTP method dispatch detection.

- **Tests**
  - Added coverage for `switch` and `if` method dispatch, multiple verbs, and method-specific request/response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->