### PR TITLE
chore+test: prune uncalled metadata query API, cover return-type resolution

### DIFF
--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -452,9 +452,6 @@ func GenerateMetadataWithLogger(pkgs map[string]map[string]*ast.File, fileToInfo
 	// Process function return types to fill ResolvedType
 	metadata.ProcessFunctionReturnTypes()
 
-	// Finalize string pool
-	metadata.StringPool.Finalize()
-
 	if logger != nil {
 		logger.Println("process assignment Count:", processAssignmentCount)
 	}
@@ -463,38 +460,6 @@ func GenerateMetadataWithLogger(pkgs map[string]map[string]*ast.File, fileToInfo
 	}
 
 	return metadata
-}
-
-// ClassifyArgument determines the type of an argument for enhanced processing
-func (m *Metadata) ClassifyArgument(arg *CallArgument) ArgumentType {
-	switch arg.GetKind() {
-	case KindCall, KindFuncLit:
-		return ArgTypeFunctionCall
-	case KindTypeConversion:
-		// Type conversions are not function calls and should be handled differently
-		return ArgTypeComplex
-	case KindIdent:
-		if strings.HasPrefix(arg.GetType(), "func(") {
-			return ArgTypeFunctionCall
-		}
-		return ArgTypeVariable
-	case KindLiteral:
-		return ArgTypeLiteral
-	case KindSelector:
-		return ArgTypeSelector
-	case KindUnary:
-		return ArgTypeUnary
-	case KindBinary:
-		return ArgTypeBinary
-	case KindIndex:
-		return ArgTypeIndex
-	case KindCompositeLit:
-		return ArgTypeComposite
-	case KindTypeAssert:
-		return ArgTypeTypeAssert
-	default:
-		return ArgTypeComplex
-	}
 }
 
 // BuildAssignmentRelationships builds assignment relationships for all call graph edges
@@ -575,127 +540,6 @@ func (m *Metadata) GetAssignmentRelationships() map[AssignmentKey]*AssignmentLin
 		m.assignmentRelationships = m.BuildAssignmentRelationships()
 	}
 	return m.assignmentRelationships
-}
-
-// TraverseCallGraph traverses the call graph with a visitor function
-func (m *Metadata) TraverseCallGraph(startFrom string, visitor func(*CallGraphEdge, int) bool) {
-	visited := make(map[string]bool)
-	m.traverseCallGraphHelper(startFrom, 0, visitor, visited)
-}
-
-// traverseCallGraphHelper is the internal implementation with cycle detection
-func (m *Metadata) traverseCallGraphHelper(current string, depth int, visitor func(*CallGraphEdge, int) bool, visited map[string]bool) {
-	if visited[current] {
-		return
-	}
-	visited[current] = true
-
-	if edges, exists := m.Callers[current]; exists {
-		for _, edge := range edges {
-			if !visitor(edge, depth) {
-				return
-			}
-			m.traverseCallGraphHelper(edge.Callee.BaseID(), depth+1, visitor, visited)
-		}
-	}
-}
-
-// GetCallDepth returns the call depth for a function
-func (m *Metadata) GetCallDepth(funcID string) int {
-	if depth, exists := m.callDepth[funcID]; exists {
-		return depth
-	}
-
-	// Calculate depth by traversing up the call graph
-	depth := 0
-	current := funcID
-
-	for {
-		if callers, exists := m.Callees[current]; exists && len(callers) > 0 {
-			depth++
-			current = callers[0].Caller.BaseID()
-		} else {
-			break
-		}
-	}
-
-	m.callDepth[funcID] = depth
-	return depth
-}
-
-// GetFunctionsAtDepth returns all functions at a specific call depth
-func (m *Metadata) GetFunctionsAtDepth(targetDepth int) []*CallGraphEdge {
-	var result []*CallGraphEdge
-
-	for funcID := range m.Callers {
-		if m.GetCallDepth(funcID) == targetDepth {
-			if edges, exists := m.Callers[funcID]; exists {
-				result = append(result, edges...)
-			}
-		}
-	}
-
-	return result
-}
-
-// IsReachableFrom checks if a function is reachable from another function
-func (m *Metadata) IsReachableFrom(fromFunc, toFunc string) bool {
-	visited := make(map[string]bool)
-
-	var dfs func(current string) bool
-	dfs = func(current string) bool {
-		if current == toFunc {
-			return true
-		}
-		if visited[current] {
-			return false
-		}
-		visited[current] = true
-
-		if edges, exists := m.Callers[current]; exists {
-			for _, edge := range edges {
-				if dfs(edge.Callee.BaseID()) {
-					return true
-				}
-			}
-		}
-		return false
-	}
-
-	return dfs(fromFunc)
-}
-
-// GetCallPath returns the call path from one function to another
-func (m *Metadata) GetCallPath(fromFunc, toFunc string) []*CallGraphEdge {
-	visited := make(map[string]bool)
-	var path []*CallGraphEdge
-
-	var dfs func(current string) bool
-	dfs = func(current string) bool {
-		if current == toFunc {
-			return true
-		}
-		if visited[current] {
-			return false
-		}
-		visited[current] = true
-
-		if edges, exists := m.Callers[current]; exists {
-			for _, edge := range edges {
-				path = append(path, edge)
-				if dfs(edge.Callee.BaseID()) {
-					return true
-				}
-				path = path[:len(path)-1] // backtrack
-			}
-		}
-		return false
-	}
-
-	if dfs(fromFunc) {
-		return path
-	}
-	return nil
 }
 
 // BuildFuncMap creates a map of function names to their declarations.

