### PR TITLE
fix: render []byte fields as base64 string, not array of integers

### DIFF
--- a/generator/testdata_generics_test.go
+++ b/generator/testdata_generics_test.go
@@ -70,6 +70,11 @@ func TestTestdata_GenericStructs(t *testing.T) {
 	if _, ok := userSchema.Properties["email"]; !ok {
 		t.Errorf("User schema missing expected field 'email'; got %v", userSchema.Properties)
 	}
+	// []byte fields must render the way encoding/json marshals them: a
+	// base64 string, not an array of integers.
+	if avatar := userSchema.Properties["avatar"]; avatar == nil || avatar.Type != "string" || avatar.Format != "byte" {
+		t.Errorf("User.avatar = %+v, want {type: string, format: byte}", avatar)
+	}
 	_, productSchema := findSchema("_structs_Product")
 	if productSchema == nil {
 		t.Fatalf("Product component missing; have %v", mapSchemaKeys(schemas))

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -2239,6 +2239,14 @@ func mapGoTypeToOpenAPISchema(usedTypes map[string]*Schema, goType string, meta 
 	if goTypeRef.Kind == typemodel.KindSlice {
 		elementType := strings.TrimSpace(goTypeRef.Elem.Raw())
 
+		// encoding/json marshals []byte ([]uint8) as a base64 string, not an
+		// array of integers — mirror that on the wire shape. (A "[]byte"
+		// switch arm existed below but was unreachable: this branch
+		// intercepts every slice first.)
+		if elementType == "byte" || elementType == "uint8" {
+			return &Schema{Type: "string", Format: "byte"}, schemas
+		}
+
 		var resolvedType string
 		if resolvedType = resolveUnderlyingType(elementType, meta); resolvedType == "" {
 			resolvedType = elementType
@@ -2335,14 +2343,6 @@ func mapGoTypeToOpenAPISchema(usedTypes map[string]*Schema, goType string, meta 
 		return &Schema{Type: "boolean"}, schemas
 	case "time.Time":
 		return &Schema{Type: "string", Format: "date-time"}, schemas
-	case "[]byte":
-		return &Schema{Type: "string", Format: "byte"}, schemas
-	case "[]string":
-		return &Schema{Type: "array", Items: &Schema{Type: "string"}}, schemas
-	case "[]time.Time":
-		return &Schema{Type: "array", Items: &Schema{Type: "string", Format: "date-time"}}, schemas
-	case "[]int":
-		return &Schema{Type: "array", Items: &Schema{Type: "integer"}}, schemas
 	case "interface{}", "struct{}", "any":
 		return &Schema{Type: "object"}, schemas
 	default:

--- a/internal/spec/mapper_comprehensive_test.go
+++ b/internal/spec/mapper_comprehensive_test.go
@@ -947,7 +947,8 @@ func testMapGoTypeToOpenAPISchema_PrimitiveTypes(t *testing.T) {
 		{"float64", "number"},
 		{"bool", "boolean"},
 		{"time.Time", "string"},
-		{"[]byte", "array"},
+		{"[]byte", "string"},  // base64, like encoding/json
+		{"[]uint8", "string"}, // alias of []byte
 		{"[]string", "array"},
 		{"[]time.Time", "array"},
 		{"[]int", "array"},

--- a/testdata/generic_structs/main.go
+++ b/testdata/generic_structs/main.go
@@ -35,9 +35,10 @@ type Pair[K any, V any] struct {
 }
 
 type User struct {
-	ID    int    `json:"id"`
-	Name  string `json:"name"`
-	Email string `json:"email"`
+	ID     int    `json:"id"`
+	Name   string `json:"name"`
+	Email  string `json:"email"`
+	Avatar []byte `json:"avatar,omitempty"`
 }
 
 type Product struct {


### PR DESCRIPTION
## What

`[]byte` struct fields rendered as `{type: array, items: {type: integer, minimum: 0}}` — but `encoding/json` marshals `[]byte` (`[]uint8`) as a **base64 string**, so the generated spec disagreed with the actual wire format.

## Root cause

The mapper *had* the correct mapping — a `case "[]byte": return {type: string, format: byte}` switch arm — but it was unreachable: the `KindSlice` branch intercepts every `[]…` type before the switch. Found by the coverage sweep's dead-branch analysis in #128 (flagged there, fixed here as its own reviewable change per house rules).

## Fix

- The slice branch special-cases `byte`/`uint8` elements → `{type: string, format: byte}`.
- The four shadowed switch arms (`[]byte`, `[]string`, `[]time.Time`, `[]int`) are deleted; the latter three produced byte-identical output through the slice branch, so this is pure dead-code removal with no behavior change for them.

## Coverage

- Fixture: `testdata/generic_structs` `User` gains `Avatar []byte`; the generics structural test asserts `{type: string, format: byte}`.
- Unit: `[]byte` and `[]uint8` expectations in the primitive-mapping table.

## Verification

Full suite green — metadata goldens byte-identical (the goldens record Go types, not schemas), determinism, all framework fixtures; lint/vet/gofmt clean; ratchet passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)