### PR TITLE
Revert coverage badges-branch approach (use Actions-bot bypass instead)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write   # push the badge data to the `badges` branch
+  contents: write   # <-- Needed for pushing changes
 
 jobs:
   coverage:
@@ -16,34 +16,38 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
         go-version: '1.26.2'
 
-    - name: Compute coverage badge data
-      run: |
-        chmod +x scripts/update-coverage-badge.sh
-        ./scripts/update-coverage-badge.sh
+    - name: Make script executable
+      run: chmod +x scripts/update-coverage-badge.sh
 
-    - name: Publish badge data to the badges branch
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Run coverage badge update script
+      run: ./scripts/update-coverage-badge.sh
+
+    - name: Commit and push changes
       run: |
-        # The badge lives on a dedicated, unprotected `badges` branch as a
-        # shields.io endpoint file, so updating it never touches the protected
-        # main branch. Build the branch in a throwaway repo and force-push it
-        # (badge data has no history worth keeping).
-        tmp="$(mktemp -d)"
-        cp coverage.json "$tmp/coverage.json"
-        cd "$tmp"
-        git init -q
-        git config user.email "action@github.com"
-        git config user.name "GitHub Action"
-        git checkout -q -b badges
-        git add coverage.json
-        git commit -q -m "Update coverage badge data"
-        git push -q --force \
-          "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
-          badges
+        # Configure git
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        
+        # Add changes
+        git add README.md
+        
+        # Check if there are changes to commit
+        if git diff --quiet && git diff --staged --quiet; then
+          echo "No changes to commit"
+        else
+          echo "Committing changes..."
+          git commit -m "Update coverage badge"
+          
+          # Push changes to main branch
+          echo "Pushing to main branch"
+          git push origin main
+        fi

--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,6 @@ output.txt
 test_output.txt
 coverage.txt
 coverage.html
-coverage.json
 
 /apispec
 /apidiag

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # APISpec: Generate OpenAPI from Go code
 
