### PR TITLE
chore: attribute cross-package coverage via -coverpkg

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,8 +38,11 @@ jobs:
     - name: Download dependencies
       run: go mod download
 
+    # -coverpkg=./... attributes coverage across packages, so the fixture
+    # suites in generator/ credit the internal pipeline code they exercise
+    # (same methodology as the badge in scripts/update-coverage-badge.sh).
     - name: Run tests
-      run: go test -v -race -coverprofile=coverage.out ./...
+      run: go test -v -race -coverpkg=./... -coverprofile=coverage.out ./...
 
     - name: Run integration tests
       run: go test -v ./cmd/apispec/...

--- a/Makefile
+++ b/Makefile
@@ -63,9 +63,11 @@ build-apidiag:
 test:
 	go test ./...
 
-# Run tests with coverage report
+# Run tests with coverage report. -coverpkg attributes cross-package coverage
+# so the generator/ fixture suites credit the internal code they exercise
+# (same methodology as the CI badge).
 coverage:
-	go test -coverprofile=coverage.out ./...
+	go test -coverpkg=./... -coverprofile=coverage.out ./...
 	go tool cover -func=coverage.out
 	go tool cover -html=coverage.out -o coverage.html
 	@echo "Coverage report generated: coverage.html"

--- a/scripts/update-coverage-badge.sh
+++ b/scripts/update-coverage-badge.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 COVERAGE_FILE="coverage.txt"
 README_FILE="README.md"
-THRESHOLD=45  # Minimum acceptable coverage %
+THRESHOLD=80  # Minimum acceptable coverage %
 
 # Library packages only. The cmd/* mains (notably cmd/apispecui's ~1400-line
 # main.go) and the root main are CLI glue with no unit tests; counting their
@@ -11,16 +11,24 @@ THRESHOLD=45  # Minimum acceptable coverage %
 # matches what an IDE coverage run over the library subtree reports.
 LIB_PKGS=(./internal/... ./generator/... ./pkg/... ./spec/...)
 
+# Cross-package attribution (-coverpkg): without it, go test only credits a
+# package's own tests, so the generator/ fixture suite — which exercises the
+# whole metadata→tracker→extractor→mapper pipeline end-to-end — counts for
+# nothing in the packages it actually covers (lazytree.go reads 0% despite
+# being the default engine). The badge should report what the tests execute,
+# not where the test files happen to live.
+LIB_COVERPKG=$(IFS=,; echo "${LIB_PKGS[*]}")
+
 # Run tests and generate coverage report (library scope)
-go test "${LIB_PKGS[@]}" -coverprofile=$COVERAGE_FILE
+go test "${LIB_PKGS[@]}" -coverpkg="$LIB_COVERPKG" -coverprofile=$COVERAGE_FILE
 
 # Extract coverage percentage
 COVERAGE=$(go tool cover -func=$COVERAGE_FILE | grep total | awk '{print substr($3, 1, length($3)-1)}')
 
 # Determine badge color on a graduated scale (codecov-style) rather than a
-# three-band cliff, so the colour tracks coverage smoothly. For a tool whose
-# CLI/UI glue is intentionally left untested, library coverage in the 65–80%
-# range is healthy and should read green-ish, not alarming red.
+# three-band cliff, so the colour tracks coverage smoothly. With cross-package
+# attribution the library sits in the 80s and is being ratcheted toward 95%,
+# so green starts at 75 and brightgreen marks the 90s.
 if (( $(echo "$COVERAGE >= 90" | bc -l) )); then
     COLOR="brightgreen"
 elif (( $(echo "$COVERAGE >= 75" | bc -l) )); then


### PR DESCRIPTION
## What

Switches all three coverage surfaces — the badge script, the CI test workflow's coverage report, and `make coverage` — to use `-coverpkg` for cross-package attribution. Raises the badge threshold from 45 to 80.

## Why

Plain `go test -coverprofile` only credits a package's **own** tests. This repo's architecture is a pipeline whose primary behavioral tests live in `generator/` (fixture projects + structural assertions) and deliberately exercise `internal/metadata`, `internal/spec`, `internal/engine`, etc. end-to-end — and got zero coverage credit for it. The starkest symptom: `internal/spec/lazytree.go` reported **0%** despite being the default tracker engine executed by every fixture test.

With `-coverpkg` over the same library scope (`./internal/... ./generator/... ./pkg/... ./spec/...`), the **same test suite** reports:

| | before | after |
|---|---|---|
| Library coverage | 68.4% | **82.5%** |

No test was added or changed — this makes the number honest, not inflated. It reports what the tests execute rather than where the test files happen to live.

The existing cmd/* exclusion for the badge is unchanged (documented in the script). The CI workflow's informational report and `make coverage` use `-coverpkg=./...` over their existing full-repo scope.

## Verification

- Ran `scripts/update-coverage-badge.sh` locally: reports `82.5% (green)`, passes the new 80 threshold (README badge restore left to the post-merge workflow as usual).
- `make coverage` produces the cross-attributed HTML report.

This is phase 0 of the coverage push toward 95%: fix measurement first, then close the ~2,050 genuinely-uncovered statements in follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)