### PR TITLE
fix(cli): honor absolute --output paths

### DIFF
--- a/cmd/apispec/main.go
+++ b/cmd/apispec/main.go
@@ -496,7 +496,13 @@ func writeOutput(openAPISpec interface{}, config *CLIConfig, genEngine *engine.E
 			return nil
 		}
 	} else {
-		outputPath := filepath.Join(genEngine.ModuleRoot(), config.OutputFile)
+		// Relative --output paths land in the analyzed module (so
+		// `apispec --dir proj -o spec.yaml` writes proj/spec.yaml);
+		// absolute paths must be honored as given, not joined under it.
+		outputPath := config.OutputFile
+		if !filepath.IsAbs(outputPath) {
+			outputPath = filepath.Join(genEngine.ModuleRoot(), outputPath)
+		}
 
 		// Create file
 		file, err := os.OpenFile(outputPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)


### PR DESCRIPTION
`--output /abs/path.yaml` was silently joined under the analyzed module root (`filepath.Join(ModuleRoot(), "/abs/path.yaml")` → `<module>/abs/path.yaml`), so the spec never landed where asked — generation logged success while file creation failed on missing intermediate directories. Found while benchmarking PR #132 with outputs redirected to a scratch directory.

Relative paths keep the existing behaviour (land in the analyzed module, matching `scripts/compare-spec.sh` expectations); absolute paths are now honored as given. Verified both cases manually against a fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)