### PR TITLE
fix(chi): document r.Method / r.MethodFunc / r.Handle / r.HandleFunc registrations

### DIFF
--- a/generator/testdata_chi_method_handle_test.go
+++ b/generator/testdata_chi_method_handle_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/spec"
+)
+
+// TestTestdata_ChiMethodHandle locks in chi's non-verb registration surface:
+// r.Method(http.MethodGet, ...) / r.MethodFunc (verb from the first argument,
+// including stdlib http.Method* constants), r.Handle with an opaque
+// http.Handler value (path + defaulted GET, at minimum), and r.HandleFunc
+// whose handler dispatches on r.Method (must split per verb — the defaulted
+// method must not be marked explicit).
+func TestTestdata_ChiMethodHandle(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "chi_method_handle", spec.DefaultChiConfig())
+	noDanglingRefs(t, out)
+
+	want := map[string][]string{
+		"/live":    {"GET"},           // plain r.Get with a func value
+		"/health":  {"GET"},           // r.Method(http.MethodGet, ..., http.Handler value)
+		"/ready":   {"POST"},          // r.MethodFunc(http.MethodPost, ...)
+		"/metrics": {"GET"},           // r.Handle with an opaque handler: defaulted GET
+		"/items":   {"GET", "DELETE"}, // r.HandleFunc + switch r.Method: split per verb
+	}
+	for path, methods := range want {
+		item, ok := out.Paths[path]
+		if !ok {
+			t.Errorf("path %q missing; have %v", path, mapPathKeys(out.Paths))
+			continue
+		}
+		for _, m := range methods {
+			if opFor(item, m) == nil {
+				t.Errorf("%s %s: expected operation, missing", m, path)
+			}
+		}
+	}
+
+	// The verb came from the constant argument, so it is explicit: /health
+	// must not pick up extra verbs and must not fall back to the POST preset.
+	if health, ok := out.Paths["/health"]; ok {
+		if opFor(health, "POST") != nil {
+			t.Errorf("/health should not carry a POST operation (verb is http.MethodGet)")
+		}
+	}
+
+	// The dispatch split must not leak the default onto non-served verbs.
+	if items, ok := out.Paths["/items"]; ok {
+		if opFor(items, "POST") != nil {
+			t.Errorf("/items should not carry a POST operation (handler serves GET/DELETE)")
+		}
+	}
+}

--- a/internal/metadata/expression.go
+++ b/internal/metadata/expression.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"go/ast"
+	"go/constant"
 	"go/token"
 	"go/types"
 )
@@ -161,7 +162,22 @@ func handleIdent(e *ast.Ident, info *types.Info, pkgName string, fset *token.Fil
 	arg.SetPkg(pkg)
 	arg.SetType(typeStr)
 	arg.SetPosition(getPosition(e.Pos(), fset))
+	setConstStringValue(arg, e, info)
 	return arg
+}
+
+// setConstStringValue records a constant expression's evaluated value — a
+// fact go/types already proved — so consumers see the same value a string
+// literal would carry (e.g. verb-from-argument route patterns reading
+// http.MethodGet, or const path strings). Scoped to string constants so
+// numeric idents (http.StatusOK everywhere) keep their existing shape.
+func setConstStringValue(arg *CallArgument, e ast.Expr, info *types.Info) {
+	if info == nil {
+		return
+	}
+	if tv, ok := info.Types[e]; ok && tv.Value != nil && tv.Value.Kind() == constant.String {
+		arg.SetValue(tv.Value.ExactString())
+	}
 }
 
 // handleSelector processes selector expressions with StringPool integration
@@ -217,6 +233,7 @@ func handleSelector(e *ast.SelectorExpr, info *types.Info, pkgName string, fset 
 	arg.SetType(typeStr)
 	arg.SetPosition(getPosition(e.Pos(), fset))
 	arg.ReceiverType = receiverArg
+	setConstStringValue(arg, e, info)
 
 	return arg
 }

--- a/internal/spec/config_chi.go
+++ b/internal/spec/config_chi.go
@@ -51,6 +51,33 @@ func DefaultChiConfig() *APISpecConfig {
 					HandlerArgIndex: 1,
 					RecvTypeRegex:   "^github.com/go-chi/chi(/v\\d)?\\.\\*?(Router|Mux)$",
 				},
