### PR TITLE
feat: type model phase 3 — unify lookup and AST boundaries on TypeRef

### DIFF
--- a/docs/TYPE_MODEL.md
+++ b/docs/TYPE_MODEL.md
@@ -55,7 +55,7 @@ The type model is the single largest architectural change in the codebase
 (GAP #8), so it lands in phases, each independently shippable and each
 verified against the golden fixtures:
 
-**Phase 1 — foundation (this change).**
+**Phase 1 — foundation.** *(landed)*
 - `internal/typemodel` exists with the structured core, full unit coverage,
   and round-trip guarantees.
 - A boundary differential test
@@ -89,19 +89,41 @@ verified against the golden fixtures:
   `traceGenericOrigin`) consume `Parse(...).Core()` fields directly.
 - Deleted from `legacy.go` (no callers remain): `NormalizeInstance`,
   `ArgPackage`, `SimplifyArg`, `SimpleName`.
-- **Still on `ParseParts` deliberately** — everything feeding `typeByName` /
-  metadata type lookups (`findTypesInMetadata`, `generateStructSchema`'s key
-  parsing, `isInterfaceTypeName`, `lookupWrapperType`): metadata keys a
-  generic declaration *with* its parameter brackets (`"Page[T]"`, via
-  `getTypeName`), and `ParseParts`'s opaque-unqualified-generic quirk matches
-  that format where the structured core name (`"Page"`) would miss. This
-  lookup invariant is the phase-3 boundary: both sides must move together.
+- Everything feeding `typeByName`/metadata type lookups stayed on
+  `ParseParts` in this phase, pending the lookup-side migration below.
 