--- a/internal/metadata/return_type_resolution_test.go
+++ b/internal/metadata/return_type_resolution_test.go
@@ -1,0 +1,327 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// returnTypeMeta builds a small metadata world for the return-type resolvers:
+// a package-level variable, a function with assignments (concrete and chained),
+// a struct type with a field, and a func-typed variable for signature
+// extraction.
+func returnTypeMeta() *Metadata {
+	sp := NewStringPool()
+	m := &Metadata{
+		StringPool: sp,
+		Packages: map[string]*Package{
+			"app": {
+				Files: map[string]*File{
+					"app.go": {
+						Variables: map[string]*Variable{
+							"globalUser": {Name: sp.Get("globalUser"), Type: sp.Get("User")},
+							"mk":         {Name: sp.Get("mk"), Type: sp.Get("func(int) User")},
+						},
+						Types: map[string]*Type{
+							"User": {
+								Name: sp.Get("User"),
+								Kind: sp.Get("struct"),
+								Fields: []Field{
+									{Name: sp.Get("Name"), Type: sp.Get("string")},
+								},
+							},
+						},
+						Functions: map[string]*Function{},
+					},
+				},
+			},
+		},
+	}
+
+	fn := &Function{Name: sp.Get("handler"), AssignmentMap: map[string][]Assignment{}}
+	// Direct concrete-type assignment.
+	fn.AssignmentMap["u"] = []Assignment{{
+		VariableName: sp.Get("u"),
+		ConcreteType: sp.Get("User"),
+		Value:        CallArgument{Kind: -1, Name: -1, Value: -1, Raw: -1, Pkg: -1, Type: -1, Position: -1, ResolvedType: -1, GenericTypeName: -1, Meta: m},
+	}}
+	// Chained assignment: no concrete type, value is the ident "u", so
+	// resolution must recurse through the assignment map.
+	chainedVal := CallArgument{Kind: sp.Get(KindIdent), Name: sp.Get("u"), Value: -1, Raw: -1, Pkg: -1, Type: -1, Position: -1, ResolvedType: -1, GenericTypeName: -1, Meta: m}
+	fn.AssignmentMap["chained"] = []Assignment{{
+		VariableName: sp.Get("chained"),
+		ConcreteType: -1,
+		Value:        chainedVal,
+	}}
+	m.Packages["app"].Files["app.go"].Functions["handler"] = fn
+	return m
+}
+
+func arg(m *Metadata, kind string) *CallArgument {
+	a := NewCallArgument(m)
+	if kind != "" {
+		a.SetKind(kind)
+	}
+	return a
+}
+
+func TestDetermineResolvedTypeFromReturnVar(t *testing.T) {
+	m := returnTypeMeta()
+
+	tests := []struct {
+		name string
+		mk   func() *CallArgument
+		want string
+	}{
+		{
+			name: "ident resolves package variable",
+			mk: func() *CallArgument {
+				a := arg(m, KindIdent)
+				a.SetName("globalUser")
+				return a
+			},
+			want: "User",
+		},
+		{
+			name: "ident resolves concrete assignment",
+			mk: func() *CallArgument {
+				a := arg(m, KindIdent)
+				a.SetName("u")
+				return a
+			},
+			want: "User",
+		},
+		{
+			name: "ident recurses through chained assignment",
+			mk: func() *CallArgument {
+				a := arg(m, KindIdent)
+				a.SetName("chained")
+				return a
+			},
+			want: "User",
+		},
+		{
+			name: "ident falls back to its own name",
+			mk: func() *CallArgument {
+				a := arg(m, KindIdent)
+				a.SetName("mystery")
+				return a
+			},
+			want: "mystery",
+		},
+		{
+			name: "selector resolves struct field type",
+			mk: func() *CallArgument {
+				a := arg(m, KindSelector)
+				x := arg(m, KindIdent)
+				x.SetName("globalUser")
+				sel := arg(m, KindIdent)
+				sel.SetName("Name")
+				a.X, a.Sel = x, sel
+				return a
+			},
+			want: "string",
+		},
+		{
+			name: "selector falls back to concatenation",
+			mk: func() *CallArgument {
+				a := arg(m, KindSelector)
+				x := arg(m, KindIdent)
+				x.SetName("globalUser")
+				sel := arg(m, KindIdent)
+				sel.SetName("Missing")
+				a.X, a.Sel = x, sel
+				return a
+			},
+			want: "User.Missing",
+		},
+		{
+			name: "selector without parts uses own type",
+			mk: func() *CallArgument {
+				a := arg(m, KindSelector)
+				a.SetType("Fallback")
+				return a
+			},
+			want: "Fallback",
+		},
+		{
+			name: "call without Fun is opaque func",
+			mk: func() *CallArgument {
+				return arg(m, KindCall)
+			},
+			want: "func()",
+		},
+		{
+			name: "call extracts return type from func-typed variable",
+			mk: func() *CallArgument {
+				a := arg(m, KindCall)
+				fun := arg(m, KindIdent)
+				fun.SetName("mk")
+				a.Fun = fun
+				return a
+			},
+			want: "User",
+		},
+		{
+			name: "call passes through non-func type",
+			mk: func() *CallArgument {
+				a := arg(m, KindCall)
+				fun := arg(m, KindIdent)
+				fun.SetName("globalUser")
+				a.Fun = fun
+				return a
+			},
+			want: "User",
+		},
+		{
+			name: "composite literal resolves via X",
+			mk: func() *CallArgument {
+				a := arg(m, KindCompositeLit)
+				x := arg(m, KindIdent)
+				x.SetName("globalUser")
+				a.X = x
+				return a
+			},
+			want: "User",
+		},
+		{
+			name: "composite literal without X uses own type",
+			mk: func() *CallArgument {
+				a := arg(m, KindCompositeLit)
+				a.SetType("User")
+				return a
+			},
+			want: "User",
+		},
+		{
+			name: "unary adds pointer",
+			mk: func() *CallArgument {
+				a := arg(m, KindUnary)
+				x := arg(m, KindIdent)
+				x.SetName("globalUser")
+				a.X = x
+				return a
+			},
+			want: "*User",
+		},
+		{
+			name: "star dereferences pointer type",
+			mk: func() *CallArgument {
+				a := arg(m, KindStar)
+				a.SetType("*User")
+				x := arg(m, KindIdent)
+				x.SetName("ptr")
+				a.X = x
+				return a
+			},
+			want: "ptr", // base "ptr" has no pointer prefix to cut
+		},
+		{
+			name: "unary without X uses own type",
+			mk: func() *CallArgument {
+				a := arg(m, KindUnary)
+				a.SetType("*User")
+				return a
+			},
+			want: "*User",
+		},
+		{
+			name: "literal returns its type",
+			mk: func() *CallArgument {
+				a := arg(m, KindLiteral)
+				a.SetType("string")
+				return a
+			},
+			want: "string",
+		},
+		{
+			name: "unknown kind falls back to type field",
+			mk: func() *CallArgument {
+				a := arg(m, KindRaw)
+				a.SetType("whatever")
+				return a
+			},
+			want: "whatever",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := m.determineResolvedTypeFromReturnVar(tt.mk(), "app", "handler"); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestAnalyzeAssignmentValue covers the expression-kind dispatch with no type
+// info (the info-nil branches every expression kind falls back to).
+func TestAnalyzeAssignmentValue(t *testing.T) {
+	m := returnTypeMeta()
+	fset := token.NewFileSet()
+
+	parse := func(src string) (pkg string, got *CallArgument) {
+		t.Helper()
+		expr, err := parser.ParseExpr(src)
+		if err != nil {
+			t.Fatalf("parse %q: %v", src, err)
+		}
+		return analyzeAssignmentValue(expr, nil, "handler", "app", m, fset)
+	}
+
+	if pkg, got := analyzeAssignmentValue(nil, nil, "handler", "app", m, fset); pkg != "app" || got != nil {
+		t.Errorf("nil expr = (%q, %v), want (app, nil)", pkg, got)
+	}
+
+	// Identifier: traced through the metadata (no origin here, nil type).
+	if pkg, _ := parse("someVar"); pkg == "" {
+		t.Error("ident should keep a package")
+	}
+
+	// Selector with ident base takes the trace path.
+	if pkg, _ := parse("pkg.Field"); pkg == "" {
+		t.Error("selector should keep a package")
+	}
+
+	// Direct and method calls take the call branches.
+	if pkg, _ := parse("newUser()"); pkg == "" {
+		t.Error("call should keep a package")
+	}
+	if pkg, _ := parse("svc.Create()"); pkg == "" {
+		t.Error("method call should keep a package")
+	}
+
+	// Type assertion yields the asserted type.
+	if _, got := parse("v.(User)"); got == nil || got.GetName() != "User" {
+		t.Errorf("type assertion arg = %+v, want User ident", got)
+	}
+
+	// Star expression recurses into the base.
+	if pkg, _ := parse("*ptr"); pkg == "" {
+		t.Error("star should keep a package")
+	}
+
+	// Composite literal reports its type.
+	if _, got := parse("User{}"); got == nil || got.GetName() != "User" {
+		t.Errorf("composite literal arg = %+v, want User ident", got)
+	}
+
+	// Anything else falls through to ExprToCallArgument.
+	if _, got := parse("1 + 2"); got == nil {
+		t.Error("binary expr should produce a call argument")
+	}
+}

--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -126,11 +126,6 @@ func (sp *StringPool) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
-// Finalize cleans up the string pool by removing the lookup map
-func (sp *StringPool) Finalize() {
-	// sp.strings = nil
-}
-
 // Metadata represents the complete metadata for a Go codebase
 type Metadata struct {
 	StringPool *StringPool         `yaml:"string_pool,omitempty"`
@@ -228,30 +223,6 @@ func (m *Metadata) BuildCallGraphMaps() {
 			m.Args[argBase] = append(m.Args[argBase], edge)
 		}
 	}
-}
-
-// GetCallersOfFunction returns all edges where the given function is the caller
-func (m *Metadata) GetCallersOfFunction(pkg, funcName string) []*CallGraphEdge {
-	baseID := fmt.Sprintf("%s.%s", pkg, funcName)
-	return m.Callers[baseID]
-}
-
-// GetCalleesOfFunction returns all edges where the given function is called
-func (m *Metadata) GetCalleesOfFunction(pkg, funcName string) []*CallGraphEdge {
-	baseID := fmt.Sprintf("%s.%s", pkg, funcName)
-	return m.Callees[baseID]
-}
-
-// GetCallersOfMethod returns all edges where the given method is the caller
-func (m *Metadata) GetCallersOfMethod(pkg, recvType, methodName string) []*CallGraphEdge {
-	baseID := fmt.Sprintf("%s.%s.%s", pkg, recvType, methodName)
-	return m.Callers[baseID]
-}
-
-// GetCalleesOfMethod returns all edges where the given method is called
-func (m *Metadata) GetCalleesOfMethod(pkg, recvType, methodName string) []*CallGraphEdge {
-	baseID := fmt.Sprintf("%s.%s.%s", pkg, recvType, methodName)
-	return m.Callees[baseID]
 }
 
 // IsSubset checks if array 'a' is a subset of array 'b'
@@ -743,19 +714,6 @@ func (a *CallArgument) SetResolvedType(resolvedType string) {
 	}
 }
 
-func (a *CallArgument) SetGenericTypeName(genericTypeName string) {
-	if a.Meta.StringPool != nil {
-		a.GenericTypeName = a.Meta.StringPool.Get(genericTypeName)
-	}
-}
-
-// SetScope sets the scope string using StringPool
-func (c *Call) SetScope(scope string) {
-	if c.Meta.StringPool != nil {
-		c.Scope = c.Meta.StringPool.Get(scope)
-	}
-}
-
 func (a *CallArgument) TypeParams() map[string]string {
 	if a.TypeParamMap == nil {
 		a.TypeParamMap = map[string]string{}
@@ -967,14 +925,6 @@ func (c *Call) BaseID() string {
 
 	c.baseIDCache = c.identifier.ID(BaseID)
 	return c.baseIDCache
-}
-
-// GenericID returns the identifier with generic type parameters but no position
-func (c *Call) GenericID() string {
-	if c.identifier == nil {
-		c.buildIdentifier()
-	}
-	return c.identifier.ID(GenericID)
 }
 
 // InstanceID returns the full instance identifier with position and generics


### PR DESCRIPTION
## What

Phase 2 (fourth slice), two commits:

### 1. Dead-code follow-up (`-206 lines`)

The phase-1 audit's RTA pass missed a cluster of `Metadata` methods because `Metadata` flows through yaml reflection, which marks every exported method "reachable". Direct reference search confirms **zero callers anywhere** for: `ClassifyArgument`, `TraverseCallGraph`(+helper), `GetCallDepth`, `GetFunctionsAtDepth`, `IsReachableFrom`, `GetCallPath`, the four `GetCallers/CalleesOfFunction/Method` accessors, `CallArgument.SetGenericTypeName`, `Call.SetScope`, `Call.GenericID` (the method — the `GenericID` const stays), and the empty no-op `StringPool.Finalize` + its call site. The `callDepth` map stays: the recursion cap in `BuildCallGraphMaps` uses it.

### 2. Tests for the live resolution gaps

`determineResolvedTypeFromReturnVar` and its per-kind resolvers ran at 0–33% (`resolveCallReturnType`, `resolveCompositeReturnType`, `resolveUnaryReturnType` had never executed — they're what `ProcessFunctionReturnTypes` uses to fill `ResolvedType`). New table tests drive every dispatch arm against a constructed metadata world:
- ident → package variable / concrete assignment / **chained assignment recursion** through `AssignmentMap` / name fallback
- selector → `FindFieldType` hit and concatenation fallback
- call → `func(...)` signature return-type extraction via a func-typed variable, opaque and pass-through forms
- composite / unary / star / literal / raw forms

`analyzeAssignmentValue` (30.8%) gets parsed-AST coverage of every expression branch on the no-type-info path (ident, selector, direct/method call, type assertion, star, composite literal, fallthrough).

## Verification

Full suite green — goldens byte-identical (deleted code was uncalled, so zero output drift); lint/vet/gofmt clean. Metadata package self-coverage 68.9% → 75.0%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)