### PR TITLE
ci(coverage): push badge commit with a PAT so it works under branch protection

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,11 @@ jobs:
       uses: actions/checkout@v6
       with:
         fetch-depth: 0
-        token: ${{ secrets.GITHUB_TOKEN }}
+        # BADGE_TOKEN is a PAT (or GitHub App token) whose owner is allowed to
+        # bypass branch protection on main — the default GITHUB_TOKEN cannot be
+        # granted that bypass, so the badge commit below would be rejected.
+        # actions/checkout persists this token, so `git push` uses it too.
+        token: ${{ secrets.BADGE_TOKEN }}
 
     - name: Set up Go
       uses: actions/setup-go@v6
@@ -45,8 +49,10 @@ jobs:
           echo "No changes to commit"
         else
           echo "Committing changes..."
-          git commit -m "Update coverage badge"
-          
+          # [skip ci] stops this push from re-triggering the workflow — a PAT
+          # push (unlike GITHUB_TOKEN) would otherwise fire it again.
+          git commit -m "Update coverage badge [skip ci]"
+
           # Push changes to main branch
           echo "Pushing to main branch"
           git push origin main


### PR DESCRIPTION
Follow-up to the badge revert (#107). The restored workflow commits the coverage badge to `main` with the default `GITHUB_TOKEN`, which branch protection rejects and **cannot** be granted a bypass. Switch the badge job to a PAT whose owner *can* bypass.

## Changes
- `coverage.yml` checkout uses `token: ${{ secrets.BADGE_TOKEN }}` (actions/checkout persists it, so `git push origin main` uses it too).
- The auto-commit message gets `[skip ci]` so the PAT push doesn't re-trigger the workflow (a PAT push, unlike `GITHUB_TOKEN`, would otherwise fire it again).

## Required setup (one-time, manual)
1. Create a **fine-grained PAT**: Settings → Developer settings → Fine-grained tokens → this repo, permission **Contents: Read and write**. The token owner must be allowed to bypass `main`'s protection (a repo admin, with admin-bypass allowed, or added to the bypass list).
2. Add it as a repo secret named **`BADGE_TOKEN`** (Settings → Secrets and variables → Actions).

Once the secret exists and this PR merges, the next push to `main` updates the badge again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)