-**Phase 3 — metadata carries structure.**
-- `metadata.getTypeName` call sites move to `FromExpr(...).String()` (proven
-  byte-identical by the boundary test), then the interesting ones keep the
-  `TypeRef` instead of the string — `CallArgument`, `Field`, assignment and
-  return records — with the string pool retained as the serialization format.
+**Phase 3 — the lookup boundary and the AST boundary unify.** *(landed)*
+- *Correction discovered here:* the metadata `Types` map was **already keyed
+  by the bare declared name** (`tspec.Name.Name`; a generic declaration is
+  stored as `"Page"`, its parameters in `Type.TypeParams`) — the bracketed
+  `getTypeName(tspec)` form (`"Page[T]"`) is only the *methods-table* key
+  convention, matching how a generic method-receiver expression renders. The
+  phase-2 worry that the `ParseParts` opaque quirk was load-bearing for
+  lookups was wrong: the quirk merely made unqualified generic names *miss*.
+- All lookup sites migrated to the structured core: `typeByName` now takes
+  `(pkg, name)` and every caller (`findTypesInMetadata`,
+  `generateStructSchema`'s key parsing incl. the concrete-vs-declaration
+  argument split via `Constraint`, `isInterfaceTypeName`,
+  `lookupWrapperType`) parses with `typemodel.Parse(...).Core()`.
+- `metadata.getTypeName`'s expression cases delegate to
+  `FromExpr(...).String()` — one render path for every layer. Two shapes the
+  old stringifier lost are now recorded correctly, proven by
+  `TestMetadata_BoundaryShapeImprovements`:
+  - fixed-size array fields keep their length (`[4]byte`, feeding the
+    mapper's existing maxItems/maxLength handling) — previously `[]byte`;
+  - methods on multi-parameter generic types attach (an `IndexListExpr`
+    receiver like `Pair[K, V]` previously stringified to `""`, filing the
+    method under the empty key and losing it).
+  `TypeSpec`/`FieldList` (the methods-table naming convention) are the only
+  shapes still rendered locally.
+- Zero drift on all goldens and fixtures.
+
+**Phase 4 — metadata carries structure (remaining).**
+- The interesting metadata records keep the `TypeRef` instead of the string —
+  `CallArgument`, `Field`, assignment and return records — with the string
+  pool retained as the serialization format.
+- The ~60 remaining ad-hoc `*`/`[]` prefix-trims in `internal/spec` collapse
+  onto `Core()`/renderers as their surrounding code is touched.
 
 **End state.** Strings exist only at two boundaries: metadata serialization
 (string pool) and OpenAPI component naming (sanitizer over `Internal()`).

--- a/internal/metadata/boundary_shapes_test.go
+++ b/internal/metadata/boundary_shapes_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata_test
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"testing"
+
+	metadata "github.com/ehabterra/apispec/internal/metadata"
+	"golang.org/x/tools/go/packages"
+)
+
+// TestMetadata_BoundaryShapeImprovements locks in the two type shapes the
+// AST boundary lost before it rendered through the structured type model
+// (phase 3 of docs/TYPE_MODEL.md):
+//
+//   - a fixed-size array field recorded "[]byte" — the length was dropped, so
+//     the mapper could never emit maxItems/maxLength for it;
+//   - a method on a multi-parameter generic type vanished entirely — the
+//     receiver Pair[K, V] is an IndexListExpr, which stringified to "", so
+//     the method was filed under the empty key and never attached.
+func TestMetadata_BoundaryShapeImprovements(t *testing.T) {
+	fset := token.NewFileSet()
+
+	src := []testModule{{
+		Name: "shapes",
+		Files: map[string]interface{}{"main.go": `package main
+
+type Pair[K any, V any] struct {
+	First  K
+	Second V
+}
+
+func (p Pair[K, V]) Sum() string { return "" }
+
+type Packet struct {
+	Header [4]byte
+	Labels [2]string
+}
+
+func main() {}
+`}}}
+
+	cfg := exportModules(t, src)
+	cfg.Mode = packages.NeedName | packages.NeedFiles | packages.NeedSyntax | packages.NeedTypes | packages.NeedTypesInfo | packages.NeedImports
+	cfg.Fset = fset
+	cfg.Tests = false
+
+	pkgs, err := packages.Load(cfg, "./...")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pkgsMetadata := map[string]map[string]*ast.File{}
+	fileToInfo := map[*ast.File]*types.Info{}
+	importPaths := map[string]string{}
+	for _, pkg := range pkgs {
+		if pkg.PkgPath == "" {
+			continue
+		}
+		pkgsMetadata[pkg.PkgPath] = make(map[string]*ast.File)
+		for i, f := range pkg.Syntax {
+			if i < len(pkg.GoFiles) {
+				pkgsMetadata[pkg.PkgPath][pkg.GoFiles[i]] = f
+				fileToInfo[f] = pkg.TypesInfo
+				importPaths[pkg.GoFiles[i]] = pkg.PkgPath
+			}
+		}
+	}
+
+	meta := metadata.GenerateMetadata(pkgsMetadata, fileToInfo, importPaths, fset)
+
+	str := func(id int) string { return meta.StringPool.GetString(id) }
+	findType := func(name string) *metadata.Type {
+		for _, pkg := range meta.Packages {
+			for _, file := range pkg.Files {
+				if typ, ok := file.Types[name]; ok {
+					return typ
+				}
+			}
+		}
+		return nil
+	}
+
+	// Fixed-size array fields keep their length.
+	packet := findType("Packet")
+	if packet == nil {
+		t.Fatal("Packet type not found")
+	}
+	fieldTypes := map[string]string{}
+	for _, f := range packet.Fields {
+		fieldTypes[str(f.Name)] = str(f.Type)
+	}
+	if fieldTypes["Header"] != "[4]byte" {
+		t.Errorf("Packet.Header type = %q, want \"[4]byte\" (length preserved)", fieldTypes["Header"])
+	}
+	if fieldTypes["Labels"] != "[2]string" {
+		t.Errorf("Packet.Labels type = %q, want \"[2]string\" (length preserved)", fieldTypes["Labels"])
+	}
+
+	// Methods on a multi-parameter generic type attach to it.
+	pair := findType("Pair")
+	if pair == nil {
+		t.Fatal("Pair type not found")
+	}
+	var methods []string
+	for _, m := range pair.Methods {
+		methods = append(methods, str(m.Name))
+	}
+	found := false
+	for _, m := range methods {
+		if m == "Sum" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("Pair methods = %v, want Sum attached (IndexListExpr receiver)", methods)
+	}
+}

