### PR TITLE
ci: fix coverage badge for protected main (shields endpoint on badges branch)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write   # <-- Needed for pushing changes
+  contents: write   # push the badge data to the `badges` branch
 
 jobs:
   coverage:
@@ -16,38 +16,34 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
         go-version: '1.26.2'
 
-    - name: Make script executable
-      run: chmod +x scripts/update-coverage-badge.sh
-
-    - name: Run coverage badge update script
-      run: ./scripts/update-coverage-badge.sh
-
-    - name: Commit and push changes
+    - name: Compute coverage badge data
       run: |
-        # Configure git
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        
-        # Add changes
-        git add README.md
-        
-        # Check if there are changes to commit
-        if git diff --quiet && git diff --staged --quiet; then
-          echo "No changes to commit"
-        else
-          echo "Committing changes..."
-          git commit -m "Update coverage badge"
-          
-          # Push changes to main branch
-          echo "Pushing to main branch"
-          git push origin main
-        fi
+        chmod +x scripts/update-coverage-badge.sh
+        ./scripts/update-coverage-badge.sh
+
+    - name: Publish badge data to the badges branch
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        # The badge lives on a dedicated, unprotected `badges` branch as a
+        # shields.io endpoint file, so updating it never touches the protected
+        # main branch. Build the branch in a throwaway repo and force-push it
+        # (badge data has no history worth keeping).
+        tmp="$(mktemp -d)"
+        cp coverage.json "$tmp/coverage.json"
+        cd "$tmp"
+        git init -q
+        git config user.email "action@github.com"
+        git config user.name "GitHub Action"
+        git checkout -q -b badges
+        git add coverage.json
+        git commit -q -m "Update coverage badge data"
+        git push -q --force \
+          "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+          badges

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ output.txt
 test_output.txt
 coverage.txt
 coverage.html
+coverage.json
 
 /apispec
 /apidiag

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # APISpec: Generate OpenAPI from Go code
 