-[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ehabterra/apispec/badges/coverage.json)](https://github.com/ehabterra/apispec/actions/workflows/coverage.yml)
+[![Coverage](https://img.shields.io/badge/coverage-68.5%25-yellowgreen.svg)](https://github.com/ehabterra/apispec)
 [![Go Version](https://img.shields.io/badge/go-1.26+-00ADD8?style=flat&logo=go)](https://go.dev/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/ehabterra/apispec/blob/main/LICENSE)
 [![GitHub Actions](https://img.shields.io/github/actions/workflow/status/ehabterra/apispec/ci.yml?branch=main&label=CI&logo=github)](https://github.com/ehabterra/apispec/actions/workflows/ci.yml)

--- a/scripts/update-coverage-badge.sh
+++ b/scripts/update-coverage-badge.sh
@@ -1,14 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
-# Computes library test coverage and writes a shields.io "endpoint" badge file
-# (coverage.json). The CI workflow publishes that file to the unprotected
-# `badges` branch, and the README badge reads it from there — so the coverage
-# badge never requires a commit to the protected main branch.
-
 COVERAGE_FILE="coverage.txt"
-BADGE_FILE="coverage.json"
-THRESHOLD=45 # Minimum acceptable coverage %
+README_FILE="README.md"
+THRESHOLD=45  # Minimum acceptable coverage %
 
 # Library packages only. The cmd/* mains (notably cmd/apispecui's ~1400-line
 # main.go) and the root main are CLI glue with no unit tests; counting their
@@ -26,29 +21,39 @@ COVERAGE=$(go tool cover -func=$COVERAGE_FILE | grep total | awk '{print substr(
 # three-band cliff, so the colour tracks coverage smoothly. For a tool whose
 # CLI/UI glue is intentionally left untested, library coverage in the 65–80%
 # range is healthy and should read green-ish, not alarming red.
-if (($(echo "$COVERAGE >= 90" | bc -l))); then
-	COLOR="brightgreen"
-elif (($(echo "$COVERAGE >= 75" | bc -l))); then
-	COLOR="green"
-elif (($(echo "$COVERAGE >= 65" | bc -l))); then
-	COLOR="yellowgreen"
-elif (($(echo "$COVERAGE >= 50" | bc -l))); then
-	COLOR="yellow"
-elif (($(echo "$COVERAGE >= 40" | bc -l))); then
-	COLOR="orange"
+if (( $(echo "$COVERAGE >= 90" | bc -l) )); then
+    COLOR="brightgreen"
+elif (( $(echo "$COVERAGE >= 75" | bc -l) )); then
+    COLOR="green"
+elif (( $(echo "$COVERAGE >= 65" | bc -l) )); then
+    COLOR="yellowgreen"
+elif (( $(echo "$COVERAGE >= 50" | bc -l) )); then
+    COLOR="yellow"
+elif (( $(echo "$COVERAGE >= 40" | bc -l) )); then
+    COLOR="orange"
 else
-	COLOR="red"
+    COLOR="red"
 fi
 
 # Enforce coverage threshold
-if (($(echo "$COVERAGE < $THRESHOLD" | bc -l))); then
-	echo "Coverage ($COVERAGE%) is below threshold ($THRESHOLD%). Failing."
-	exit 1
+if (( $(echo "$COVERAGE < $THRESHOLD" | bc -l) )); then
+    echo "Coverage ($COVERAGE%) is below threshold ($THRESHOLD%). Failing."
+    exit 1
 fi
 
-# Write the shields.io endpoint badge data.
-cat >"$BADGE_FILE" <<JSON
-{"schemaVersion":1,"label":"coverage","message":"${COVERAGE}%","color":"${COLOR}"}
-JSON
+# Prepare badge URL
+BADGE_URL="https://img.shields.io/badge/coverage-${COVERAGE}%25-${COLOR}.svg"
 
-echo "Coverage: ${COVERAGE}% (${COLOR}) -> ${BADGE_FILE}"
+# Update or insert badge
+if grep -q "img.shields.io/badge/coverage" "$README_FILE"; then
+    echo "Updating coverage badge..."
+    sed -i.bak -E "s|!\[Coverage\]\(https://img.shields.io/badge/coverage-[0-9]+(\.[0-9]+)?%25-[a-z]+\.svg\)|![Coverage](${BADGE_URL})|" "$README_FILE"
+else
+    echo "Adding new coverage badge after the title..."
+    # Insert badge after first title line (starts with '# ')
+    awk -v badge="![Coverage](${BADGE_URL})" '
+    NR==1 {print; print ""; print badge; next} {print}
+    ' "$README_FILE" > "${README_FILE}.tmp" && mv "${README_FILE}.tmp" "$README_FILE"
+fi
+
+echo "Coverage updated: ${COVERAGE}% (${COLOR})"


### PR DESCRIPTION
Reverts #106. We're going with an **Actions-bot bypass** of branch protection instead of a dedicated `badges` branch, so the Coverage Badge workflow keeps committing the badge directly to `main`.

Restores the original approach:
- `README.md` — static shields coverage badge.
- `scripts/update-coverage-badge.sh` — edits the README badge in place.
- `.github/workflows/coverage.yml` — commits `README.md` and pushes to `main`.
- `.gitignore` — drops the `coverage.json` entry.

This also immediately fixes the currently-broken badge (main still points at the now-deleted `badges` branch).

### Required repo setting (manual)
For the workflow's `git push origin main` to succeed under branch protection, allow the Actions bot to bypass:
- **Rulesets** (Settings → Rules → Rulesets → your `main` ruleset → **Bypass list** → add the bypass actor), **or**
- **Classic protection** (Settings → Branches → `main` rule): uncheck "Do not allow bypassing the above settings" and ensure the push isn't blocked by "Restrict who can push."

If the default `GITHUB_TOKEN` can't be granted bypass in your setup, use a PAT / GitHub App token in the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)