--- a/internal/metadata/helpers.go
+++ b/internal/metadata/helpers.go
@@ -20,6 +20,8 @@ import (
 	"go/token"
 	"go/types"
 	"strings"
+
+	"github.com/ehabterra/apispec/internal/typemodel"
 )
 
 const (
@@ -27,13 +29,22 @@ const (
 	defaultScopeUnexported = "unexported"
 )
 
-// getTypeName extracts a type name from an AST expression
+// getTypeName extracts a type name from an AST node. Type expressions render
+// through the structured type model (typemodel.FromExpr), so every layer
+// parses and prints types through one code path; only the two non-expression
+// node shapes stay here:
+//
+//   - *ast.TypeSpec renders with its declared parameter-NAME list (Page[T]) —
+//     the methods-table key convention, matching how a generic method
+//     receiver expression renders (allTypeMethods is keyed by both).
+//   - *ast.FieldList renders that bracketed name list.
+//
+// Note the Types map itself is keyed by the bare tspec.Name.Name, not this
+// bracketed form.
 func getTypeName(nd ast.Node, info *types.Info) string {
-	if nd == nil {
-		return ""
-	}
-
 	switch t := nd.(type) {
+	case nil:
+		return ""
 	case *ast.TypeSpec:
 		var list string
 
@@ -50,43 +61,9 @@ func getTypeName(nd ast.Node, info *types.Info) string {
 			}
 		}
 		return fmt.Sprintf("[%s]", strings.TrimSuffix(string(result), ", "))
-	case *ast.Ident:
-		return t.Name
-	case *ast.StarExpr:
-		return "*" + getTypeName(t.X, info)
-	case *ast.IndexExpr:
-		return fmt.Sprintf("%s[%s]", getTypeName(t.X, info), getTypeName(t.Index, info))
-	case *ast.SelectorExpr:
-		if x, ok := t.X.(*ast.Ident); ok {
-			if obj := info.ObjectOf(x); obj != nil {
-				if pkg, ok := obj.(*types.PkgName); ok {
-					return pkg.Imported().Path() + "." + t.Sel.Name
-				}
-				return obj.Name() + "." + t.Sel.Name
-			}
-			return x.Name + "." + t.Sel.Name
-		}
-		return t.Sel.Name
-	case *ast.ArrayType:
-		return "[]" + getTypeName(t.Elt, info)
-	case *ast.MapType:
-		return "map[" + getTypeName(t.Key, info) + "]" + getTypeName(t.Value, info)
-	case *ast.InterfaceType:
-		return "interface{}"
-	case *ast.StructType:
-		// For nested struct types, we'll return a placeholder
-		// The actual structure will be captured in the Field.NestedType
-		return "struct{}"
-	case *ast.FuncType:
-		return "func"
-	case *ast.ChanType:
-		switch t.Dir {
-		case ast.SEND:
-			return "chan<- " + getTypeName(t.Value, info)
-		case ast.RECV:
-			return "<-chan " + getTypeName(t.Value, info)
-		}
-		return "chan " + getTypeName(t.Value, info)
+	}
+	if e, ok := nd.(ast.Expr); ok {
+		return typemodel.FromExpr(e, info).String()
 	}
 	return ""
 }

--- a/internal/metadata/typeref_boundary_test.go
+++ b/internal/metadata/typeref_boundary_test.go
@@ -25,14 +25,13 @@ import (
 	"github.com/ehabterra/apispec/internal/typemodel"
 )
 