+				{
+					// r.Method(http.MethodGet, "/health", handler) /
+					// r.MethodFunc(http.MethodPost, "/ready", fn) — the verb is
+					// the first argument.
+					CallRegex:       `^Method(Func)?$`,
+					PathFromArg:     true,
+					HandlerFromArg:  true,
+					MethodArgIndex:  0,
+					PathArgIndex:    1,
+					HandlerArgIndex: 2,
+					RecvTypeRegex:   "^github.com/go-chi/chi(/v\\d)?\\.\\*?(Router|Mux)$",
+				},
+				{
+					// r.Handle("/metrics", handler) / r.HandleFunc("/items", fn)
+					// route EVERY verb to the handler. Emit the handler-name
+					// verb when the name carries one; otherwise default (GET)
+					// without marking it explicit, so a `switch r.Method`
+					// handler still splits into one operation per verb.
+					CallRegex:         `^Handle(Func)?$`,
+					PathFromArg:       true,
+					HandlerFromArg:    true,
+					MethodFromHandler: true,
+					MethodArgIndex:    -1,
+					PathArgIndex:      0,
+					HandlerArgIndex:   1,
+					RecvTypeRegex:     "^github.com/go-chi/chi(/v\\d)?\\.\\*?(Router|Mux)$",
+				},
 			},
 			RequestContext: netHTTPRequestContext,
 			RequestBodyPatterns: []RequestBodyPattern{

--- a/internal/spec/extractor_sweep_test.go
+++ b/internal/spec/extractor_sweep_test.go
@@ -703,6 +703,19 @@ func TestSweepExtractMethodFromFunctionNameWithConfig(t *testing.T) {
 	if got := b.extractMethodFromFunctionNameWithConfig("zzz", cfg); got != "HEAD" {
 		t.Errorf("default method: got %q, want HEAD", got)
 	}
+
+	// The matched report separates evidence from fallback: a mapping hit is
+	// explicit; the DefaultMethod is not (so verb-less registrations stay
+	// open to method-dispatch splitting).
+	if m, matched := b.methodFromFunctionName("xy", cfg); m != "PUT" || !matched {
+		t.Errorf("mapping hit: got (%q,%v), want (PUT,true)", m, matched)
+	}
+	if m, matched := b.methodFromFunctionName("zzz", cfg); m != "HEAD" || matched {
+		t.Errorf("default fallback: got (%q,%v), want (HEAD,false)", m, matched)
+	}
+	if m, matched := b.methodFromFunctionName("", cfg); m != "" || matched {
+		t.Errorf("empty name: got (%q,%v), want (\"\",false)", m, matched)
+	}
 }
 
 // --- extractor.go ------------------------------------------------------------

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -265,12 +265,15 @@ func (r *RoutePatternMatcherImpl) extractRouteDetails(node TrackerNodeInterface,
 		routeInfo.MethodExplicit = true
 		found = true
 	} else if r.pattern.MethodFromHandler && r.pattern.HandlerFromArg && len(edge.Args) > r.pattern.HandlerArgIndex {
-		// Extract method from handler function name
+		// Extract method from handler function name. Only a real mapping hit
+		// makes the verb explicit — a DefaultMethod fallback keeps the route
+		// open so a `switch r.Method` handler still splits per dispatch verb.
 		handlerArg := edge.Args[r.pattern.HandlerArgIndex]
 		handlerName := r.contextProvider.GetArgumentInfo(handlerArg)
 		if handlerName != "" {
-			routeInfo.Method = r.extractMethodFromFunctionNameWithConfig(handlerName, r.pattern.MethodExtraction)
-			routeInfo.MethodExplicit = true
+			var matched bool
+			routeInfo.Method, matched = r.methodFromFunctionName(handlerName, r.pattern.MethodExtraction)
+			routeInfo.MethodExplicit = matched
 			found = true
 		}
 	} else if r.pattern.MethodArgIndex >= 0 && len(edge.Args) > r.pattern.MethodArgIndex {
@@ -1026,8 +1029,17 @@ func traceGenericOrigin(node TrackerNodeInterface, typeName string) string {
 }
 
 func (b *BasePatternMatcher) extractMethodFromFunctionNameWithConfig(funcName string, config *MethodExtractionConfig) string {
+	method, _ := b.methodFromFunctionName(funcName, config)
+	return method
+}
+
+// methodFromFunctionName additionally reports whether a mapping word actually
+// matched. A false report means the returned method is config.DefaultMethod
+// (or empty) — a fallback, not evidence from the name — so callers can leave
+// the route non-explicit and let method-dispatch splitting refine it.
+func (b *BasePatternMatcher) methodFromFunctionName(funcName string, config *MethodExtractionConfig) (string, bool) {
 	if funcName == "" {
-		return ""
+		return "", false
 	}
 
 	// Use default config if none provided
@@ -1073,7 +1085,7 @@ func (b *BasePatternMatcher) extractMethodFromFunctionNameWithConfig(funcName st
 		for _, mapping := range mappings {
 			for _, pattern := range mapping.Patterns {
 				if words[0] == patternWord(pattern) {
-					return mapping.Method
+					return mapping.Method, true
 				}
 			}
 		}
@@ -1086,14 +1098,14 @@ func (b *BasePatternMatcher) extractMethodFromFunctionNameWithConfig(funcName st
 				p := patternWord(pattern)
 				for _, w := range words {
 					if w == p {
-						return mapping.Method
+						return mapping.Method, true
 					}
 				}
 			}
 		}
 	}
 
-	return config.DefaultMethod
+	return config.DefaultMethod, false
 }
 
 // splitNameWords splits an identifier into words at non-letter separators

--- a/internal/spec/tests/constants.yaml
+++ b/internal/spec/tests/constants.yaml
@@ -83,7 +83,7 @@ packages:
                   value:
                     kind: 7
                     name: 24
-                    value: -1
+                    value: 2
                     raw: -1
                     pkg: 10
                     type: 25

--- a/testdata/chi_method_handle/go.mod
+++ b/testdata/chi_method_handle/go.mod
@@ -1,0 +1,5 @@
+module github.com/ehabterra/apispec/testdata/chi_method_handle
+
+go 1.24.3
+
+require github.com/go-chi/chi/v5 v5.2.2

--- a/testdata/chi_method_handle/go.sum
+++ b/testdata/chi_method_handle/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=
+github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=

--- a/testdata/chi_method_handle/main.go
+++ b/testdata/chi_method_handle/main.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// HealthStatus is the /health response body.
+type HealthStatus struct {
+	Status string `json:"status"`
+	Uptime int64  `json:"uptime"`
+}
+
+// HealthHandler implements http.Handler and is registered via r.Method.
+type HealthHandler struct{}
+
+func (h *HealthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(HealthStatus{Status: "ok"})
+}
+
+// MetricsHandler is an opaque http.Handler (promhttp.Handler() stand-in),
+// registered via r.Handle.
+type MetricsHandler struct{}
+
+func (m *MetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("metrics"))
+}
+
+// Deps carries handlers as values, mirroring dependency-injected routers.
+type Deps struct {
+	Health  *HealthHandler
+	Metrics http.Handler
+}
+
+// ServeLive is a plain func value registered via r.Get.
+func ServeLive(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("live"))
+}
+
+// readyHandler is registered via r.MethodFunc.
+func readyHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(HealthStatus{Status: "ready"})
+}
+
+// itemsHandler dispatches on r.Method and is registered verb-less via
+// r.HandleFunc — it must split into one operation per verb.
+func itemsHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("items"))
+	case http.MethodDelete:
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+// NewRouter registers the same kind of endpoint several ways.
+func NewRouter(deps Deps) *chi.Mux {
+	r := chi.NewRouter()
+
+	r.Get("/live", ServeLive)                        // func value
+	r.Method(http.MethodGet, "/health", deps.Health) // http.Handler via Method
+	r.MethodFunc(http.MethodPost, "/ready", readyHandler)
+	r.Handle("/metrics", deps.Metrics) // opaque http.Handler
+	r.HandleFunc("/items", itemsHandler)
+
+	return r
+}
+
+func main() {
+	deps := Deps{Health: &HealthHandler{}, Metrics: &MetricsHandler{}}
+	_ = http.ListenAndServe(":8080", NewRouter(deps))
+}


