### PR TITLE
fix: match method names on word boundaries, not substrings

### DIFF
--- a/internal/spec/extractor_sweep_test.go
+++ b/internal/spec/extractor_sweep_test.go
@@ -245,7 +245,7 @@ func TestSweepExtractRouteDetails(t *testing.T) {
 		m := NewRoutePatternMatcher(RoutePattern{
 			MethodFromHandler: true, HandlerFromArg: true, HandlerArgIndex: 0, MethodArgIndex: -1,
 		}, cfg, cp, nil)
-		edge := sweepEdge(meta, "main", "app", "Handle", "app", "", "", sweepIdent(meta, "deleteUser"))
+		edge := sweepEdge(meta, "main", "app", "Handle", "app", "", "", sweepIdent(meta, "deleteWidget"))
 		route := NewRouteInfo()
 		if !m.extractRouteDetails(sweepNode(edge), route) {
 			t.Fatal("expected details to be found")
@@ -355,10 +355,9 @@ func TestSweepInferMethodFromContext(t *testing.T) {
 		meta := exSweepMeta()
 		cp := NewContextProvider(meta)
 		m := NewRoutePatternMatcher(RoutePattern{MethodExtraction: DefaultMethodExtractionConfig()}, cfg, cp, nil)
-		// "deleteUser" (not "...Widget"): the contains-matcher would otherwise
-		// spot "get" inside "widget" and short-circuit to GET before the
-		// caller-name prefix can win.
-		edge := sweepEdge(meta, "deleteUser", "app", "HandleFunc", "mux", "", "")
+		// "deleteWidget" pins the word-boundary fix: the old substring
+		// matcher spotted "get" inside "widget" and returned GET.
+		edge := sweepEdge(meta, "deleteWidget", "app", "HandleFunc", "mux", "", "")
 		if got := m.inferMethodFromContext(&TrackerNode{}, edge); got != "DELETE" {
 			t.Errorf("inferMethodFromContext() = %q, want DELETE", got)
 		}
@@ -368,10 +367,11 @@ func TestSweepInferMethodFromContext(t *testing.T) {
 		meta := exSweepMeta()
 		cp := NewContextProvider(meta)
 		m := NewRoutePatternMatcher(RoutePattern{MethodExtraction: DefaultMethodExtractionConfig()}, cfg, cp, nil)
-		// Handler arg "updateUser" (not "...Widget"): "widget" contains "get"
-		// and would resolve to GET before the "update" prefix can map to PUT.
+		// "updateWidget" pins the word-boundary fix on the handler-arg path:
+		// the old substring matcher resolved "widget" to GET before the
+		// "update" prefix could map to PUT.
 		edge := sweepEdge(meta, "createThing", "app", "HandleFunc", "mux", "", "",
-			sweepLit(meta, `"/x"`), sweepIdent(meta, "updateUser"))
+			sweepLit(meta, `"/x"`), sweepIdent(meta, "updateWidget"))
 		if got := m.inferMethodFromContext(&TrackerNode{}, edge); got != "PUT" {
 			t.Errorf("inferMethodFromContext() = %q, want PUT from handler arg", got)
 		}

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -17,6 +17,7 @@ package spec
 import (
 	"net/http"
 	"strings"
+	"unicode"
 
 	"github.com/ehabterra/apispec/internal/metadata"
 	"github.com/ehabterra/apispec/internal/typemodel"
@@ -1034,10 +1035,17 @@ func (b *BasePatternMatcher) extractMethodFromFunctionNameWithConfig(funcName st
 		config = DefaultMethodExtractionConfig()
 	}
 
-	// Prepare function name based on case sensitivity
-	searchName := funcName
+	// Split the identifier into words at camelCase boundaries and
+	// non-letter separators so a pattern only ever matches a whole word:
+	// "deleteWidget" is [delete widget], and the "get" inside "widget" must
+	// not match. The old substring checks lowercased the name first, which
+	// erased the camel boundary and let GET (checked first) claim any name
+	// containing those three letters.
+	words := splitNameWords(funcName)
 	if !config.CaseSensitive {
-		searchName = strings.ToLower(funcName)
+		for i, w := range words {
+			words[i] = strings.ToLower(w)
+		}
 	}
 
 	// Sort mappings by priority (highest first)
@@ -1053,36 +1061,33 @@ func (b *BasePatternMatcher) extractMethodFromFunctionNameWithConfig(funcName st
 		}
 	}
 
-	// Check prefix matches first if enabled
-	if config.UsePrefix {
+	patternWord := func(pattern string) string {
+		if !config.CaseSensitive {
+			return strings.ToLower(pattern)
+		}
+		return pattern
+	}
+
+	// Check the leading word first if enabled ("deleteUser" → DELETE).
+	if config.UsePrefix && len(words) > 0 {
 		for _, mapping := range mappings {
 			for _, pattern := range mapping.Patterns {
-				searchPattern := pattern
-				if !config.CaseSensitive {
-					searchPattern = strings.ToLower(pattern)
-				}
-
-				if strings.HasPrefix(searchName, searchPattern) {
-					// Make sure it's a word boundary (not part of another word)
-					if len(searchName) == len(searchPattern) || !b.isLetter(rune(searchName[len(searchPattern)])) {
-						return mapping.Method
-					}
+				if words[0] == patternWord(pattern) {
+					return mapping.Method
 				}
 			}
 		}
 	}
 
-	// Check contains matches if enabled
+	// Then any whole word if enabled ("handleUserDelete" → DELETE).
 	if config.UseContains {
 		for _, mapping := range mappings {
 			for _, pattern := range mapping.Patterns {
-				searchPattern := pattern
-				if !config.CaseSensitive {
-					searchPattern = strings.ToLower(pattern)
-				}
-
-				if strings.Contains(searchName, searchPattern) {
-					return mapping.Method
+				p := patternWord(pattern)
+				for _, w := range words {
+					if w == p {
+						return mapping.Method
+					}
 				}
 			}
 		}
@@ -1091,7 +1096,34 @@ func (b *BasePatternMatcher) extractMethodFromFunctionNameWithConfig(funcName st
 	return config.DefaultMethod
 }
 
-// isLetter checks if a rune is a letter
-func (b *BasePatternMatcher) isLetter(r rune) bool {
-	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
+// splitNameWords splits an identifier into words at non-letter separators
+// and camelCase boundaries: "handleHTTPDelete" → [handle HTTP Delete],
+// "delete_widget" → [delete widget]. An uppercase run followed by a
+// lowercase letter starts a new word (the "HTTPServer" → HTTP+Server rule).
+func splitNameWords(name string) []string {
+	var words []string
+	var cur []rune
+	runes := []rune(name)
+	flush := func() {
+		if len(cur) > 0 {
+			words = append(words, string(cur))
+			cur = nil
+		}
+	}
+	for i, r := range runes {
+		if !unicode.IsLetter(r) {
+			flush()
+			continue
+		}
+		if len(cur) > 0 && unicode.IsUpper(r) {
+			prev := cur[len(cur)-1]
+			if unicode.IsLower(prev) ||
+				(unicode.IsUpper(prev) && i+1 < len(runes) && unicode.IsLower(runes[i+1])) {
+				flush()
+			}
+		}
+		cur = append(cur, r)
+	}
+	flush()
+	return words
 }


### PR DESCRIPTION
## The bug

`deleteWidget` inferred **GET**. Two compounding defects in `extractMethodFromFunctionNameWithConfig`:

1. The prefix pass lowercased the name *before* its word-boundary check — camelCase names (`deleteWidget` → `deletewidget`) always failed the boundary test (`'w'` is a letter) and fell through.
2. The contains pass had **no** boundary check, and GET's mapping is evaluated first — so the `get` inside `wid`**`get`** won before DELETE's `delete` was ever considered. Same class of false match: `put` in `compute`/`deputy`, `add` in `address`, `new` in `renew`, `head` in `ahead`.

## The fix

Identifiers are now split into words at camelCase boundaries and non-letter separators (`handleHTTPDelete` → `[handle HTTP Delete]`, uppercase-run rule included) and patterns match **whole words only**: `UsePrefix` checks the leading word, `UseContains` any word. Priority ordering, case-sensitivity, and `DefaultMethod` semantics are unchanged.

## Blast radius

- Shipped router configs (chi/gin/echo/fiber `MethodFromCall`) extract from single-verb callee names (`Get`, `Post`, …) — unaffected, all fixtures byte-identical.
- The fix matters for `methodFromHandler` / `inferFromContext` (mux-style and user-supplied configs) where arbitrary handler names flow in.
- The sweep tests that had to rename `deleteWidget`→`deleteUser` *because of this bug* now use the Widget names again and pin the fix on both inference paths (caller-name and handler-arg).

## Found along the way (not changed here)

`ExtractRoute` initializes `Method: http.MethodPost` as a default, which pre-empts name inference entirely for plain single-call registrations (`r.HandleFunc("/widgets/{id}", deleteWidget)` stays POST regardless of matcher correctness). Whether such routes should infer from the handler name instead of defaulting to POST is a separate, larger behavior decision — it would flip method verbs across existing projects — so it's flagged rather than bundled.

## Verification

Full suite green — goldens, determinism, all framework fixtures unchanged; lint/vet/gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic HTTP method detection from handler and function names.
  * Method names are now recognized as complete words, reducing incorrect matches from partial names or unrelated text.
  * Prefix-based detection now consistently evaluates the beginning of a function name, while contains-based detection checks individual name components.

* **Tests**
  * Updated coverage to verify DELETE and PUT method inference scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->