-// TestFromExpr_MatchesGetTypeName is the boundary contract for the structured
-// type model: for every type-expression shape the legacy string stringifier
-// (getTypeName) understands, typemodel.FromExpr must produce a TypeRef whose
-// dotted rendering is byte-identical — so migrating a getTypeName call site to
-// FromExpr(...).String() cannot change metadata output. The two documented
-// divergences (below) are cases where the flat string *dropped* information
-// and the structured form keeps it.
-func TestFromExpr_MatchesGetTypeName(t *testing.T) {
+// TestBoundaryTypeNames characterizes the AST-boundary type rendering.
+// getTypeName's expression cases delegate to typemodel.FromExpr (phase 3 of
+// docs/TYPE_MODEL.md), so this pins the exact string every shape records into
+// metadata — including the two shapes the pre-typemodel stringifier lost:
+// array lengths ([4]byte used to record "[]byte") and multi-argument generic
+// instantiations (IndexListExpr used to record "").
+func TestBoundaryTypeNames(t *testing.T) {
 	src := `package p
 
 import "net/http"
@@ -75,14 +74,23 @@ var (
 		t.Fatalf("typecheck: %v", err)
 	}
 
-	// Vars whose flat-string form loses information; the structured form must
-	// keep it instead of matching.
-	better := map[string]string{
-		// getTypeName renders every array as a slice, dropping the length.
-		"m": "[4]byte",
-		// getTypeName has no IndexListExpr case at all: a multi-argument
-		// generic instantiation stringified to "".
-		"l": "Pair[int, string]",
+	want := map[string]string{
+		"a":  "int",
+		"b":  "*string",
+		"c":  "[]Local",
+		"d":  "map[string][]*int",
+		"e":  "chan int",
+		"f":  "chan<- int",
+		"g":  "<-chan int",
+		"h":  "interface{}",
+		"i":  "struct{}",
+		"j":  "func",
+		"k":  "Box[int]",
+		"l":  "Pair[int, string]",
+		"m":  "[4]byte",
+		"n":  "net/http.Handler",
+		"o":  "*net/http.Request",
+		"p2": "map[Local][]Box[Local]",
 	}
 
 	checked := 0
@@ -97,18 +105,22 @@ var (
 				continue
 			}
 			name := vspec.Names[0].Name
-			got := typemodel.FromExpr(vspec.Type, info).String()
-			if want, diverges := better[name]; diverges {
-				if got != want {
-					t.Errorf("var %s: FromExpr = %q, want the information-preserving %q", name, got, want)
-				}
-			} else if legacy := getTypeName(vspec.Type, info); got != legacy {
-				t.Errorf("var %s: FromExpr = %q, getTypeName = %q — boundary forms must agree", name, got, legacy)
+			expected, known := want[name]
+			if !known {
+				t.Errorf("var %s: no expectation in the table; add one", name)
+				continue
+			}
+			if got := getTypeName(vspec.Type, info); got != expected {
+				t.Errorf("var %s: getTypeName = %q, want %q", name, got, expected)
+			}
+			// The delegation invariant: getTypeName IS the structured render.
+			if got, direct := getTypeName(vspec.Type, info), typemodel.FromExpr(vspec.Type, info).String(); got != direct {
+				t.Errorf("var %s: getTypeName = %q but FromExpr.String() = %q — delegation broken", name, got, direct)
 			}
 			checked++
 		}
 	}
-	if checked < 16 {
-		t.Fatalf("only %d vars checked; corpus incomplete", checked)
+	if checked != len(want) {
+		t.Fatalf("checked %d vars, want table has %d; corpus and table drifted", checked, len(want))
 	}
 }

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -2437,7 +2437,11 @@ func isInterfaceTypeName(typeName string, meta *metadata.Metadata) bool {
 	if typeName == "" || meta == nil {
 		return false
 	}
-	t := typeByName(TypeParts(typeName), meta)
+	core := typemodel.Parse(typeName).Core()
+	if core == nil {
+		return false
+	}
+	t := typeByName(core.Pkg, core.Name, meta)
 	return t != nil && getStringFromPool(meta, t.Kind) == "interface"
 }
 

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -877,67 +877,56 @@ func findTypesInMetadata(meta *metadata.Metadata, typeName string) map[string]*m
 		return nil
 	}
 
-	typeParts := TypeParts(typeName)
-	var pkgName string
+	core := typemodel.Parse(typeName).Core()
+	if core == nil {
+		return metaTypes
+	}
 
-	if !metadata.IsPrimitiveType(typeParts.PkgName) && typeParts.PkgName != "" {
-		pkgName = typeParts.PkgName + "."
+	var pkgName string
+	if !metadata.IsPrimitiveType(core.Pkg) && core.Pkg != "" {
+		pkgName = core.Pkg + "."
 	}
 
 	// Generics
-	if len(typeParts.GenericTypes) > 0 {
-		for _, part := range typeParts.GenericTypes {
-			genericType := strings.Fields(part)
-			switch len(genericType) {
-			case 0:
-				continue
-			case 1:
-				// Concrete instantiation argument (e.g. "User" in Page[User]).
-				// Don't register it here: this map has one entry per schema to
-				// emit, and callers that want a single type for goType pick the
-				// first non-nil entry — a second one would non-deterministically
-				// shadow the parametric type itself. The concrete argument is
-				// emitted as its own component through the parametric struct's
-				// field resolution instead.
-				continue
-			default:
-				// Declaration form "T constraint" (e.g. "T any").
-				if metadata.IsPrimitiveType(genericType[1]) {
-					metaTypes[pkgName+genericType[0]+"-"+genericType[1]] = nil
-				} else {
-					genericTypeParts := TypeParts(genericType[0])
-
-					if t := typeByName(genericTypeParts, meta); t != nil {
-						metaTypes[pkgName+genericType[0]+"_"+genericType[1]] = t
-					}
-				}
-			}
+	for _, arg := range core.Args {
+		if arg.Constraint == "" {
+			// Concrete instantiation argument (e.g. "User" in Page[User]).
+			// Don't register it here: this map has one entry per schema to
+			// emit, and callers that want a single type for goType pick the
+			// first non-nil entry — a second one would non-deterministically
+			// shadow the parametric type itself. The concrete argument is
+			// emitted as its own component through the parametric struct's
+			// field resolution instead.
+			continue
+		}
+		// Declaration form "T constraint" (e.g. "T any").
+		if metadata.IsPrimitiveType(arg.Constraint) {
+			metaTypes[pkgName+arg.Name+"-"+arg.Constraint] = nil
+		} else if t := typeByName("", arg.Name, meta); t != nil {
+			metaTypes[pkgName+arg.Name+"_"+arg.Constraint] = t
 		}
 	}
 
 	if typeName != "" {
-		metaTypes[typeName] = typeByName(typeParts, meta)
+		metaTypes[typeName] = typeByName(core.Pkg, core.Name, meta)
 	}
 
 	return metaTypes
 }
 
-// typeByName looks a type up in metadata by the Parts view of its name.
-//
-// Callers must produce Parts with ParseParts (spec's TypeParts), NOT the
-// structured typemodel.Parse: metadata keys a generic declaration with its
-// parameter brackets included ("Page[T]", via getTypeName), and ParseParts's
-// opaque-unqualified-generic quirk matches that format where the structured
-// core name ("Page") would miss. The two sides migrate together in phase 3
-// of docs/TYPE_MODEL.md.
-func typeByName(typeParts Parts, meta *metadata.Metadata) *metadata.Type {
+// typeByName looks a type up in metadata by its parsed core: first in the
+// named package, then across all packages. Metadata keys a type by its bare
+// declared name (tspec.Name.Name — a generic declaration is stored as "Page",
+// its parameters in Type.TypeParams), so callers pass the structured core
+// name (typemodel.Parse(...).Core().Name), never a bracketed form.
+func typeByName(pkgName, typeName string, meta *metadata.Metadata) *metadata.Type {
 	if meta == nil {
 		return nil
 	}
 
-	if typeParts.PkgName != "" && typeParts.TypeName != "" {
-		if pkg, exists := meta.Packages[typeParts.PkgName]; exists {
-			if typ := typeInPackage(pkg, typeParts.TypeName); typ != nil {
+	if pkgName != "" && typeName != "" {
+		if pkg, exists := meta.Packages[pkgName]; exists {
+			if typ := typeInPackage(pkg, typeName); typ != nil {
 				return typ
 			}
 		}
@@ -947,8 +936,8 @@ func typeByName(typeParts Parts, meta *metadata.Metadata) *metadata.Type {
 	// stable (cached) sorted order so the chosen type is deterministic across
 	// runs — otherwise map iteration would pick a different package's type and
 	// flip the schema between runs.
-	for _, pkgName := range meta.SortedPackageNames() {
-		if typ := typeInPackage(meta.Packages[pkgName], typeParts.TypeName); typ != nil {
+	for _, pkg := range meta.SortedPackageNames() {
+		if typ := typeInPackage(meta.Packages[pkg], typeName); typ != nil {
 			return typ
 		}
 	}
@@ -1054,13 +1043,27 @@ func generateSchemaFromType(usedTypes map[string]*Schema, key string, typ *metad
 // allConcreteGenericArgs reports whether every generic part is a concrete type
 // argument (a single token) rather than a declaration entry ("T any"), which
 // carries its constraint after a space.
-func allConcreteGenericArgs(parts []string) bool {
-	for _, p := range parts {
-		if p == "" || strings.Contains(p, " ") {
+func allConcreteGenericArgs(args []*typemodel.TypeRef) bool {
+	for _, a := range args {
+		if a == nil || a.Constraint != "" || genericArgText(a) == "" {
 			return false
 		}
 	}
-	return len(parts) > 0
+	return len(args) > 0
+}
+
+// genericArgText renders one generic argument for the substitution map,
+// preferring the exact text it was parsed from (what the legacy split
+// produced) and falling back to the simple rendering for programmatically
+// built refs.
+func genericArgText(a *typemodel.TypeRef) string {
+	if a == nil {
+		return ""
+	}
+	if r := a.Raw(); r != "" {
+		return r
+	}
+	return a.Simple()
 }
 
 // substituteTypeParams replaces a parametric field type with its concrete
@@ -1096,15 +1099,14 @@ func substituteTypeParams(fieldType string, genericTypes map[string]string) stri
 func generateStructSchema(usedTypes map[string]*Schema, key string, typ *metadata.Type, meta *metadata.Metadata, cfg *APISpecConfig, visitedTypes map[string]bool) (*Schema, map[string]*Schema) {
 	schemas := map[string]*Schema{}
 
-	keyParts := TypeParts(key)
+	keyCore := typemodel.Parse(key).Core()
 	genericTypes := map[string]string{}
 
 	// concreteGenerics reports whether the key carries concrete type arguments
-	// (Page[User]) rather than the bare declaration (Page[T any]). Concrete
-	// arguments are single tokens; a declaration entry carries its constraint
-	// after a space ("T any").
-	concreteGenerics := len(keyParts.GenericTypes) > 0 && len(typ.TypeParams) > 0 &&
-		allConcreteGenericArgs(keyParts.GenericTypes)
+	// (Page[User]) rather than the bare declaration (Page[T any]) — a
+	// declaration argument carries its constraint ("T any").
+	concreteGenerics := keyCore != nil && len(keyCore.Args) > 0 && len(typ.TypeParams) > 0 &&
+		allConcreteGenericArgs(keyCore.Args)
 
 	switch {
 	case concreteGenerics:
@@ -1112,16 +1114,15 @@ func generateStructSchema(usedTypes map[string]*Schema, key string, typ *metadat
 		// the concrete arguments, so a parametric field (Data T / Items []T)
 		// substitutes to the concrete type.
 		for i, param := range typ.TypeParams {
-			if i < len(keyParts.GenericTypes) {
-				genericTypes[param] = keyParts.GenericTypes[i]
+			if i < len(keyCore.Args) {
+				genericTypes[param] = genericArgText(keyCore.Args[i])
 			}
 		}
-	case len(keyParts.GenericTypes) > 0:
+	case keyCore != nil && len(keyCore.Args) > 0:
 		// Declaration form: keep the legacy placeholder behavior (field T maps
 		// to the "T-constraint" stand-in).
-		for _, part := range keyParts.GenericTypes {
-			genericType := strings.Split(part, " ")
-			genericTypes[genericType[0]] = strings.ReplaceAll(part, " ", "-")
+		for _, arg := range keyCore.Args {
+			genericTypes[arg.Name] = strings.ReplaceAll(genericArgText(arg), " ", "-")
 		}
 	}
 

--- a/internal/spec/mapper_test.go
+++ b/internal/spec/mapper_test.go
@@ -927,13 +927,13 @@ func TestTypeByName(t *testing.T) {
 	}
 
 	// Test finding type by name
-	typ := typeByName(Parts{PkgName: "main", TypeName: "User"}, meta)
+	typ := typeByName("main", "User", meta)
 	if typ == nil {
 		t.Error("Should find type by name")
 	}
 
 	// Test finding non-existent type
-	typ = typeByName(Parts{PkgName: "main", TypeName: "NonExistentType"}, meta)
+	typ = typeByName("main", "NonExistentType", meta)
 	if typ != nil {
 		t.Error("Should not find non-existent type")
 	}

--- a/internal/spec/wrapper_specialisation.go
+++ b/internal/spec/wrapper_specialisation.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/ehabterra/apispec/internal/metadata"
+	"github.com/ehabterra/apispec/internal/typemodel"
 )
 
 // wrapperFieldOverride describes one field of a wrapper-style
@@ -367,12 +368,11 @@ func lookupWrapperType(meta *metadata.Metadata, goType string) *metadata.Type {
 	if meta == nil || goType == "" {
 		return nil
 	}
-	goType = strings.TrimPrefix(goType, "*")
-	parts := TypeParts(goType)
-	if parts.TypeName == "" {
+	core := typemodel.Parse(goType).Core()
+	if core == nil || core.Name == "" {
 		return nil
 	}
-	return typeByName(parts, meta)
+	return typeByName(core.Pkg, core.Name, meta)
 }
 
 // wrapperFieldIsGeneric reports whether the declared type of the named

--- a/internal/typemodel/typemodel.go
+++ b/internal/typemodel/typemodel.go
@@ -24,11 +24,13 @@
 //     target model. New code should build and consume TypeRef values and only
 //     render to a string at an output boundary (component naming,
 //     serialization).
-//   - Transitional string views (ParseParts, NormalizeInstance, SimplifyArg,
-//     SimpleName, ArgPackage, SplitArgs in legacy.go) — exact behavioral ports
-//     of the helpers that used to live in internal/spec, kept byte-compatible
-//     so consumers can migrate to the structured core one at a time with zero
-//     output drift. Each documents its quirks and its structured replacement.
+//   - Transitional string views (ParseParts and SplitArgs in legacy.go) —
+//     exact behavioral ports of the helpers that used to live in
+//     internal/spec, kept byte-compatible so consumers can migrate to the
+//     structured core one at a time with zero output drift. Each documents
+//     its quirks and its structured replacement; the views already migrated
+//     off (NormalizeInstance, SimplifyArg, SimpleName, ArgPackage) have been
+//     deleted.
 //
 // See docs/TYPE_MODEL.md for the migration plan.
 package typemodel


### PR DESCRIPTION
Phase 3 of the structured type model. Two coordinated migrations, **zero golden drift**, plus two real bug fixes proven by a new test.

### Correction from phase 2

Investigating the planned "coordinated key migration" showed the phase-2 assumption was wrong: metadata's `Types` map is **already keyed by the bare declared name** (`f.Types[tspec.Name.Name]`) — the bracketed `getTypeName(tspec)` form (`"Page[T]"`) is only the *methods-table* key convention (it matches how a generic method-receiver expression renders). The `ParseParts` opaque quirk was never load-bearing for lookups; it merely made unqualified generic names **miss**. Docs and the `typeByName` comment are corrected.

### Lookup boundary → structured

`typeByName` now takes `(pkg, name)`; every caller parses with `typemodel.Parse(...).Core()`:
- `findTypesInMetadata` (incl. the declaration-form argument handling, now driven by `Constraint` instead of `strings.Fields`),
- `generateStructSchema`'s key parsing (concrete-vs-declaration split via `Constraint` — also fixes the corner where a nested multi-arg concrete like `Box[Pair[K, V]]` was misclassified as a declaration because it contains a space),
- `isInterfaceTypeName`, `lookupWrapperType`.

### AST boundary → structured

`metadata.getTypeName`'s expression cases delegate to `typemodel.FromExpr(...).String()` — one parse/render path for every layer. Two shapes the old stringifier *lost* are now recorded, locked in by `TestMetadata_BoundaryShapeImprovements`:
- **fixed-size array fields keep their length** (`[4]byte` was recorded as `[]byte`), feeding the mapper's existing `maxItems`/`maxLength` machinery;
- **methods on multi-parameter generic types attach** — an `IndexListExpr` receiver (`Pair[K, V]`) stringified to `""`, filing the method under the empty key and losing it.

The boundary differential test became an explicit characterization (`TestBoundaryTypeNames`) since the two sides are now one code path.

### Remaining (phase 4, tracked in docs/TYPE_MODEL.md)

`CallArgument`/`Field`/assignment records carry `TypeRef` (string pool stays as the serialization format); remaining ad-hoc prefix-trims collapse as their code is touched.

## Verification

Full `go test ./...` green with **all goldens and fixtures unchanged**; `-race` green on the four affected packages; `golangci-lint`/`vet`/`gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
