### PR TITLE
test: cover engine option/filter paths and FuncLit visualization nodes

### DIFF
--- a/internal/engine/engine_helpers_test.go
+++ b/internal/engine/engine_helpers_test.go
@@ -1,0 +1,127 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"testing"
+	"time"
+
+	spec "github.com/ehabterra/apispec/internal/spec"
+)
+
+// TestVerboseLogger covers both gates of every logging method.
+func TestVerboseLogger(t *testing.T) {
+	for _, verbose := range []bool{true, false} {
+		vl := NewVerboseLogger(verbose)
+		vl.Printf("format %d\n", 1)
+		vl.Println("line")
+		vl.Print("raw")
+		vl.Warnf("warn %s\n", "always")
+	}
+}
+
+func TestReportPhase(t *testing.T) {
+	// nil engine is a no-op.
+	var nilEngine *Engine
+	nilEngine.reportPhase("noop", time.Millisecond)
+
+	// OnPhase callback fires with the phase name.
+	var gotPhase string
+	e := NewEngine(&EngineConfig{OnPhase: func(phase string, elapsed time.Duration) {
+		gotPhase = phase
+	}})
+	e.reportPhase("load", 5*time.Millisecond)
+	if gotPhase != "load" {
+		t.Errorf("OnPhase got %q, want load", gotPhase)
+	}
+
+	// A panicking callback must not crash the engine.
+	p := NewEngine(&EngineConfig{OnPhase: func(string, time.Duration) { panic("boom") }})
+	p.reportPhase("load", time.Millisecond)
+
+	// No callback configured.
+	NewEngine(&EngineConfig{}).reportPhase("load", time.Millisecond)
+}
+
+func TestEngineAccessors(t *testing.T) {
+	e := NewEngine(&EngineConfig{})
+	if got := e.GetUnresolvedSecurity(); len(got) != 0 {
+		t.Errorf("fresh engine unresolved security = %v", got)
+	}
+	if got := e.SkippedPackages(); len(got) != 0 {
+		t.Errorf("fresh engine skipped packages = %v", got)
+	}
+	if got := e.ModuleRoot(); got != "" {
+		t.Errorf("fresh engine module root = %q", got)
+	}
+}
+
+func TestMergeIncludeExcludePatterns(t *testing.T) {
+	e := NewEngine(&EngineConfig{
+		IncludeFiles:     []string{"a.go"},
+		IncludePackages:  []string{"pkgA"},
+		IncludeFunctions: []string{"FnA"},
+		IncludeTypes:     []string{"TypeA"},
+		ExcludeFiles:     []string{"b.go"},
+		ExcludePackages:  []string{"pkgB"},
+		ExcludeFunctions: []string{"FnB"},
+		ExcludeTypes:     []string{"TypeB"},
+	})
+	cfg := &spec.APISpecConfig{}
+	e.mergeIncludeExcludePatterns(cfg)
+
+	if len(cfg.Include.Files) == 0 || cfg.Include.Files[len(cfg.Include.Files)-1] != "a.go" {
+		t.Errorf("include files not merged: %v", cfg.Include.Files)
+	}
+	if len(cfg.Include.Packages) == 0 || len(cfg.Include.Functions) == 0 || len(cfg.Include.Types) == 0 {
+		t.Error("include patterns not merged")
+	}
+	if len(cfg.Exclude.Files) == 0 || cfg.Exclude.Files[len(cfg.Exclude.Files)-1] != "b.go" {
+		t.Errorf("exclude files not merged: %v", cfg.Exclude.Files)
+	}
+	if len(cfg.Exclude.Packages) == 0 || len(cfg.Exclude.Functions) == 0 || len(cfg.Exclude.Types) == 0 {
+		t.Error("exclude patterns not merged")
+	}
+}
+
+func TestShouldIncludeFile(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  EngineConfig
+		file string
+		want bool
+	}{
+		{"plain file no patterns", EngineConfig{}, "handler.go", true},
+		{"auto-exclude test suffix", EngineConfig{AutoExcludeTests: true}, "handler_test.go", false},
+		{"auto-exclude tests dir", EngineConfig{AutoExcludeTests: true}, "pkg/tests/x.go", false},
+		{"tests off keeps test file", EngineConfig{}, "handler_test.go", true},
+		{"auto-exclude mock suffix", EngineConfig{AutoExcludeMocks: true}, "store_mock.go", false},
+		{"auto-exclude fakes", EngineConfig{AutoExcludeMocks: true}, "db_fakes.go", false},
+		{"mocks off keeps mock", EngineConfig{}, "store_mock.go", true},
+		{"exclude pattern wins", EngineConfig{ExcludeFiles: []string{"*.gen.go"}}, "api.gen.go", false},
+		{"include pattern matches", EngineConfig{IncludeFiles: []string{"api*.go"}}, "api_routes.go", true},
+		{"include pattern misses", EngineConfig{IncludeFiles: []string{"api*.go"}}, "internal.go", false},
+		{"exclude beats include", EngineConfig{IncludeFiles: []string{"*.go"}, ExcludeFiles: []string{"skip.go"}}, "skip.go", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := c.cfg
+			e := NewEngine(&cfg)
+			if got := e.shouldIncludeFile(c.file); got != c.want {
+				t.Errorf("shouldIncludeFile(%q) = %v, want %v", c.file, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/spec/visualization_funclit_test.go
+++ b/internal/spec/visualization_funclit_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+func TestExtractFuncLitSignature(t *testing.T) {
+	sp := metadata.NewStringPool()
+	meta := &metadata.Metadata{StringPool: sp}
+
+	if got := extractFuncLitSignature(nil, &metadata.Call{}); got != "" {
+		t.Errorf("nil meta = %q", got)
+	}
+	if got := extractFuncLitSignature(meta, nil); got != "" {
+		t.Errorf("nil caller = %q", got)
+	}
+
+	withRecv := &metadata.Call{Meta: meta, Name: sp.Get("Create"), RecvType: sp.Get("Handler")}
+	if got := extractFuncLitSignature(meta, withRecv); got != "Handler" {
+		t.Errorf("receiver signature = %q, want Handler", got)
+	}
+
+	noRecv := &metadata.Call{Meta: meta, Name: sp.Get("main"), RecvType: -1}
+	if got := extractFuncLitSignature(meta, noRecv); got != "func()" {
+		t.Errorf("fallback = %q, want func()", got)
+	}
+}
+
+func TestEnsureParentFunctionNode(t *testing.T) {
+	sp := metadata.NewStringPool()
+	meta := &metadata.Metadata{StringPool: sp}
+	meta.BuildCallGraphMaps()
+
+	if got := ensureParentFunctionNode(meta, nil, nil, nil, nil); got != "" {
+		t.Errorf("nil parent = %q", got)
+	}
+
+	parent := &metadata.Call{
+		Meta:     meta,
+		Name:     sp.Get("registerRoutes"),
+		Pkg:      sp.Get("main"),
+		RecvType: sp.Get("Server"),
+	}
+	data := &CytoscapeData{}
+	visited := map[string]bool{}
+	counter := 0
+
+	id := ensureParentFunctionNode(meta, parent, data, visited, &counter)
+	if id == "" {
+		t.Fatal("no node ID returned")
+	}
+	if len(data.Nodes) != 1 {
+		t.Fatalf("nodes = %d, want 1", len(data.Nodes))
+	}
+	n := data.Nodes[0].Data
+	if n.FunctionName != "registerRoutes" || n.Package != "main" {
+		t.Errorf("node data = %+v", n)
+	}
+	if n.Label != "Server.registerRoutes" {
+		t.Errorf("label = %q, want Server.registerRoutes", n.Label)
+	}
+	if n.IsParentFunction != "true" {
+		t.Errorf("IsParentFunction = %q", n.IsParentFunction)
+	}
+
+	// Second call for the same parent reuses the existing node.
+	id2 := ensureParentFunctionNode(meta, parent, data, visited, &counter)
+	if id2 != id {
+		t.Errorf("existing node id = %q, want %q", id2, id)
+	}
+	if len(data.Nodes) != 1 {
+		t.Errorf("nodes after reuse = %d, want 1", len(data.Nodes))
+	}
+}


### PR DESCRIPTION
## What

Phase 2 (seventh and final slice): tests for `internal/engine` and the FuncLit branch of `internal/spec/visualization.go`.

**Engine** (`engine.go` 78.8% before):
- `VerboseLogger` — both gates of all four methods (`Warnf` is deliberately verbose-independent).
- `reportPhase` — nil-engine no-op, `OnPhase` callback delivery, and the defensive recovery when a callback panics.
- The UI-facing accessors `GetUnresolvedSecurity`/`SkippedPackages`/`ModuleRoot` — these looked dead at 0% but are called from `cmd/apispecui`, which sits outside library coverage scope.
- `mergeIncludeExcludePatterns` — all eight CLI pattern slices merged into the loaded config.
- `shouldIncludeFile` — precedence table: auto-exclude tests/mocks on/off, exclude-beats-include, include-miss rejection.

**Visualization**:
- `extractFuncLitSignature` — receiver-type signature vs the `func()` fallback, nil guards.
- `ensureParentFunctionNode` (0%) — parent-node creation with the receiver-qualified label and `IsParentFunction` marking, plus the existing-node reuse path.

## Verification

Full suite green (no production code touched); lint/vet/gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)