### PR TITLE
test: final sweep to 95% library coverage

### DIFF
--- a/internal/diagserver/server_sweep_test.go
+++ b/internal/diagserver/server_sweep_test.go
@@ -1,0 +1,214 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diagserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+	"github.com/ehabterra/apispec/internal/spec"
+)
+
+// TestPackageHierarchyTree drives handlePackageHierarchy through its buildTree
+// recursion: nested package names produce a parent→child→grandchild tree, the
+// non-root detection (a package whose prefix is also a package), and the
+// depth-0 rename. A pre-seeded dataCache short-circuits getAllData so no real
+// diagram generation is needed.
+func TestPackageHierarchyTree(t *testing.T) {
+	s := New(&Config{Host: "localhost", Port: 8080, DiagramType: "call-graph", PageSize: 50, MaxDepth: 3})
+	// Nested packages; "root/a/b/" (trailing slash) exercises the empty-name guard.
+	s.metadata = &metadata.Metadata{Packages: map[string]*metadata.Package{
+		"root":       {},
+		"root/a":     {},
+		"root/a/b":   {},
+		"root/a/b/":  {},
+		"standalone": {},
+	}}
+	s.cache = map[string]*spec.PaginatedCytoscapeData{}
+	// getAllData(diagramType, true) => cacheKey "call-graph:full".
+	s.dataCache = map[string]*spec.CytoscapeData{
+		"call-graph:full": {
+			Nodes: []spec.CytoscapeNode{
+				{Data: spec.CytoscapeNodeData{ID: "n1", Package: "root/a"}},
+				{Data: spec.CytoscapeNodeData{ID: "n2", Package: "root/a/b"}},
+				{Data: spec.CytoscapeNodeData{ID: "n3", Package: ""}}, // empty package skipped
+			},
+		},
+	}
+
+	w := httptest.NewRecorder()
+	s.handlePackageHierarchy(w, httptest.NewRequest(http.MethodGet, "/api/diagram/packages", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("packages -> %d", w.Code)
+	}
+	var resp PackageHierarchyResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.TotalCount != 2 {
+		t.Errorf("TotalCount = %d, want 2", resp.TotalCount)
+	}
+	// "root" and "standalone" are roots; "root/a"* nest under root.
+	var sawRoot bool
+	for _, rp := range resp.RootPackages {
+		if rp.FullPath == "root" {
+			sawRoot = true
+			if len(rp.Children) == 0 {
+				t.Error("root should have children")
+			}
+			// Count aggregates descendants (n1 under root/a, n2 under root/a/b).
+			if rp.Count != 2 {
+				t.Errorf("root aggregate count = %d, want 2", rp.Count)
+			}
+		}
+	}
+	if !sawRoot {
+		t.Error("expected a 'root' package node")
+	}
+}
+
+// TestPackageHierarchyMetadataFailure covers the ensureMetadata error branch of
+// handlePackageHierarchy (the other handlers' equivalents are already covered).
+func TestPackageHierarchyMetadataFailure(t *testing.T) {
+	s := New(&Config{Host: "localhost", Port: 8080, DiagramType: "call-graph", InputDir: t.TempDir()})
+	w := httptest.NewRecorder()
+	s.handlePackageHierarchy(w, httptest.NewRequest(http.MethodGet, "/api/diagram/packages", nil))
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("packages without loadable metadata -> %d, want 500", w.Code)
+	}
+}
+
+// TestPaginatedDiagramClampsAndCache covers the page/size/depth clamping edges
+// of handlePaginatedDiagram and the generatePaginatedDataInternal cache-hit
+// path (a second identical request is served from the cache).
+func TestPaginatedDiagramClampsAndCache(t *testing.T) {
+	s := injectedServer(t)
+	mux := muxFor(s)
+
+	// size > 2000 clamps to 2000; depth < 0 clamps to 0.
+	q := "/api/diagram/page?page=1&size=99999&depth=-5"
+	if w := do(mux, http.MethodGet, q); w.Code != http.StatusOK {
+		t.Fatalf("clamped page request -> %d", w.Code)
+	}
+	// Identical request again -> internal cache hit.
+	if w := do(mux, http.MethodGet, q); w.Code != http.StatusOK {
+		t.Fatalf("cached page request -> %d", w.Code)
+	}
+}
+
+// TestPaginatedDiagramVerbose covers the Verbose logging branch inside
+// generatePaginatedDataInternal.
+func TestPaginatedDiagramVerbose(t *testing.T) {
+	s := injectedServer(t)
+	s.config.Verbose = true
+	mux := muxFor(s)
+	if w := do(mux, http.MethodGet, "/api/diagram/page?page=1&size=10&depth=2"); w.Code != http.StatusOK {
+		t.Fatalf("verbose page request -> %d", w.Code)
+	}
+}
+
+// TestTrackerTreePagination drives the tracker-tree branches of
+// generatePaginatedDataInternal: the tracker-tree ordering, the non-call-graph
+// depth-filter else branch, the tracker-tree pagination slice, and (with a
+// tiny page size) the parent-node re-injection.
+func TestTrackerTreePagination(t *testing.T) {
+	s := injectedServer(t)
+	s.config.DiagramType = "tracker-tree"
+	mux := muxFor(s)
+
+	for _, q := range []string{
+		"/api/diagram/page?page=1&size=1&depth=2",
+		"/api/diagram/page?page=2&size=1&depth=2",
+		"/api/diagram/page?page=999&size=1", // start beyond len -> empty page
+	} {
+		if w := do(mux, http.MethodGet, q); w.Code != http.StatusOK {
+			t.Errorf("tracker-tree %s -> %d", q, w.Code)
+		}
+	}
+}
+
+// TestExportBranches covers handleExport's CORS header branch, the depth<0
+// clamp and the ensureMetadata failure path.
+func TestExportBranches(t *testing.T) {
+	s := injectedServer(t)
+	s.config.EnableCORS = true
+	mux := muxFor(s)
+
+	w := do(mux, http.MethodGet, "/api/diagram/export?format=json&depth=-2")
+	if w.Code != http.StatusOK {
+		t.Fatalf("cors json export -> %d", w.Code)
+	}
+	if w.Header().Get("Access-Control-Allow-Origin") != "*" {
+		t.Error("export missing CORS header")
+	}
+
+	bad := New(&Config{Host: "localhost", Port: 8080, DiagramType: "call-graph", InputDir: t.TempDir()})
+	badMux := muxFor(bad)
+	if w := do(badMux, http.MethodGet, "/api/diagram/export?format=json"); w.Code != http.StatusInternalServerError {
+		t.Errorf("export without loadable metadata -> %d, want 500", w.Code)
+	}
+}
+
+// TestCalculateCallGraphDepthCycle exercises calculateCallGraphDepth's
+// no-root fallback: a pure cycle leaves every node with a non-zero in-degree,
+// so the initial root scan finds nothing and the fallback loop runs.
+func TestCalculateCallGraphDepthCycle(t *testing.T) {
+	s := newTestServer()
+	data := &spec.CytoscapeData{
+		Nodes: []spec.CytoscapeNode{
+			{Data: spec.CytoscapeNodeData{ID: "A"}},
+			{Data: spec.CytoscapeNodeData{ID: "B"}},
+			{Data: spec.CytoscapeNodeData{ID: "C"}},
+		},
+		Edges: []spec.CytoscapeEdge{
+			{Data: spec.CytoscapeEdgeData{Source: "A", Target: "B"}},
+			{Data: spec.CytoscapeEdgeData{Source: "B", Target: "C"}},
+			{Data: spec.CytoscapeEdgeData{Source: "C", Target: "A"}},
+		},
+	}
+	// No panic and no roots discovered -> empty depth map from the fallback.
+	if depths := s.calculateCallGraphDepth(data); len(depths) != 0 {
+		t.Errorf("pure cycle should yield no reachable depths, got %v", depths)
+	}
+}
+
+// TestNodeMatchesFiltersExtra covers the CallPaths file-match branch and the
+// generics-miss branch of nodeMatchesFilters that the existing table omits.
+func TestNodeMatchesFiltersExtra(t *testing.T) {
+	// File match via CallPaths when the node has no direct Position.
+	nodeViaCallPath := spec.CytoscapeNode{Data: spec.CytoscapeNodeData{
+		Label:     "pkg.Handler.Create",
+		Position:  "",
+		CallPaths: []spec.CallPathInfo{{Position: "internal/handler.go:42"}},
+	}}
+	if !nodeMatchesFilters(nodeViaCallPath, nil, []string{"handler.go"}, nil, nil, nil, "") {
+		t.Error("expected a file match through CallPaths")
+	}
+	if nodeMatchesFilters(nodeViaCallPath, nil, []string{"missing.go"}, nil, nil, nil, "") {
+		t.Error("unmatched file should reject even via CallPaths")
+	}
+
+	// Generics present but no filter matches -> reject.
+	genericNode := spec.CytoscapeNode{Data: spec.CytoscapeNodeData{
+		Label:    "pkg.Do",
+		Generics: map[string]string{"T": "int"},
+	}}
+	if nodeMatchesFilters(genericNode, nil, nil, nil, nil, []string{"string"}, "") {
+		t.Error("generics-miss should reject the node")
+	}
+}