### PR DESCRIPTION
## Problem

A chi router registering the same kind of endpoint three ways:

```go
r.Get("/live", ServeLive)                          // func value
r.Method(http.MethodGet, "/health", deps.Health)   // http.Handler via Method
r.Handle("/metrics", deps.Metrics)                 // opaque http.Handler
```

documented **only `/live`** — the chi config had a single route pattern (the `r.Get/Post/...` verb calls).

## Fix (three pieces)

1. **`config_chi.go`** — add `^Method(Func)?$` (verb from argument 0) and `^Handle(Func)?$` (verb from handler name, defaulting open to GET) route patterns, receiver-scoped to chi `Router`/`Mux` exactly like the existing verb pattern.

2. **`metadata/expression.go`** — `r.Method(http.MethodGet, ...)` needs the *value* of a stdlib constant. A constant expression's evaluated value is a fact go/types has already proved, so metadata records it (layering rule: metadata records facts): ident/selector arguments now carry their constant **string** value, formatted exactly like a literal. Numeric constants (`http.StatusOK` everywhere) are deliberately excluded to bound the change. One metadata golden line changes (regenerated via `-update`).

3. **`pattern_matchers.go`** — `methodFromFunctionName` now reports whether a mapping word actually matched, and the handler-name branch marks the verb explicit only on a real hit. This keeps the two chi `Handle` semantics from fighting: an opaque handler (`promhttp.Handler()`) gets a single defaulted GET, while `r.HandleFunc("/items", h)` with `switch r.Method` still splits into one operation per served verb — a *defaulted* method is a fallback, not evidence, so it must not suppress dispatch splitting.

## Fixture / test

`testdata/chi_method_handle` registers all five styles; the structural test asserts the exact verb sets:

| path | registration | expected |
|---|---|---|
| `/live` | `r.Get` + func value | GET |
| `/health` | `r.Method(http.MethodGet, ..., deps.Health)` | GET (not POST preset) |
| `/ready` | `r.MethodFunc(http.MethodPost, ...)` | POST |
| `/metrics` | `r.Handle(..., deps.Metrics)` opaque | GET |
| `/items` | `r.HandleFunc` + `switch r.Method` | GET + DELETE, no POST |

Full suite passes; goldens regenerated only via `-update` (1 line); gofmt/vet/golangci-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)