-[![Coverage](https://img.shields.io/badge/coverage-68.5%25-yellowgreen.svg)](https://github.com/ehabterra/apispec)
+[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ehabterra/apispec/badges/coverage.json)](https://github.com/ehabterra/apispec/actions/workflows/coverage.yml)
 [![Go Version](https://img.shields.io/badge/go-1.26+-00ADD8?style=flat&logo=go)](https://go.dev/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/ehabterra/apispec/blob/main/LICENSE)
 [![GitHub Actions](https://img.shields.io/github/actions/workflow/status/ehabterra/apispec/ci.yml?branch=main&label=CI&logo=github)](https://github.com/ehabterra/apispec/actions/workflows/ci.yml)

--- a/scripts/update-coverage-badge.sh
+++ b/scripts/update-coverage-badge.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 set -euo pipefail
 
+# Computes library test coverage and writes a shields.io "endpoint" badge file
+# (coverage.json). The CI workflow publishes that file to the unprotected
+# `badges` branch, and the README badge reads it from there — so the coverage
+# badge never requires a commit to the protected main branch.
+
 COVERAGE_FILE="coverage.txt"
-README_FILE="README.md"
-THRESHOLD=45  # Minimum acceptable coverage %
+BADGE_FILE="coverage.json"
+THRESHOLD=45 # Minimum acceptable coverage %
 
 # Library packages only. The cmd/* mains (notably cmd/apispecui's ~1400-line
 # main.go) and the root main are CLI glue with no unit tests; counting their
@@ -21,39 +26,29 @@ COVERAGE=$(go tool cover -func=$COVERAGE_FILE | grep total | awk '{print substr(
 # three-band cliff, so the colour tracks coverage smoothly. For a tool whose
 # CLI/UI glue is intentionally left untested, library coverage in the 65–80%
 # range is healthy and should read green-ish, not alarming red.
-if (( $(echo "$COVERAGE >= 90" | bc -l) )); then
-    COLOR="brightgreen"
-elif (( $(echo "$COVERAGE >= 75" | bc -l) )); then
-    COLOR="green"
-elif (( $(echo "$COVERAGE >= 65" | bc -l) )); then
-    COLOR="yellowgreen"
-elif (( $(echo "$COVERAGE >= 50" | bc -l) )); then
-    COLOR="yellow"
-elif (( $(echo "$COVERAGE >= 40" | bc -l) )); then
-    COLOR="orange"
+if (($(echo "$COVERAGE >= 90" | bc -l))); then
+	COLOR="brightgreen"
+elif (($(echo "$COVERAGE >= 75" | bc -l))); then
+	COLOR="green"
+elif (($(echo "$COVERAGE >= 65" | bc -l))); then
+	COLOR="yellowgreen"
+elif (($(echo "$COVERAGE >= 50" | bc -l))); then
+	COLOR="yellow"
+elif (($(echo "$COVERAGE >= 40" | bc -l))); then
+	COLOR="orange"
 else
-    COLOR="red"
+	COLOR="red"
 fi
 
 # Enforce coverage threshold
-if (( $(echo "$COVERAGE < $THRESHOLD" | bc -l) )); then
-    echo "Coverage ($COVERAGE%) is below threshold ($THRESHOLD%). Failing."
-    exit 1
+if (($(echo "$COVERAGE < $THRESHOLD" | bc -l))); then
+	echo "Coverage ($COVERAGE%) is below threshold ($THRESHOLD%). Failing."
+	exit 1
 fi
 
-# Prepare badge URL
-BADGE_URL="https://img.shields.io/badge/coverage-${COVERAGE}%25-${COLOR}.svg"
+# Write the shields.io endpoint badge data.
+cat >"$BADGE_FILE" <<JSON
+{"schemaVersion":1,"label":"coverage","message":"${COVERAGE}%","color":"${COLOR}"}
+JSON
 
-# Update or insert badge
-if grep -q "img.shields.io/badge/coverage" "$README_FILE"; then
-    echo "Updating coverage badge..."
-    sed -i.bak -E "s|!\[Coverage\]\(https://img.shields.io/badge/coverage-[0-9]+(\.[0-9]+)?%25-[a-z]+\.svg\)|![Coverage](${BADGE_URL})|" "$README_FILE"
-else
-    echo "Adding new coverage badge after the title..."
-    # Insert badge after first title line (starts with '# ')
-    awk -v badge="![Coverage](${BADGE_URL})" '
-    NR==1 {print; print ""; print badge; next} {print}
-    ' "$README_FILE" > "${README_FILE}.tmp" && mv "${README_FILE}.tmp" "$README_FILE"
-fi
-
-echo "Coverage updated: ${COVERAGE}% (${COLOR})"
+echo "Coverage: ${COVERAGE}% (${COLOR}) -> ${BADGE_FILE}"


### PR DESCRIPTION
## Problem

The **Coverage Badge** workflow baked the coverage % into the README badge URL and `git push`ed the change to `main`. Now that `main` is protected, that push is rejected — the badge job can no longer update.

## Fix

Switch to a shields.io **endpoint badge** whose data lives on a dedicated, unprotected `badges` branch, so updating the badge never touches `main`:

- **`scripts/update-coverage-badge.sh`** now writes `coverage.json` (shields endpoint schema `{schemaVersion, label, message, color}`) instead of editing README. Coverage computation, the graduated colour scale, and the 45% threshold gate are unchanged.
- **`.github/workflows/coverage.yml`** force-pushes `coverage.json` to the `badges` branch from a throwaway repo (`git init` in a temp dir) — it never commits to `main`.
- **README** badge reads the endpoint from `raw.githubusercontent.com/.../badges/coverage.json`, so the URL is static and never needs another commit.
- **`.gitignore`**: `coverage.json`.

## Verified

- Script produces valid endpoint JSON: `{"schemaVersion":1,"label":"coverage","message":"68.8%","color":"yellowgreen"}`.
- The `badges` branch is **seeded** so the badge resolves immediately (no broken-badge window): `raw.githubusercontent.com/.../badges/coverage.json` returns 200 and `img.shields.io/endpoint?...` renders 200.

No new secrets required (`GITHUB_TOKEN` with `contents: write` can push to the unprotected `badges` branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dynamic coverage badge that displays the latest test coverage percentage and status color.
  * Coverage badge data is now published automatically when changes are pushed to the main branch or coverage is manually generated.

* **Documentation**
  * Updated the README to use the new live coverage badge instead of a static percentage.

* **Chores**
  * Coverage output files are now excluded from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->