--- a/internal/engine/engine_sweep_test.go
+++ b/internal/engine/engine_sweep_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEngineCtx(t *testing.T) {
+	if NewEngine(&EngineConfig{}).ctx() == nil {
+		t.Error("default ctx must not be nil")
+	}
+	type key struct{}
+	custom := context.WithValue(context.Background(), key{}, "v")
+	e := NewEngine(&EngineConfig{Context: custom})
+	if e.ctx().Value(key{}) != "v" {
+		t.Error("configured context not returned")
+	}
+}
+
+func TestModuleImportPath(t *testing.T) {
+	e := NewEngine(&EngineConfig{})
+
+	// No module root resolved yet.
+	if got := e.moduleImportPath(); got != "" {
+		t.Errorf("empty root = %q", got)
+	}
+
+	// go.mod present: the module line wins.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("// comment\nmodule example.com/mymod\n\ngo 1.26\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	e.config.moduleRoot = dir
+	if got := e.moduleImportPath(); got != "example.com/mymod" {
+		t.Errorf("module path = %q, want example.com/mymod", got)
+	}
+
+	// go.mod without a module line.
+	dir2 := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir2, "go.mod"), []byte("go 1.26\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	e.config.moduleRoot = dir2
+	if got := e.moduleImportPath(); got != "" {
+		t.Errorf("missing module line = %q, want empty", got)
+	}
+
+	// go.mod unreadable/missing.
+	e.config.moduleRoot = filepath.Join(dir2, "nope")
+	if got := e.moduleImportPath(); got != "" {
+		t.Errorf("missing go.mod = %q, want empty", got)
+	}
+}
+
+func TestShouldIncludePackage(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  EngineConfig
+		pkg  string
+		want bool
+	}{
+		{"plain package", EngineConfig{}, "example.com/app/api", true},
+		{"cgo sqlite skipped", EngineConfig{SkipCGOPackages: true}, "github.com/mattn/go-sqlite3", false},
+		{"cgo graft-tensorflow skipped", EngineConfig{SkipCGOPackages: true}, "github.com/x/graft/tensorflow", false},
+		{"cgo off keeps sqlite", EngineConfig{}, "github.com/mattn/go-sqlite3", true},
+		{"auto-exclude _test pkg", EngineConfig{AutoExcludeTests: true}, "example.com/app/foo_test", false},
+		{"auto-exclude mocks pkg", EngineConfig{AutoExcludeMocks: true}, "example.com/app/mocks", false},
+		{"auto-exclude stubs pkg", EngineConfig{AutoExcludeMocks: true}, "example.com/app/stubs", false},
+		{"exclude pattern", EngineConfig{ExcludePackages: []string{"internal"}}, "example.com/app/internal", false},
+		{"exclude last-segment match", EngineConfig{ExcludePackages: []string{"vendor*"}}, "example.com/app/vendorx", false},
+		{"include pattern hit", EngineConfig{IncludePackages: []string{"*api*"}}, "example.com/app/api", true},
+		{"include last-segment hit", EngineConfig{IncludePackages: []string{"api"}}, "example.com/app/api", true},
+		{"include pattern miss", EngineConfig{IncludePackages: []string{"*api*"}}, "example.com/app/db", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := c.cfg
+			e := NewEngine(&cfg)
+			if got := e.shouldIncludePackage(c.pkg); got != c.want {
+				t.Errorf("shouldIncludePackage(%q) = %v, want %v", c.pkg, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/insight/metrics_sweep_test.go
+++ b/internal/insight/metrics_sweep_test.go
@@ -553,6 +553,11 @@ func TestResolveInterfaceImplHandler(t *testing.T) {
 			"Real": {Name: pool.Get("Real"), Methods: []metadata.Method{
 				{Name: pool.Get("Handle"), Position: pool.Get("/impl/r.go:30:1")},
 			}},
+			// Ghost.Handle exists as a method but has no caller edge and no
+			// factory FuncLit — the "impl with no body" branch.
+			"Ghost": {Name: pool.Get("Ghost"), Methods: []metadata.Method{
+				{Name: pool.Get("Handle"), Position: pool.Get("/impl/g.go:40:1")},
+			}},
 		}},
 	}}
 	meta.Callers["example.com/impl.Real.Handle"] = []*metadata.CallGraphEdge{{

--- a/internal/insight/metrics_sweep_test.go
+++ b/internal/insight/metrics_sweep_test.go
@@ -1,0 +1,643 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package insight
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+	"github.com/ehabterra/apispec/internal/spec"
+)
+
+// sweepMeta builds an empty metadata with a fresh string pool, plus a call
+// factory that always sets Meta so BaseID/GetString work on synthetic calls.
+func sweepMeta() (*metadata.Metadata, func(pkg, recv, name, pos string) metadata.Call) {
+	meta := &metadata.Metadata{
+		StringPool: metadata.NewStringPool(),
+		Callers:    map[string][]*metadata.CallGraphEdge{},
+		Packages:   map[string]*metadata.Package{},
+	}
+	mk := func(pkg, recv, name, pos string) metadata.Call {
+		return metadata.Call{
+			Meta:     meta,
+			Pkg:      meta.StringPool.Get(pkg),
+			RecvType: meta.StringPool.Get(recv),
+			Name:     meta.StringPool.Get(name),
+			Position: meta.StringPool.Get(pos),
+		}
+	}
+	return meta, mk
+}
+
+func TestCalleeIsStdOrBuiltinAndClassifyPkg(t *testing.T) {
+	meta, mk := sweepMeta()
+	meta.CurrentModulePath = "example.com/app"
+
+	builtin := mk("", "", "append", "")
+	if !calleeIsStdOrBuiltin(meta, &builtin) {
+		t.Error("append should be reported as builtin")
+	}
+
+	cases := []struct {
+		pkg, recv, want string
+	}{
+		{"whatever", "error", "standard"},      // err.Error() on the builtin error interface
+		{"", "", "standard"},                   // universe scope
+		{"example.com/app", "", "project"},     // module root
+		{"example.com/app/sub", "", "project"}, // module subpackage
+		{"fmt", "", "standard"},                // stdlib, no dot in first segment
+		{"net/http", "", "standard"},           // stdlib with slash
+		{"github.com/gin-gonic/gin", "", "library"} /* third-party */}
+	for _, c := range cases {
+		if got := classifyPkg(meta, c.pkg, c.recv); got != c.want {
+			t.Errorf("classifyPkg(%q, %q) = %q, want %q", c.pkg, c.recv, got, c.want)
+		}
+	}
+}
+
+// TestAnalyzeAdjacency_EdgeCases drives the shared BFS core through its
+// self-edge skip, chain-depth tracking, nil/pointer/value argument counting
+// and the depth-truncation guard.
+func TestAnalyzeAdjacency_EdgeCases(t *testing.T) {
+	meta, mk := sweepMeta()
+	pool := meta.StringPool
+	const pkg = "example.com/app"
+	const root = pkg + ".H.Do"
+
+	rootCall := mk(pkg, "H", "Do", "/app/h.go:5:1")
+	selfEdge := &metadata.CallGraphEdge{Caller: rootCall, Callee: mk(pkg, "H", "Do", "/app/h.go:6:2")}
+	ptrArg := &metadata.CallArgument{Meta: meta, Type: pool.Get("*Foo")}
+	valArg := &metadata.CallArgument{Meta: meta, Type: pool.Get("Bar")}
+	toA := &metadata.CallGraphEdge{
+		Caller:     rootCall,
+		Callee:     mk(pkg, "S", "A", "/app/s.go:10:3"),
+		ChainDepth: 3,
+		Args:       []*metadata.CallArgument{nil, ptrArg, valArg},
+	}
+	meta.Callers[root] = []*metadata.CallGraphEdge{selfEdge, toA}
+
+	// A long chain under A trips the maxTraceDepth guard.
+	prev := "S"
+	prevName := "A"
+	for i := 0; i < 20; i++ {
+		recv := fmt.Sprintf("C%d", i)
+		key := pkg + "." + prev + "." + prevName
+		meta.Callers[key] = []*metadata.CallGraphEdge{{
+			Caller: mk(pkg, prev, prevName, ""),
+			Callee: mk(pkg, recv, "Run", ""),
+		}}
+		prev, prevName = recv, "Run"
+	}
+
+	m, tg := analyzeFromHandler(meta, root)
+	if !m.DepthTruncated {
+		t.Error("expected DepthTruncated for a >maxTraceDepth chain")
+	}
+	if m.ChainDepth != 3 {
+		t.Errorf("ChainDepth = %d, want 3", m.ChainDepth)
+	}
+	if m.PointerArgs != 1 || m.ValueArgs != 1 {
+		t.Errorf("args = ptr %d / val %d, want 1 / 1", m.PointerArgs, m.ValueArgs)
+	}
+	for _, n := range tg.Nodes {
+		if n.ID == root && n.Kind != "handler" {
+			t.Errorf("root kind = %q", n.Kind)
+		}
+	}
+}
+
+// fanOutMeta builds a root with a huge fan-out (601 leaves plus a "Zzz"
+// callee that has its own callee), enough to trip the maxReachable cap and
+// the trace-graph node budget.
+func fanOutMeta(t *testing.T) (*metadata.Metadata, string) {
+	t.Helper()
+	meta, mk := sweepMeta()
+	const pkg = "example.com/app"
+	root := pkg + ".H.Do"
+	rootCall := mk(pkg, "H", "Do", "")
+
+	edges := []*metadata.CallGraphEdge{{Caller: rootCall, Callee: mk(pkg, "", "Zzz", "")}}
+	for i := 0; i <= 600; i++ {
+		edges = append(edges, &metadata.CallGraphEdge{
+			Caller: rootCall,
+			Callee: mk(pkg, "", fmt.Sprintf("F%03d", i), ""),
+		})
+	}
+	meta.Callers[root] = edges
+	// Zzz has a callee, so adj gains a source that the 60-node trace graph
+	// excludes (it sorts after every Fxxx id).
+	meta.Callers[pkg+".Zzz"] = []*metadata.CallGraphEdge{{
+		Caller: mk(pkg, "", "Zzz", ""),
+		Callee: mk(pkg, "", "Sub", ""),
+	}}
+	return meta, root
+}
+
+func TestAnalyze_ReachableAndGraphCaps(t *testing.T) {
+	meta, root := fanOutMeta(t)
+
+	m, tg := analyzeFromHandler(meta, root)
+	if !m.DepthTruncated {
+		t.Error("adjacency: expected DepthTruncated once maxReachable is exceeded")
+	}
+	if !tg.Truncated || len(tg.Nodes) != maxGraphNodes {
+		t.Errorf("adjacency: trace graph = %d nodes truncated=%v, want %d/true", len(tg.Nodes), tg.Truncated, maxGraphNodes)
+	}
+
+	m2, tg2, ok := analyzeResolvedCallGraph(meta, root)
+	if !ok || !m2.DepthTruncated {
+		t.Errorf("resolved: ok=%v truncated=%v, want true/true", ok, m2.DepthTruncated)
+	}
+	if !tg2.Truncated {
+		t.Error("resolved: trace graph should be truncated")
+	}
+}
+
+// TestAnalyzeResolvedCallGraph_EdgeCases exercises the resolved-call-graph
+// fallback: missing root, self edges, diamond revisits, chain depth, args,
+// deep-chain truncation and interface→implementation resolution.
+func TestAnalyzeResolvedCallGraph_EdgeCases(t *testing.T) {
+	meta, mk := sweepMeta()
+	pool := meta.StringPool
+	const pkg = "example.com/app"
+	const root = pkg + ".H.Do"
+
+	if _, _, ok := analyzeResolvedCallGraph(meta, "no.such.Root"); ok {
+		t.Fatal("unknown root must report ok=false")
+	}
+
+	rootCall := mk(pkg, "H", "Do", "/app/h.go:5:1")
+	ptrArg := &metadata.CallArgument{Meta: meta, Type: pool.Get("*Foo")}
+	valArg := &metadata.CallArgument{Meta: meta, Type: pool.Get("Bar")}
+	meta.Callers[root] = []*metadata.CallGraphEdge{
+		{Caller: rootCall, Callee: mk(pkg, "H", "Do", "/app/h.go:6:2")}, // self edge → skipped
+		{Caller: rootCall, Callee: mk(pkg, "S", "A", "/app/s.go:10:3"), ChainDepth: 2,
+			Args: []*metadata.CallArgument{nil, ptrArg, valArg}},
+		{Caller: rootCall, Callee: mk(pkg, "", "D1", "")},
+		{Caller: rootCall, Callee: mk(pkg, "", "D2", "")},
+		{Caller: rootCall, Callee: mk(pkg, "UseCase", "Check", "/app/h.go:9:3")},
+	}
+	// Diamond: D1 and D2 both call DX, so the second enqueue sees it visited.
+	for _, d := range []string{"D1", "D2"} {
+		meta.Callers[pkg+"."+d] = []*metadata.CallGraphEdge{{
+			Caller: mk(pkg, "", d, ""),
+			Callee: mk(pkg, "", "DX", ""),
+		}}
+	}
+	// Deep chain under S.A trips the depth cap.
+	prev, prevName := "S", "A"
+	for i := 0; i < 20; i++ {
+		recv := fmt.Sprintf("C%d", i)
+		meta.Callers[pkg+"."+prev+"."+prevName] = []*metadata.CallGraphEdge{{
+			Caller: mk(pkg, prev, prevName, ""),
+			Callee: mk(pkg, recv, "Run", ""),
+		}}
+		prev, prevName = recv, "Run"
+	}
+	// UseCase.Check has no body but is an interface method with a concrete impl.
+	meta.Packages[pkg] = &metadata.Package{Files: map[string]*metadata.File{
+		"h.go": {Types: map[string]*metadata.Type{
+			"UseCase": {
+				Kind:          pool.Get("interface"),
+				ImplementedBy: []int{pool.Get("example.com/impl.Pay")},
+			},
+		}},
+	}}
+	meta.Callers["example.com/impl.Pay.Check"] = []*metadata.CallGraphEdge{{
+		Caller: mk("example.com/impl", "Pay", "Check", "/impl/p.go:30:1"),
+		Callee: mk("example.com/impl", "Repo", "Load", "/impl/p.go:31:2"),
+	}}
+
+	m, tg, ok := analyzeResolvedCallGraph(meta, root)
+	if !ok {
+		t.Fatal("analyzeResolvedCallGraph should succeed")
+	}
+	if !m.DepthTruncated {
+		t.Error("expected DepthTruncated for the deep chain")
+	}
+	if m.ChainDepth != 2 || m.PointerArgs != 1 || m.ValueArgs != 1 {
+		t.Errorf("chain=%d ptr=%d val=%d, want 2/1/1", m.ChainDepth, m.PointerArgs, m.ValueArgs)
+	}
+	found := false
+	for _, n := range tg.Nodes {
+		if n.ID == "example.com/impl.Pay.Check" {
+			found = true
+			if !n.Resolved {
+				t.Error("concrete impl should carry the Resolved badge")
+			}
+		}
+	}
+	if !found {
+		t.Error("interface method did not resolve to its concrete implementation")
+	}
+}
+
+// fakeTrackerNode is a minimal spec.TrackerNodeInterface for driving
+// analyzeTrackerSubtree without building a real tracker tree.
+type fakeTrackerNode struct {
+	key      string
+	edge     *metadata.CallGraphEdge
+	children []spec.TrackerNodeInterface
+}
+
+func (f *fakeTrackerNode) GetKey() string                           { return f.key }
+func (f *fakeTrackerNode) GetParent() spec.TrackerNodeInterface     { return nil }
+func (f *fakeTrackerNode) GetChildren() []spec.TrackerNodeInterface { return f.children }
+func (f *fakeTrackerNode) GetEdge() *metadata.CallGraphEdge         { return f.edge }
+func (f *fakeTrackerNode) GetArgument() *metadata.CallArgument      { return nil }
+func (f *fakeTrackerNode) GetTypeParamMap() map[string]string       { return nil }
+
+func TestAnalyzeTrackerSubtree(t *testing.T) {
+	meta, mk := sweepMeta()
+	pool := meta.StringPool
+	const pkg = "example.com/app"
+	rootCall := mk(pkg, "H", "Do", "/app/h.go:5:1")
+
+	t.Run("no children → no handler body", func(t *testing.T) {
+		if _, _, ok := analyzeTrackerSubtree(meta, &fakeTrackerNode{}); ok {
+			t.Error("empty route node should report ok=false")
+		}
+	})
+
+	t.Run("only builtin callees → no adjacency", func(t *testing.T) {
+		route := &fakeTrackerNode{children: []spec.TrackerNodeInterface{
+			&fakeTrackerNode{edge: &metadata.CallGraphEdge{
+				Caller: rootCall,
+				Callee: mk("", "", "len", ""),
+			}},
+		}}
+		if _, _, ok := analyzeTrackerSubtree(meta, route); ok {
+			t.Error("builtin-only subtree should report ok=false")
+		}
+	})
+
+	t.Run("full walk", func(t *testing.T) {
+		ptrArg := &metadata.CallArgument{Meta: meta, Type: pool.Get("*Foo")}
+		// Deep nested chain to trip the depth guard: level i's edge is
+		// C(i-1) → C(i), with the handler calling C0 at the top.
+		var deepChild *fakeTrackerNode
+		for i := 17; i >= 0; i-- {
+			caller := rootCall
+			if i > 0 {
+				caller = mk(pkg, "", fmt.Sprintf("C%d", i-1), "")
+			}
+			node := &fakeTrackerNode{edge: &metadata.CallGraphEdge{
+				Caller: caller,
+				Callee: mk(pkg, "", fmt.Sprintf("C%d", i), ""),
+			}}
+			if deepChild != nil {
+				node.children = []spec.TrackerNodeInterface{deepChild}
+			}
+			deepChild = node
+		}
+
+		// Interface resolution boundary: the child edge's Caller is neither the
+		// enclosing function nor the callee → surfaces the concrete impl node.
+		resolved := &fakeTrackerNode{edge: &metadata.CallGraphEdge{
+			Caller: mk("example.com/impl", "Pay", "Check", "/impl/p.go:30:1"),
+			Callee: mk("example.com/impl", "Repo", "Load", "/impl/p.go:31:2"),
+		}}
+		svc := &fakeTrackerNode{
+			edge: &metadata.CallGraphEdge{
+				Caller:     rootCall,
+				Callee:     mk(pkg, "S", "A", "/app/s.go:10:3"),
+				ChainDepth: 2,
+				Args:       []*metadata.CallArgument{nil, ptrArg},
+			},
+			children: []spec.TrackerNodeInterface{resolved},
+		}
+
+		// Edge-less wrapper node whose children are re-queued in place.
+		wrapper := &fakeTrackerNode{children: []spec.TrackerNodeInterface{
+			&fakeTrackerNode{edge: &metadata.CallGraphEdge{Caller: rootCall, Callee: mk(pkg, "S", "B", "")}},
+		}}
+
+		// Duplicate keys: the second node is skipped by the visited set.
+		dup1 := &fakeTrackerNode{key: "dup", edge: &metadata.CallGraphEdge{Caller: rootCall, Callee: mk(pkg, "S", "C", "")}}
+		dup2 := &fakeTrackerNode{key: "dup", edge: &metadata.CallGraphEdge{Caller: rootCall, Callee: mk(pkg, "S", "D", "")}}
+
+		route := &fakeTrackerNode{children: []spec.TrackerNodeInterface{svc, wrapper, dup1, dup2, deepChild}}
+		m, tg, ok := analyzeTrackerSubtree(meta, route)
+		if !ok {
+			t.Fatal("analyzeTrackerSubtree should succeed")
+		}
+		if !m.DepthTruncated {
+			t.Error("expected DepthTruncated for the nested chain")
+		}
+		if m.ChainDepth != 2 || m.PointerArgs != 1 {
+			t.Errorf("chain=%d ptr=%d, want 2/1", m.ChainDepth, m.PointerArgs)
+		}
+		var sawResolved, sawDupSkip bool
+		for _, n := range tg.Nodes {
+			if n.ID == "example.com/impl.Pay.Check" && n.Resolved {
+				sawResolved = true
+			}
+			if n.ID == pkg+".S.D" {
+				sawDupSkip = true // dup2 shares dup1's key → must NOT appear
+			}
+		}
+		if !sawResolved {
+			t.Error("resolution-boundary node missing from the trace")
+		}
+		if sawDupSkip {
+			t.Error("node with an already-visited key should be skipped")
+		}
+	})
+
+	t.Run("reachable cap", func(t *testing.T) {
+		kids := make([]spec.TrackerNodeInterface, 0, 602)
+		for i := 0; i <= 601; i++ {
+			kids = append(kids, &fakeTrackerNode{edge: &metadata.CallGraphEdge{
+				Caller: rootCall,
+				Callee: mk(pkg, "", fmt.Sprintf("F%03d", i), ""),
+			}})
+		}
+		m, _, ok := analyzeTrackerSubtree(meta, &fakeTrackerNode{children: kids})
+		if !ok || !m.DepthTruncated {
+			t.Errorf("ok=%v truncated=%v, want true/true", ok, m.DepthTruncated)
+		}
+	})
+}
+
+func TestCachedTrackerTree_NilMeta(t *testing.T) {
+	if cachedTrackerTree(nil) != nil {
+		t.Error("nil metadata must yield a nil tree")
+	}
+}
+
+func TestResolveImplementers_EdgeCases(t *testing.T) {
+	meta, mk := sweepMeta()
+	pool := meta.StringPool
+
+	empty := mk("", "", "", "")
+	if got := resolveImplementers(meta, &empty); got != nil {
+		t.Errorf("empty callee should resolve to nil, got %v", got)
+	}
+
+	meta.Packages["example.com/api"] = &metadata.Package{Files: map[string]*metadata.File{
+		"i.go": {Types: map[string]*metadata.Type{
+			"Svc": {
+				Kind:          pool.Get("interface"),
+				ImplementedBy: []int{pool.Get("nodots"), pool.Get("trailing.")},
+			},
+		}},
+	}}
+	callee := mk("example.com/api", "Svc", "Handle", "")
+	if got := resolveImplementers(meta, &callee); len(got) != 0 {
+		t.Errorf("malformed implementer names should be skipped, got %v", got)
+	}
+}
+
+func TestEnumeratePaths_Caps(t *testing.T) {
+	adj := map[string][]string{"r": {"a", "b"}}
+	if out := enumeratePaths(adj, "r", 0); len(out) != 0 {
+		t.Errorf("cap 0 should yield no paths, got %v", out)
+	}
+	if out := enumeratePaths(adj, "r", 1); len(out) != 1 {
+		t.Errorf("cap 1 should yield exactly one path, got %v", out)
+	}
+}
+
+func TestCountPaths_MemoAndTruncation(t *testing.T) {
+	// Diamond: D's count is memoised on the B branch and reused on the C branch.
+	diamond := map[string][]string{"A": {"B", "C"}, "B": {"D"}, "C": {"D"}, "D": {"E"}}
+	if n, tr := countPaths(diamond, "A"); n != 2 || tr {
+		t.Errorf("diamond = %d trunc=%v, want 2 false", n, tr)
+	}
+
+	// Doubled edges: 2^10 = 1024 paths exceed maxPaths → truncated.
+	wide := map[string][]string{}
+	for i := 0; i < 10; i++ {
+		next := fmt.Sprintf("n%d", i+1)
+		wide[fmt.Sprintf("n%d", i)] = []string{next, next}
+	}
+	if n, tr := countPaths(wide, "n0"); n != maxPaths || !tr {
+		t.Errorf("wide = %d trunc=%v, want %d true", n, tr, maxPaths)
+	}
+}
+
+func TestGrade_MiddleBands(t *testing.T) {
+	if g, lb := grade(Metrics{MaxDepth: 6, CallPaths: 30, FanoutMax: 10}); g != "B" || lb {
+		t.Errorf("grade = %s lb=%v, want B false", g, lb)
+	}
+	if g, _ := grade(Metrics{MaxDepth: 9, CallPaths: 100}); g != "C" {
+		t.Errorf("grade = %s, want C", g)
+	}
+}
+
+func TestBuildTraceGraph_NoEdges(t *testing.T) {
+	meta, _ := sweepMeta()
+	_, tg := analyzeFromHandler(meta, "example.com/app.Lonely")
+	if tg.Edges == nil {
+		t.Error("Edges must be non-nil for JSON")
+	}
+	if len(tg.Edges) != 0 || len(tg.Nodes) != 1 {
+		t.Errorf("nodes=%d edges=%d, want 1/0", len(tg.Nodes), len(tg.Edges))
+	}
+}
+
+func TestSortedSites_CallerTieBreak(t *testing.T) {
+	sites := map[string]CallSite{
+		"k1": {Pos: "/p/a.go:1", Caller: "beta"},
+		"k2": {Pos: "/p/a.go:1", Caller: "alpha"},
+	}
+	out := sortedSites(sites)
+	if len(out) != 2 || out[0].Caller != "alpha" || out[1].Caller != "beta" {
+		t.Errorf("tie-break by caller failed: %v", out)
+	}
+}
+
+// --- endpoint.go sweeps ------------------------------------------------------
+
+func TestBuildEndpointWithSource_NilInputs(t *testing.T) {
+	rep := BuildEndpointWithSource(nil, nil, nil, "get", "/x", TraceSourceTracker)
+	if rep.Found || rep.Method != "GET" || rep.Path != "/x" {
+		t.Errorf("nil spec should degrade gracefully: %+v", rep)
+	}
+
+	// Nil Callers map triggers the lazy BuildCallGraphMaps branch.
+	s := &spec.OpenAPISpec{Paths: map[string]spec.PathItem{
+		"/x": {Get: &spec.Operation{OperationID: "example.com/x.Nope", Responses: map[string]spec.Response{"200": {}}}},
+	}}
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	rep = BuildEndpointWithSource(s, meta, nil, "GET", "/x", TraceSourceTracker)
+	if !rep.Found || rep.HandlerFound {
+		t.Errorf("found=%v handlerFound=%v, want true/false", rep.Found, rep.HandlerFound)
+	}
+	if meta.Callers == nil {
+		t.Error("BuildCallGraphMaps should have populated Callers")
+	}
+}
+
+func TestResolveHandlerKey_Paths(t *testing.T) {
+	meta, mk := sweepMeta()
+	pool := meta.StringPool
+	const pkg = "example.com/hd"
+
+	meta.Packages[pkg] = &metadata.Package{Files: map[string]*metadata.File{
+		"h.go": {Types: map[string]*metadata.Type{
+			"handler": {Name: pool.Get("handler"), Methods: []metadata.Method{
+				{Name: pool.Get("List"), Position: pool.Get("/hd/h.go:10:2")},
+			}},
+			"maker": {Name: pool.Get("maker"), Methods: []metadata.Method{
+				{Name: pool.Get("Make"), Position: pool.Get("/hd/m.go:20:1")},
+			}},
+		}},
+		"fn.go": {Functions: map[string]*metadata.Function{
+			"Serve": {Name: pool.Get("Serve"), Position: pool.Get("/hd/fn.go:5:1")},
+		}},
+	}}
+	meta.Callers[pkg+".handler.List"] = []*metadata.CallGraphEdge{{
+		Caller: mk(pkg, "handler", "List", "/hd/h.go:10:2"),
+	}}
+	meta.Callers[pkg+".FuncLit:/hd/m.go:22:9"] = []*metadata.CallGraphEdge{{
+		Caller: mk(pkg, "", "FuncLit", "/hd/m.go:22:9"),
+	}}
+
+	// Receiver-insensitive candidate that is itself a caller.
+	key, pos := resolveHandlerKey(meta, pkg+".Handler.List")
+	if key != pkg+".handler.List" || pos != "/hd/h.go:10" {
+		t.Errorf("candidate resolution = %q @ %q", key, pos)
+	}
+
+	// Handler-factory: the method is not a caller, its FuncLit is.
+	key, pos = resolveHandlerKey(meta, pkg+".Maker.Make")
+	if key != pkg+".FuncLit:/hd/m.go:22:9" || pos != "/hd/m.go:20" {
+		t.Errorf("funclit resolution = %q @ %q", key, pos)
+	}
+
+	// Plain-function candidate (scanned from file Functions) that never
+	// resolves to a caller: falls through with the declaration position.
+	key, pos = resolveHandlerKey(meta, pkg+".Serve")
+	if key != pkg+".Serve" || pos != "/hd/fn.go:5" {
+		t.Errorf("function-scan fallback = %q @ %q", key, pos)
+	}
+
+	// Nothing matches at all.
+	key, pos = resolveHandlerKey(meta, pkg+".Nothing")
+	if key != pkg+".Nothing" || pos != "" {
+		t.Errorf("miss fallback = %q @ %q", key, pos)
+	}
+}
+
+func TestResolveInterfaceImplHandler(t *testing.T) {
+	meta, mk := sweepMeta()
+	pool := meta.StringPool
+
+	meta.Packages["example.com/api"] = &metadata.Package{Files: map[string]*metadata.File{
+		"i.go": {Types: map[string]*metadata.Type{
+			"Svc": {Kind: pool.Get("interface"), ImplementedBy: []int{
+				pool.Get("nodots"),
+				pool.Get("example.com/impl.Real"),
+			}},
+			"Svc2":  {Kind: pool.Get("interface"), ImplementedBy: []int{pool.Get("example.com/impl.Ghost")}},
+			"Other": {Kind: pool.Get("struct")},
+		}},
+	}}
+	meta.Packages["example.com/impl"] = &metadata.Package{Files: map[string]*metadata.File{
+		"r.go": {Types: map[string]*metadata.Type{
+			"Real": {Name: pool.Get("Real"), Methods: []metadata.Method{
+				{Name: pool.Get("Handle"), Position: pool.Get("/impl/r.go:30:1")},
+			}},
+		}},
+	}}
+	meta.Callers["example.com/impl.Real.Handle"] = []*metadata.CallGraphEdge{{
+		Caller: mk("example.com/impl", "Real", "Handle", "/impl/r.go:30:1"),
+	}}
+
+	cases := []struct {
+		name, opID, wantKey, wantPos string
+	}{
+		{"unparseable opID", "plain", "", ""},
+		{"unknown package", "example.com/nope.Svc.Handle", "", ""},
+		{"non-interface receiver", "example.com/api.Other.Handle", "", ""},
+		{"impl with no body", "example.com/api.Svc2.Handle", "", ""},
+		{"direct concrete method", "example.com/api.Svc.Handle", "example.com/impl.Real.Handle", "/impl/r.go:30"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			key, pos := resolveInterfaceImplHandler(meta, c.opID)
+			if key != c.wantKey || pos != c.wantPos {
+				t.Errorf("= %q @ %q, want %q @ %q", key, pos, c.wantKey, c.wantPos)
+			}
+		})
+	}
+}
+
+func TestSplitOpID_EdgeCases(t *testing.T) {
+	if p, r, m := splitOpID3("plain"); p != "" || r != "" || m != "" {
+		t.Errorf("splitOpID3(plain) = %q %q %q", p, r, m)
+	}
+	if p, n := splitOpID("nodot"); p != "" || n != "" {
+		t.Errorf("splitOpID(nodot) = %q %q", p, n)
+	}
+	meta, _ := sweepMeta()
+	if keys, file, line := candidateHandlerKeys(meta, "nodot"); keys != nil || file != "" || line != 0 {
+		t.Errorf("candidateHandlerKeys(nodot) = %v %q %d", keys, file, line)
+	}
+}
+
+func TestImplMethodPos_Misses(t *testing.T) {
+	meta, _ := sweepMeta()
+	pool := meta.StringPool
+	meta.Packages["example.com/impl"] = &metadata.Package{Files: map[string]*metadata.File{
+		"r.go": {Types: map[string]*metadata.Type{
+			"Real": {Name: pool.Get("Real"), Methods: []metadata.Method{
+				{Name: pool.Get("Handle"), Position: pool.Get("/impl/r.go:30:1")},
+			}},
+		}},
+	}}
+
+	if f, l := implMethodPos(meta, "example.com/absent", "X", "M"); f != "" || l != 0 {
+		t.Errorf("missing package = %q:%d", f, l)
+	}
+	if f, l := implMethodPos(meta, "example.com/impl", "Ghost", "M"); f != "" || l != 0 {
+		t.Errorf("missing type = %q:%d", f, l)
+	}
+	if f, l := implMethodPos(meta, "example.com/impl", "Real", "Nope"); f != "" || l != 0 {
+		t.Errorf("missing method = %q:%d", f, l)
+	}
+	if f, l := implMethodPos(meta, "example.com/impl", "Real", "Handle"); f != "/impl/r.go" || l != 30 {
+		t.Errorf("hit = %q:%d, want /impl/r.go:30", f, l)
+	}
+}
+
+func TestSchemaSummary_Extras(t *testing.T) {
+	sweepRef := func(name string) *spec.Schema { return &spec.Schema{Ref: refPrefix + name} }
+
+	// allOf with a nil member is skipped.
+	if got := schemaSummary(&spec.Schema{AllOf: []*spec.Schema{nil, sweepRef("Env")}}); got != "allOf[Env]" {
+		t.Errorf("allOf with nil = %q", got)
+	}
+	// Typeless object with >5 properties gets the ellipsis.
+	props := map[string]*spec.Schema{}
+	for _, k := range []string{"a", "b", "c", "d", "e", "f"} {
+		props[k] = &spec.Schema{Type: "string"}
+	}
+	got := schemaSummary(&spec.Schema{Properties: props})
+	if !strings.HasPrefix(got, "object{a, b, c, d, e") || !strings.Contains(got, "…") {
+		t.Errorf("object props = %q", got)
+	}
+	// No type, no properties → plain object.
+	if got := schemaSummary(&spec.Schema{}); got != "object" {
+		t.Errorf("bare schema = %q", got)
+	}
+	// shortName falls back from underscores to dots to the raw string.
+	if shortName("a.b") != "b" || shortName("plain") != "plain" {
+		t.Errorf("shortName fallbacks broken: %q %q", shortName("a.b"), shortName("plain"))
+	}
+}

--- a/internal/metadata/metadata_sweep_test.go
+++ b/internal/metadata/metadata_sweep_test.go
@@ -1,0 +1,1296 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"errors"
+	"go/ast"
+	"go/importer"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// sweepMeta returns a minimal Metadata suitable for constructing
+// CallArguments and exercising resolver helpers directly.
+func sweepMeta() *Metadata {
+	return &Metadata{
+		StringPool: NewStringPool(),
+		Packages:   map[string]*Package{},
+	}
+}
+
+// sweepParseExpr parses a single expression and fails the test on error.
+func sweepParseExpr(t *testing.T, src string) ast.Expr {
+	t.Helper()
+	e, err := parser.ParseExpr(src)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", src, err)
+	}
+	return e
+}
+
+// sweepParseFile parses a whole file without type-checking.
+func sweepParseFile(t *testing.T, src string) (*ast.File, *token.FileSet) {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "sweep.go", src, 0)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	return file, fset
+}
+
+// sweepTypeCheck parses and fully type-checks a file.
+func sweepTypeCheck(t *testing.T, src string) (*ast.File, *types.Info, *token.FileSet) {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "sweep.go", src, 0)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	info := &types.Info{
+		Types:     map[ast.Expr]types.TypeAndValue{},
+		Defs:      map[*ast.Ident]types.Object{},
+		Uses:      map[*ast.Ident]types.Object{},
+		Instances: map[*ast.Ident]types.Instance{},
+	}
+	conf := types.Config{Importer: importer.Default()}
+	if _, err := conf.Check("p", fset, []*ast.File{file}, info); err != nil {
+		t.Fatalf("typecheck: %v", err)
+	}
+	return file, info, fset
+}
+
+// sweepIdent builds an ident CallArgument with just a name.
+func sweepIdent(m *Metadata, name string) *CallArgument {
+	a := arg(m, KindIdent)
+	a.SetName(name)
+	return a
+}
+
+// sweepLit builds a literal CallArgument with a value.
+func sweepLit(m *Metadata, value string) *CallArgument {
+	a := arg(m, KindLiteral)
+	a.SetValue(value)
+	return a
+}
+
+// sweepCall builds a Call with all pool indices explicitly unset so a zero
+// index never aliases whatever string happens to sit at pool slot 0.
+func sweepCall(m *Metadata, name, pkg string) Call {
+	return Call{
+		Meta:         m,
+		Name:         m.StringPool.Get(name),
+		Pkg:          m.StringPool.Get(pkg),
+		Position:     -1,
+		RecvType:     -1,
+		Scope:        -1,
+		SignatureStr: -1,
+	}
+}
+
+// --- expression.go ---
+
+func TestSweepCallArgToStringFallbacks(t *testing.T) {
+	m := sweepMeta()
+
+	if got := CallArgToString(nil); got != "" {
+		t.Errorf("nil arg: got %q", got)
+	}
+
+	cases := []struct {
+		name  string
+		build func() *CallArgument
+		want  string
+	}{
+		{"selector no X", func() *CallArgument {
+			a := arg(m, KindSelector)
+			a.Sel = sweepIdent(m, "Sel")
+			return a
+		}, "Sel"},
+		{"call no fun", func() *CallArgument { return arg(m, KindCall) }, "call()"},
+		{"unary no X", func() *CallArgument {
+			a := arg(m, KindUnary)
+			a.SetValue("&")
+			return a
+		}, "&"},
+		{"binary no operands", func() *CallArgument {
+			a := arg(m, KindBinary)
+			a.SetValue("+")
+			return a
+		}, "+"},
+		{"index no operands", func() *CallArgument { return arg(m, KindIndex) }, "index"},
+		{"index list with X", func() *CallArgument {
+			a := arg(m, KindIndexList)
+			a.X = sweepIdent(m, "G")
+			a.Args = []*CallArgument{sweepIdent(m, "int"), sweepIdent(m, "string")}
+			return a
+		}, "G[int, string]"},
+		{"index list no X", func() *CallArgument { return arg(m, KindIndexList) }, "index_list"},
+		{"paren no X", func() *CallArgument { return arg(m, KindParen) }, "()"},
+		{"star no X", func() *CallArgument { return arg(m, KindStar) }, "*"},
+		{"array type no X", func() *CallArgument {
+			a := arg(m, KindArrayType)
+			a.SetValue("5")
+			return a
+		}, "[5]"},
+		{"slice with bounds", func() *CallArgument {
+			a := arg(m, KindSlice)
+			a.X = sweepIdent(m, "xs")
+			a.Args = []*CallArgument{sweepLit(m, "1"), sweepLit(m, "2")}
+			return a
+		}, "xs[1:2]"},
+		{"slice no X", func() *CallArgument { return arg(m, KindSlice) }, "slice"},
+		{"composite no X", func() *CallArgument { return arg(m, KindCompositeLit) }, "{}"},
+		{"key value no X", func() *CallArgument { return arg(m, KindKeyValue) }, "key: value"},
+		{"type assert full", func() *CallArgument {
+			a := arg(m, KindTypeAssert)
+			a.X = sweepIdent(m, "v")
+			a.Fun = sweepIdent(m, "int")
+			return a
+		}, "v.(int)"},
+		{"type assert no X", func() *CallArgument { return arg(m, KindTypeAssert) }, "type_assert"},
+		{"chan with X", func() *CallArgument {
+			a := arg(m, KindChanType)
+			a.X = sweepIdent(m, "int")
+			return a
+		}, "chan int"},
+		{"chan no X", func() *CallArgument { return arg(m, KindChanType) }, "chan"},
+		{"map no X", func() *CallArgument { return arg(m, KindMapType) }, "map"},
+		{"ellipsis no X", func() *CallArgument { return arg(m, KindEllipsis) }, "..."},
+		{"func type no fun", func() *CallArgument { return arg(m, KindFuncType) }, "func()"},
+	}
+	for _, tc := range cases {
+		if got := CallArgToString(tc.build()); got != tc.want {
+			t.Errorf("%s: got %q want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestSweepExprToCallArgumentArms(t *testing.T) {
+	m := sweepMeta()
+	fset := token.NewFileSet()
+
+	// Type assertion dispatch arm.
+	ta := ExprToCallArgument(sweepParseExpr(t, "v.(int)"), nil, "p", fset, m)
+	if ta.GetKind() != KindTypeAssert {
+		t.Errorf("type assert kind: got %q", ta.GetKind())
+	}
+
+	// Fallback arm for expressions with no dedicated handler.
+	bad := ExprToCallArgument(&ast.BadExpr{}, nil, "p", fset, m)
+	if bad.GetKind() != KindRaw {
+		t.Errorf("bad expr kind: got %q", bad.GetKind())
+	}
+
+	// Array type with a declared length.
+	at := ExprToCallArgument(sweepParseExpr(t, "[5]int"), nil, "p", fset, m)
+	if at.GetKind() != KindArrayType || at.GetValue() != "5" {
+		t.Errorf("array type: kind %q value %q", at.GetKind(), at.GetValue())
+	}
+
+	// Three-index slice expression (Max set).
+	sl := ExprToCallArgument(sweepParseExpr(t, "xs[1:2:3]"), nil, "p", fset, m)
+	if sl.GetKind() != KindSlice || len(sl.Args) != 3 {
+		t.Errorf("slice expr: kind %q args %d", sl.GetKind(), len(sl.Args))
+	}
+
+	// Directional channels.
+	send := ExprToCallArgument(sweepParseExpr(t, "chan<- int"), nil, "p", fset, m)
+	if send.GetValue() != "send" {
+		t.Errorf("send chan: got %q", send.GetValue())
+	}
+	recv := ExprToCallArgument(sweepParseExpr(t, "<-chan int"), nil, "p", fset, m)
+	if recv.GetValue() != "recv" {
+		t.Errorf("recv chan: got %q", recv.GetValue())
+	}
+
+	// Struct type with an embedded field.
+	st := ExprToCallArgument(sweepParseExpr(t, "struct{ int; A string }"), nil, "p", fset, m)
+	if st.GetKind() != KindStructType || len(st.Args) != 2 {
+		t.Fatalf("struct type: kind %q fields %d", st.GetKind(), len(st.Args))
+	}
+	if st.Args[0].GetKind() != KindEmbed {
+		t.Errorf("embedded field kind: got %q", st.Args[0].GetKind())
+	}
+}
+
+func TestSweepHandleSelectorPkgName(t *testing.T) {
+	m := sweepMeta()
+	selIdent := ast.NewIdent("util")
+	sel := &ast.SelectorExpr{X: ast.NewIdent("a"), Sel: selIdent}
+	imported := types.NewPackage("example.com/util", "util")
+	importing := types.NewPackage("example.com/app", "app")
+	info := &types.Info{Uses: map[*ast.Ident]types.Object{
+		selIdent: types.NewPkgName(token.NoPos, importing, "util", imported),
+	}}
+
+	res := ExprToCallArgument(sel, info, "app", token.NewFileSet(), m)
+	if res.GetPkg() != "example.com/util" {
+		t.Errorf("selector pkg-name object: got pkg %q", res.GetPkg())
+	}
+}
+
+// --- analysis.go ---
+
+func TestSweepIsTypeConversionArms(t *testing.T) {
+	if isTypeConversion(&ast.CallExpr{Fun: ast.NewIdent("f")}, nil) {
+		t.Error("nil info should never report a conversion")
+	}
+
+	emptyInfo := &types.Info{Types: map[ast.Expr]types.TypeAndValue{}}
+	star := &ast.CallExpr{Fun: &ast.StarExpr{X: ast.NewIdent("T")}}
+	if !isTypeConversion(star, emptyInfo) {
+		t.Error("star-expr fun should be a conversion")
+	}
+	iface := &ast.CallExpr{Fun: &ast.InterfaceType{Methods: &ast.FieldList{}}}
+	if !isTypeConversion(iface, emptyInfo) {
+		t.Error("interface-type fun should be a conversion")
+	}
+
+	// Parenthesized conversion resolves through info.Types[fun].IsType().
+	file, info, _ := sweepTypeCheck(t, "package p\n\ntype T int\n\nvar x = (T)(1)\n")
+	var conv *ast.CallExpr
+	ast.Inspect(file, func(n ast.Node) bool {
+		if c, ok := n.(*ast.CallExpr); ok {
+			conv = c
+		}
+		return true
+	})
+	if conv == nil {
+		t.Fatal("conversion call not found")
+	}
+	if !isTypeConversion(conv, info) {
+		t.Error("(T)(1) should be a conversion")
+	}
+}
+
+func TestSweepGetCalleeFunctionNameAndPackageArms(t *testing.T) {
+	fset := token.NewFileSet()
+	file := &ast.File{}
+	mkSel := func(x ast.Expr, name string) *ast.SelectorExpr {
+		return &ast.SelectorExpr{X: x, Sel: ast.NewIdent(name)}
+	}
+
+	// Ident receiver typed as a bare interface.
+	identX := ast.NewIdent("r")
+	ifaceType := types.NewInterfaceType(nil, nil)
+	ifaceType.Complete()
+	infoVar := &types.Info{Uses: map[*ast.Ident]types.Object{
+		identX: types.NewVar(token.NoPos, nil, "r", ifaceType),
+	}}
+	name, pkg, recv := getCalleeFunctionNameAndPackage(mkSel(identX, "Read"), file, "p",
+		map[*ast.File]*types.Info{file: infoVar}, nil, fset)
+	if name != "Read" || pkg != "p" || recv != "interface" {
+		t.Errorf("iface var receiver: got (%q,%q,%q)", name, pkg, recv)
+	}
+
+	// Complex receiver whose type is a Named with a nil package (error).
+	callX := &ast.CallExpr{Fun: ast.NewIdent("f")}
+	infoErr := &types.Info{Types: map[ast.Expr]types.TypeAndValue{
+		callX: {Type: types.Universe.Lookup("error").Type()},
+	}}
+	name, pkg, recv = getCalleeFunctionNameAndPackage(mkSel(callX, "Error"), file, "p",
+		map[*ast.File]*types.Info{file: infoErr}, nil, fset)
+	if name != "Error" || pkg != "p" || recv != "error" {
+		t.Errorf("error receiver: got (%q,%q,%q)", name, pkg, recv)
+	}
+
+	// Complex receiver typed as a bare interface.
+	callX2 := &ast.CallExpr{Fun: ast.NewIdent("g")}
+	infoIface := &types.Info{Types: map[ast.Expr]types.TypeAndValue{
+		callX2: {Type: ifaceType},
+	}}
+	name, pkg, recv = getCalleeFunctionNameAndPackage(mkSel(callX2, "Do"), file, "p",
+		map[*ast.File]*types.Info{file: infoIface}, nil, fset)
+	if name != "Do" || pkg != "p" || recv != "interface" {
+		t.Errorf("iface complex receiver: got (%q,%q,%q)", name, pkg, recv)
+	}
+
+	// Complex receiver typed as a basic type: no switch arm matches.
+	callX3 := &ast.CallExpr{Fun: ast.NewIdent("h")}
+	infoBasic := &types.Info{Types: map[ast.Expr]types.TypeAndValue{
+		callX3: {Type: types.Typ[types.Int]},
+	}}
+	name, pkg, recv = getCalleeFunctionNameAndPackage(mkSel(callX3, "Do"), file, "p",
+		map[*ast.File]*types.Info{file: infoBasic}, nil, fset)
+	if name != "Do" || pkg != "p" || recv != "" {
+		t.Errorf("basic receiver fallback: got (%q,%q,%q)", name, pkg, recv)
+	}
+
+	// CallExpr recurses into its Fun.
+	name, _, _ = getCalleeFunctionNameAndPackage(&ast.CallExpr{Fun: ast.NewIdent("mk")}, file, "p", nil, nil, fset)
+	if name != "mk" {
+		t.Errorf("call expr recursion: got %q", name)
+	}
+
+	// IndexListExpr recurses into X.
+	name, _, _ = getCalleeFunctionNameAndPackage(&ast.IndexListExpr{X: ast.NewIdent("gen")}, file, "p", nil, nil, fset)
+	if name != "gen" {
+		t.Errorf("index list recursion: got %q", name)
+	}
+
+	// Unhandled expression kinds resolve to nothing.
+	name, pkg, recv = getCalleeFunctionNameAndPackage(&ast.BasicLit{Kind: token.INT, Value: "1"}, file, "p", nil, nil, fset)
+	if name != "" || pkg != "" || recv != "" {
+		t.Errorf("unhandled expr: got (%q,%q,%q)", name, pkg, recv)
+	}
+}
+
+func TestSweepFindParentFunctionTopLevelLit(t *testing.T) {
+	m := sweepMeta()
+	file, fset := sweepParseFile(t, "package p\n\nvar f = func() int { return 1 }\n")
+	var lit *ast.FuncLit
+	ast.Inspect(file, func(n ast.Node) bool {
+		if fl, ok := n.(*ast.FuncLit); ok {
+			lit = fl
+		}
+		return true
+	})
+	if lit == nil {
+		t.Fatal("func lit not found")
+	}
+	name, parts, sig := findParentFunction(file, lit.Body.Lbrace+1, &types.Info{}, fset, m)
+	if name != "" || parts != "" || sig != "" {
+		t.Errorf("top-level func lit has no parent, got (%q,%q,%q)", name, parts, sig)
+	}
+}
+
+func TestSweepAnalyzeAssignmentValueFallbacks(t *testing.T) {
+	m := sweepMeta()
+	fset := token.NewFileSet()
+
+	// Selector whose base is not a plain identifier.
+	selExpr := &ast.SelectorExpr{X: &ast.CallExpr{Fun: ast.NewIdent("f")}, Sel: ast.NewIdent("Field")}
+	pkg, argOut := analyzeAssignmentValue(selExpr, nil, "h", "p", m, fset)
+	if pkg != "p" || argOut == nil {
+		t.Errorf("selector fallback: pkg %q arg %v", pkg, argOut)
+	}
+
+	// Call whose Fun is neither ident nor ident-based selector. A non-nil
+	// (empty) info is required: the fallback still runs ExprToCallArgument,
+	// which reaches extractParamsAndTypeParams and dereferences info for the
+	// IndexExpr fun. Real callers always pass a populated info here.
+	callExpr := sweepParseExpr(t, "fns[0]()")
+	pkg, argOut = analyzeAssignmentValue(callExpr, &types.Info{}, "h", "p", m, fset)
+	if pkg != "p" || argOut == nil {
+		t.Errorf("call fallback: pkg %q arg %v", pkg, argOut)
+	}
+
+	// Type assertion with no asserted type (switch guard form).
+	taExpr := &ast.TypeAssertExpr{X: ast.NewIdent("v")}
+	pkg, argOut = analyzeAssignmentValue(taExpr, nil, "h", "p", m, fset)
+	if pkg != "p" || argOut == nil || argOut.GetType() != "interface{}" {
+		t.Errorf("type assert fallback: pkg %q type %q", pkg, argOut.GetType())
+	}
+}
+
+func TestSweepTraceVariableOriginTypeParam(t *testing.T) {
+	m := sweepMeta()
+	edge := CallGraphEdge{TypeParamMap: map[string]string{"T": "app.User"}}
+	edge.Caller = sweepCall(m, "main", "app")
+	edge.Callee = sweepCall(m, "Handle", "app")
+	m.CallGraph = []CallGraphEdge{edge}
+
+	ov, op, ot, caller := TraceVariableOrigin("T", "Handle", "app", m)
+	if ov != "T" || op != "app" || caller != "main" {
+		t.Errorf("got (%q,%q,%q)", ov, op, caller)
+	}
+	if ot == nil || ot.GetType() != "app.User" {
+		t.Fatalf("expected concrete type app.User, got %v", ot)
+	}
+}
+
+func TestSweepTraceVariableOriginReturnUnwrap(t *testing.T) {
+	m := sweepMeta()
+	sp := m.StringPool
+
+	// Function-path callee whose return value is a selector wrapping an ident.
+	selRet := arg(m, KindSelector)
+	selRet.Sel = sweepIdent(m, "res")
+	fnH := &Function{Name: sp.Get("h"), AssignmentMap: map[string][]Assignment{
+		"v": {{VariableName: sp.Get("v"), CalleeFunc: "mk", CalleePkg: "app", Value: *sweepLit(m, "0")}},
+	}}
+	fnMk := &Function{Name: sp.Get("mk"), ReturnVars: []CallArgument{*selRet}}
+	m.Packages["app"] = &Package{Files: map[string]*File{
+		"a.go": {Functions: map[string]*Function{"h": fnH, "mk": fnMk}},
+	}}
+
+	ov, op, _, caller := TraceVariableOrigin("v", "h", "app", m)
+	if ov != "res" || op != "app" || caller != "mk" {
+		t.Errorf("function selector unwrap: got (%q,%q,%q)", ov, op, caller)
+	}
+
+	// Method-path callees: unary→literal (break + literal return) and
+	// selector→ident (recursive trace).
+	unaryRet := arg(m, KindUnary)
+	unaryRet.X = sweepLit(m, "1")
+	selRet2 := arg(m, KindSelector)
+	selRet2.Sel = sweepIdent(m, "z")
+	typS := &Type{Name: sp.Get("S"), Methods: []Method{
+		{Name: sp.Get("mval"), ReturnVars: []CallArgument{*unaryRet}},
+		{Name: sp.Get("msel"), ReturnVars: []CallArgument{*selRet2}},
+	}}
+	fnH2 := &Function{Name: sp.Get("h2"), AssignmentMap: map[string][]Assignment{
+		"w":  {{VariableName: sp.Get("w"), CalleeFunc: "mval", CalleePkg: "app2", Value: *sweepLit(m, "0")}},
+		"w2": {{VariableName: sp.Get("w2"), CalleeFunc: "msel", CalleePkg: "app2", Value: *sweepLit(m, "0")}},
+	}}
+	m.Packages["app2"] = &Package{Files: map[string]*File{
+		"b.go": {Functions: map[string]*Function{"h2": fnH2}, Types: map[string]*Type{"S": typS}},
+	}}
+
+	_, op, ot, _ := TraceVariableOrigin("w", "h2", "app2", m)
+	if op != "app2" || ot == nil || ot.GetKind() != KindLiteral {
+		t.Errorf("method literal return: pkg %q origin %v", op, ot)
+	}
+	ov, op, _, caller = TraceVariableOrigin("w2", "h2", "app2", m)
+	if ov != "z" || op != "app2" || caller != "msel" {
+		t.Errorf("method selector unwrap: got (%q,%q,%q)", ov, op, caller)
+	}
+}
+
+// --- types.go ---
+
+func TestSweepStringPoolGuards(t *testing.T) {
+	var zero StringPool
+	if got := zero.Get("x"); got != -1 {
+		t.Errorf("zero-value pool Get: got %d", got)
+	}
+
+	sp := NewStringPool()
+	wantErr := errors.New("boom")
+	if err := sp.UnmarshalYAML(func(interface{}) error { return wantErr }); !errors.Is(err, wantErr) {
+		t.Errorf("UnmarshalYAML error passthrough: got %v", err)
+	}
+}
+
+func TestSweepExtractGenericTypesPlainList(t *testing.T) {
+	got := ExtractGenericTypes("pkg.F[int,string]")
+	if len(got) != 2 || got[0] != "int" || got[1] != "string" {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestSweepTraverseCallerChildrenSelfLoop(t *testing.T) {
+	m := sweepMeta()
+	edgeAB := CallGraphEdge{Caller: sweepCall(m, "a", "p"), Callee: sweepCall(m, "b", "p")}
+	edgeBB := CallGraphEdge{Caller: sweepCall(m, "b", "p"), Callee: sweepCall(m, "b", "p")}
+	m.CallGraph = []CallGraphEdge{edgeAB, edgeBB}
+	m.BuildCallGraphMaps()
+
+	var visits int
+	m.TraverseCallerChildren(&m.CallGraph[0], func(parent, child *CallGraphEdge) { visits++ })
+	if visits != 1 {
+		t.Errorf("self loop should be visited once, got %d", visits)
+	}
+
+	// At the self-calling depth cap the child edge is skipped entirely.
+	m.callDepth[m.CallGraph[0].Callee.BaseID()] = MaxSelfCallingDepth
+	visits = 0
+	m.TraverseCallerChildren(&m.CallGraph[0], func(parent, child *CallGraphEdge) { visits++ })
+	if visits != 0 {
+		t.Errorf("capped self loop should be skipped, got %d visits", visits)
+	}
+}
+
+func TestSweepCallArgumentGuards(t *testing.T) {
+	m := sweepMeta()
+
+	c := &Call{Scope: -1, Meta: m}
+	if got := c.GetScope(); got != "" {
+		t.Errorf("negative scope: got %q", got)
+	}
+
+	a := arg(m, KindIdent)
+	if got := a.GetGenericTypeName(); got != "" {
+		t.Errorf("unset generic type name: got %q", got)
+	}
+
+	defer func() {
+		if recover() == nil {
+			t.Error("NewCallArgument(nil) should panic")
+		}
+	}()
+	NewCallArgument(nil)
+}
+
+func TestSweepCallArgumentIDArms(t *testing.T) {
+	m := sweepMeta()
+
+	withTParams := func(a *CallArgument) *CallArgument {
+		a.TypeParamMap = map[string]string{"T": "int"}
+		return a
+	}
+	emptyIdent := func() *CallArgument { return arg(m, KindIdent) }
+
+	// Selector: X's type-param suffix propagates to the selector ID.
+	sel := arg(m, KindSelector)
+	sel.X = withTParams(sweepIdent(m, "recv"))
+	sel.Sel = sweepIdent(m, "M")
+	if got := sel.ID(); !strings.Contains(got, "[T=int]") {
+		t.Errorf("selector tparam propagation: got %q", got)
+	}
+
+	// Call with no Fun falls back to the kind label.
+	if got := arg(m, KindCall).ID(); got != KindCall {
+		t.Errorf("call no fun: got %q", got)
+	}
+	// Call with a generic Fun propagates its type params.
+	call := arg(m, KindCall)
+	call.Fun = withTParams(sweepIdent(m, "F"))
+	if got := call.ID(); !strings.Contains(got, "[T=int]") {
+		t.Errorf("call tparam propagation: got %q", got)
+	}
+
+	// Type conversion, with and without Fun.
+	conv := arg(m, KindTypeConversion)
+	conv.Fun = sweepIdent(m, "T")
+	if got := conv.ID(); !strings.Contains(got, "T") {
+		t.Errorf("conversion with fun: got %q", got)
+	}
+	if got := arg(m, KindTypeConversion).ID(); got != KindTypeConversion {
+		t.Errorf("conversion without fun: got %q", got)
+	}
+
+	// Unary: empty X ID falls back to the arg's package; tparams propagate;
+	// missing X yields an empty ID.
+	un := arg(m, KindUnary)
+	un.SetValue("&")
+	un.SetPkg("pk")
+	un.X = emptyIdent()
+	if got := un.ID(); got != "pk" { // leading "&" is trimmed by ID()
+		t.Errorf("unary pkg fallback: got %q", got)
+	}
+	un2 := arg(m, KindUnary)
+	un2.SetValue("&")
+	un2.X = withTParams(sweepIdent(m, "v"))
+	if got := un2.ID(); !strings.Contains(got, "[T=int]") {
+		t.Errorf("unary tparam propagation: got %q", got)
+	}
+	if got := arg(m, KindUnary).ID(); got != "" {
+		t.Errorf("unary without X: got %q", got)
+	}
+
+	// Composite literal: same three shapes.
+	cl := arg(m, KindCompositeLit)
+	cl.X = withTParams(sweepIdent(m, "User"))
+	if got := cl.ID(); !strings.Contains(got, "[T=int]") {
+		t.Errorf("composite tparam propagation: got %q", got)
+	}
+	if got := arg(m, KindCompositeLit).ID(); got != "" {
+		t.Errorf("composite without X: got %q", got)
+	}
+
+	// Index: pkg fallback, tparam propagation, and missing X.
+	ix := arg(m, KindIndex)
+	ix.SetPkg("pk")
+	ix.X = emptyIdent()
+	if got := ix.ID(); got != "pk" {
+		t.Errorf("index pkg fallback: got %q", got)
+	}
+	ix2 := arg(m, KindIndex)
+	ix2.X = withTParams(sweepIdent(m, "xs"))
+	if got := ix2.ID(); !strings.Contains(got, "[T=int]") {
+		t.Errorf("index tparam propagation: got %q", got)
+	}
+	if got := arg(m, KindIndex).ID(); got != "" {
+		t.Errorf("index without X: got %q", got)
+	}
+}
+
+func TestSweepCallBuildIdentifierNilMeta(t *testing.T) {
+	c := &Call{}
+	if got := c.BaseID(); got != "." {
+		t.Errorf("nil-meta BaseID: got %q", got)
+	}
+}
+
+func TestSweepExtractReturnTypeFromSignatureCallKind(t *testing.T) {
+	m := sweepMeta()
+	sig := arg(m, KindCall)
+	fun := sweepIdent(m, "mk")
+	fun.SetType("User")
+	sig.Fun = fun
+	if got := m.extractReturnTypeFromSignature(*sig); got != "User" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestSweepExtractTypeFromCallArgumentArms(t *testing.T) {
+	m := sweepMeta()
+
+	mkTyped := func(kind, typ string) *CallArgument {
+		a := arg(m, kind)
+		a.SetType(typ)
+		return a
+	}
+
+	cases := []struct {
+		name  string
+		build func() *CallArgument
+		want  string
+	}{
+		{"call no fun", func() *CallArgument { return arg(m, KindCall) }, "func()"},
+		{"composite no X", func() *CallArgument { return mkTyped(KindCompositeLit, "User") }, "User"},
+		{"unary no X", func() *CallArgument { return mkTyped(KindUnary, "User") }, "User"},
+		{"literal", func() *CallArgument { return mkTyped(KindLiteral, "string") }, "string"},
+		{"sized array", func() *CallArgument {
+			a := arg(m, KindArrayType)
+			a.SetValue("5")
+			a.X = mkTyped(KindLiteral, "int")
+			return a
+		}, "[5]int"},
+		{"array no X", func() *CallArgument { return mkTyped(KindArrayType, "int") }, "[]int"},
+		{"slice with X", func() *CallArgument {
+			a := arg(m, KindSlice)
+			a.X = mkTyped(KindLiteral, "int")
+			return a
+		}, "[]int"},
+		{"slice no X", func() *CallArgument { return mkTyped(KindSlice, "int") }, "[]int"},
+		{"map fallback type", func() *CallArgument { return mkTyped(KindMapType, "map[string]int") }, "map[string]int"},
+		{"star no X", func() *CallArgument { return mkTyped(KindStar, "User") }, "*User"},
+	}
+	for _, tc := range cases {
+		if got := m.extractTypeFromCallArgument(tc.build()); got != tc.want {
+			t.Errorf("%s: got %q want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestSweepResolveUnaryReturnTypeDeref(t *testing.T) {
+	m := sweepMeta()
+	rv := arg(m, KindUnary)
+	rv.SetType("*User")
+	x := arg(m, KindLiteral)
+	x.SetType("*User")
+	rv.X = x
+	if got := m.resolveUnaryReturnType(rv, "p"); got != "User" {
+		t.Errorf("deref: got %q", got)
+	}
+}
+
+func TestSweepProcessFunctionCallReturnTypeCallKind(t *testing.T) {
+	m := sweepMeta()
+	sp := m.StringPool
+
+	sig := arg(m, KindFuncType)
+	sig.ResolvedType = sp.Get("User")
+	m.Packages["app"] = &Package{Files: map[string]*File{
+		"a.go": {Functions: map[string]*Function{"mk": {Name: sp.Get("mk"), Signature: *sig}}},
+	}}
+
+	a := arg(m, KindCall)
+	a.SetName("mk")
+	a.SetPkg("app")
+	a.Fun = arg(m, KindCall) // nested-call shape: name/pkg read from the outer arg
+	m.processFunctionCallReturnType(a)
+	if got := a.GetResolvedType(); got != "User" {
+		t.Errorf("resolved type: got %q", got)
+	}
+}
+
+func TestSweepGetInterfaceResolutionFound(t *testing.T) {
+	m := sweepMeta()
+	m.RegisterInterfaceResolution("Iface", "Struct", "p", "Concrete", "pos")
+	got, ok := m.GetInterfaceResolution("Iface", "Struct", "p")
+	if !ok || got != "Concrete" {
+		t.Errorf("got (%q,%v)", got, ok)
+	}
+}
+
+// --- metadata.go ---
+
+func TestSweepCallIdentifierIDGenericAndDefault(t *testing.T) {
+	ci := NewCallIdentifier("p", "f", "", "1:2", map[string]string{"T": "int"})
+	if got := ci.ID(GenericID); got != "p.f[T=int]" {
+		t.Errorf("generic ID: got %q", got)
+	}
+	plain := NewCallIdentifier("p", "f", "", "", nil)
+	if got := plain.ID(GenericID); got != "p.f" {
+		t.Errorf("generic ID without generics: got %q", got)
+	}
+	if got := plain.ID(CallIdentifierType(99)); got != "p.f" {
+		t.Errorf("unknown ID type: got %q", got)
+	}
+}
+
+func TestSweepGenerateMetadataModulePathInference(t *testing.T) {
+	fset := token.NewFileSet()
+	empty := map[string]map[string]*ast.File{}
+	noInfo := map[*ast.File]*types.Info{}
+
+	// No common prefix: the shorter dotted path wins via its module part.
+	md := GenerateMetadata(empty, noInfo, map[string]string{
+		"a.go": "zzz/bar/baz/quxx/more",
+		"b.go": "a.com/internal/x",
+	}, fset)
+	if md.CurrentModulePath != "a.com" {
+		t.Errorf("module part inference: got %q", md.CurrentModulePath)
+	}
+
+	// Empty first path: the dotted path is adopted wholesale.
+	md = GenerateMetadata(empty, noInfo, map[string]string{
+		"a.go": "",
+		"b.go": "a.com/x",
+	}, fset)
+	if md.CurrentModulePath != "a.com/x" {
+		t.Errorf("whole-path fallback: got %q", md.CurrentModulePath)
+	}
+}
+
+func TestSweepGenerateMetadataSkipsMockReceivers(t *testing.T) {
+	src := "package p\n\ntype MockSvc struct{}\n\nfunc (m MockSvc) Do() {}\n\ntype Svc struct{}\n\nfunc (s Svc) Run() {}\n"
+	file, info, fset := sweepTypeCheck(t, src)
+	md := GenerateMetadata(
+		map[string]map[string]*ast.File{"p": {"p.go": file}},
+		map[*ast.File]*types.Info{file: info},
+		map[string]string{"p.go": "p"},
+		fset,
+	)
+	pkg := md.Packages["p"]
+	if pkg == nil {
+		t.Fatal("package p missing")
+	}
+	var sawSvcRun, sawMock bool
+	for _, f := range pkg.Files {
+		for name, typ := range f.Types {
+			if strings.Contains(strings.ToLower(name), "mock") {
+				sawMock = true
+			}
+			for _, meth := range typ.Methods {
+				if md.StringPool.GetString(meth.Name) == "Run" {
+					sawSvcRun = true
+				}
+			}
+		}
+	}
+	if !sawSvcRun {
+		t.Error("Svc.Run not recorded")
+	}
+	if sawMock {
+		t.Error("mock type should have been skipped")
+	}
+}
+
+func TestSweepBuildFuncMapEmptyPkgName(t *testing.T) {
+	fd := &ast.FuncDecl{Name: ast.NewIdent("F"), Type: &ast.FuncType{}}
+	file := &ast.File{Name: ast.NewIdent(""), Decls: []ast.Decl{fd}}
+	fm := BuildFuncMap(map[string]map[string]*ast.File{"p": {"a.go": file}})
+	if fm["F"] == nil {
+		t.Errorf("expected bare key for empty package name, got keys %v", fm)
+	}
+}
+
+func TestSweepCollectConstantsNonValueSpec(t *testing.T) {
+	m := sweepMeta()
+	gd := &ast.GenDecl{Tok: token.CONST, Specs: []ast.Spec{
+		&ast.TypeSpec{Name: ast.NewIdent("T"), Type: ast.NewIdent("int")},
+	}}
+	file := &ast.File{Name: ast.NewIdent("p"), Decls: []ast.Decl{gd}}
+	if got := collectConstants(file, nil, "p", token.NewFileSet(), m); len(got) != 0 {
+		t.Errorf("expected no constants, got %v", got)
+	}
+}
+
+func TestSweepProcessTypeSpecSkips(t *testing.T) {
+	m := sweepMeta()
+	f := &File{Types: map[string]*Type{"User": {}}}
+
+	processTypeSpec(&ast.TypeSpec{Name: ast.NewIdent("MockUser")}, nil, "p", nil, f, nil, nil, m, false)
+	processTypeSpec(&ast.TypeSpec{Name: ast.NewIdent("User")}, nil, "p", nil, f, nil, nil, m, true)
+	if len(f.Types) != 1 {
+		t.Errorf("both specs should be skipped, got %d types", len(f.Types))
+	}
+}
+
+func TestSweepIsMarshalerSignatureGuards(t *testing.T) {
+	withParam := types.NewSignatureType(nil, nil, nil,
+		types.NewTuple(types.NewParam(token.NoPos, nil, "x", types.Typ[types.Int])), nil, false)
+	if isMarshalerSignature(withParam) {
+		t.Error("signature with params is not a marshaler")
+	}
+	oneResult := types.NewSignatureType(nil, nil, nil, nil,
+		types.NewTuple(types.NewParam(token.NoPos, nil, "", types.Typ[types.Bool])), false)
+	if isMarshalerSignature(oneResult) {
+		t.Error("signature with one result is not a marshaler")
+	}
+}
+
+func TestSweepRecordExternalTypeFactsArms(t *testing.T) {
+	m := &Metadata{StringPool: NewStringPool(), CurrentModulePath: "example.com/me"}
+
+	// Named type with a nil package (error) is ignored and allocates nothing.
+	recordExternalTypeFacts(types.Universe.Lookup("error").Type(), m)
+	if m.ExternalTypes != nil {
+		t.Fatal("error type must not allocate the facts map")
+	}
+
+	// A channel of an external named type records the element type and lazily
+	// allocates the map.
+	extPkg := types.NewPackage("github.com/ext/lib", "lib")
+	named := types.NewNamed(types.NewTypeName(token.NoPos, extPkg, "T", nil), types.Typ[types.String], nil)
+	recordExternalTypeFacts(types.NewChan(types.SendRecv, named), m)
+	if _, ok := m.ExternalTypes["github.com/ext/lib.T"]; !ok {
+		t.Errorf("chan element fact missing: %v", m.ExternalTypes)
+	}
+
+	// Recursive external type (type R []R) terminates via the cycle guard.
+	rec := types.NewNamed(types.NewTypeName(token.NoPos, extPkg, "R", nil), nil, nil)
+	rec.SetUnderlying(types.NewSlice(rec))
+	recordExternalTypeFacts(rec, m)
+	if _, ok := m.ExternalTypes["lib.R"]; !ok {
+		t.Errorf("recursive type fact missing: %v", m.ExternalTypes)
+	}
+}
+
+func TestSweepAnonStructKeyGuards(t *testing.T) {
+	fset := token.NewFileSet()
+	if got := AnonStructKey(token.NoPos, fset, "p"); got != "" {
+		t.Errorf("NoPos: got %q", got)
+	}
+	if got := AnonStructKey(token.Pos(1), nil, "p"); got != "" {
+		t.Errorf("nil fset: got %q", got)
+	}
+	if got := AnonStructKey(token.Pos(999999), fset, "p"); got != "" {
+		t.Errorf("unregistered pos: got %q", got)
+	}
+}
+
+func TestSweepProcessLocalAnonymousStructsGuards(t *testing.T) {
+	m := sweepMeta()
+	fset := token.NewFileSet()
+	tf := fset.AddFile("x.go", -1, 100)
+	pos := tf.Pos(5)
+	st := types.NewStruct(nil, nil)
+
+	info := &types.Info{Defs: map[*ast.Ident]types.Object{
+		ast.NewIdent("a"): types.NewVar(token.NoPos, nil, "a", st), // invalid pos → empty key
+		ast.NewIdent("b"): types.NewVar(pos, nil, "b", st),
+		ast.NewIdent("c"): types.NewVar(pos, nil, "c", st), // duplicate key
+	}}
+	f := &File{Types: map[string]*Type{}}
+	processLocalAnonymousStructs(&ast.File{}, info, "p", fset, f, m)
+	if len(f.Types) != 1 {
+		t.Errorf("expected exactly one anon struct type, got %d", len(f.Types))
+	}
+}
+
+func TestSweepProcessStructFieldsEmbedded(t *testing.T) {
+	m := sweepMeta()
+	st, ok := sweepParseExpr(t, "struct{ int; A string }").(*ast.StructType)
+	if !ok {
+		t.Fatal("not a struct type")
+	}
+	typ := &Type{}
+	processStructFields(st, "p", m, typ, nil)
+	if len(typ.Embeds) != 1 || len(typ.Fields) != 1 {
+		t.Errorf("embeds %d fields %d", len(typ.Embeds), len(typ.Fields))
+	}
+}
+
+func TestSweepProcessFunctionsMockAndConstDecl(t *testing.T) {
+	m := sweepMeta()
+	file, fset := sweepParseFile(t, "package p\n\nfunc MockThing() {}\n\nfunc realFn() { const c = 1 }\n")
+	f := &File{Functions: map[string]*Function{}}
+	processFunctions(file, nil, "p", fset, f, nil, nil, m)
+	if _, ok := f.Functions["MockThing"]; ok {
+		t.Error("mock function should be skipped")
+	}
+	if _, ok := f.Functions["realFn"]; !ok {
+		t.Error("realFn should be recorded")
+	}
+}
+
+func TestSweepProcessVariablesNonValueSpec(t *testing.T) {
+	m := sweepMeta()
+	gd := &ast.GenDecl{Tok: token.VAR, Specs: []ast.Spec{
+		&ast.TypeSpec{Name: ast.NewIdent("T"), Type: ast.NewIdent("int")},
+	}}
+	file := &ast.File{Name: ast.NewIdent("p"), Decls: []ast.Decl{gd}}
+	f := &File{Variables: map[string]*Variable{}}
+	processVariables(file, nil, "p", token.NewFileSet(), f, m)
+	if len(f.Variables) != 0 {
+		t.Errorf("expected no variables, got %d", len(f.Variables))
+	}
+}
+
+func TestSweepProcessAssignmentArms(t *testing.T) {
+	m := sweepMeta()
+	fset := token.NewFileSet()
+
+	// More RHS than LHS with no enclosing function: nothing is recorded.
+	assign := &ast.AssignStmt{
+		Lhs: []ast.Expr{ast.NewIdent("x")},
+		Rhs: []ast.Expr{
+			&ast.BasicLit{Kind: token.INT, Value: "1"},
+			&ast.BasicLit{Kind: token.INT, Value: "2"},
+		},
+		Tok: token.ASSIGN,
+	}
+	if got := processAssignment(assign, &ast.File{Name: ast.NewIdent("p")}, nil, "p", fset, nil, nil, m); len(got) != 0 {
+		t.Errorf("expected no assignments, got %d", len(got))
+	}
+
+	// Star-expression LHS lands in the raw fallback arm.
+	file, fset2 := sweepParseFile(t, "package p\n\nfunc h() { *gp = 5 }\n")
+	var starAssign *ast.AssignStmt
+	ast.Inspect(file, func(n ast.Node) bool {
+		if a, ok := n.(*ast.AssignStmt); ok {
+			starAssign = a
+		}
+		return true
+	})
+	if starAssign == nil {
+		t.Fatal("assignment not found")
+	}
+	got := processAssignment(starAssign, file, nil, "p", fset2, nil, nil, m)
+	if len(got) != 1 || m.StringPool.GetString(got[0].ConcreteType) != "raw" {
+		t.Fatalf("raw fallback: got %+v", got)
+	}
+}
+
+func TestSweepGetTypeWithGenericsParen(t *testing.T) {
+	identV := ast.NewIdent("v")
+	paren := &ast.ParenExpr{X: identV}
+	info := &types.Info{
+		Uses:  map[*ast.Ident]types.Object{identV: types.NewVar(token.NoPos, nil, "v", types.Typ[types.Int])},
+		Types: map[ast.Expr]types.TypeAndValue{},
+	}
+	typ := getTypeWithGenerics(paren, info)
+	if typ == nil || typ.String() != "int" {
+		t.Errorf("got %v", typ)
+	}
+}
+
+func TestSweepProcessCallExpressionSkipsMock(t *testing.T) {
+	m := sweepMeta()
+	file, fset := sweepParseFile(t, "package p\n\nfunc h() { MockDo() }\n")
+	var call *ast.CallExpr
+	ast.Inspect(file, func(n ast.Node) bool {
+		if c, ok := n.(*ast.CallExpr); ok {
+			call = c
+		}
+		return true
+	})
+	if call == nil {
+		t.Fatal("call not found")
+	}
+	processCallExpression(call, file, nil, "p", nil, map[*ast.File]*types.Info{}, nil, fset, m, nil, nil, nil)
+	if len(m.CallGraph) != 0 {
+		t.Errorf("mock callee must not create edges, got %d", len(m.CallGraph))
+	}
+}
+
+func TestSweepAstFileFromFnReceiverFuncFallback(t *testing.T) {
+	m := sweepMeta()
+	astF := &ast.File{}
+	m.Packages["p"] = &Package{Files: map[string]*File{
+		"a.go": {Functions: map[string]*Function{"Do": {}}},
+	}}
+	pkgs := map[string]map[string]*ast.File{"p": {"a.go": astF}}
+	if got := astFileFromFn("p", "Do", "*Recv", pkgs, m); got != astF {
+		t.Errorf("receiver lookup should fall back to the same-named function's file")
+	}
+}
+
+// sweepGenericFunc builds a *types.Func with the given type-parameter names,
+// each also used as the type of one positional parameter.
+func sweepGenericFunc(name string, tparamNames ...string) *types.Func {
+	anyType := types.Universe.Lookup("any").Type()
+	tparams := make([]*types.TypeParam, len(tparamNames))
+	params := make([]*types.Var, len(tparamNames))
+	for i, tn := range tparamNames {
+		tparams[i] = types.NewTypeParam(types.NewTypeName(token.NoPos, nil, tn, nil), anyType)
+		params[i] = types.NewParam(token.NoPos, nil, "p"+tn, tparams[i])
+	}
+	sig := types.NewSignatureType(nil, nil, tparams, types.NewTuple(params...), nil, false)
+	return types.NewFunc(token.NoPos, nil, name, sig)
+}
+
+func TestSweepExtractParamsAndTypeParams(t *testing.T) {
+	m := sweepMeta()
+
+	run := func(call *ast.CallExpr, info *types.Info, args []*CallArgument) (map[string]CallArgument, map[string]string) {
+		paramArgMap := map[string]CallArgument{}
+		typeParamMap := map[string]string{}
+		extractParamsAndTypeParams(call, info, args, paramArgMap, typeParamMap)
+		return paramArgMap, typeParamMap
+	}
+
+	t.Run("index expr with selector base", func(t *testing.T) {
+		selSel := ast.NewIdent("Foo")
+		call := &ast.CallExpr{
+			Fun: &ast.IndexExpr{
+				X:     &ast.SelectorExpr{X: ast.NewIdent("ext"), Sel: selSel},
+				Index: ast.NewIdent("int"),
+			},
+			Args: []ast.Expr{ast.NewIdent("v")},
+		}
+		info := &types.Info{Uses: map[*ast.Ident]types.Object{selSel: sweepGenericFunc("Foo", "T")}}
+		pam, tpm := run(call, info, []*CallArgument{arg(m, KindIdent)})
+		if tpm["T"] != "int" {
+			t.Errorf("tpm: %v", tpm)
+		}
+		if _, ok := pam["pT"]; !ok {
+			t.Errorf("pam: %v", pam)
+		}
+	})
+
+	t.Run("index list expr ident base", func(t *testing.T) {
+		funX := ast.NewIdent("Bar")
+		call := &ast.CallExpr{
+			Fun: &ast.IndexListExpr{
+				X:       funX,
+				Indices: []ast.Expr{ast.NewIdent("int"), ast.NewIdent("string")},
+			},
+			Args: []ast.Expr{ast.NewIdent("a"), ast.NewIdent("b")},
+		}
+		info := &types.Info{Uses: map[*ast.Ident]types.Object{funX: sweepGenericFunc("Bar", "T", "U")}}
+		_, tpm := run(call, info, []*CallArgument{arg(m, KindIdent), arg(m, KindIdent)})
+		if tpm["T"] != "int" || tpm["U"] != "string" {
+			t.Errorf("tpm: %v", tpm)
+		}
+	})
+
+	t.Run("index list expr selector base", func(t *testing.T) {
+		selSel := ast.NewIdent("Baz")
+		call := &ast.CallExpr{
+			Fun: &ast.IndexListExpr{
+				X:       &ast.SelectorExpr{X: ast.NewIdent("ext"), Sel: selSel},
+				Indices: []ast.Expr{ast.NewIdent("int"), ast.NewIdent("string")},
+			},
+		}
+		info := &types.Info{Uses: map[*ast.Ident]types.Object{selSel: sweepGenericFunc("Baz", "T", "U")}}
+		_, tpm := run(call, info, nil)
+		if tpm["T"] != "int" || tpm["U"] != "string" {
+			t.Errorf("tpm: %v", tpm)
+		}
+	})
+
+	t.Run("inference from generic function argument", func(t *testing.T) {
+		funIdent := ast.NewIdent("Generic")
+		argIdent := ast.NewIdent("h")
+		call := &ast.CallExpr{Fun: funIdent, Args: []ast.Expr{argIdent}}
+		anyType := types.Universe.Lookup("any").Type()
+		argTP := types.NewTypeParam(types.NewTypeName(token.NoPos, nil, "A", nil), anyType)
+		argSig := types.NewSignatureType(nil, nil, []*types.TypeParam{argTP},
+			types.NewTuple(types.NewParam(token.NoPos, nil, "x", argTP)), nil, false)
+		info := &types.Info{
+			Uses:      map[*ast.Ident]types.Object{funIdent: sweepGenericFunc("Generic", "T")},
+			Types:     map[ast.Expr]types.TypeAndValue{argIdent: {Type: argSig}},
+			Instances: map[*ast.Ident]types.Instance{},
+		}
+		_, tpm := run(call, info, []*CallArgument{arg(m, KindIdent)})
+		if len(tpm) == 0 {
+			t.Errorf("expected an inferred entry, got %v", tpm)
+		}
+	})
+
+	t.Run("inference from plain function argument", func(t *testing.T) {
+		funIdent := ast.NewIdent("Generic")
+		argIdent := ast.NewIdent("h")
+		call := &ast.CallExpr{Fun: funIdent, Args: []ast.Expr{argIdent}}
+		plainSig := types.NewSignatureType(nil, nil, nil,
+			types.NewTuple(types.NewParam(token.NoPos, nil, "x", types.Typ[types.Int])), nil, false)
+		info := &types.Info{
+			Uses:      map[*ast.Ident]types.Object{funIdent: sweepGenericFunc("Generic", "T")},
+			Types:     map[ast.Expr]types.TypeAndValue{argIdent: {Type: plainSig}},
+			Instances: map[*ast.Ident]types.Instance{},
+		}
+		pam, _ := run(call, info, []*CallArgument{arg(m, KindIdent)})
+		if _, ok := pam["pT"]; !ok {
+			t.Errorf("pam: %v", pam)
+		}
+	})
+}
+
+func TestSweepApplyTypeParameterResolutionNil(t *testing.T) {
+	applyTypeParameterResolution(nil)                     // must not panic
+	applyTypeParameterResolutionToArgument(nil, nil, nil) // must not panic
+}
+
+// --- dependency_analyzer.go ---
+
+// sweepPkg builds a *packages.Package whose Syntax is one parsed file with the
+// given import paths.
+func sweepPkg(t *testing.T, pkgPath, pkgName string, imports ...string) *packages.Package {
+	t.Helper()
+	var b strings.Builder
+	b.WriteString("package " + pkgName + "\n")
+	for _, imp := range imports {
+		b.WriteString("import _ \"" + imp + "\"\n")
+	}
+	file, _ := sweepParseFile(t, b.String())
+	return &packages.Package{PkgPath: pkgPath, Name: pkgName, Syntax: []*ast.File{file}}
+}
+
+func TestSweepFrameworkDetectorAnalyze(t *testing.T) {
+	app := sweepPkg(t, "myapp-svc/app", "app",
+		"github.com/gin-gonic/gin", "myapp-svc/models", "myapp-svc/utilmock")
+	// An empty import path is skipped by the dependency-graph builder.
+	app.Syntax[0].Imports = append(app.Syntax[0].Imports, &ast.ImportSpec{Path: &ast.BasicLit{Kind: token.STRING, Value: `""`}})
+
+	models := sweepPkg(t, "myapp-svc/models", "models", "myapp-svc/util")
+	util := sweepPkg(t, "myapp-svc/util", "util")
+	mid := sweepPkg(t, "myapp-svc/mid", "mid", "myapp-svc/app")
+	dep2 := sweepPkg(t, "myapp-svc/dep2", "dep2", "myapp-svc/mid")
+	mocks := sweepPkg(t, "myapp-svc/mocks", "mocks", "myapp-svc/app")
+	pkgs := []*packages.Package{app, models, util, mid, dep2, mocks}
+
+	fd := NewFrameworkDetector()
+	list, err := fd.AnalyzeFrameworkDependencies(pkgs, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+
+	byPath := map[string]*FrameworkDependency{}
+	for _, dep := range list.AllPackages {
+		byPath[dep.PackagePath] = dep
+	}
+	if d := byPath["myapp-svc/app"]; d == nil || d.FrameworkType != "gin" || !d.IsDirect {
+		t.Errorf("app: %+v", byPath["myapp-svc/app"])
+	}
+	if d := byPath["myapp-svc/mid"]; d == nil || d.FrameworkType != "dependent" {
+		t.Errorf("mid (direct dependent): %+v", byPath["myapp-svc/mid"])
+	}
+	if d := byPath["myapp-svc/dep2"]; d == nil || d.FrameworkType != "dependent" {
+		t.Errorf("dep2 (transitive dependent): %+v", byPath["myapp-svc/dep2"])
+	}
+	if d := byPath["myapp-svc/models"]; d == nil || d.FrameworkType != "imported" {
+		t.Errorf("models (imported): %+v", byPath["myapp-svc/models"])
+	}
+	if d := byPath["myapp-svc/util"]; d == nil || d.FrameworkType != "imported" {
+		t.Errorf("util (recursively imported): %+v", byPath["myapp-svc/util"])
+	}
+	if _, ok := byPath["myapp-svc/mocks"]; ok {
+		t.Error("mock package should be excluded")
+	}
+	if _, ok := byPath["myapp-svc/utilmock"]; ok {
+		t.Error("mock import should be excluded")
+	}
+
+	// Direct helper coverage against the populated detector.
+	if fd.isPackageImportedByProject("nope/never") {
+		t.Error("unknown import should not be project-imported")
+	}
+}
+
+func TestSweepFrameworkDetectorDepthAndExternal(t *testing.T) {
+	app := sweepPkg(t, "myapp-svc/app", "app", "github.com/gin-gonic/gin", "myapp-svc/models")
+	models := sweepPkg(t, "myapp-svc/models", "models", "myapp-svc/util")
+	util := sweepPkg(t, "myapp-svc/util", "util")
+	pkgs := []*packages.Package{app, models, util}
+
+	// Depth 1: models is included, its own import is not followed.
+	fd := NewFrameworkDetector()
+	fd.Configure(false, 1)
+	list, err := fd.AnalyzeFrameworkDependencies(pkgs, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	var sawUtil bool
+	for _, dep := range list.AllPackages {
+		if dep.PackagePath == "myapp-svc/util" {
+			sawUtil = true
+		}
+	}
+	if sawUtil {
+		t.Error("depth limit should stop recursion before util")
+	}
+
+	// IncludeExternalPackages pulls in the framework import itself.
+	fd2 := NewFrameworkDetector()
+	fd2.Configure(true, 3)
+	list2, err := fd2.AnalyzeFrameworkDependencies(pkgs, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("analyze external: %v", err)
+	}
+	var sawGin bool
+	for _, dep := range list2.AllPackages {
+		if dep.PackagePath == "github.com/gin-gonic/gin" {
+			sawGin = true
+		}
+	}
+	if !sawGin {
+		t.Error("external mode should include the gin import")
+	}
+}
+
+func TestSweepFrameworkDetectorHelpers(t *testing.T) {
+	// DisableFramework must allocate the map when the config starts empty.
+	bare := NewFrameworkDetectorWithConfig(FrameworkDetectorConfig{})
+	bare.DisableFramework("http")
+	if !bare.config.DisabledFrameworks["http"] {
+		t.Error("DisableFramework on zero config did not record the framework")
+	}
+
+	// Custom framework keys are appended after the known ones, before http.
+	cfg := DefaultFrameworkDetectorConfig()
+	cfg.FrameworkPatterns["custom"] = []string{"x.y/custom"}
+	fd := NewFrameworkDetectorWithConfig(cfg)
+	order := fd.frameworkDetectionOrder()
+	if len(order) < 2 || order[len(order)-1] != "http" {
+		t.Fatalf("order: %v", order)
+	}
+	var sawCustom bool
+	for _, k := range order {
+		if k == "custom" {
+			sawCustom = true
+		}
+	}
+	if !sawCustom {
+		t.Errorf("custom key missing from order: %v", order)
+	}
+
+	// A disabled framework's patterns are skipped during detection.
+	appPkg := sweepPkg(t, "myapp-svc/app", "app", "github.com/gin-gonic/gin")
+	fd2 := NewFrameworkDetector()
+	fd2.DisableFramework("gin")
+	if got := fd2.detectFrameworkType(appPkg); got != "" {
+		t.Errorf("disabled gin still detected: %q", got)
+	}
+
+	// detectProjectRoot: empty detector, then divergent paths where the
+	// non-domain path names the root.
+	fd3 := NewFrameworkDetector()
+	if got := fd3.detectProjectRoot(); got != "" {
+		t.Errorf("empty detector root: %q", got)
+	}
+	fd3.packages["abc/x"] = nil
+	fd3.packages["zzz.io/y"] = nil
+	fd3.packages["qqq.io/z"] = nil
+	if got := fd3.detectProjectRoot(); got != "abc" {
+		t.Errorf("divergent root: %q", got)
+	}
+
+	// fallbackProjectPackageDetection heuristics.
+	fd4 := NewFrameworkDetector()
+	if !fd4.fallbackProjectPackageDetection("x.io/deep/models/things") {
+		t.Error("project pattern /models/ should match")
+	}
+	if !fd4.fallbackProjectPackageDetection("my-proj/pkgname") {
+		t.Error("hyphenated first segment should match")
+	}
+
+	// isProjectRelatedPackage rejects mock packages outright.
+	if fd4.isProjectRelatedPackage("some/mockthing") {
+		t.Error("mock import should not be project-related")
+	}
+}

--- a/internal/metadata/metadata_sweep_test.go
+++ b/internal/metadata/metadata_sweep_test.go
@@ -1205,11 +1205,17 @@ func TestSweepFrameworkDetectorDepthAndExternal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("analyze: %v", err)
 	}
-	var sawUtil bool
+	var sawModels, sawUtil bool
 	for _, dep := range list.AllPackages {
+		if dep.PackagePath == "myapp-svc/models" {
+			sawModels = true
+		}
 		if dep.PackagePath == "myapp-svc/util" {
 			sawUtil = true
 		}
+	}
+	if !sawModels {
+		t.Error("depth 1 should still include the direct dependency models")
 	}
 	if sawUtil {
 		t.Error("depth limit should stop recursion before util")

--- a/internal/profiler/profiler_sweep_test.go
+++ b/internal/profiler/profiler_sweep_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiler
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestStartProfileCreateErrors drives the os.Create failure branches of the
+// CPU and trace start paths (and the Start error-wrapping around them) by
+// pointing the profile file at a subdirectory that does not exist. Start's
+// MkdirAll creates OutputDir but not the extra path segment.
+func TestStartProfileCreateErrors(t *testing.T) {
+	t.Run("cpu", func(t *testing.T) {
+		cfg := DefaultProfilerConfig()
+		cfg.OutputDir = t.TempDir()
+		cfg.CPUProfile = true
+		cfg.CPUProfilePath = filepath.Join("nonexistent", "cpu.prof")
+		if err := NewProfiler(cfg).Start(); err == nil {
+			t.Fatal("expected Start to fail when the CPU profile path is unwritable")
+		}
+	})
+
+	t.Run("trace", func(t *testing.T) {
+		cfg := DefaultProfilerConfig()
+		cfg.OutputDir = t.TempDir()
+		cfg.TraceProfile = true
+		cfg.TraceProfilePath = filepath.Join("nonexistent", "trace.out")
+		p := NewProfiler(cfg)
+		if err := p.Start(); err == nil {
+			_ = p.Stop()
+			t.Fatal("expected Start to fail when the trace profile path is unwritable")
+		}
+	})
+}
+
+// TestStopProfileCreateErrors reaches the os.Create failure branches of
+// stopMemProfile/stopBlockProfile/stopMutexProfile and Stop's combined-error
+// return. Stop runs these whenever their configured path is non-empty, so no
+// Start is required.
+func TestStopProfileCreateErrors(t *testing.T) {
+	cfg := DefaultProfilerConfig()
+	cfg.OutputDir = t.TempDir()
+	cfg.MemProfilePath = filepath.Join("nonexistent", "mem.prof")
+	cfg.BlockProfilePath = filepath.Join("nonexistent", "block.prof")
+	cfg.MutexProfilePath = filepath.Join("nonexistent", "mutex.prof")
+
+	if err := NewProfiler(cfg).Stop(); err == nil {
+		t.Fatal("expected Stop to report the profile-write failures")
+	}
+}
+
+// TestWriteToFileMkdirError covers the MkdirAll failure branch of WriteToFile
+// by placing the target directory underneath a regular file.
+func TestWriteToFileMkdirError(t *testing.T) {
+	fileAsDir := filepath.Join(t.TempDir(), "not-a-dir")
+	f, err := os.Create(fileAsDir)
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("setup close: %v", err)
+	}
+
+	mc := NewMetricsCollector()
+	mc.AddMetric("x", MetricTypeCounter, 1, "count", nil)
+	target := filepath.Join(fileAsDir, "sub", "metrics.json")
+	if err := mc.WriteToFile(target); err == nil {
+		t.Fatal("expected WriteToFile to fail when the parent path is a file")
+	}
+}
+
+// TestCollectSystemMetricsTick lets the 1s system-metrics ticker fire so the
+// periodic collection body (memory + goroutine sampling and the goroutine-leak
+// detection guard) runs. A burst of blocked goroutines between two ticks trips
+// the leak threshold branch.
+func TestCollectSystemMetricsTick(t *testing.T) {
+	mc := NewMetricsCollector()
+	mc.Start()
+
+	// First tick establishes the goroutine baseline.
+	time.Sleep(1200 * time.Millisecond)
+
+	// Spawn well over the 100-goroutine leak threshold and hold them across the
+	// next tick so currentGoroutines exceeds baseline+100.
+	release := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 150; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-release
+		}()
+	}
+	time.Sleep(1200 * time.Millisecond)
+
+	close(release)
+	wg.Wait()
+	if err := mc.Stop(); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+
+	// The periodic collection should have recorded system gauges.
+	sawMemory := false
+	for _, m := range mc.GetMetrics() {
+		if m.Name == "memory.alloc" {
+			sawMemory = true
+			break
+		}
+	}
+	if !sawMemory {
+		t.Error("expected the system-metrics ticker to record memory.alloc")
+	}
+	// Guard against goroutine leakage from the collector itself.
+	runtime.GC()
+}

--- a/internal/spec/extractor_sweep_test.go
+++ b/internal/spec/extractor_sweep_test.go
@@ -1,0 +1,1685 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// --- shared builders -------------------------------------------------------
+
+// exSweepMeta returns a fresh metadata carrier whose string pool has index 0
+// burned by a sentinel. Several production checks treat pool index 0 as
+// "unset" (e.g. Assignment.ConcreteType != 0), so no real string used by
+// these tests may land on index 0.
+func exSweepMeta() *metadata.Metadata {
+	pool := metadata.NewStringPool()
+	pool.Get("\x00sweep-sentinel")
+	return &metadata.Metadata{StringPool: pool}
+}
+
+// sweepCall builds a metadata.Call with every pooled field set explicitly:
+// an untouched zero field would resolve to pool index 0 (the sentinel).
+func sweepCall(meta *metadata.Metadata, name, pkg, recvType, position string) metadata.Call {
+	return metadata.Call{
+		Meta:     meta,
+		Name:     meta.StringPool.Get(name),
+		Pkg:      meta.StringPool.Get(pkg),
+		RecvType: meta.StringPool.Get(recvType),
+		Position: meta.StringPool.Get(position),
+	}
+}
+
+// sweepEdge builds a call edge caller -> callee (positions on the callee so
+// Callee.ID() carries an "@file:line:col" suffix when calleePos != "").
+func sweepEdge(meta *metadata.Metadata, callerName, callerPkg, calleeName, calleePkg, calleeRecv, calleePos string, args ...*metadata.CallArgument) *metadata.CallGraphEdge {
+	return &metadata.CallGraphEdge{
+		Caller:   sweepCall(meta, callerName, callerPkg, "", ""),
+		Callee:   sweepCall(meta, calleeName, calleePkg, calleeRecv, calleePos),
+		Position: meta.StringPool.Get(""),
+		Args:     args,
+	}
+}
+
+func sweepIdent(meta *metadata.Metadata, name string) *metadata.CallArgument {
+	a := metadata.NewCallArgument(meta)
+	a.SetKind(metadata.KindIdent)
+	a.SetName(name)
+	return a
+}
+
+func sweepLit(meta *metadata.Metadata, value string) *metadata.CallArgument {
+	a := metadata.NewCallArgument(meta)
+	a.SetKind(metadata.KindLiteral)
+	a.SetValue(value)
+	return a
+}
+
+func sweepNode(edge *metadata.CallGraphEdge) *TrackerNode {
+	return &TrackerNode{CallGraphEdge: edge}
+}
+
+// sweepInterfaceMeta returns metadata declaring interface app.Animal plus
+// concrete structs app.Dog / app.Cat, for the interface-narrowing helpers.
+func sweepInterfaceMeta() *metadata.Metadata {
+	meta := exSweepMeta()
+	pool := meta.StringPool
+	meta.Packages = map[string]*metadata.Package{
+		"app": {
+			Files: map[string]*metadata.File{
+				"app/main.go": {
+					Types: map[string]*metadata.Type{
+						"Animal": {Name: pool.Get("Animal"), Pkg: pool.Get("app"), Kind: pool.Get("interface")},
+						"Dog":    {Name: pool.Get("Dog"), Pkg: pool.Get("app"), Kind: pool.Get("struct")},
+						"Cat":    {Name: pool.Get("Cat"), Pkg: pool.Get("app"), Kind: pool.Get("struct")},
+					},
+					Functions: map[string]*metadata.Function{},
+				},
+			},
+		},
+	}
+	return meta
+}
+
+// --- pattern_matchers.go ----------------------------------------------------
+
+func TestSweepResolvePathArg(t *testing.T) {
+	meta := exSweepMeta()
+	b := NewBasePatternMatcher(&APISpecConfig{}, NewContextProvider(meta), nil)
+
+	callNamed := metadata.NewCallArgument(meta)
+	callNamed.SetKind(metadata.KindCall)
+	callNamed.SetName("mountPoint")
+
+	callFunOnly := metadata.NewCallArgument(meta)
+	callFunOnly.SetKind(metadata.KindCall)
+	callFunOnly.Fun = sweepIdent(meta, "makePath")
+
+	callAnon := metadata.NewCallArgument(meta)
+	callAnon.SetKind(metadata.KindCall)
+
+	tests := []struct {
+		name     string
+		arg      *metadata.CallArgument
+		wantPath string
+		wantDyn  string
+	}{
+		{"nil arg", nil, "", ""},
+		{"named call", callNamed, "{mountPoint}", "mountPoint"},
+		{"call named via Fun", callFunOnly, "{makePath}", "makePath"},
+		{"anonymous call falls back to path", callAnon, "{path}", "path"},
+		{"literal passes through", sweepLit(meta, `"/users"`), "/users", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, dyn := b.resolvePathArg(tt.arg)
+			if path != tt.wantPath || dyn != tt.wantDyn {
+				t.Errorf("resolvePathArg() = (%q, %q), want (%q, %q)", path, dyn, tt.wantPath, tt.wantDyn)
+			}
+		})
+	}
+}
+
+func TestSweepRouteMatcherMatchNode(t *testing.T) {
+	meta := exSweepMeta()
+	cp := NewContextProvider(meta)
+	cfg := &APISpecConfig{}
+
+	tests := []struct {
+		name    string
+		pattern RoutePattern
+		edge    *metadata.CallGraphEdge
+		want    bool
+	}{
+		{
+			name:    "call regex mismatch",
+			pattern: RoutePattern{CallRegex: "^GET$"},
+			edge:    sweepEdge(meta, "main", "app", "POST", "app", "", ""),
+			want:    false,
+		},
+		{
+			name:    "recv-only fq type matches exact RecvType",
+			pattern: RoutePattern{RecvType: "Router"},
+			edge:    sweepEdge(meta, "main", "app", "GET", "", "Router", ""),
+			want:    true,
+		},
+		{
+			name:    "function name regex mismatch",
+			pattern: RoutePattern{CallRegex: "^GET$", FunctionNameRegex: "^setup"},
+			edge:    sweepEdge(meta, "main", "app", "GET", "app", "", ""),
+			want:    false,
+		},
+		{
+			name:    "recv type regex mismatch",
+			pattern: RoutePattern{RecvTypeRegex: `^chi\.Mux$`},
+			edge:    sweepEdge(meta, "main", "app", "GET", "other", "Router", ""),
+			want:    false,
+		},
+		{
+			name:    "exact recv type mismatch",
+			pattern: RoutePattern{RecvType: "chi.Mux"},
+			edge:    sweepEdge(meta, "main", "app", "GET", "other", "Router", ""),
+			want:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewRoutePatternMatcher(tt.pattern, cfg, cp, nil)
+			if got := m.MatchNode(sweepNode(tt.edge)); got != tt.want {
+				t.Errorf("MatchNode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSweepRouteMatcherExtractRoute(t *testing.T) {
+	meta := exSweepMeta()
+	cp := NewContextProvider(meta)
+	cfg := &APISpecConfig{}
+
+	t.Run("file falls back to argument position", func(t *testing.T) {
+		m := NewRoutePatternMatcher(RoutePattern{MethodArgIndex: -1}, cfg, cp, nil)
+		edge := sweepEdge(meta, "main", "app", "Get", "app", "", "")
+		arg := sweepIdent(meta, "h")
+		arg.SetPosition("app/main.go:5:2")
+		node := &TrackerNode{CallGraphEdge: edge, CallArgument: arg}
+		route := NewRouteInfo()
+		m.ExtractRoute(node, route)
+		if route.File != "app/main.go:5:2" {
+			t.Errorf("File = %q, want argument position", route.File)
+		}
+	})
+
+	t.Run("nil edge takes metadata from argument node", func(t *testing.T) {
+		m := NewRoutePatternMatcher(RoutePattern{MethodArgIndex: -1}, cfg, cp, nil)
+		arg := sweepIdent(meta, "h")
+		node := &TrackerNode{CallArgument: arg}
+		route := &RouteInfo{
+			File: "f.go", Package: "app",
+			Response: map[string]*ResponseInfo{}, UsedTypes: map[string]*Schema{},
+		}
+		m.ExtractRoute(node, route)
+		if route.Metadata != meta {
+			t.Errorf("expected metadata to come from the argument node")
+		}
+	})
+
+	t.Run("handler ident is traced to its origin package", func(t *testing.T) {
+		m := NewRoutePatternMatcher(RoutePattern{MethodArgIndex: -1, HandlerFromArg: true, HandlerArgIndex: 0}, cfg, cp, nil)
+		edge := sweepEdge(meta, "setupRoutes", "app", "Handle", "app", "", "", sweepIdent(meta, "myHandler"))
+		route := NewRouteInfo()
+		found := m.ExtractRoute(sweepNode(edge), route)
+		if !found {
+			t.Fatal("expected handler extraction to report found")
+		}
+		if route.Handler == "" {
+			t.Error("expected a traced handler name")
+		}
+		if route.Package == "" {
+			t.Error("expected the traced origin package to be recorded")
+		}
+	})
+}
+
+func TestSweepExtractRouteDetails(t *testing.T) {
+	cfg := &APISpecConfig{}
+
+	t.Run("method from handler name", func(t *testing.T) {
+		meta := exSweepMeta()
+		cp := NewContextProvider(meta)
+		m := NewRoutePatternMatcher(RoutePattern{
+			MethodFromHandler: true, HandlerFromArg: true, HandlerArgIndex: 0, MethodArgIndex: -1,
+		}, cfg, cp, nil)
+		edge := sweepEdge(meta, "main", "app", "Handle", "app", "", "", sweepIdent(meta, "deleteUser"))
+		route := NewRouteInfo()
+		if !m.extractRouteDetails(sweepNode(edge), route) {
+			t.Fatal("expected details to be found")
+		}
+		if route.Method != "DELETE" || !route.MethodExplicit {
+			t.Errorf("Method = %q (explicit=%v), want DELETE explicit", route.Method, route.MethodExplicit)
+		}
+	})
+
+	t.Run("method arg falls back to const-resolved argument info", func(t *testing.T) {
+		meta := exSweepMeta()
+		pool := meta.StringPool
+		// A const declared in metadata: GetArgumentInfo resolves the ident to
+		// its literal value "DELETE" while GetValue stays the raw expression.
+		meta.Packages = map[string]*metadata.Package{
+			"net/http": {Files: map[string]*metadata.File{
+				"h.go": {Variables: map[string]*metadata.Variable{
+					"MethodDelete": {Tok: pool.Get("const"), Value: pool.Get(`"DELETE"`)},
+				}},
+			}},
+		}
+		cp := NewContextProvider(meta)
+		m := NewRoutePatternMatcher(RoutePattern{MethodArgIndex: 0}, cfg, cp, nil)
+		arg := sweepIdent(meta, "MethodDelete")
+		arg.SetPkg("net/http")
+		arg.SetValue("http.MethodDelete") // raw value: not a valid method by itself
+		edge := sweepEdge(meta, "main", "app", "Handle", "app", "", "", arg)
+		route := NewRouteInfo()
+		if !m.extractRouteDetails(sweepNode(edge), route) {
+			t.Fatal("expected details to be found")
+		}
+		if route.Method != "DELETE" {
+			t.Errorf("Method = %q, want DELETE via argument info", route.Method)
+		}
+	})
+
+	t.Run("unresolvable method infers from context", func(t *testing.T) {
+		meta := exSweepMeta()
+		cp := NewContextProvider(meta)
+		m := NewRoutePatternMatcher(RoutePattern{
+			MethodArgIndex: 0, MethodExtraction: DefaultMethodExtractionConfig(),
+		}, cfg, cp, nil)
+		arg := sweepIdent(meta, "someVerb")
+		arg.SetValue("someVerb")
+		edge := sweepEdge(meta, "listThings", "app", "Handle", "app", "", "", arg)
+		route := NewRouteInfo()
+		if !m.extractRouteDetails(sweepNode(edge), route) {
+			t.Fatal("expected details to be found")
+		}
+		if route.Method != "GET" {
+			t.Errorf("Method = %q, want GET inferred from caller name", route.Method)
+		}
+	})
+
+	t.Run("dynamic path arg records a placeholder param", func(t *testing.T) {
+		meta := exSweepMeta()
+		cp := NewContextProvider(meta)
+		m := NewRoutePatternMatcher(RoutePattern{PathFromArg: true, PathArgIndex: 0, MethodArgIndex: -1}, cfg, cp, nil)
+		pathCall := metadata.NewCallArgument(meta)
+		pathCall.SetKind(metadata.KindCall)
+		pathCall.SetName("mountPoint")
+		edge := sweepEdge(meta, "main", "app", "Mount", "app", "", "", pathCall)
+		route := NewRouteInfo()
+		m.extractRouteDetails(sweepNode(edge), route)
+		if route.Path != "{mountPoint}" {
+			t.Errorf("Path = %q, want {mountPoint}", route.Path)
+		}
+		if len(route.DynamicParams) != 1 || route.DynamicParams[0] != "mountPoint" {
+			t.Errorf("DynamicParams = %v, want [mountPoint]", route.DynamicParams)
+		}
+	})
+}
+
+func TestSweepInferMethodFromContext(t *testing.T) {
+	cfg := &APISpecConfig{}
+
+	t.Run("sibling Methods call resolved via argument info", func(t *testing.T) {
+		meta := exSweepMeta()
+		pool := meta.StringPool
+		meta.Packages = map[string]*metadata.Package{
+			"net/http": {Files: map[string]*metadata.File{
+				"h.go": {Variables: map[string]*metadata.Variable{
+					"MethodPut": {Tok: pool.Get("const"), Value: pool.Get(`"PUT"`)},
+				}},
+			}},
+		}
+		cp := NewContextProvider(meta)
+		m := NewRoutePatternMatcher(RoutePattern{MethodExtraction: DefaultMethodExtractionConfig()}, cfg, cp, nil)
+
+		methodArg := sweepIdent(meta, "MethodPut")
+		methodArg.SetPkg("net/http")
+		methodArg.SetValue("http.MethodPut")
+		siblingEdge := sweepEdge(meta, "main", "app", "Methods", "mux", "", "", methodArg)
+
+		parent := &TrackerNode{}
+		self := &TrackerNode{Parent: parent}
+		sibling := &TrackerNode{CallGraphEdge: siblingEdge, Parent: parent}
+		parent.Children = []*TrackerNode{self, sibling}
+
+		edge := sweepEdge(meta, "main", "app", "HandleFunc", "mux", "", "")
+		if got := m.inferMethodFromContext(self, edge); got != "PUT" {
+			t.Errorf("inferMethodFromContext() = %q, want PUT", got)
+		}
+	})
+
+	t.Run("caller name yields the method", func(t *testing.T) {
+		meta := exSweepMeta()
+		cp := NewContextProvider(meta)
+		m := NewRoutePatternMatcher(RoutePattern{MethodExtraction: DefaultMethodExtractionConfig()}, cfg, cp, nil)
+		// "deleteUser" (not "...Widget"): the contains-matcher would otherwise
+		// spot "get" inside "widget" and short-circuit to GET before the
+		// caller-name prefix can win.
+		edge := sweepEdge(meta, "deleteUser", "app", "HandleFunc", "mux", "", "")
+		if got := m.inferMethodFromContext(&TrackerNode{}, edge); got != "DELETE" {
+			t.Errorf("inferMethodFromContext() = %q, want DELETE", got)
+		}
+	})
+
+	t.Run("handler argument yields the method when caller maps to POST", func(t *testing.T) {
+		meta := exSweepMeta()
+		cp := NewContextProvider(meta)
+		m := NewRoutePatternMatcher(RoutePattern{MethodExtraction: DefaultMethodExtractionConfig()}, cfg, cp, nil)
+		// Handler arg "updateUser" (not "...Widget"): "widget" contains "get"
+		// and would resolve to GET before the "update" prefix can map to PUT.
+		edge := sweepEdge(meta, "createThing", "app", "HandleFunc", "mux", "", "",
+			sweepLit(meta, `"/x"`), sweepIdent(meta, "updateUser"))
+		if got := m.inferMethodFromContext(&TrackerNode{}, edge); got != "PUT" {
+			t.Errorf("inferMethodFromContext() = %q, want PUT from handler arg", got)
+		}
+	})
+}
+
+func TestSweepMountMatcherMatchNode(t *testing.T) {
+	meta := exSweepMeta()
+	cp := NewContextProvider(meta)
+	cfg := &APISpecConfig{}
+
+	tests := []struct {
+		name    string
+		pattern MountPattern
+		edge    *metadata.CallGraphEdge
+		want    bool
+	}{
+		{
+			name:    "call regex mismatch",
+			pattern: MountPattern{CallRegex: "^Mount$", IsMount: true},
+			edge:    sweepEdge(meta, "main", "app", "Route", "chi", "", ""),
+			want:    false,
+		},
+		{
+			name:    "function name regex mismatch",
+			pattern: MountPattern{CallRegex: "^Mount$", FunctionNameRegex: "^setup", IsMount: true},
+			edge:    sweepEdge(meta, "main", "app", "Mount", "chi", "", ""),
+			want:    false,
+		},
+		{
+			name:    "recv type regex mismatch",
+			pattern: MountPattern{RecvTypeRegex: `^chi\.Mux$`, IsMount: true},
+			edge:    sweepEdge(meta, "main", "app", "Mount", "other", "Router", ""),
+			want:    false,
+		},
+		{
+			name:    "exact recv type mismatch",
+			pattern: MountPattern{RecvType: "chi.Mux", IsMount: true},
+			edge:    sweepEdge(meta, "main", "app", "Mount", "other", "Router", ""),
+			want:    false,
+		},
+		{
+			name:    "full match returns IsMount",
+			pattern: MountPattern{CallRegex: "^Mount$", RecvType: "chi.Mux", IsMount: true},
+			edge:    sweepEdge(meta, "main", "app", "Mount", "chi", "Mux", ""),
+			want:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewMountPatternMatcher(tt.pattern, cfg, cp, nil)
+			if got := m.MatchNode(sweepNode(tt.edge)); got != tt.want {
+				t.Errorf("MatchNode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSweepSecurityMatcher(t *testing.T) {
+	meta := exSweepMeta()
+	cp := NewContextProvider(meta)
+	cfg := &APISpecConfig{}
+
+	t.Run("nil node and nil edge", func(t *testing.T) {
+		m := NewSecurityPatternMatcher(SecurityPattern{CallRegex: "^Use$"}, cfg, cp, nil)
+		if m.MatchNode(nil) {
+			t.Error("MatchNode(nil) = true, want false")
+		}
+		if m.ExtractMiddleware(nil) != nil {
+			t.Error("ExtractMiddleware(nil) != nil")
+		}
+		if m.ExtractMiddlewareFromEdge(nil) != nil {
+			t.Error("ExtractMiddlewareFromEdge(nil) != nil")
+		}
+	})
+
+	t.Run("match edge rejections", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			pattern SecurityPattern
+			edge    *metadata.CallGraphEdge
+		}{
+			{"call regex", SecurityPattern{CallRegex: "^Use$"}, sweepEdge(meta, "main", "app", "Get", "chi", "", "")},
+			{"function name regex", SecurityPattern{CallRegex: "^Use$", FunctionNameRegex: "^setup"}, sweepEdge(meta, "main", "app", "Use", "chi", "", "")},
+			{"exact recv type", SecurityPattern{RecvType: "chi.Mux"}, sweepEdge(meta, "main", "app", "Use", "other", "Router", "")},
+		}
+		for _, tt := range tests {
+			m := NewSecurityPatternMatcher(tt.pattern, cfg, cp, nil)
+			if m.MatchEdge(tt.edge) {
+				t.Errorf("%s: MatchEdge() = true, want false", tt.name)
+			}
+		}
+	})
+
+	t.Run("priority counts function name regex", func(t *testing.T) {
+		m := NewSecurityPatternMatcher(SecurityPattern{CallRegex: "x", FunctionNameRegex: "y", RecvType: "z"}, cfg, cp, nil)
+		if got := m.GetPriority(); got != 18 {
+			t.Errorf("GetPriority() = %d, want 18", got)
+		}
+	})
+
+	t.Run("negative middleware arg index clamps to zero", func(t *testing.T) {
+		m := NewSecurityPatternMatcher(SecurityPattern{Scope: SecurityScopeRouter, MiddlewareArgIndex: -1}, cfg, cp, nil)
+		mw := sweepIdent(meta, "authMW")
+		mw.SetPkg("app")
+		edge := sweepEdge(meta, "main", "app", "Use", "chi", "Mux", "", mw)
+		refs := m.ExtractMiddlewareFromEdge(edge)
+		if len(refs) != 1 || refs[0].FunctionName != "authMW" {
+			t.Errorf("refs = %+v, want single authMW ref", refs)
+		}
+	})
+}
+
+func TestSweepRequestMatcherMatchNodeAndPriority(t *testing.T) {
+	meta := exSweepMeta()
+	cp := NewContextProvider(meta)
+	cfg := &APISpecConfig{}
+
+	t.Run("nil node", func(t *testing.T) {
+		m := NewRequestPatternMatcher(RequestBodyPattern{CallRegex: "^Bind$"}, cfg, cp, nil)
+		if m.MatchNode(nil) {
+			t.Error("MatchNode(nil) = true, want false")
+		}
+	})
+
+	rejections := []struct {
+		name    string
+		pattern RequestBodyPattern
+		edge    *metadata.CallGraphEdge
+	}{
+		{"call regex", RequestBodyPattern{CallRegex: "^Bind$"}, sweepEdge(meta, "h", "app", "JSON", "gin", "", "")},
+		{"function name regex", RequestBodyPattern{CallRegex: "^Bind$", FunctionNameRegex: "^handle"}, sweepEdge(meta, "main", "app", "Bind", "gin", "", "")},
+		{"recv type regex", RequestBodyPattern{RecvTypeRegex: `^gin\.Context$`}, sweepEdge(meta, "h", "app", "Bind", "other", "Ctx", "")},
+		{"exact recv type", RequestBodyPattern{RecvType: "gin.Context"}, sweepEdge(meta, "h", "app", "Bind", "other", "Ctx", "")},
+	}
+	for _, tt := range rejections {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewRequestPatternMatcher(tt.pattern, cfg, cp, nil)
+			if m.MatchNode(sweepNode(tt.edge)) {
+				t.Errorf("MatchNode() = true, want false")
+			}
+		})
+	}
+
+	t.Run("priority branches", func(t *testing.T) {
+		m := NewRequestPatternMatcher(RequestBodyPattern{FunctionNameRegex: "y", RecvTypeRegex: "z"}, cfg, cp, nil)
+		if got := m.GetPriority(); got != 8 {
+			t.Errorf("GetPriority() = %d, want 8", got)
+		}
+	})
+}
+
+func TestSweepRequestBodySource(t *testing.T) {
+	meta := exSweepMeta()
+	cp := NewContextProvider(meta)
+	cfg := &APISpecConfig{}
+
+	t.Run("nil edge", func(t *testing.T) {
+		m := NewRequestPatternMatcher(RequestBodyPattern{}, cfg, cp, nil)
+		if m.bodySource(nil) != nil {
+			t.Error("bodySource(nil) != nil")
+		}
+	})
+
+	t.Run("body from receiver resolves via chain parent", func(t *testing.T) {
+		m := NewRequestPatternMatcher(RequestBodyPattern{BodyFromReceiver: true}, cfg, cp, nil)
+		src := sweepIdent(meta, "r")
+		edge := sweepEdge(meta, "h", "app", "Decode", "json", "Decoder", "")
+		edge.ChainParent = sweepEdge(meta, "h", "app", "NewDecoder", "json", "", "", src)
+		got := m.bodySource(edge)
+		if got != src {
+			t.Errorf("bodySource() = %v, want the chain-parent factory arg", got)
+		}
+	})
+}
+
+func TestSweepRequestExtractRequest(t *testing.T) {
+	cfg := &APISpecConfig{Defaults: Defaults{RequestContentType: "application/json"}}
+
+	t.Run("call arg uses its return type", func(t *testing.T) {
+		meta := exSweepMeta()
+		cp := NewContextProvider(meta)
+		m := NewRequestPatternMatcher(RequestBodyPattern{TypeFromArg: true, TypeArgIndex: 0}, cfg, cp, nil)
+		arg := metadata.NewCallArgument(meta)
+		arg.SetKind(metadata.KindCall)
+		arg.Fun = sweepIdent(meta, "readUser")
+		arg.SetType("app.User")
+		edge := sweepEdge(meta, "h", "app", "Decode", "json", "", "", arg)
+		req := m.ExtractRequest(sweepNode(edge), NewRouteInfo())
+		if req == nil || req.BodyType != "app.User" {
+			t.Fatalf("req = %+v, want BodyType app.User", req)
+		}
+	})
+
+	t.Run("resolved type wins", func(t *testing.T) {
+		meta := exSweepMeta()
+		cp := NewContextProvider(meta)
+		m := NewRequestPatternMatcher(RequestBodyPattern{TypeFromArg: true, TypeArgIndex: 0}, cfg, cp, nil)
+		arg := sweepIdent(meta, "v")
+		arg.SetResolvedType("app.Widget")
+		edge := sweepEdge(meta, "h", "app", "Decode", "json", "", "", arg)
+		req := m.ExtractRequest(sweepNode(edge), NewRouteInfo())
+		if req == nil || req.BodyType != "app.Widget" {
+			t.Fatalf("req = %+v, want BodyType app.Widget", req)
+		}
+	})
+
+	t.Run("generic arg resolves through type param map", func(t *testing.T) {
+		meta := exSweepMeta()
+		cp := NewContextProvider(meta)
+		m := NewRequestPatternMatcher(RequestBodyPattern{TypeFromArg: true, TypeArgIndex: 0}, cfg, cp, nil)
+		arg := sweepIdent(meta, "v")
+		arg.IsGenericType = true
+		arg.GenericTypeName = meta.StringPool.Get("T")
+		edge := sweepEdge(meta, "h", "app", "Decode", "json", "", "", arg)
+		// Seed via the edge: TrackerNode.TypeParams() rebuilds its map from the
+		// edge/arg/parent on every read, so a directly-set node.typeParamMap is
+		// discarded.
+		edge.TypeParamMap = map[string]string{"T": "app.Item"}
+		node := sweepNode(edge)
+		req := m.ExtractRequest(node, NewRouteInfo())
+		if req == nil || req.BodyType != "app.Item" {
+			t.Fatalf("req = %+v, want BodyType app.Item", req)
+		}
+	})
+
+	t.Run("deref strips pointer and param rebinds through wrapper", func(t *testing.T) {
+		meta := exSweepMeta()
+		cp := NewContextProvider(meta)
+		m := NewRequestPatternMatcher(RequestBodyPattern{TypeFromArg: true, TypeArgIndex: 0, Deref: true}, cfg, cp, nil)
+
+		concrete := metadata.NewCallArgument(meta)
+		concrete.SetKind(metadata.KindIdent)
+		concrete.SetName("u")
+		concrete.SetResolvedType("*app.User")
+
+		parentEdge := sweepEdge(meta, "handler", "app", "readRequest", "app", "", "")
+		parentEdge.ParamArgMap = map[string]metadata.CallArgument{"v": *concrete}
+		parent := sweepNode(parentEdge)
+
+		param := sweepIdent(meta, "v")
+		edge := sweepEdge(meta, "readRequest", "app", "Decode", "json", "", "", param)
+		node := sweepNode(edge)
+		node.Parent = parent
+
+		req := m.ExtractRequest(node, NewRouteInfo())
+		if req == nil || req.BodyType != "app.User" {
+			t.Fatalf("req = %+v, want BodyType app.User via wrapper rebinding + deref", req)
+		}
+	})
+}
+
+func TestSweepRequestResolveTypeOrigin(t *testing.T) {
+	meta := exSweepMeta()
+	cp := NewContextProvider(meta)
+	m := NewRequestPatternMatcher(RequestBodyPattern{}, &APISpecConfig{}, cp, nil)
+
+	t.Run("selector fast path uses recorded type", func(t *testing.T) {
+		sel := metadata.NewCallArgument(meta)
+		sel.SetKind(metadata.KindSelector)
+		sel.SetType("string")
+		node := sweepNode(sweepEdge(meta, "h", "app", "Bind", "gin", "", ""))
+		if got := m.resolveTypeOrigin(sel, node, "orig"); got != "string" {
+			t.Errorf("resolveTypeOrigin(selector) = %q, want string", got)
+		}
+	})
+
+	t.Run("ident resolves through edge assignments", func(t *testing.T) {
+		arg := sweepIdent(meta, "u")
+		edge := sweepEdge(meta, "h", "app", "Bind", "gin", "", "")
+		edge.AssignmentMap = map[string][]metadata.Assignment{
+			"u": {{ConcreteType: meta.StringPool.Get("app.User")}},
+		}
+		if got := m.resolveTypeOrigin(arg, sweepNode(edge), "any"); got != "app.User" {
+			t.Errorf("resolveTypeOrigin(ident) = %q, want app.User", got)
+		}
+	})
+
+	t.Run("fallthrough keeps original type", func(t *testing.T) {
+		lit := sweepLit(meta, "42")
+		node := sweepNode(sweepEdge(meta, "h", "app", "Bind", "gin", "", ""))
+		if got := m.resolveTypeOrigin(lit, node, "int"); got != "int" {
+			t.Errorf("resolveTypeOrigin(literal) = %q, want int", got)
+		}
+	})
+}
+
+func TestSweepBaseMatcherGuards(t *testing.T) {
+	t.Run("empty pattern never matches", func(t *testing.T) {
+		b := NewBasePatternMatcher(&APISpecConfig{}, NewContextProvider(exSweepMeta()), nil)
+		if b.matchPattern("", "anything") {
+			t.Error("matchPattern(\"\") = true, want false")
+		}
+	})
+
+	t.Run("trace and assignment lookups degrade without metadata", func(t *testing.T) {
+		b := NewBasePatternMatcher(&APISpecConfig{}, NewContextProvider(nil), nil)
+		v, p, typ, fn := b.traceVariable("x", "f", "pkg")
+		if v != "x" || p != "pkg" || typ != nil || fn != "" {
+			t.Errorf("traceVariable = (%q,%q,%v,%q), want passthrough", v, p, typ, fn)
+		}
+		arg := metadata.NewCallArgument(exSweepMeta())
+		if got := b.findAssignmentFunction(arg); got != nil {
+			t.Errorf("findAssignmentFunction = %v, want nil", got)
+		}
+	})
+}
+
+func TestSweepExtractMethodFromFunctionNameWithConfig(t *testing.T) {
+	b := NewBasePatternMatcher(&APISpecConfig{}, NewContextProvider(exSweepMeta()), nil)
+
+	if got := b.extractMethodFromFunctionNameWithConfig("", nil); got != "" {
+		t.Errorf("empty func name: got %q, want empty", got)
+	}
+
+	// Mappings deliberately listed in ascending priority so the sort has to
+	// reorder them: the higher-priority longer prefix must win.
+	cfg := &MethodExtractionConfig{
+		MethodMappings: []MethodMapping{
+			{Patterns: []string{"x"}, Method: "GET", Priority: 1},
+			{Patterns: []string{"xy"}, Method: "PUT", Priority: 5},
+		},
+		UsePrefix:     true,
+		DefaultMethod: "HEAD",
+	}
+	if got := b.extractMethodFromFunctionNameWithConfig("xy", cfg); got != "PUT" {
+		t.Errorf("priority sort: got %q, want PUT", got)
+	}
+	if got := b.extractMethodFromFunctionNameWithConfig("zzz", cfg); got != "HEAD" {
+		t.Errorf("default method: got %q, want HEAD", got)
+	}
+}
+
+// --- extractor.go ------------------------------------------------------------
+
+func TestSweepSmallHelpers(t *testing.T) {
+	t.Run("appendUniqueStrings", func(t *testing.T) {
+		base := []string{"a"}
+		if got := appendUniqueStrings(base); len(got) != 1 || &got[0] != &base[0] {
+			t.Errorf("no extras must return base unchanged, got %v", got)
+		}
+		if got := appendUniqueStrings([]string{"a", "a"}, "a", "b"); len(got) != 2 || got[0] != "a" || got[1] != "b" {
+			t.Errorf("got %v, want [a b]", got)
+		}
+	})
+
+	t.Run("frameChainKey without edge joins the chain", func(t *testing.T) {
+		got := frameChainKey([]string{"x", "y"}, &TrackerNode{})
+		if got != "x"+chainSep+"y" {
+			t.Errorf("frameChainKey = %q, want joined chain", got)
+		}
+	})
+
+	t.Run("preferRequestInfo", func(t *testing.T) {
+		concrete := &RequestInfo{Schema: &Schema{Ref: "#/x"}}
+		generic := &RequestInfo{Schema: &Schema{Type: "object"}}
+		if got := preferRequestInfo(nil, generic); got != generic {
+			t.Error("nil cur must yield next")
+		}
+		if got := preferRequestInfo(generic, nil); got != generic {
+			t.Error("nil next must keep cur")
+		}
+		if got := preferRequestInfo(generic, concrete); got != concrete {
+			t.Error("concrete next must win")
+		}
+		if got := preferRequestInfo(concrete, generic); got != concrete {
+			t.Error("concrete cur must win")
+		}
+		if got := preferRequestInfo(generic, generic); got != generic {
+			t.Error("tie keeps last-write-wins")
+		}
+	})
+
+	t.Run("requestIsConcrete guards", func(t *testing.T) {
+		if requestIsConcrete(nil) || requestIsConcrete(&RequestInfo{}) {
+			t.Error("nil/schema-less request must not be concrete")
+		}
+	})
+
+	t.Run("preferResponseInfo", func(t *testing.T) {
+		cur := &ResponseInfo{BodyType: "app.User", Schema: &Schema{Ref: "#/u"}}
+		errResp := &ResponseInfo{BodyType: "app.ErrorDTO", Schema: &Schema{Ref: "#/e"}}
+		if got := preferResponseInfo(cur, nil); got != cur {
+			t.Error("nil next must keep cur")
+		}
+		if got := preferResponseInfo(cur, errResp); got != cur {
+			t.Error("error-named next must lose")
+		}
+		if got := preferResponseInfo(errResp, cur); got != cur {
+			t.Error("error-named cur must lose")
+		}
+		a := &ResponseInfo{BodyType: "app.A", Schema: &Schema{Ref: "#/a"}}
+		b := &ResponseInfo{BodyType: "app.B", Schema: &Schema{Ref: "#/b"}}
+		if got := preferResponseInfo(b, a); got != a {
+			t.Error("lexicographic tie-break must pick the smaller BodyType")
+		}
+		if got := preferResponseInfo(a, b); got != a {
+			t.Error("lexicographic tie-break must keep the smaller BodyType")
+		}
+	})
+
+	t.Run("determineLiteralType uint", func(t *testing.T) {
+		if got := determineLiteralType("18446744073709551615"); got != "uint" {
+			t.Errorf("got %q, want uint", got)
+		}
+	})
+
+	t.Run("preprocessingBodyType", func(t *testing.T) {
+		for in, want := range map[string]string{"*User": "User", "&User": "User", "[]User": "User", "*": "*"} {
+			if got := preprocessingBodyType(in); got != want {
+				t.Errorf("preprocessingBodyType(%q) = %q, want %q", in, got, want)
+			}
+		}
+	})
+
+	t.Run("isInterfaceTypeName", func(t *testing.T) {
+		meta := sweepInterfaceMeta()
+		if isInterfaceTypeName("", meta) {
+			t.Error("empty name must not be an interface")
+		}
+		if isInterfaceTypeName("app.Animal", nil) {
+			t.Error("nil meta must not resolve")
+		}
+		if !isInterfaceTypeName("app.Animal", meta) {
+			t.Error("app.Animal must resolve to an interface")
+		}
+		if isInterfaceTypeName("app.Dog", meta) {
+			t.Error("app.Dog is a struct")
+		}
+		if isInterfaceTypeName("map[string]int", meta) {
+			t.Error("map types are never interfaces")
+		}
+	})
+}
+
+func TestSweepCalleePosition(t *testing.T) {
+	meta := exSweepMeta()
+	tests := []struct {
+		name     string
+		pos      string
+		wantFile string
+		wantLine int
+		wantCol  int
+	}{
+		{"no position", "", "app.fn", 0, 0},
+		{"no colon", "main.go", "main.go", 0, 0},
+		{"one colon", "main.go:10", "main.go", 0, 10},
+		{"full position", "main.go:10:5", "main.go", 10, 5},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			edge := sweepEdge(meta, "h", "app", "fn", "app", "", tt.pos)
+			file, line, col := calleePosition(sweepNode(edge))
+			if file != tt.wantFile || line != tt.wantLine || col != tt.wantCol {
+				t.Errorf("calleePosition() = (%q,%d,%d), want (%q,%d,%d)", file, line, col, tt.wantFile, tt.wantLine, tt.wantCol)
+			}
+		})
+	}
+	t.Run("nil edge", func(t *testing.T) {
+		file, line, col := calleePosition(&TrackerNode{})
+		if file != "" || line != 0 || col != 0 {
+			t.Errorf("calleePosition(no edge) = (%q,%d,%d), want zero values", file, line, col)
+		}
+	})
+}
+
+func TestSweepExtractorGuards(t *testing.T) {
+	meta := exSweepMeta()
+	tree := NewMockTrackerTree(meta, metadata.TrackerLimits{})
+	cfg := &APISpecConfig{
+		Framework: FrameworkConfig{
+			SecurityPatterns: []SecurityPattern{{CallRegex: "^With$", Scope: SecurityScopeRoute, MiddlewareArgIndex: 0}},
+		},
+	}
+	ext := NewExtractor(tree, cfg)
+
+	t.Run("traverse tolerates nil node", func(t *testing.T) {
+		var routes []*RouteInfo
+		ext.traverseForRoutesWithVisited(nil, "", nil, nil, nil, &routes, map[string]bool{})
+		if len(routes) != 0 {
+			t.Errorf("routes = %v, want none", routes)
+		}
+	})
+
+	t.Run("collectChainSecurity guards", func(t *testing.T) {
+		if got := ext.collectChainSecurity(nil); got != nil {
+			t.Errorf("nil node: got %v", got)
+		}
+		if got := ext.collectChainSecurity(&TrackerNode{}); got != nil {
+			t.Errorf("nil edge: got %v", got)
+		}
+	})
+
+	t.Run("collectChainSecurity walks chain parents", func(t *testing.T) {
+		mw := sweepIdent(meta, "authMW")
+		mw.SetPkg("app")
+		routeEdge := sweepEdge(meta, "main", "app", "Get", "chi", "Mux", "")
+		routeEdge.ChainParent = sweepEdge(meta, "main", "app", "With", "chi", "Mux", "", mw)
+		refs := ext.collectChainSecurity(sweepNode(routeEdge))
+		if len(refs) != 1 || refs[0].FunctionName != "authMW" {
+			t.Errorf("refs = %+v, want single authMW", refs)
+		}
+	})
+
+	t.Run("responseMatcherIndex without edge", func(t *testing.T) {
+		if got := ext.responseMatcherIndex(&TrackerNode{}); got != -1 {
+			t.Errorf("got %d, want -1", got)
+		}
+	})
+
+	t.Run("extractResponsesMatched without matchers", func(t *testing.T) {
+		node := sweepNode(sweepEdge(meta, "h", "app", "JSON", "gin", "", ""))
+		if got := ext.extractResponsesMatched(node, NewRouteInfo()); got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+
+	t.Run("handlerCallDepths guards and cache", func(t *testing.T) {
+		empty := ext.handlerCallDepths(&RouteInfo{})
+		if len(empty) != 0 {
+			t.Errorf("empty function: got %v", empty)
+		}
+		route := &RouteInfo{Function: "app.h", Metadata: meta}
+		first := ext.handlerCallDepths(route)
+		second := ext.handlerCallDepths(route)
+		if len(first) != 1 || first["app.h"] != 0 {
+			t.Errorf("depths = %v, want {app.h:0}", first)
+		}
+		// The memo must return the identical map on a second call.
+		if &first == &second {
+			t.Log("map header comparison is not meaningful; assert equality instead")
+		}
+		if len(second) != len(first) {
+			t.Errorf("cached call returned different depths: %v vs %v", second, first)
+		}
+	})
+
+	t.Run("calleeMiddlewareRef nil edge", func(t *testing.T) {
+		if got := ext.calleeMiddlewareRef(nil); got != (MiddlewareRef{}) {
+			t.Errorf("got %+v, want zero", got)
+		}
+	})
+}
+
+func TestSweepExpandMiddlewareRefs(t *testing.T) {
+	t.Run("nil metadata keeps refs", func(t *testing.T) {
+		tree := NewMockTrackerTree(nil, metadata.TrackerLimits{})
+		cfg := &APISpecConfig{SecurityMappings: []SecurityMapping{{FunctionNameRegex: "^jwt$"}}}
+		ext := NewExtractor(tree, cfg)
+		refs := []MiddlewareRef{{FunctionName: "custom", Pkg: "app"}}
+		got := ext.expandMiddlewareRefs(refs)
+		if len(got) != 1 || got[0].FunctionName != "custom" {
+			t.Errorf("got %+v, want refs unchanged", got)
+		}
+	})
+
+	t.Run("identity-less ref survives look-through", func(t *testing.T) {
+		meta := exSweepMeta()
+		meta.BuildCallGraphMaps()
+		tree := NewMockTrackerTree(meta, metadata.TrackerLimits{})
+		cfg := &APISpecConfig{SecurityMappings: []SecurityMapping{{FunctionNameRegex: "^jwt$"}}}
+		ext := NewExtractor(tree, cfg)
+		refs := []MiddlewareRef{{Position: "x.go:1:1"}}
+		got := ext.expandMiddlewareRefs(refs)
+		if len(got) != 1 {
+			t.Errorf("got %+v, want the empty-identity ref kept", got)
+		}
+	})
+}
+
+func TestSweepHandleMountNodeWithAssignment(t *testing.T) {
+	meta := exSweepMeta()
+	tree := NewMockTrackerTree(meta, metadata.TrackerLimits{})
+	ext := NewExtractor(tree, &APISpecConfig{})
+
+	assignment := sweepIdent(meta, "sub")
+	assignment.SetPkg("app")
+
+	child := sweepNode(sweepEdge(meta, "routes", "app", "Get", "chi", "Mux", ""))
+	target := &TrackerNode{key: assignment.ID(), Children: []*TrackerNode{child}}
+	tree.AddRoot(target)
+
+	var routes []*RouteInfo
+	visited := map[string]bool{}
+	node := &TrackerNode{}
+	// Path empty on purpose: handleRouterAssignment must inherit mountTags
+	// (the mountPath == "" branch), not synthesize tags from the path.
+	ext.handleMountNode(node, MountInfo{Assignment: assignment}, "", []string{"inherited"}, nil, nil, &routes, visited)
+	if len(routes) != 0 {
+		t.Errorf("no route patterns configured: routes = %v, want none", routes)
+	}
+	if !visited[child.GetKey()+"@"] {
+		t.Errorf("expected the assigned router's child to be traversed; visited = %v", visited)
+	}
+}
+
+func TestSweepApplyOverrides(t *testing.T) {
+	cfg := &APISpecConfig{Overrides: []Override{{
+		FunctionName:   "app.h",
+		Summary:        "overridden",
+		ResponseStatus: 200,
+		ResponseType:   "*app.User",
+		Tags:           []string{"users"},
+	}}}
+	applier := NewOverrideApplier(cfg)
+	route := &RouteInfo{
+		Function: "app.h",
+		Response: map[string]*ResponseInfo{"200": {StatusCode: 0, BodyType: "old"}},
+	}
+	applier.ApplyOverrides(route)
+	if route.Summary != "overridden" {
+		t.Errorf("Summary = %q", route.Summary)
+	}
+	if route.Response["200"].StatusCode != 200 {
+		t.Errorf("StatusCode = %d, want 200", route.Response["200"].StatusCode)
+	}
+	if route.Response["200"].BodyType != "app.User" {
+		t.Errorf("BodyType = %q, want app.User", route.Response["200"].BodyType)
+	}
+	if len(route.Tags) != 1 || route.Tags[0] != "users" {
+		t.Errorf("Tags = %v", route.Tags)
+	}
+	if !applier.HasOverride("app.h") || applier.HasOverride("app.other") {
+		t.Error("HasOverride mismatch")
+	}
+}
+
+func TestSweepResponseMatcherMatchNodeAndPriority(t *testing.T) {
+	meta := exSweepMeta()
+	cp := NewContextProvider(meta)
+	cfg := &APISpecConfig{}
+
+	t.Run("nil node", func(t *testing.T) {
+		m := NewResponsePatternMatcher(ResponsePattern{CallRegex: "^JSON$"}, cfg, cp, nil)
+		if m.MatchNode(nil) {
+			t.Error("MatchNode(nil) = true")
+		}
+	})
+
+	rejections := []struct {
+		name    string
+		pattern ResponsePattern
+		edge    *metadata.CallGraphEdge
+	}{
+		{"call regex", ResponsePattern{CallRegex: "^JSON$"}, sweepEdge(meta, "h", "app", "Bind", "gin", "", "")},
+		{"function name regex", ResponsePattern{CallRegex: "^JSON$", FunctionNameRegex: "^handle"}, sweepEdge(meta, "main", "app", "JSON", "gin", "", "")},
+		{"exact recv type", ResponsePattern{RecvType: "gin.Context"}, sweepEdge(meta, "h", "app", "JSON", "other", "Ctx", "")},
+	}
+	for _, tt := range rejections {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewResponsePatternMatcher(tt.pattern, cfg, cp, nil)
+			if m.MatchNode(sweepNode(tt.edge)) {
+				t.Errorf("MatchNode() = true, want false")
+			}
+		})
+	}
+
+	t.Run("priority branches", func(t *testing.T) {
+		m := NewResponsePatternMatcher(ResponsePattern{FunctionNameRegex: "y", RecvType: "z"}, cfg, cp, nil)
+		if got := m.GetPriority(); got != 8 {
+			t.Errorf("GetPriority() = %d, want 8", got)
+		}
+	})
+}
+
+func TestSweepExtractResponse(t *testing.T) {
+	cfg := &APISpecConfig{Defaults: Defaults{ResponseContentType: "application/json"}}
+
+	t.Run("unresolved status steps below the least existing", func(t *testing.T) {
+		meta := exSweepMeta()
+		m := NewResponsePatternMatcher(ResponsePattern{}, cfg, NewContextProvider(meta), nil)
+		route := NewRouteInfo()
+		route.Response["-1"] = &ResponseInfo{StatusCode: -1}
+		node := sweepNode(sweepEdge(meta, "h", "app", "JSON", "gin", "", ""))
+		if got := m.ExtractResponse(node, route); got != nil {
+			t.Errorf("nothing resolved: got %+v, want nil", got)
+		}
+	})
+
+	t.Run("body adopts the lowest bodyless status", func(t *testing.T) {
+		meta := exSweepMeta()
+		m := NewResponsePatternMatcher(ResponsePattern{TypeFromArg: true, TypeArgIndex: 0}, cfg, NewContextProvider(meta), nil)
+		route := NewRouteInfo()
+		route.Response["400"] = &ResponseInfo{StatusCode: 400}
+		route.Response["200"] = &ResponseInfo{StatusCode: 200}
+		arg := sweepIdent(meta, "u")
+		arg.SetResolvedType("app.User")
+		node := sweepNode(sweepEdge(meta, "h", "app", "JSON", "gin", "", "", arg))
+		got := m.ExtractResponse(node, route)
+		if len(got) != 1 || got[0].StatusCode != 200 || got[0].BodyType != "app.User" {
+			t.Fatalf("got %+v, want one 200/app.User response", got)
+		}
+	})
+
+	t.Run("no bodyless status leaves the unknown slot", func(t *testing.T) {
+		meta := exSweepMeta()
+		m := NewResponsePatternMatcher(ResponsePattern{TypeFromArg: true, TypeArgIndex: 0}, cfg, NewContextProvider(meta), nil)
+		route := NewRouteInfo()
+		route.Response["200"] = &ResponseInfo{StatusCode: 200, BodyType: "app.Existing"}
+		arg := sweepIdent(meta, "u")
+		arg.SetResolvedType("app.User")
+		node := sweepNode(sweepEdge(meta, "h", "app", "JSON", "gin", "", "", arg))
+		got := m.ExtractResponse(node, route)
+		if len(got) != 1 || got[0].StatusCode >= 100 {
+			t.Fatalf("got %+v, want an unknown-status response", got)
+		}
+	})
+}
+
+func TestSweepExpandStatusesFromIdent(t *testing.T) {
+	cfg := &APISpecConfig{}
+
+	t.Run("nil metadata", func(t *testing.T) {
+		m := NewResponsePatternMatcher(ResponsePattern{}, cfg, NewContextProvider(nil), nil)
+		meta := exSweepMeta()
+		edge := sweepEdge(meta, "h", "app", "JSON", "gin", "", "")
+		if got := m.expandStatusesFromIdent(sweepIdent(meta, "code"), edge); got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+
+	t.Run("caller function not found", func(t *testing.T) {
+		meta := exSweepMeta()
+		m := NewResponsePatternMatcher(ResponsePattern{}, cfg, NewContextProvider(meta), nil)
+		edge := sweepEdge(meta, "h", "app", "JSON", "gin", "", "")
+		if got := m.expandStatusesFromIdent(sweepIdent(meta, "code"), edge); got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+
+	t.Run("branched assignments expand to distinct statuses", func(t *testing.T) {
+		meta := exSweepMeta()
+		mkCallAssign := func(args ...*metadata.CallArgument) metadata.Assignment {
+			call := metadata.NewCallArgument(meta)
+			call.SetKind(metadata.KindCall)
+			call.Fun = sweepIdent(meta, "respond")
+			call.Args = args
+			return metadata.Assignment{Value: *call}
+		}
+		nonCall := metadata.Assignment{Value: *sweepIdent(meta, "other")}
+		meta.Packages = map[string]*metadata.Package{
+			"app": {Files: map[string]*metadata.File{
+				"h.go": {Functions: map[string]*metadata.Function{
+					"h": {AssignmentMap: map[string][]metadata.Assignment{
+						"code": {
+							nonCall,
+							mkCallAssign(nil, sweepLit(meta, "400")),
+							mkCallAssign(sweepLit(meta, "400")),
+							mkCallAssign(sweepLit(meta, "500")),
+						},
+					}},
+				}},
+			}},
+		}
+		m := NewResponsePatternMatcher(ResponsePattern{}, cfg, NewContextProvider(meta), nil)
+		edge := sweepEdge(meta, "h", "app", "JSON", "gin", "", "")
+		got := m.expandStatusesFromIdent(sweepIdent(meta, "code"), edge)
+		if len(got) != 2 || got[0] != 400 || got[1] != 500 {
+			t.Errorf("got %v, want [400 500]", got)
+		}
+	})
+}
+
+func TestSweepResponseResolveTypeOrigin(t *testing.T) {
+	meta := exSweepMeta()
+	m := NewResponsePatternMatcher(ResponsePattern{}, &APISpecConfig{}, NewContextProvider(meta), nil)
+
+	t.Run("generic concrete resolution", func(t *testing.T) {
+		arg := sweepIdent(meta, "v")
+		arg.IsGenericType = true
+		arg.GenericTypeName = meta.StringPool.Get("T")
+		edge := sweepEdge(meta, "h", "app", "JSON", "gin", "", "")
+		// Seed via the edge: TrackerNode.TypeParams() rebuilds its map on every
+		// read, so a directly-set node.typeParamMap would be discarded.
+		edge.TypeParamMap = map[string]string{"T": "app.Item"}
+		node := sweepNode(edge)
+		if got := m.resolveTypeOrigin(arg, node, "T"); got != "app.Item" {
+			t.Errorf("got %q, want app.Item", got)
+		}
+	})
+
+	t.Run("selector fast path", func(t *testing.T) {
+		sel := metadata.NewCallArgument(meta)
+		sel.SetKind(metadata.KindSelector)
+		sel.SetType("string")
+		node := sweepNode(sweepEdge(meta, "h", "app", "JSON", "gin", "", ""))
+		if got := m.resolveTypeOrigin(sel, node, "orig"); got != "string" {
+			t.Errorf("got %q, want string", got)
+		}
+	})
+
+	t.Run("ident assignment resolution", func(t *testing.T) {
+		arg := sweepIdent(meta, "v")
+		edge := sweepEdge(meta, "h", "app", "JSON", "gin", "", "")
+		edge.AssignmentMap = map[string][]metadata.Assignment{
+			"v": {{ConcreteType: meta.StringPool.Get("app.User")}},
+		}
+		if got := m.resolveTypeOrigin(arg, sweepNode(edge), "any"); got != "app.User" {
+			t.Errorf("got %q, want app.User", got)
+		}
+	})
+}
+
+func TestSweepConcreteFromEnclosingFunc(t *testing.T) {
+	meta := sweepInterfaceMeta()
+	pool := meta.StringPool
+	appFile := meta.Packages["app"].Files["app/main.go"]
+	appFile.Functions["handler"] = &metadata.Function{
+		AssignmentMap: map[string][]metadata.Assignment{
+			"a": {
+				{ConcreteType: 0},                      // unset: skipped
+				{ConcreteType: pool.Get("app.Animal")}, // interface: skipped
+				{ConcreteType: pool.Get("app.Dog")},    // the single concrete
+				{ConcreteType: pool.Get("app.Dog")},    // duplicate concrete: not ambiguous
+			},
+		},
+	}
+	appFile.Functions["ambiguous"] = &metadata.Function{
+		AssignmentMap: map[string][]metadata.Assignment{
+			"a": {
+				{ConcreteType: pool.Get("app.Dog")},
+				{ConcreteType: pool.Get("app.Cat")},
+			},
+		},
+	}
+	m := NewResponsePatternMatcher(ResponsePattern{}, &APISpecConfig{}, NewContextProvider(meta), nil)
+	arg := sweepIdent(meta, "a")
+
+	t.Run("nil edge", func(t *testing.T) {
+		if got := m.concreteFromEnclosingFunc(arg, nil, "app.Animal"); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+	t.Run("empty caller name", func(t *testing.T) {
+		edge := sweepEdge(meta, "", "app", "Encode", "json", "", "")
+		if got := m.concreteFromEnclosingFunc(arg, edge, "app.Animal"); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+	t.Run("caller function not found", func(t *testing.T) {
+		edge := sweepEdge(meta, "nosuch", "app", "Encode", "json", "", "")
+		if got := m.concreteFromEnclosingFunc(arg, edge, "app.Animal"); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+	t.Run("single concrete wins", func(t *testing.T) {
+		edge := sweepEdge(meta, "handler", "app", "Encode", "json", "", "")
+		if got := m.concreteFromEnclosingFunc(arg, edge, "app.Animal"); got != "app.Dog" {
+			t.Errorf("got %q, want app.Dog", got)
+		}
+	})
+	t.Run("ambiguous keeps the interface", func(t *testing.T) {
+		edge := sweepEdge(meta, "ambiguous", "app", "Encode", "json", "", "")
+		if got := m.concreteFromEnclosingFunc(arg, edge, "app.Animal"); got != "" {
+			t.Errorf("got %q, want empty (honest over wrong)", got)
+		}
+	})
+}
+
+func TestSweepConcreteFromParamBinding(t *testing.T) {
+	meta := sweepInterfaceMeta()
+	m := NewResponsePatternMatcher(ResponsePattern{}, &APISpecConfig{}, NewContextProvider(meta), nil)
+	arg := sweepIdent(meta, "v")
+
+	newChain := func(paramArg *metadata.CallArgument, mapName string) *TrackerNode {
+		edge := sweepEdge(meta, "writeAnimal", "app", "Encode", "json", "", "", arg)
+		parentEdge := sweepEdge(meta, "handler", "app", "writeAnimal", "app", "", "")
+		if paramArg != nil {
+			parentEdge.ParamArgMap = map[string]metadata.CallArgument{mapName: *paramArg}
+		} else {
+			parentEdge.ParamArgMap = map[string]metadata.CallArgument{}
+		}
+		node := sweepNode(edge)
+		node.Parent = sweepNode(parentEdge)
+		return node
+	}
+
+	t.Run("nil edge", func(t *testing.T) {
+		if got := m.concreteFromParamBinding(arg, &TrackerNode{}, "app.Animal"); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+	t.Run("param not bound at the call site", func(t *testing.T) {
+		if got := m.concreteFromParamBinding(arg, newChain(nil, ""), "app.Animal"); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+	t.Run("interface-typed caller arg keeps the interface", func(t *testing.T) {
+		ifaceArg := sweepIdent(meta, "a")
+		ifaceArg.SetPkg("app")
+		ifaceArg.SetType("app.Animal")
+		if got := m.concreteFromParamBinding(arg, newChain(ifaceArg, "v"), "app.Animal"); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+	t.Run("concrete caller arg resolves", func(t *testing.T) {
+		dogArg := sweepIdent(meta, "d")
+		dogArg.SetPkg("app")
+		dogArg.SetType("app.Dog")
+		got := m.concreteFromParamBinding(arg, newChain(dogArg, "v"), "app.Animal")
+		if got == "" || !strings.Contains(got, "Dog") {
+			t.Errorf("got %q, want the concrete Dog type", got)
+		}
+	})
+}
+
+func TestSweepConcreteFromCalleeReturn(t *testing.T) {
+	meta := sweepInterfaceMeta()
+	appFile := meta.Packages["app"].Files["app/main.go"]
+
+	returnVar := func(typ string) metadata.CallArgument {
+		a := metadata.NewCallArgument(meta)
+		a.SetKind(metadata.KindIdent)
+		a.SetName("r")
+		a.SetPkg("app")
+		a.SetType(typ)
+		return *a
+	}
+	appFile.Functions["makeAnimal"] = &metadata.Function{
+		ReturnVars: []metadata.CallArgument{returnVar("app.Animal"), returnVar("app.Dog")},
+	}
+	appFile.Functions["makeEither"] = &metadata.Function{
+		ReturnVars: []metadata.CallArgument{returnVar("app.Dog"), returnVar("app.Cat")},
+	}
+
+	m := NewResponsePatternMatcher(ResponsePattern{}, &APISpecConfig{}, NewContextProvider(meta), nil)
+	edge := sweepEdge(meta, "handler", "app", "Encode", "json", "", "")
+
+	newCallArg := func(selName string) *metadata.CallArgument {
+		call := metadata.NewCallArgument(meta)
+		call.SetKind(metadata.KindCall)
+		fun := metadata.NewCallArgument(meta)
+		fun.SetKind(metadata.KindSelector)
+		fun.SetPkg("app")
+		fun.Sel = sweepIdent(meta, selName)
+		call.Fun = fun
+		return call
+	}
+
+	t.Run("nil Fun", func(t *testing.T) {
+		bare := metadata.NewCallArgument(meta)
+		bare.SetKind(metadata.KindCall)
+		if got := m.concreteFromCalleeReturn(bare, edge, "app.Animal"); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+	t.Run("callee not found", func(t *testing.T) {
+		if got := m.concreteFromCalleeReturn(newCallArg("nosuch"), edge, "app.Animal"); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+	t.Run("single concrete return resolves via selector name", func(t *testing.T) {
+		got := m.concreteFromCalleeReturn(newCallArg("makeAnimal"), edge, "app.Animal")
+		if got == "" || !strings.Contains(got, "Dog") {
+			t.Errorf("got %q, want the concrete Dog type", got)
+		}
+	})
+	t.Run("ambiguous returns keep the interface", func(t *testing.T) {
+		if got := m.concreteFromCalleeReturn(newCallArg("makeEither"), edge, "app.Animal"); got != "" {
+			t.Errorf("got %q, want empty (honest over wrong)", got)
+		}
+	})
+}
+
+func TestSweepParamMatcher(t *testing.T) {
+	meta := exSweepMeta()
+	cp := NewContextProvider(meta)
+	cfg := &APISpecConfig{}
+
+	t.Run("match node rejections", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			pattern ParamPattern
+			node    TrackerNodeInterface
+		}{
+			{"nil node", ParamPattern{CallRegex: "^Param$"}, nil},
+			{"call regex", ParamPattern{CallRegex: "^Param$"}, sweepNode(sweepEdge(meta, "h", "app", "Query", "gin", "", ""))},
+			{"function name regex", ParamPattern{CallRegex: "^Param$", FunctionNameRegex: "^handle"}, sweepNode(sweepEdge(meta, "main", "app", "Param", "gin", "", ""))},
+			{"recv type regex", ParamPattern{RecvTypeRegex: `^gin\.Context$`}, sweepNode(sweepEdge(meta, "h", "app", "Param", "other", "Ctx", ""))},
+			{"exact recv type", ParamPattern{RecvType: "gin.Context"}, sweepNode(sweepEdge(meta, "h", "app", "Param", "other", "Ctx", ""))},
+		}
+		for _, tt := range tests {
+			m := NewParamPatternMatcher(tt.pattern, cfg, cp, nil)
+			if m.MatchNode(tt.node) {
+				t.Errorf("%s: MatchNode() = true, want false", tt.name)
+			}
+		}
+	})
+
+	t.Run("priority branches", func(t *testing.T) {
+		m := NewParamPatternMatcher(ParamPattern{CallRegex: "x", FunctionNameRegex: "y", RecvTypeRegex: "z"}, cfg, cp, nil)
+		if got := m.GetPriority(); got != 18 {
+			t.Errorf("GetPriority() = %d, want 18", got)
+		}
+	})
+
+	t.Run("extract param with literal type arg", func(t *testing.T) {
+		m := NewParamPatternMatcher(ParamPattern{ParamIn: "path", ParamArgIndex: 0, TypeFromArg: true, TypeArgIndex: 1}, cfg, cp, nil)
+		edge := sweepEdge(meta, "h", "app", "Param", "gin", "", "", sweepLit(meta, `"id"`), sweepLit(meta, "42"))
+		param := m.ExtractParam(sweepNode(edge), NewRouteInfo())
+		if param == nil || param.Name != "id" || !param.Required {
+			t.Fatalf("param = %+v, want required path param id", param)
+		}
+		if param.Schema == nil || param.Schema.Type != "integer" {
+			t.Errorf("Schema = %+v, want integer from the literal", param.Schema)
+		}
+	})
+
+	t.Run("extract param derefs resolved pointer type", func(t *testing.T) {
+		m := NewParamPatternMatcher(ParamPattern{ParamIn: "query", ParamArgIndex: 0, TypeFromArg: true, TypeArgIndex: 1, Deref: true}, cfg, cp, nil)
+		typed := sweepIdent(meta, "v")
+		typed.SetResolvedType("*string")
+		edge := sweepEdge(meta, "h", "app", "Query", "gin", "", "", sweepLit(meta, `"q"`), typed)
+		param := m.ExtractParam(sweepNode(edge), NewRouteInfo())
+		if param == nil || param.Schema == nil || param.Schema.Type != "string" {
+			t.Fatalf("param = %+v, want string schema after deref", param)
+		}
+		if param.Required {
+			t.Error("query params must not be forced required")
+		}
+	})
+}
+
+func TestSweepParamResolveTypeOrigin(t *testing.T) {
+	meta := exSweepMeta()
+	m := NewParamPatternMatcher(ParamPattern{}, &APISpecConfig{}, NewContextProvider(meta), nil)
+	node := sweepNode(sweepEdge(meta, "h", "app", "Param", "gin", "", ""))
+
+	t.Run("resolved type fast path", func(t *testing.T) {
+		arg := sweepIdent(meta, "v")
+		arg.SetResolvedType("int")
+		if got := m.resolveTypeOrigin(arg, node, "orig"); got != "int" {
+			t.Errorf("got %q, want int", got)
+		}
+	})
+	t.Run("generic resolution", func(t *testing.T) {
+		arg := sweepIdent(meta, "v")
+		arg.IsGenericType = true
+		arg.GenericTypeName = meta.StringPool.Get("T")
+		edge := sweepEdge(meta, "h", "app", "Param", "gin", "", "")
+		// Seed via the edge: TrackerNode.TypeParams() rebuilds its map on every
+		// read, so a directly-set node.typeParamMap would be discarded.
+		edge.TypeParamMap = map[string]string{"T": "int"}
+		n := sweepNode(edge)
+		if got := m.resolveTypeOrigin(arg, n, "T"); got != "int" {
+			t.Errorf("got %q, want int", got)
+		}
+	})
+	t.Run("selector fast path", func(t *testing.T) {
+		sel := metadata.NewCallArgument(meta)
+		sel.SetKind(metadata.KindSelector)
+		sel.SetType("string")
+		if got := m.resolveTypeOrigin(sel, node, "orig"); got != "string" {
+			t.Errorf("got %q, want string", got)
+		}
+	})
+	t.Run("ident assignment resolution", func(t *testing.T) {
+		arg := sweepIdent(meta, "v")
+		edge := sweepEdge(meta, "h", "app", "Param", "gin", "", "")
+		edge.AssignmentMap = map[string][]metadata.Assignment{
+			"v": {{ConcreteType: meta.StringPool.Get("uuid.UUID")}},
+		}
+		if got := m.resolveTypeOrigin(arg, sweepNode(edge), "string"); got != "uuid.UUID" {
+			t.Errorf("got %q, want uuid.UUID", got)
+		}
+	})
+	t.Run("fallthrough keeps original", func(t *testing.T) {
+		if got := m.resolveTypeOrigin(sweepLit(meta, "1"), node, "int"); got != "int" {
+			t.Errorf("got %q, want int", got)
+		}
+	})
+}
+
+func TestSweepPairAndFillResponses(t *testing.T) {
+	meta := exSweepMeta()
+	// handler -> helper edge gives the two callers distinct BFS depths.
+	meta.CallGraph = []metadata.CallGraphEdge{
+		*sweepEdge(meta, "handler", "app", "helper", "app", "", ""),
+	}
+	meta.BuildCallGraphMaps()
+
+	cfg := &APISpecConfig{
+		Framework: FrameworkConfig{
+			ResponsePatterns: []ResponsePattern{{
+				CallRegex: "^JSON$", StatusFromArg: true, StatusArgIndex: 0, TypeFromArg: true, TypeArgIndex: 1,
+			}},
+		},
+		Defaults: Defaults{ResponseContentType: "application/json"},
+	}
+	tree := NewMockTrackerTree(meta, metadata.TrackerLimits{})
+	ext := NewExtractor(tree, cfg)
+
+	userArg := func() *metadata.CallArgument {
+		a := sweepIdent(meta, "u")
+		a.SetResolvedType("app.User")
+		return a
+	}
+	errArg := func() *metadata.CallArgument {
+		a := sweepIdent(meta, "e")
+		a.SetResolvedType("app.Payload")
+		return a
+	}
+
+	// Known status with body (line 20).
+	n1 := sweepNode(sweepEdge(meta, "handler", "app", "JSON", "fiber", "Ctx", "h.go:20:3", sweepLit(meta, "200"), userArg()))
+	// Sub-100 status and no body: nothing usable, must be dropped (line 15).
+	n2 := sweepNode(sweepEdge(meta, "handler", "app", "JSON", "fiber", "Ctx", "h.go:15:2", sweepLit(meta, "42")))
+	// Unknown status + body in the handler frame (depth 0): default slot.
+	n3 := sweepNode(sweepEdge(meta, "handler", "app", "JSON", "fiber", "Ctx", "h.go:5:1", sweepIdent(meta, "code"), userArg()))
+	// Unknown status + body two hops down (depth 1): outbound payload, dropped.
+	n4 := sweepNode(sweepEdge(meta, "helper", "app", "JSON", "fiber", "Ctx", "z.go:2:1", sweepIdent(meta, "code"), errArg()))
+
+	route := &RouteInfo{
+		Function:  "app.handler",
+		Metadata:  meta,
+		Response:  map[string]*ResponseInfo{},
+		UsedTypes: map[string]*Schema{},
+	}
+	candidates := []responseCandidate{
+		{node: n1, chain: ""},
+		{node: n2, chain: ""},
+		{node: n3, chain: ""},
+		{node: n4, chain: ""},
+	}
+	ext.pairAndFillResponses(route, candidates)
+
+	if len(route.Response) != 2 {
+		t.Fatalf("Response = %+v, want exactly the 200 and default slots", route.Response)
+	}
+	if got := route.Response["200"]; got == nil || got.BodyType != "app.User" {
+		t.Errorf("200 slot = %+v, want app.User", got)
+	}
+	if got := route.Response["-1"]; got == nil || got.BodyType != "app.User" {
+		t.Errorf("default slot = %+v, want the shallow app.User body", got)
+	}
+	for slot := range route.Response {
+		if slot == "42" {
+			t.Error("sub-100 bodyless fragment must be dropped")
+		}
+	}
+}
+
+func TestSweepAccessorKeyRecovery(t *testing.T) {
+	newMuxExtractor := func(meta *metadata.Metadata) *Extractor {
+		cfg := &APISpecConfig{Framework: FrameworkConfig{ParamPatterns: []ParamPattern{{
+			CallRegex:      "^Vars$",
+			RecvTypeRegex:  `github\.com/gorilla/mux`,
+			NameFromMapKey: true,
+			ParamIn:        "path",
+		}}}}
+		return NewExtractor(NewMockTrackerTree(meta, metadata.TrackerLimits{}), cfg)
+	}
+
+	t.Run("nil-guards", func(t *testing.T) {
+		meta := exSweepMeta()
+		ext := newMuxExtractor(meta)
+		ext.recordPathVarKeyMismatches(nil)
+		ext.recordPathVarKeyMismatches(&RouteInfo{Metadata: meta}) // no Function
+		ext.completeMapKeyPathParams(nil)
+		if len(ext.PathParamMismatches()) != 0 {
+			t.Errorf("mismatches = %v, want none", ext.PathParamMismatches())
+		}
+	})
+
+	t.Run("invalid accessor regex recovers nothing", func(t *testing.T) {
+		meta := exSweepMeta()
+		meta.Packages = map[string]*metadata.Package{
+			"app": {Files: map[string]*metadata.File{"h.go": {Functions: map[string]*metadata.Function{"h": {}}}}},
+		}
+		ext := newMuxExtractor(meta)
+		route := &RouteInfo{Function: "app.h", Package: "app", Metadata: meta}
+		keys := ext.recoverAccessorKeys(route, ParamPattern{CallRegex: "("})
+		if keys != nil {
+			t.Errorf("keys = %v, want nil for invalid regex", keys)
+		}
+	})
+
+	t.Run("mismatched key recorded once", func(t *testing.T) {
+		meta := exSweepMeta()
+		indexExpr := metadata.NewCallArgument(meta)
+		indexExpr.SetKind(metadata.KindIndex)
+		indexExpr.X = sweepIdent(meta, "vars")
+		lit := metadata.NewCallArgument(meta)
+		lit.SetKind(metadata.KindLiteral)
+		lit.SetValue(`"userId"`)
+		indexExpr.Fun = lit
+
+		fn := &metadata.Function{AssignmentMap: map[string][]metadata.Assignment{
+			"vars": {{CalleeFunc: "Vars", CalleePkg: "github.com/gorilla/mux", Value: *sweepIdent(meta, "r")}},
+			"id":   {{Value: *indexExpr}},
+		}}
+		meta.Packages = map[string]*metadata.Package{
+			"app": {Files: map[string]*metadata.File{"h.go": {Functions: map[string]*metadata.Function{"h": fn}}}},
+		}
+		ext := newMuxExtractor(meta)
+		route := &RouteInfo{Function: "app.h", Package: "app", Metadata: meta, Method: "GET", Path: "/users/{id}"}
+		ext.recordPathVarKeyMismatches(route)
+		ext.recordPathVarKeyMismatches(route) // second pass must dedupe
+		mismatches := ext.PathParamMismatches()
+		if len(mismatches) != 1 || mismatches[0].Key != "userId" {
+			t.Fatalf("mismatches = %+v, want exactly one userId entry", mismatches)
+		}
+	})
+}
+
+func TestSweepIsAccessorCall(t *testing.T) {
+	meta := exSweepMeta()
+	callRe, _ := cachedRegex("^Vars$")
+	recvRe, _ := cachedRegex("mux")
+
+	newCall := func(kind string, fun *metadata.CallArgument) *metadata.CallArgument {
+		a := metadata.NewCallArgument(meta)
+		a.SetKind(kind)
+		a.Fun = fun
+		return a
+	}
+	selFun := func(pkg, name string) *metadata.CallArgument {
+		f := metadata.NewCallArgument(meta)
+		f.SetKind(metadata.KindSelector)
+		f.Sel = sweepIdent(meta, name)
+		f.Sel.SetPkg(pkg)
+		return f
+	}
+
+	tests := []struct {
+		name string
+		x    *metadata.CallArgument
+		want bool
+	}{
+		{"nil", nil, false},
+		{"not a call", sweepIdent(meta, "vars"), false},
+		{"selector accessor matches", newCall(metadata.KindCall, selFun("github.com/gorilla/mux", "Vars")), true},
+		{"call name mismatch", newCall(metadata.KindCall, selFun("github.com/gorilla/mux", "Other")), false},
+		{"pkg mismatch", newCall(metadata.KindCall, selFun("net/http", "Vars")), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isAccessorCall(tt.x, callRe, recvRe); got != tt.want {
+				t.Errorf("isAccessorCall() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSweepFindFunctionByName(t *testing.T) {
+	meta := exSweepMeta()
+	fn := &metadata.Function{}
+	meta.Packages = map[string]*metadata.Package{
+		"a":   {Files: map[string]*metadata.File{"a.go": {Functions: map[string]*metadata.Function{}}}},
+		"lib": {Files: map[string]*metadata.File{"l.go": {Functions: map[string]*metadata.Function{"helper": fn}}}},
+	}
+
+	if findFunctionByName(nil, "a", "x") != nil {
+		t.Error("nil meta must yield nil")
+	}
+	if findFunctionByName(meta, "a", "") != nil {
+		t.Error("empty name must yield nil")
+	}
+	if got := findFunctionByName(meta, "lib", "helper"); got != fn {
+		t.Error("direct package lookup failed")
+	}
+	// Fallback: the named package doesn't declare it, another one does.
+	if got := findFunctionByName(meta, "a", "helper"); got != fn {
+		t.Error("fallback lookup across packages failed")
+	}
+	if findFunctionByName(meta, "a", "nosuch") != nil {
+		t.Error("unknown name must yield nil")
+	}
+}
+
+func TestSweepHandlerReachesAccessorAndEdgeMatch(t *testing.T) {
+	pattern := ParamPattern{CallRegex: "^Vars$", RecvTypeRegex: "mux"}
+
+	t.Run("guards", func(t *testing.T) {
+		meta := exSweepMeta()
+		ext := NewExtractor(NewMockTrackerTree(meta, metadata.TrackerLimits{}), &APISpecConfig{})
+		if ext.handlerReachesAccessor(&RouteInfo{Function: "app.h"}, pattern) {
+			t.Error("nil metadata must not reach")
+		}
+		if ext.handlerReachesAccessor(&RouteInfo{Metadata: meta}, pattern) {
+			t.Error("empty function must not reach")
+		}
+	})
+
+	t.Run("package mismatch does not reach", func(t *testing.T) {
+		meta := exSweepMeta()
+		meta.CallGraph = []metadata.CallGraphEdge{
+			// Same bare name, wrong package: must be skipped.
+			*sweepEdge(meta, "h", "other", "Vars", "github.com/gorilla/mux", "", ""),
+		}
+		meta.BuildCallGraphMaps()
+		ext := NewExtractor(NewMockTrackerTree(meta, metadata.TrackerLimits{}), &APISpecConfig{})
+		route := &RouteInfo{Function: "app.h", Package: "app", Metadata: meta}
+		if ext.handlerReachesAccessor(route, pattern) {
+			t.Error("caller in another package must not satisfy reachability")
+		}
+	})
+
+	t.Run("edgeMatchesAccessor recv-only and mismatch", func(t *testing.T) {
+		meta := exSweepMeta()
+		// RecvType set with empty pkg exercises the fq = recvType branch.
+		edge := sweepEdge(meta, "h", "app", "Vars", "", "muxRouter", "")
+		if !edgeMatchesAccessor(meta, edge, pattern) {
+			t.Error("recv-only fq type should match the mux regex")
+		}
+		other := sweepEdge(meta, "h", "app", "Vars", "", "chiRouter", "")
+		if edgeMatchesAccessor(meta, other, pattern) {
+			t.Error("non-mux receiver must not match")
+		}
+	})
+}

--- a/internal/spec/extractor_sweep_test.go
+++ b/internal/spec/extractor_sweep_test.go
@@ -740,8 +740,13 @@ func TestSweepSmallHelpers(t *testing.T) {
 		if got := preferRequestInfo(concrete, generic); got != concrete {
 			t.Error("concrete cur must win")
 		}
-		if got := preferRequestInfo(generic, generic); got != generic {
-			t.Error("tie keeps last-write-wins")
+		genericB := &RequestInfo{Schema: &Schema{Type: "object"}}
+		if got := preferRequestInfo(generic, genericB); got != genericB {
+			t.Error("generic tie must keep the newer request (last-write-wins)")
+		}
+		concreteB := &RequestInfo{Schema: &Schema{Ref: "#/y"}}
+		if got := preferRequestInfo(concrete, concreteB); got != concreteB {
+			t.Error("concrete tie must keep the newer request")
 		}
 	})
 
@@ -900,13 +905,16 @@ func TestSweepExtractorGuards(t *testing.T) {
 		if len(first) != 1 || first["app.h"] != 0 {
 			t.Errorf("depths = %v, want {app.h:0}", first)
 		}
-		// The memo must return the identical map on a second call.
-		if &first == &second {
-			t.Log("map header comparison is not meaningful; assert equality instead")
-		}
+		// The memo must return the identical map: a mutation through one
+		// reference is visible through a fresh fetch.
 		if len(second) != len(first) {
 			t.Errorf("cached call returned different depths: %v vs %v", second, first)
 		}
+		first["zz_probe"] = 99
+		if third := ext.handlerCallDepths(route); third["zz_probe"] != 99 {
+			t.Error("handlerCallDepths did not return the cached map")
+		}
+		delete(first, "zz_probe")
 	})
 
 	t.Run("calleeMiddlewareRef nil edge", func(t *testing.T) {

--- a/internal/spec/mapper_sweep_test.go
+++ b/internal/spec/mapper_sweep_test.go
@@ -1,0 +1,849 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"go/constant"
+	"go/token"
+	"go/types"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+	"github.com/ehabterra/apispec/internal/typemodel"
+)
+
+// sweepMeta builds a metadata fixture with a small type zoo used across the
+// sweep tests: a plain struct, an alias enum, a struct-kind "enum carrier"
+// (constants typed after it), and a generic declaration.
+func sweepMeta(t *testing.T) (*metadata.Metadata, *metadata.StringPool) {
+	t.Helper()
+	pool := metadata.NewStringPool()
+	meta := &metadata.Metadata{
+		StringPool: pool,
+		Packages: map[string]*metadata.Package{
+			"main": {
+				Files: map[string]*metadata.File{
+					"main.go": {
+						Types: map[string]*metadata.Type{
+							"User": {
+								Name: pool.Get("User"),
+								Pkg:  pool.Get("main"),
+								Kind: pool.Get("struct"),
+								Fields: []metadata.Field{
+									{Name: pool.Get("Name"), Type: pool.Get("string")},
+								},
+							},
+							"Other": {
+								Name: pool.Get("Other"),
+								Pkg:  pool.Get("main"),
+								Kind: pool.Get("struct"),
+								Fields: []metadata.Field{
+									{Name: pool.Get("ID"), Type: pool.Get("int")},
+								},
+							},
+							// Alias enum: Status -> string.
+							"Status": {
+								Name:   pool.Get("Status"),
+								Pkg:    pool.Get("main"),
+								Kind:   pool.Get("alias"),
+								Target: pool.Get("string"),
+							},
+							// Struct-kind type with same-named constants: its
+							// underlying type does not resolve to a primitive, so
+							// slice/array/map element handling takes the complex
+							// path and enum detection still finds the constants.
+							"StatusE": {
+								Name: pool.Get("StatusE"),
+								Pkg:  pool.Get("main"),
+								Kind: pool.Get("struct"),
+							},
+							// Generic declaration Page[T any].
+							"Page": {
+								Name:       pool.Get("Page"),
+								Pkg:        pool.Get("main"),
+								Kind:       pool.Get("struct"),
+								TypeParams: []string{"T"},
+								Fields: []metadata.Field{
+									{Name: pool.Get("Data"), Type: pool.Get("T")},
+								},
+							},
+							// A type named like a declared constraint, so the
+							// non-primitive-constraint branch of
+							// findTypesInMetadata can resolve "T Stringer".
+							"T": {
+								Name: pool.Get("T"),
+								Pkg:  pool.Get("main"),
+								Kind: pool.Get("struct"),
+							},
+							"Stringer": {
+								Name: pool.Get("Stringer"),
+								Pkg:  pool.Get("main"),
+								Kind: pool.Get("interface"),
+							},
+						},
+						Variables: map[string]*metadata.Variable{
+							"StatusEActive": {
+								Name:          pool.Get("StatusEActive"),
+								Tok:           pool.Get("const"),
+								Type:          pool.Get("StatusE"),
+								ComputedValue: "active",
+								GroupIndex:    1,
+							},
+							"StatusEInactive": {
+								Name:          pool.Get("StatusEInactive"),
+								Tok:           pool.Get("const"),
+								Type:          pool.Get("StatusE"),
+								ComputedValue: "inactive",
+								GroupIndex:    1,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return meta, pool
+}
+
+func TestLoadAPISpecConfig_ErrorPaths(t *testing.T) {
+	dir := t.TempDir()
+
+	tests := []struct {
+		name    string
+		content string
+		missing bool
+	}{
+		{name: "missing file", missing: true},
+		{name: "invalid yaml", content: "info: [unclosed"},
+		{
+			// A mapping with no identity matcher fails ValidateSecurity.
+			name:    "invalid security config",
+			content: "securityMappings:\n  - schemes:\n      - bearerAuth: []\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(dir, strings.ReplaceAll(tt.name, " ", "_")+".yaml")
+			if !tt.missing {
+				if err := os.WriteFile(path, []byte(tt.content), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			cfg, err := LoadAPISpecConfig(path)
+			if err == nil {
+				t.Fatalf("expected error, got config %+v", cfg)
+			}
+		})
+	}
+}
+
+func TestMapMetadataToOpenAPIWithDiagnostics_InfoFallbacks(t *testing.T) {
+	meta, _ := sweepMeta(t)
+	tree := NewMockTrackerTree(meta, metadata.TrackerLimits{})
+
+	// Description set means cfg.Info wins, but the empty Title/Version must
+	// fall back to the GeneratorConfig values.
+	cfg := DefaultAPISpecConfig()
+	cfg.Info = Info{Description: "configured description"}
+
+	genCfg := GeneratorConfig{OpenAPIVersion: "3.1.1", Title: "Gen Title", APIVersion: "9.9.9"}
+	spec, diag, err := MapMetadataToOpenAPIWithDiagnostics(tree, cfg, genCfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if diag == nil {
+		t.Fatal("expected non-nil diagnostics")
+	}
+	if spec.Info.Title != "Gen Title" {
+		t.Errorf("Title = %q, want fallback %q", spec.Info.Title, "Gen Title")
+	}
+	if spec.Info.Version != "9.9.9" {
+		t.Errorf("Version = %q, want fallback %q", spec.Info.Version, "9.9.9")
+	}
+	if spec.Info.Description != "configured description" {
+		t.Errorf("Description = %q, want configured value", spec.Info.Description)
+	}
+}
+
+func TestForEachPathParam_NestedAndUnbalanced(t *testing.T) {
+	t.Run("nested braces in pattern", func(t *testing.T) {
+		var names, patterns []string
+		forEachPathParam("/users/{id:[0-9]{3}}/posts/{slug}", func(name, pattern string) {
+			names = append(names, name)
+			patterns = append(patterns, pattern)
+		})
+		if !reflect.DeepEqual(names, []string{"id", "slug"}) {
+			t.Errorf("names = %v", names)
+		}
+		if !reflect.DeepEqual(patterns, []string{"[0-9]{3}", ""}) {
+			t.Errorf("patterns = %v", patterns)
+		}
+	})
+
+	t.Run("unbalanced placeholder stops scan", func(t *testing.T) {
+		var names []string
+		forEachPathParam("/users/{id", func(name, _ string) { names = append(names, name) })
+		if len(names) != 0 {
+			t.Errorf("expected no params from unbalanced path, got %v", names)
+		}
+	})
+}
+
+func TestStripParamPatterns_NestedAndUnbalanced(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"nested braces", "/users/{id:[0-9]{3}}/x", "/users/{id}/x"},
+		{"unbalanced copies remainder", "/users/{id:[0-9]", "/users/{id:[0-9]"},
+		{"plain placeholder", "/a/{b}", "/a/{b}"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stripParamPatterns(tt.in); got != tt.want {
+				t.Errorf("stripParamPatterns(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAppendDynamicParamRefs_SkipsCoveredNames(t *testing.T) {
+	params := []Parameter{
+		{Name: "inline", In: "path"},
+		{Ref: dynamicParamRef("id")}, // covers "id" via $ref target
+	}
+	got := appendDynamicParamRefs(params, []string{"id", "inline", "fresh"})
+	if len(got) != 3 {
+		t.Fatalf("expected 3 params (2 existing + 1 new ref), got %d: %+v", len(got), got)
+	}
+	if got[2].Ref != dynamicParamRef("fresh") {
+		t.Errorf("appended ref = %q, want %q", got[2].Ref, dynamicParamRef("fresh"))
+	}
+}
+
+func TestAddDynamicPathParamComponents_NilComponents(t *testing.T) {
+	// Must be a no-op, not a panic.
+	addDynamicPathParamComponents(nil, []*RouteInfo{{DynamicParams: []string{"id"}}})
+}
+
+func TestDynamicParamComponentName_Empty(t *testing.T) {
+	if got := dynamicParamComponentName(""); got != "PathParam" {
+		t.Errorf("dynamicParamComponentName(\"\") = %q, want PathParam", got)
+	}
+}
+
+func TestRefTargetName(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  string
+		want string
+	}{
+		{"non-parameter ref", "#/components/schemas/User", ""},
+		{"bare Param suffix leaves empty key", "#/components/parameters/Param", ""},
+		{"round trip", dynamicParamRef("userId"), "userId"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := refTargetName(tt.ref); got != tt.want {
+				t.Errorf("refTargetName(%q) = %q, want %q", tt.ref, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsGenericObjectResponse_NilSchema(t *testing.T) {
+	if !isGenericObjectResponse(&ResponseInfo{Schema: nil}) {
+		t.Error("nil schema must count as the generic object fallback")
+	}
+}
+
+func TestFindTypesInMetadata_EdgeCases(t *testing.T) {
+	meta, _ := sweepMeta(t)
+
+	t.Run("nil metadata", func(t *testing.T) {
+		if got := findTypesInMetadata(nil, "main.User"); got != nil {
+			t.Errorf("expected nil for nil metadata, got %v", got)
+		}
+	})
+
+	t.Run("generic declaration with primitive constraint", func(t *testing.T) {
+		got := findTypesInMetadata(meta, "main.Page[T any]")
+		if typ, ok := got["main.T-any"]; !ok || typ != nil {
+			t.Errorf("expected nil placeholder entry for main.T-any, got %v", got)
+		}
+		if got["main.Page[T any]"] == nil {
+			t.Errorf("expected Page type entry, got %v", got)
+		}
+	})
+
+	t.Run("generic declaration with named constraint", func(t *testing.T) {
+		got := findTypesInMetadata(meta, "main.Page[T Stringer]")
+		if typ, ok := got["main.T_Stringer"]; !ok || typ == nil {
+			t.Errorf("expected resolved entry for main.T_Stringer, got %v", got)
+		}
+	})
+}
+
+func TestTypeByName_NilMetadata(t *testing.T) {
+	if got := typeByName("main", "User", nil); got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+}
+
+func TestTypeInPackage_NilPackage(t *testing.T) {
+	if got := typeInPackage(nil, "User"); got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+}
+
+func TestGenerateSchemaFromType_VisitedReturnsRef(t *testing.T) {
+	meta, pool := sweepMeta(t)
+	typ := meta.Packages["main"].Files["main.go"].Types["User"]
+	_ = pool
+
+	visited := map[string]bool{"main.User" + generateSchemaFromTypeKey: true}
+	schema, _ := generateSchemaFromType(map[string]*Schema{}, "main.User", typ, meta, DefaultAPISpecConfig(), visited)
+	if schema == nil || schema.Ref == "" {
+		t.Fatalf("expected $ref for already-visited type, got %+v", schema)
+	}
+}
+
+func TestAllConcreteGenericArgs_NilAndConstraint(t *testing.T) {
+	if allConcreteGenericArgs([]*typemodel.TypeRef{nil}) {
+		t.Error("nil arg must not count as concrete")
+	}
+	if allConcreteGenericArgs(nil) {
+		t.Error("empty args must not count as concrete")
+	}
+}
+
+func TestSubstituteTypeParams(t *testing.T) {
+	tests := []struct {
+		name      string
+		fieldType string
+		generics  map[string]string
+		want      string
+	}{
+		{"no generics", "T", nil, "T"},
+		{"plain param", "T", map[string]string{"T": "User"}, "User"},
+		{"pointer param", "*T", map[string]string{"T": "User"}, "*User"},
+		{"slice of pointer param", "[]*T", map[string]string{"T": "User"}, "[]*User"},
+		{"unrelated type unchanged", "*Other", map[string]string{"T": "User"}, "*Other"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := substituteTypeParams(tt.fieldType, tt.generics); got != tt.want {
+				t.Errorf("substituteTypeParams(%q) = %q, want %q", tt.fieldType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerateStructSchema_DeclarationFormGenerics(t *testing.T) {
+	meta, _ := sweepMeta(t)
+	page := meta.Packages["main"].Files["main.go"].Types["Page"]
+
+	schema, _ := generateStructSchema(map[string]*Schema{}, "main.Page[T any]", page, meta, DefaultAPISpecConfig(), map[string]bool{})
+	if schema == nil || schema.Type != "object" {
+		t.Fatalf("expected object schema, got %+v", schema)
+	}
+	// The parametric field maps through the "T-any" placeholder.
+	if schema.Properties["Data"] == nil {
+		t.Fatalf("expected Data property, got %+v", schema.Properties)
+	}
+}
+
+func TestGenerateStructSchema_FieldBranches(t *testing.T) {
+	meta, pool := sweepMeta(t)
+
+	typ := &metadata.Type{
+		Name: pool.Get("Wrapper"),
+		Pkg:  pool.Get("main"),
+		Kind: pool.Get("struct"),
+		Fields: []metadata.Field{
+			// json:"-" fields and unexported fields are skipped.
+			{Name: pool.Get("Hidden"), Type: pool.Get("string"), Tag: pool.Get(`json:"-"`)},
+			{Name: pool.Get("secret"), Type: pool.Get("string")},
+			// Field whose type is pre-marked in usedTypes with a nil schema:
+			// forces the $ref + deferred body resolution branch.
+			{Name: pool.Get("Other"), Type: pool.Get("Other")},
+			// Field resolved via user typeMapping to a complex (object) schema:
+			// must be promoted to a component and replaced by a $ref.
+			{Name: pool.Get("Meta"), Type: pool.Get("Meta")},
+		},
+	}
+
+	cfg := DefaultAPISpecConfig()
+	cfg.TypeMapping = []TypeMapping{
+		{
+			GoType: "main.Meta",
+			OpenAPIType: &Schema{
+				Type:       "object",
+				Properties: map[string]*Schema{"k": {Type: "string"}},
+			},
+		},
+	}
+
+	usedTypes := map[string]*Schema{"main.Other": nil}
+	schema, schemas := generateStructSchema(usedTypes, "main.Wrapper", typ, meta, cfg, map[string]bool{})
+	if schema == nil {
+		t.Fatal("expected schema")
+	}
+	if _, ok := schema.Properties["Hidden"]; ok {
+		t.Error(`json:"-" field must be skipped`)
+	}
+	if _, ok := schema.Properties["secret"]; ok {
+		t.Error("unexported field must be skipped")
+	}
+	other := schema.Properties["Other"]
+	if other == nil || other.Ref == "" {
+		t.Errorf("expected $ref for pre-marked type, got %+v", other)
+	}
+	if schemas["main.Other"] == nil {
+		t.Error("expected deferred body schema for main.Other to be resolved")
+	}
+	metaProp := schema.Properties["Meta"]
+	if metaProp == nil || metaProp.Ref == "" {
+		t.Errorf("expected promoted $ref for typeMapping object schema, got %+v", metaProp)
+	}
+	if s := schemas["main.Meta"]; s == nil || s.Type != "object" || s.Properties["k"] == nil {
+		t.Errorf("expected promoted component for main.Meta, got %+v", s)
+	}
+}
+
+func TestGenerateStructSchema_NestedTypeNilSchemaFallback(t *testing.T) {
+	meta, pool := sweepMeta(t)
+
+	// An externalTypes entry with a nil OpenAPIType makes
+	// generateSchemaFromType return nil, exercising the fallback lookup in the
+	// nested-type branch.
+	cfg := DefaultAPISpecConfig()
+	cfg.ExternalTypes = []ExternalType{{Name: "main.Nested", OpenAPIType: nil}}
+
+	typ := &metadata.Type{
+		Name: pool.Get("Holder"),
+		Pkg:  pool.Get("main"),
+		Kind: pool.Get("struct"),
+		Fields: []metadata.Field{
+			{
+				Name: pool.Get("Nested"),
+				Type: pool.Get("main.Nested"),
+				NestedType: &metadata.Type{
+					Name: pool.Get("main.Nested"),
+					Kind: pool.Get("struct"),
+				},
+			},
+		},
+	}
+
+	schema, _ := generateStructSchema(map[string]*Schema{}, "main.Holder", typ, meta, cfg, map[string]bool{})
+	if schema == nil {
+		t.Fatal("expected schema")
+	}
+	if _, ok := schema.Properties["Nested"]; !ok {
+		t.Error("expected Nested property to be present (even with nil schema)")
+	}
+}
+
+func TestGenerateStructSchema_EnumOnArrayAndMapFields(t *testing.T) {
+	meta, pool := sweepMeta(t)
+
+	// Both fields carry the enum-backed type name "main.StatusE" as their
+	// declared type, with a NestedType alias shaping the schema as an array
+	// (Items) or a map (AdditionalProperties). detectEnumFromConstants then
+	// routes the values through the array/object switch arms.
+	typ := &metadata.Type{
+		Name: pool.Get("EnumHolder"),
+		Pkg:  pool.Get("main"),
+		Kind: pool.Get("struct"),
+		Fields: []metadata.Field{
+			{
+				Name: pool.Get("List"),
+				Type: pool.Get("main.StatusE"),
+				NestedType: &metadata.Type{
+					Name:   pool.Get("main.StatusEList"),
+					Kind:   pool.Get("alias"),
+					Target: pool.Get("[]string"),
+				},
+			},
+			{
+				Name: pool.Get("ByKey"),
+				Type: pool.Get("main.StatusE"),
+				NestedType: &metadata.Type{
+					Name:   pool.Get("main.StatusEMap"),
+					Kind:   pool.Get("alias"),
+					Target: pool.Get("map[string]string"),
+				},
+			},
+		},
+	}
+
+	schema, _ := generateStructSchema(map[string]*Schema{}, "main.EnumHolder", typ, meta, DefaultAPISpecConfig(), map[string]bool{})
+	if schema == nil {
+		t.Fatal("expected schema")
+	}
+	list := schema.Properties["List"]
+	if list == nil || list.Type != "array" || list.Items == nil {
+		t.Fatalf("expected array schema for List, got %+v", list)
+	}
+	if len(list.Items.Enum) != 2 {
+		t.Errorf("expected enum on array items, got %+v", list.Items)
+	}
+	byKey := schema.Properties["ByKey"]
+	if byKey == nil || byKey.Type != "object" || byKey.AdditionalProperties == nil {
+		t.Fatalf("expected map schema for ByKey, got %+v", byKey)
+	}
+	if len(byKey.AdditionalProperties.Enum) != 2 {
+		t.Errorf("expected enum on additionalProperties, got %+v", byKey.AdditionalProperties)
+	}
+}
+
+func TestGenerateSchemas_Branches(t *testing.T) {
+	meta, _ := sweepMeta(t)
+	cfg := DefaultAPISpecConfig()
+
+	usedTypes := map[string]*Schema{
+		// Well-known inline external type: resolves primitive-shaped, no component.
+		"uuid.UUID": nil,
+		// Unknown non-primitive type: gets the unresolved placeholder.
+		"foo.Unknown": nil,
+		// Generic declaration: yields a nil-typed "main.T-any" entry whose
+		// schema comes from the key's constraint suffix.
+		"main.Page[T any]": nil,
+	}
+
+	components := Components{Schemas: map[string]*Schema{}}
+	generateSchemas(usedTypes, cfg, components, meta)
+
+	if _, ok := components.Schemas["uuid_UUID"]; ok {
+		t.Error("primitive-shaped external type must not become a component")
+	}
+	placeholder := components.Schemas["foo_Unknown"]
+	if placeholder == nil || placeholder.Type != "object" || !strings.Contains(placeholder.Description, "foo.Unknown") {
+		t.Errorf("expected unresolved placeholder for foo.Unknown, got %+v", placeholder)
+	}
+	if components.Schemas["main_T-any"] == nil {
+		t.Errorf("expected schema for generic constraint placeholder, got keys %v", schemaKeys(components.Schemas))
+	}
+	if components.Schemas["main_Page_T-any"] == nil {
+		t.Errorf("expected schema for Page declaration, got keys %v", schemaKeys(components.Schemas))
+	}
+}
+
+func schemaKeys(m map[string]*Schema) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func TestResolveUnderlyingType_WrappedPrefixes(t *testing.T) {
+	meta, _ := sweepMeta(t)
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// The map[ prefix is cut and re-applied around the alias target.
+		{"map prefix", "map[Status", "map[string]string"},
+		// A slice nested behind the map prefix is consumed too; the map form
+		// still wins on reconstruction.
+		{"map then slice prefix", "map[[]Status", "map[string]string"},
+		{"star prefix", "*Status", "*string"},
+		{"not an alias", "User", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveUnderlyingType(tt.in, meta); got != tt.want {
+				t.Errorf("resolveUnderlyingType(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractValidationConstraints_PatternAndFormatRules(t *testing.T) {
+	// Every rule here maps to a non-empty Pattern.
+	patternRules := []string{
+		"alpha", "alphanum", "numeric", "alphaunicode", "alphanumunicode",
+		"hexadecimal", "hexcolor", "rgb", "rgba", "hsl", "hsla", "json",
+		"base64", "base64url", "datetime", "date", "time", "ip", "ipv4",
+		"ipv6", "cidr", "cidrv4", "cidrv6", "tcp_addr", "tcp4_addr",
+		"tcp6_addr", "udp_addr", "udp4_addr", "udp6_addr", "unix_addr",
+		"mac", "hostname", "fqdn", "isbn", "isbn10", "isbn13", "issn",
+		"uuid3", "uuid4", "uuid5", "ulid", "ascii", "printascii",
+		"multibyte", "datauri", "latitude", "longitude", "ssn",
+		"credit_card", "mongodb", "cron",
+	}
+	for _, rule := range patternRules {
+		t.Run(rule, func(t *testing.T) {
+			c := extractValidationConstraints(`validate:"` + rule + `"`)
+			if c == nil || c.Pattern == "" {
+				t.Errorf("rule %q: expected a pattern constraint, got %+v", rule, c)
+			}
+		})
+	}
+
+	t.Run("custom regexp tag", func(t *testing.T) {
+		c := extractValidationConstraints(`regexp:"^[a-z]+$"`)
+		if c == nil || c.Pattern != "^[a-z]+$" {
+			t.Errorf("expected pattern from regexp: tag, got %+v", c)
+		}
+	})
+}
+
+func TestApplyValidationConstraints_Branches(t *testing.T) {
+	minLen, maxLen := 2, 8
+
+	t.Run("nil schema is a no-op", func(t *testing.T) {
+		applyValidationConstraints(nil, &ValidationConstraints{Required: true})
+	})
+
+	t.Run("string length bounds", func(t *testing.T) {
+		s := &Schema{Type: "string"}
+		applyValidationConstraints(s, &ValidationConstraints{MinLength: &minLen, MaxLength: &maxLen})
+		if s.MinLength != 2 || s.MaxLength != 8 {
+			t.Errorf("got min/max length %d/%d, want 2/8", s.MinLength, s.MaxLength)
+		}
+	})
+
+	t.Run("integer length bounds become min/max", func(t *testing.T) {
+		s := &Schema{Type: "integer"}
+		applyValidationConstraints(s, &ValidationConstraints{MinLength: &minLen, MaxLength: &maxLen})
+		if s.Minimum != 2 || s.Maximum != 8 {
+			t.Errorf("got minimum/maximum %v/%v, want 2/8", s.Minimum, s.Maximum)
+		}
+	})
+}
+
+func TestExtractEnumValues_TypesConst(t *testing.T) {
+	mk := func(name, val string) EnumConstant {
+		return EnumConstant{
+			Name:  name,
+			Value: types.NewConst(token.NoPos, nil, name, types.Typ[types.String], constant.MakeString(val)),
+		}
+	}
+	got := extractEnumValues([]EnumConstant{mk("B", "beta"), mk("A", "alpha")})
+	want := []interface{}{"alpha", "beta"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("extractEnumValues = %v, want %v", got, want)
+	}
+}
+
+func TestTypeMatches_AliasResolvesToTarget(t *testing.T) {
+	meta, _ := sweepMeta(t)
+	if !typeMatches("Status", "string", meta) {
+		t.Error("alias Status should match its underlying type string")
+	}
+}
+
+func TestMapGoTypeToOpenAPISchema_FixedArrays(t *testing.T) {
+	meta, _ := sweepMeta(t)
+	cfg := DefaultAPISpecConfig()
+
+	t.Run("element already in usedTypes", func(t *testing.T) {
+		usedTypes := map[string]*Schema{"main.User": {Type: "object"}}
+		schema, _ := mapGoTypeToOpenAPISchema(usedTypes, "[2]main.User", meta, cfg, nil)
+		if schema == nil || schema.Type != "array" || schema.Items == nil || schema.Items.Ref == "" {
+			t.Fatalf("expected array of $ref, got %+v", schema)
+		}
+		if schema.MaxItems != 2 || schema.MinItems != 2 {
+			t.Errorf("expected fixed size 2, got max=%d min=%d", schema.MaxItems, schema.MinItems)
+		}
+	})
+
+	t.Run("element in usedTypes with nil body", func(t *testing.T) {
+		usedTypes := map[string]*Schema{"main.User": nil}
+		schema, _ := mapGoTypeToOpenAPISchema(usedTypes, "[2]main.User", meta, cfg, nil)
+		if schema == nil || schema.Type != "array" || schema.Items == nil || schema.Items.Ref == "" {
+			t.Fatalf("expected array of $ref, got %+v", schema)
+		}
+		if usedTypes["main.User"] == nil {
+			t.Error("expected nil body to be resolved and re-marked")
+		}
+	})
+
+	t.Run("complex element not in usedTypes", func(t *testing.T) {
+		schema, schemas := mapGoTypeToOpenAPISchema(map[string]*Schema{}, "[3]main.Other", meta, cfg, nil)
+		if schema == nil || schema.Type != "array" || schema.Items == nil {
+			t.Fatalf("expected array schema, got %+v", schema)
+		}
+		if schema.MaxItems != 3 || schema.MinItems != 3 {
+			t.Errorf("expected fixed size 3, got max=%d min=%d", schema.MaxItems, schema.MinItems)
+		}
+		if schemas["main.Other"] == nil {
+			t.Errorf("expected component for main.Other, got %v", schemaKeys(schemas))
+		}
+	})
+
+	t.Run("typeMapping element promoted to component", func(t *testing.T) {
+		mappedCfg := DefaultAPISpecConfig()
+		mappedCfg.TypeMapping = []TypeMapping{{
+			GoType:      "main.Meta",
+			OpenAPIType: &Schema{Type: "object", Properties: map[string]*Schema{"k": {Type: "string"}}},
+		}}
+		schema, schemas := mapGoTypeToOpenAPISchema(map[string]*Schema{}, "[2]main.Meta", meta, mappedCfg, nil)
+		if schema == nil || schema.Items == nil || schema.Items.Ref == "" {
+			t.Fatalf("expected promoted $ref items, got %+v", schema)
+		}
+		if schemas["main.Meta"] == nil {
+			t.Error("expected promoted component for main.Meta")
+		}
+	})
+
+	t.Run("array element enum applied to stored component", func(t *testing.T) {
+		_, schemas := mapGoTypeToOpenAPISchema(map[string]*Schema{}, "[2]main.StatusE", meta, cfg, nil)
+		stored := schemas["main.StatusE"]
+		if stored == nil {
+			t.Fatalf("expected component for main.StatusE, got %v", schemaKeys(schemas))
+		}
+		if len(stored.Enum) != 2 {
+			t.Errorf("expected 2 enum values on stored component, got %v", stored.Enum)
+		}
+	})
+
+	t.Run("array enum falls back onto items when no component stored", func(t *testing.T) {
+		visited := map[string]bool{"main.StatusE" + mapGoTypeToOpenAPISchemaKey: true}
+		schema, _ := mapGoTypeToOpenAPISchema(map[string]*Schema{}, "[2]main.StatusE", meta, cfg, visited)
+		if schema == nil || schema.Items == nil {
+			t.Fatalf("expected array schema, got %+v", schema)
+		}
+		if len(schema.Items.Enum) != 2 {
+			t.Errorf("expected enum on items, got %+v", schema.Items)
+		}
+	})
+}
+
+func TestMapGoTypeToOpenAPISchema_SliceBranches(t *testing.T) {
+	meta, _ := sweepMeta(t)
+	cfg := DefaultAPISpecConfig()
+
+	t.Run("element in usedTypes with nil body", func(t *testing.T) {
+		usedTypes := map[string]*Schema{"main.Other": nil}
+		schema, _ := mapGoTypeToOpenAPISchema(usedTypes, "[]main.Other", meta, cfg, nil)
+		if schema == nil || schema.Type != "array" || schema.Items == nil || schema.Items.Ref == "" {
+			t.Fatalf("expected array of $ref, got %+v", schema)
+		}
+		if usedTypes["main.Other"] == nil {
+			t.Error("expected nil body to be resolved and re-marked")
+		}
+	})
+
+	t.Run("typeMapping element promoted to component", func(t *testing.T) {
+		mappedCfg := DefaultAPISpecConfig()
+		mappedCfg.TypeMapping = []TypeMapping{{
+			GoType:      "main.Meta",
+			OpenAPIType: &Schema{Type: "object", Properties: map[string]*Schema{"k": {Type: "string"}}},
+		}}
+		schema, schemas := mapGoTypeToOpenAPISchema(map[string]*Schema{}, "[]main.Meta", meta, mappedCfg, nil)
+		if schema == nil || schema.Items == nil || schema.Items.Ref == "" {
+			t.Fatalf("expected promoted $ref items, got %+v", schema)
+		}
+		if schemas["main.Meta"] == nil {
+			t.Error("expected promoted component for main.Meta")
+		}
+	})
+
+	t.Run("enum falls back onto items when no component stored", func(t *testing.T) {
+		// Pre-visiting the element makes the recursion return a bare $ref
+		// without registering a component, so the detected enum lands on the
+		// items schema itself.
+		visited := map[string]bool{"main.StatusE" + mapGoTypeToOpenAPISchemaKey: true}
+		schema, _ := mapGoTypeToOpenAPISchema(map[string]*Schema{}, "[]main.StatusE", meta, cfg, visited)
+		if schema == nil || schema.Items == nil {
+			t.Fatalf("expected array schema, got %+v", schema)
+		}
+		if len(schema.Items.Enum) != 2 {
+			t.Errorf("expected enum on items, got %+v", schema.Items)
+		}
+	})
+}
+
+func TestMapGoTypeToOpenAPISchema_MapBranches(t *testing.T) {
+	meta, _ := sweepMeta(t)
+	cfg := DefaultAPISpecConfig()
+
+	t.Run("typeMapping value promoted to component", func(t *testing.T) {
+		mappedCfg := DefaultAPISpecConfig()
+		mappedCfg.TypeMapping = []TypeMapping{{
+			GoType:      "main.Meta",
+			OpenAPIType: &Schema{Type: "object", Properties: map[string]*Schema{"k": {Type: "string"}}},
+		}}
+		schema, schemas := mapGoTypeToOpenAPISchema(map[string]*Schema{}, "map[string]main.Meta", meta, mappedCfg, nil)
+		if schema == nil || schema.Type != "object" || schema.AdditionalProperties == nil || schema.AdditionalProperties.Ref == "" {
+			t.Fatalf("expected map with promoted $ref values, got %+v", schema)
+		}
+		if schemas["main.Meta"] == nil {
+			t.Error("expected promoted component for main.Meta")
+		}
+	})
+
+	t.Run("enum falls back onto additionalProperties", func(t *testing.T) {
+		visited := map[string]bool{"main.StatusE" + mapGoTypeToOpenAPISchemaKey: true}
+		schema, _ := mapGoTypeToOpenAPISchema(map[string]*Schema{}, "map[string]main.StatusE", meta, cfg, visited)
+		if schema == nil || schema.AdditionalProperties == nil {
+			t.Fatalf("expected map schema, got %+v", schema)
+		}
+		if len(schema.AdditionalProperties.Enum) != 2 {
+			t.Errorf("expected enum on additionalProperties, got %+v", schema.AdditionalProperties)
+		}
+	})
+}
+
+func TestMapGoTypeToOpenAPISchema_MalformedAnonStructFallback(t *testing.T) {
+	meta, _ := sweepMeta(t)
+	// Contains "struct{" but has no balanced body: must fall back to a plain
+	// object rather than a dangling $ref.
+	schema, _ := mapGoTypeToOpenAPISchema(map[string]*Schema{}, "main.struct{", meta, DefaultAPISpecConfig(), nil)
+	if schema == nil || schema.Type != "object" || schema.Ref != "" {
+		t.Fatalf("expected plain object fallback, got %+v", schema)
+	}
+}
+
+func TestAnonStructHelpers_EdgeCases(t *testing.T) {
+	t.Run("anonStructBody without struct token", func(t *testing.T) {
+		if _, ok := anonStructBody("main.User"); ok {
+			t.Error("expected ok=false without struct{")
+		}
+	})
+
+	t.Run("anonStructBody unbalanced", func(t *testing.T) {
+		if _, ok := anonStructBody("struct{Name string"); ok {
+			t.Error("expected ok=false for unbalanced struct body")
+		}
+	})
+
+	t.Run("schemaFromAnonStructLiteral unbalanced", func(t *testing.T) {
+		meta, _ := sweepMeta(t)
+		s, _ := schemaFromAnonStructLiteral(map[string]*Schema{}, "struct{Name string", meta, DefaultAPISpecConfig(), nil)
+		if s != nil {
+			t.Errorf("expected nil schema for unbalanced literal, got %+v", s)
+		}
+	})
+
+	t.Run("parseAnonField embedded field", func(t *testing.T) {
+		name, fieldType, _, ok := parseAnonField("User")
+		if ok || name != "" || fieldType != "User" {
+			t.Errorf("expected embedded (ok=false) with type User, got name=%q type=%q ok=%v", name, fieldType, ok)
+		}
+	})
+}

--- a/internal/spec/mapper_sweep_test.go
+++ b/internal/spec/mapper_sweep_test.go
@@ -333,6 +333,17 @@ func TestAllConcreteGenericArgs_NilAndConstraint(t *testing.T) {
 	if allConcreteGenericArgs(nil) {
 		t.Error("empty args must not count as concrete")
 	}
+	constrained := &typemodel.TypeRef{Kind: typemodel.KindNamed, Name: "T", Constraint: "any"}
+	if allConcreteGenericArgs([]*typemodel.TypeRef{constrained}) {
+		t.Error("declaration-form parameter (with constraint) must not count as concrete")
+	}
+	concrete := typemodel.Parse("main.User")
+	if !allConcreteGenericArgs([]*typemodel.TypeRef{concrete}) {
+		t.Error("plain named argument must count as concrete")
+	}
+	if allConcreteGenericArgs([]*typemodel.TypeRef{concrete, constrained}) {
+		t.Error("one constrained parameter poisons the whole list")
+	}
 }
 
 func TestSubstituteTypeParams(t *testing.T) {

--- a/internal/spec/spec_tails_sweep_test.go
+++ b/internal/spec/spec_tails_sweep_test.go
@@ -1,0 +1,236 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// identArg builds an ident CallArgument with the given rendered name.
+func identArg(m *metadata.Metadata, name string) *metadata.CallArgument {
+	a := metadata.NewCallArgument(m)
+	a.SetKind(metadata.KindIdent)
+	a.SetName(name)
+	return a
+}
+
+func TestWrapperSpecialisationHelpers(t *testing.T) {
+	sp := metadata.NewStringPool()
+	m := &metadata.Metadata{
+		StringPool: sp,
+		Packages: map[string]*metadata.Package{
+			"app": {
+				Files: map[string]*metadata.File{
+					"resp.go": {
+						Types: map[string]*metadata.Type{
+							"Envelope": {
+								Name: sp.Get("Envelope"),
+								Fields: []metadata.Field{
+									{Name: sp.Get("Data"), Type: sp.Get("interface{}"), Tag: sp.Get(`json:"data"`)},
+									{Name: sp.Get("Any"), Type: sp.Get("*any")},
+									{Name: sp.Get("Code"), Type: sp.Get("int")},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	cp := NewContextProvider(m)
+
+	if metadataFromContextProvider(cp) != m {
+		t.Error("metadataFromContextProvider should unwrap the impl")
+	}
+	if metadataFromContextProvider(nil) != nil {
+		t.Error("nil provider should yield nil metadata")
+	}
+
+	// paramNamesOf tolerates nil functions and nil args.
+	if got := paramNamesOf(nil); got != nil {
+		t.Errorf("paramNamesOf(nil) = %v", got)
+	}
+	fn := &metadata.Function{Signature: metadata.CallArgument{
+		Kind: -1, Name: -1, Value: -1, Raw: -1, Pkg: -1, Type: -1, Position: -1, ResolvedType: -1, GenericTypeName: -1, Meta: m,
+	}}
+	fn.Signature.Args = []*metadata.CallArgument{identArg(m, "w"), nil, identArg(m, "data")}
+	names := paramNamesOf(fn)
+	if len(names) != 3 || names[0] != "w" || names[1] != "" || names[2] != "data" {
+		t.Errorf("paramNamesOf = %v", names)
+	}
+
+	args := []*metadata.CallArgument{identArg(m, "a0"), identArg(m, "a1")}
+	if got := lookupCallArgByParamName(args, names, "data"); got != nil {
+		t.Error("index beyond call args must miss")
+	}
+	if got := lookupCallArgByParamName(args, names, "w"); got != args[0] {
+		t.Error("param name should map to positional arg")
+	}
+	if got := lookupCallArgByParamName(args, names, "absent"); got != nil {
+		t.Error("unknown param must miss")
+	}
+
+	// parentEdgeOf.
+	edge := &metadata.CallGraphEdge{}
+	parent := &TrackerNode{key: "p", CallGraphEdge: edge}
+	child := &TrackerNode{key: "c", Parent: parent}
+	if parentEdgeOf(child) != edge {
+		t.Error("parentEdgeOf should return the parent's edge")
+	}
+	if parentEdgeOf(&TrackerNode{key: "orphan"}) != nil {
+		t.Error("orphan node has no parent edge")
+	}
+
+	// lookupWrapperType via typeByName.
+	if lookupWrapperType(nil, "app.Envelope") != nil {
+		t.Error("nil meta must miss")
+	}
+	if lookupWrapperType(m, "") != nil {
+		t.Error("empty type must miss")
+	}
+	wt := lookupWrapperType(m, "app.Envelope")
+	if wt == nil {
+		t.Fatal("Envelope not found")
+	}
+
+	// wrapperFieldIsGeneric: interface{} and *any are generic; int is not.
+	if !wrapperFieldIsGeneric(m, wt, "Data") {
+		t.Error("interface{} field should be generic")
+	}
+	if !wrapperFieldIsGeneric(m, wt, "Any") {
+		t.Error("*any field should be generic")
+	}
+	if wrapperFieldIsGeneric(m, wt, "Code") {
+		t.Error("int field should not be generic")
+	}
+	if wrapperFieldIsGeneric(m, wt, "Missing") || wrapperFieldIsGeneric(m, nil, "Data") {
+		t.Error("missing field / nil type should not be generic")
+	}
+
+	// jsonNameForField: tag name, fallback to field name, missing field.
+	if got := jsonNameForField(m, wt, "Data"); got != "data" {
+		t.Errorf("json name = %q, want data", got)
+	}
+	if got := jsonNameForField(m, wt, "Code"); got != "Code" {
+		t.Errorf("untagged json name = %q, want Code", got)
+	}
+	if got := jsonNameForField(m, wt, "Missing"); got != "" {
+		t.Errorf("missing field json name = %q", got)
+	}
+	if got := jsonNameForField(m, nil, "Data"); got != "" {
+		t.Errorf("nil wrapper json name = %q", got)
+	}
+}
+
+func TestSecurityLookupAssignments(t *testing.T) {
+	sp := metadata.NewStringPool()
+	m := &metadata.Metadata{
+		StringPool: sp,
+		Packages: map[string]*metadata.Package{
+			"app": {
+				Files: map[string]*metadata.File{
+					"main.go": {
+						Functions: map[string]*metadata.Function{
+							"setup": {
+								Name: sp.Get("setup"),
+								AssignmentMap: map[string][]metadata.Assignment{
+									"authMW": {{
+										VariableName: sp.Get("authMW"),
+										CalleeFunc:   "RequireAuth",
+										CalleePkg:    "app/auth",
+										Value:        metadata.CallArgument{Kind: -1, Name: -1, Value: -1, Raw: -1, Pkg: -1, Type: -1, Position: -1, ResolvedType: -1, GenericTypeName: -1, Meta: nil},
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	edge := &metadata.CallGraphEdge{
+		Caller: metadata.Call{Meta: m, Name: sp.Get("setup"), Pkg: sp.Get("app"), RecvType: -1},
+		Callee: metadata.Call{Meta: m, Name: sp.Get("Use"), Pkg: sp.Get("gin"), RecvType: -1},
+	}
+
+	// Falls back to the caller function's assignment map.
+	assigns := lookupAssignments(edge, "authMW", m)
+	if len(assigns) != 1 || assigns[0].CalleeFunc != "RequireAuth" {
+		t.Fatalf("caller-fallback assignments = %+v", assigns)
+	}
+
+	// Edge's own map wins when present.
+	edge.AssignmentMap = map[string][]metadata.Assignment{
+		"authMW": {{CalleeFunc: "EdgeLocal"}},
+	}
+	if got := lookupAssignments(edge, "authMW", m); len(got) != 1 || got[0].CalleeFunc != "EdgeLocal" {
+		t.Errorf("edge-local assignments = %+v", got)
+	}
+
+	// Unknown variable and nil meta.
+	if got := lookupAssignments(edge, "nothing", nil); got != nil {
+		t.Errorf("nil meta = %+v", got)
+	}
+
+	// resolveMiddlewareIdentRef end-to-end over the CalleeFunc path.
+	edge.AssignmentMap = nil
+	arg := identArg(m, "authMW")
+	ref, ok := resolveMiddlewareIdentRef(edge, arg, m)
+	if !ok || ref.FunctionName != "RequireAuth" || ref.Pkg != "app/auth" {
+		t.Errorf("middleware ref = %+v ok=%v", ref, ok)
+	}
+	// Non-ident and missing-variable rejections.
+	lit := metadata.NewCallArgument(m)
+	lit.SetKind(metadata.KindLiteral)
+	if _, ok := resolveMiddlewareIdentRef(edge, lit, m); ok {
+		t.Error("literal must not resolve")
+	}
+	if _, ok := resolveMiddlewareIdentRef(edge, identArg(m, "unknown"), m); ok {
+		t.Error("unknown ident must not resolve")
+	}
+}
+
+func TestTrackerMetadataInterfaceResolution(t *testing.T) {
+	sp := metadata.NewStringPool()
+	m := &metadata.Metadata{StringPool: sp}
+	m.RegisterInterfaceResolution("Storer", "Service", "app", "PgStore", "svc.go:10")
+
+	tr := &TrackerTree{meta: m, interfaceResolutionMap: map[interfaceKey]string{}}
+
+	// Cache miss resolves from metadata and caches locally.
+	if got := tr.ResolveInterfaceFromMetadata("Storer", "Service", "app"); got != "PgStore" {
+		t.Errorf("metadata resolution = %q, want PgStore", got)
+	}
+	// Now the local cache serves it.
+	if got := tr.ResolveInterface("Storer", "Service", "app"); got != "PgStore" {
+		t.Errorf("cached resolution = %q, want PgStore", got)
+	}
+	// Unknown stays itself.
+	if got := tr.ResolveInterfaceFromMetadata("Other", "Service", "app"); got != "Other" {
+		t.Errorf("unknown resolution = %q", got)
+	}
+
+	// SyncInterfaceResolutionsFromMetadata copies the metadata view in bulk.
+	tr2 := &TrackerTree{meta: m, interfaceResolutionMap: map[interfaceKey]string{}}
+	tr2.SyncInterfaceResolutionsFromMetadata()
+	if got := tr2.ResolveInterface("Storer", "Service", "app"); got != "PgStore" {
+		t.Errorf("synced resolution = %q, want PgStore", got)
+	}
+	// Nil metadata is a no-op.
+	(&TrackerTree{interfaceResolutionMap: map[interfaceKey]string{}}).SyncInterfaceResolutionsFromMetadata()
+}


### PR DESCRIPTION
## What

The final phase-2 sweep: eight targeted test files close the remaining branch-level gaps, taking library `-coverpkg` coverage from **88.8% → 95.3%** — past the 95% goal. No production code changed; goldens byte-identical.

| Area | Before | After |
|---|---|---|
| `internal/spec/mapper.go` | 85.0% | ~99% |
| `internal/diagserver` | 89.5% | 96.9% |
| `internal/insight` metrics/endpoint | 87–88% | ~100% |
| `internal/profiler` | 86.4% | 92.4% |
| extractor / pattern_matchers / metadata / engine / spec tails | — | branch gaps closed |

Highlights: the full validator-rule table (51 subtests), generic type-param resolution seeded through `edge.TypeParamMap` (the node-level map is rebuilt on every read — a subtle test-setup trap now documented), profile-file error branches, package-hierarchy tree recursion, pagination clamps/caches, goroutine-leak detection tick.

## Deliberately not covered (analyzed, not padded)

The remaining ~4.7% is either **provably unreachable** or **not honestly testable**:
- Dead switch arms in `mapper.go` shadowed by earlier branches — notably the `[]byte → {type: string, format: byte}` case is unreachable because the slice branch intercepts first, meaning `[]byte` fields render as *array-of-integer*; flagged as a possible spec-shape issue for a separate decision, not silently "fixed" by a test.
- BFS-invariant-protected branches in `calculateCallGraphDepth`, a 30s-timeout path, embed-read errors on files that always exist, pprof global-state error branches (covering them would perturb parallel `-race` runs).
- A method-name inference quirk found en route: the contains-matcher sees "get" inside "wid**get**", so `deleteWidget` infers GET — documented in the tests via realistic names, worth a targeted fix someday.

Suspected-dead-code reports from the sweep (deliberately kept: exported API surface): `MapMetadataToOpenAPI`, `DefaultAPISpecConfig`.

## Verification

Full suite green (goldens, determinism, all framework fixtures), `golangci-lint`/`go vet`/`gofmt` clean.

## Follow-up after this merges

Bump `scripts/coverage-floor.txt` (PR #127) from 87.5 to **94.5** to lock the gain in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added extensive automated coverage across diagnostics, engine behavior, metadata analysis, profiling, API extraction, and OpenAPI schema generation.
  * Expanded validation for pagination, filtering, graph traversal, generics, middleware, request/response mapping, configuration errors, and profiling failure paths.
  * Improved confidence in edge-case handling, fallback behavior, recursion limits, caching, and malformed or incomplete inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->