### PR TITLE
perf(spec): intern extraction chain keys — fix quadratic allocation on deep graphs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,31 @@ go test ./internal/metadata -run TestGenerateMetadata -update
 scripts/compare-spec.sh                            # regenerate/diff fixture snapshots
 ```
 
+## Profiling & performance
+
+```bash
+./apispec --dir <project> --cpu-profile --mem-profile --profile-dir profiles
+                     # also: --block-profile --mutex-profile --trace-profile
+go tool pprof -top ./apispec profiles/cpu.prof
+go tool pprof -list 'FuncName' -sample_index=alloc_space ./apispec profiles/mem.prof
+make metrics-generate     # per-stage metrics JSON (--custom-metrics --metrics-path)
+make metrics-view         # interactive metrics viewer (scripts/view_metrics.sh)
+```
+
+- First-line diagnosis is the per-stage `[engine]` log lines (loaded /
+  metadata generated / tracker tree / spec mapped). With LazyTree, tree
+  expansion happens *inside* the "spec mapped" stage — a bigger mapping
+  number alone is moved work, not necessarily a regression.
+- Benchmark on a large real project, never on `testdata/` fixtures — they
+  are so small that `go/packages` load noise dominates. A/B by building
+  binaries from two `git worktree`s of the versions under comparison.
+- The extraction walk visits every tracker node: any per-child O(depth)
+  work (string concatenation, capped-cap slice appends) goes quadratic over
+  deep graphs and shows up as GC dominance (`runtime.scanObject`,
+  `runtime.madvise`) rather than as the guilty frame. Chain identity is
+  interned to int handles (`chainInterner`, extractor.go) for exactly this
+  reason — extend the interner rather than reintroducing key strings.
+
 ## Golden rules (hard-won invariants — do not relearn these)
 
 1. **Determinism is a feature.** Any map iteration whose order can reach the
@@ -76,6 +101,18 @@ scripts/compare-spec.sh                            # regenerate/diff fixture sna
 7. **Honest over wrong.** When resolution is ambiguous (two concrete types
    assigned to one interface, a type argument erased to `any`), keep the
    honest general type; never guess one concrete option.
+8. **HTTP-method precedence is a chain — don't short it.** Verb sources
+   resolve in order: explicit verb in the registration pattern
+   (`"GET /users"`, `MethodFromPath` → sets `MethodExplicit`) →
+   verb-carrying call (`.Methods("GET")`, `router.GET`) →
+   `switch r.Method` dispatch splitting (`splitMethodDispatchRoutes`,
+   fires **only** on non-explicit routes) → handler-name inference
+   (opt-in per config via `MethodExtraction`; matches whole camelCase
+   words via `splitNameWords` — "get" must never match inside "widget") →
+   the `ExtractRoute` POST default. `MethodExplicit` suppresses dispatch
+   splitting; the POST default gates name inference off for plain
+   registrations but does *not* block dispatch splitting
+   (`testdata/method_switch` guards this).
 
 ## Testing conventions
 
@@ -95,6 +132,16 @@ scripts/compare-spec.sh                            # regenerate/diff fixture sna
   change at a time.
 - New feature ⇒ new fixture + structural test + (if resolution logic) unit
   tests at the layer that changed.
+- **Coverage is ratcheted.** CI runs `scripts/check-coverage.sh` against
+  `scripts/coverage-floor.txt`; measure with `-coverpkg` over the library
+  packages and `-count=1` — per-package numbers under-report ~14 pts
+  (the `generator/` fixture suites exercise the pipeline cross-package)
+  and a stale test cache corrupts merged profiles. Bump the floor in its
+  own PR after the raising change merges.
+- **Before testing a 0%-coverage function, check its callers** — 0% usually
+  means dead code (delete it, don't test it). Caveat: the `deadcode` tool
+  (RTA) treats every exported `Metadata` method as reachable because of
+  yaml reflection — confirm dead exported methods by grep, not by tool.
 
 ## Code & PR conventions
 

--- a/internal/spec/chain_interner_test.go
+++ b/internal/spec/chain_interner_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestChainInterner(t *testing.T) {
+	t.Run("empty chain is handle 0 and reconstructs to nil", func(t *testing.T) {
+		ci := &chainInterner{}
+		if got := ci.strings(0); got != nil {
+			t.Errorf("strings(0) = %v, want nil", got)
+		}
+	})
+
+	t.Run("handles are 1-based, stable, and value-interned", func(t *testing.T) {
+		ci := &chainInterner{}
+		a := ci.push(0, "a@1")
+		if a != 1 {
+			t.Fatalf("first handle = %d, want 1", a)
+		}
+		// Same (parent, callee) must reuse the handle — this is what makes
+		// interning equivalent to string-key equality for dedupe.
+		if again := ci.push(0, "a@1"); again != a {
+			t.Errorf("re-push returned %d, want %d", again, a)
+		}
+		// A sibling with the same parent but different callee is distinct.
+		b := ci.push(0, "b@2")
+		if b == a {
+			t.Errorf("sibling collided with %d", a)
+		}
+		// The same callee under a different parent is distinct too.
+		ab := ci.push(a, "b@2")
+		if ab == b || ab == a {
+			t.Errorf("nested handle %d collided (a=%d, b=%d)", ab, a, b)
+		}
+		if len(ci.steps) != 3 {
+			t.Errorf("interned %d steps, want 3", len(ci.steps))
+		}
+	})
+
+	t.Run("strings reconstructs root-to-leaf", func(t *testing.T) {
+		ci := &chainInterner{}
+		a := ci.push(0, "root@1")
+		b := ci.push(a, "mid@2")
+		c := ci.push(b, "leaf@3")
+
+		cases := []struct {
+			handle int
+			want   []string
+		}{
+			{a, []string{"root@1"}},
+			{b, []string{"root@1", "mid@2"}},
+			{c, []string{"root@1", "mid@2", "leaf@3"}},
+		}
+		for _, tc := range cases {
+			if got := ci.strings(tc.handle); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("strings(%d) = %v, want %v", tc.handle, got, tc.want)
+			}
+		}
+
+		// Reconstruction must not disturb interning state: pushing the same
+		// steps again still reuses the existing handles.
+		if ci.push(a, "mid@2") != b || ci.push(b, "leaf@3") != c {
+			t.Errorf("handles not stable after reconstruction")
+		}
+	})
+
+	t.Run("diamond: two paths to the same callee stay distinct", func(t *testing.T) {
+		// route -> f -> shared and route -> g -> shared: the SAME call-site
+		// reached through different frames must produce different chains —
+		// that distinction is what keeps two invocations of one helper apart
+		// in response pairing.
+		ci := &chainInterner{}
+		f := ci.push(0, "f@1")
+		g := ci.push(0, "g@2")
+		viaF := ci.push(f, "shared@3")
+		viaG := ci.push(g, "shared@3")
+		if viaF == viaG {
+			t.Fatalf("diamond collapsed: %d == %d", viaF, viaG)
+		}
+		if got := ci.strings(viaF); !reflect.DeepEqual(got, []string{"f@1", "shared@3"}) {
+			t.Errorf("via f = %v", got)
+		}
+		if got := ci.strings(viaG); !reflect.DeepEqual(got, []string{"g@2", "shared@3"}) {
+			t.Errorf("via g = %v", got)
+		}
+	})
+}

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -833,9 +833,9 @@ func (e *Extractor) handleRouteNode(node TrackerNodeInterface, routeInfo *RouteI
 	// candidates are collected with their call-site CHAIN during the walk
 	// and resolved afterwards by pairAndFillResponses — see there for the
 	// order-insensitive pairing model.
-	visitedEdges := make(map[string]bool)
+	visitedEdges := make(map[chainStep]bool)
 	var respCandidates []responseCandidate
-	e.extractRouteChildren(node, routeInfo, mountTags, routes, visitedEdges, nil, "", &respCandidates)
+	e.extractRouteChildren(node, routeInfo, mountTags, routes, visitedEdges, &chainInterner{}, 0, &respCandidates)
 	e.pairAndFillResponses(routeInfo, respCandidates)
 
 	// Add map-key path params (mux.Vars) for placeholders the handler reads via
@@ -976,6 +976,56 @@ type responseCandidate struct {
 // chainSep separates call-site instance IDs in chain keys.
 const chainSep = "\x1f"
 
+// chainStep is one interned recursion step: the parent chain's handle plus
+// the callee instance ID entered at that step. The walk previously built an
+// O(depth) key string per visited child — quadratic in total bytes over deep
+// walks and the dominant allocation source on large projects; interning makes
+// each step one map operation while preserving value equality exactly, so
+// dedupe behaviour is unchanged. chainStep doubles as the response-candidate
+// dedupe key (parent = frame handle, callee = statement's call-site ID).
+type chainStep struct {
+	parent int
+	callee string
+}
+
+// chainInterner assigns stable small handles to recursion chains within one
+// route walk. Handle 0 is the empty chain — the route/handler frame.
+type chainInterner struct {
+	ids   map[chainStep]int
+	steps []chainStep // handle n is steps[n-1]
+}
+
+func (ci *chainInterner) push(parent int, callee string) int {
+	st := chainStep{parent: parent, callee: callee}
+	if id, ok := ci.ids[st]; ok {
+		return id
+	}
+	if ci.ids == nil {
+		ci.ids = map[chainStep]int{}
+	}
+	ci.steps = append(ci.steps, st)
+	ci.ids[st] = len(ci.steps)
+	return len(ci.steps)
+}
+
+// strings reconstructs a handle's chain root→leaf. Only response candidates
+// pay this cost — the hot walk never materializes chains.
+func (ci *chainInterner) strings(id int) []string {
+	var n int
+	for h := id; h != 0; h = ci.steps[h-1].parent {
+		n++
+	}
+	if n == 0 {
+		return nil
+	}
+	out := make([]string, n)
+	for h := id; h != 0; h = ci.steps[h-1].parent {
+		n--
+		out[n] = ci.steps[h-1].callee
+	}
+	return out
+}
+
 // frameChainKey identifies the FRAME a response statement executes in: the
 // recursion chain truncated at the invocation of the statement's caller
 // function (keeping the invocation prefix, so two invocations of the same
@@ -997,7 +1047,7 @@ func frameChainKey(chain []string, node TrackerNodeInterface) string {
 	return "" // route/handler frame
 }
 
-func (e *Extractor) extractRouteChildren(routeNode TrackerNodeInterface, route *RouteInfo, mountTags []string, routes *[]*RouteInfo, visitedEdges map[string]bool, chain []string, chainKey string, respCandidates *[]responseCandidate) {
+func (e *Extractor) extractRouteChildren(routeNode TrackerNodeInterface, route *RouteInfo, mountTags []string, routes *[]*RouteInfo, visitedEdges map[chainStep]bool, ci *chainInterner, chainID int, respCandidates *[]responseCandidate) {
 	for _, child := range routeNode.GetChildren() {
 		// Check for route patterns in children nodes
 		if isRoute := e.executeRoutePattern(child, route); isRoute {
@@ -1024,14 +1074,13 @@ func (e *Extractor) extractRouteChildren(routeNode TrackerNodeInterface, route *
 		// through the same frames is one candidate; the same statement in a
 		// different helper invocation is a separate one.
 		// Match first (memoized per edge — cheap), and only then build the
-		// per-(chain, site) dedupe key: constructing the key for every child
-		// dominated the allocation profile, and non-matching children never
-		// need one.
+		// per-(chain, site) dedupe key; the chain string itself is
+		// reconstructed from the interner only for actual candidates.
 		if child != nil && child.GetEdge() != nil && e.matchesResponsePattern(child) {
-			candKey := chainKey + chainSep + child.GetEdge().Callee.ID()
+			candKey := chainStep{parent: chainID, callee: child.GetEdge().Callee.ID()}
 			if !visitedEdges[candKey] {
 				visitedEdges[candKey] = true
-				*respCandidates = append(*respCandidates, responseCandidate{node: child, chain: frameChainKey(chain, child)})
+				*respCandidates = append(*respCandidates, responseCandidate{node: child, chain: frameChainKey(ci.strings(chainID), child)})
 			}
 		}
 
@@ -1040,13 +1089,11 @@ func (e *Extractor) extractRouteChildren(routeNode TrackerNodeInterface, route *
 
 		// Recursive extraction. The chain grows only through CALL nodes —
 		// argument nodes reference values within the current frame.
-		childChain, childChainKey := chain, chainKey
+		childChainID := chainID
 		if child != nil && child.GetArgument() == nil && child.GetEdge() != nil {
-			id := child.GetEdge().Callee.ID()
-			childChain = append(chain[:len(chain):len(chain)], id)
-			childChainKey = chainKey + chainSep + id
+			childChainID = ci.push(chainID, child.GetEdge().Callee.ID())
 		}
-		e.extractRouteChildren(child, route, mountTags, routes, visitedEdges, childChain, childChainKey, respCandidates)
+		e.extractRouteChildren(child, route, mountTags, routes, visitedEdges, ci, childChainID, respCandidates)
 	}
 
 	// Extract parameters from the route node itself


### PR DESCRIPTION
## Problem

Profiling spec generation on two large real projects (~100 pkgs / 5.5k call edges and ~40 pkgs / 8k call edges) showed the extraction walk dominated by GC (`runtime.madvise`, `runtime.scanObject*` ≈ 40% of samples). Line-level pprof pinned it to `extractRouteChildren`:

- `childChainKey = chainKey + chainSep + id` — an O(depth) string built for **every visited child** → quadratic total bytes over deep graphs (720ms CPU on this line alone)
- `extractRouteChildren` allocated **1.22GB — 57% of all process allocations**

Introduced after v0.4.0 with the response-candidate chain dedupe (af0fd3c), so this is a regression on deep/dense projects: on the deep-graph project, tracker+map went 3.3s (v0.4.0) → ~3.8s (main).

## Fix

Chain identity is interned to small int handles (`chainInterner`): each recursion step is one map operation, no string building on the hot path. Full chains are materialized only for actual response candidates (rare). The candidate dedupe key becomes a `chainStep{parent handle, callee ID}` struct — **value equality is preserved exactly**, so dedupe semantics are unchanged.

## Results (large real projects, local A/B)

| Metric | before | after |
|---|---|---|
| Process allocations | 2.13GB | 1.23GB (−42%) |
| `extractRouteChildren` alloc (cum) | 1.22GB | 332MB (flat: 1.5MB) |
| `extractRouteChildren` CPU | 20% of samples | out of profile top |
| "spec mapped" stage (deep-graph project) | 2.4–3.8s | 1.8–2.2s |

Combined with the lazy tracker, both projects are now faster than v0.4.0 end-to-end (one 13.7s → ~4s, the other 6.9s → ~5s).

## Zero output drift

- Outputs byte-identical before/after on **both** large projects
- Full suite (goldens, determinism, all framework fixtures) passes untouched
- gofmt / vet / golangci-lint clean

## Also included

CLAUDE.md: new "Profiling & performance" section documenting the existing profiling flags, pprof workflow, `make metrics-generate` / `metrics-view`, per-stage `[engine]` log diagnosis, and the O(depth)-per-child pitfall; plus the HTTP-method precedence chain and coverage-ratchet conventions from recent work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved internal route analysis efficiency, reducing allocation overhead during complex route extraction.
  * Preserved deterministic response pairing and existing behavior.

* **Documentation**
  * Added contributor guidance for profiling, performance measurement, HTTP-method handling, and testing conventions.
  * Documented coverage expectations and guidance for functions with no test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->