### PR TITLE
docs(auth): reconcile phase-3 status with phase-4 wiring

### DIFF
--- a/docs/AUTH_DETECTION_DESIGN.md
+++ b/docs/AUTH_DETECTION_DESIGN.md
@@ -316,8 +316,8 @@ paths:
    `Extractor.securityMatchers`) + identity resolver in security.go
    (`MiddlewareRef`, `middlewareRefFromArg` for ident/selector/call,
    `SecurityMapping.matches`, `resolveSecurity` with AND-merge / OR-alternatives
-   / public / unresolved + dedup). Unit-tested in security_test.go. Not yet
-   called from traversal (phase 4).
+   / public / unresolved + dedup). Unit-tested in security_test.go. Wired into
+   traversal by phase 4 (below).
 4. ✓ DONE — Traversal propagation + `RouteInfo.Security`. Threads accumulated
    `[]MiddlewareRef` (not resolved reqs) through the traversal and resolves once
    per route via `applyRouteSecurity`. Router-scope (`Use`) is correlated to


### PR DESCRIPTION
Closes a stale-doc contradiction (GAP §5): `docs/AUTH_DETECTION_DESIGN.md` phase 3 was marked ✓ DONE but its note still said *"Not yet called from traversal (phase 4)"* — while phase 4 (traversal propagation) is DONE and provides exactly that wiring. Updated the note to "Wired into traversal by phase 4 (below)."

Docs-only, one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the phased implementation plan to reflect that security pattern matching is now integrated into traversal.
  * Clarified the current status of identity resolution and matcher integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->