### PR TITLE
chore: add issue templates and help links

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-missing-route.yml
+++ b/.github/ISSUE_TEMPLATE/1-missing-route.yml
@@ -1,0 +1,76 @@
+name: 🕳️ Missing or wrong route
+description: A route is absent from the generated spec, or has the wrong verb/path/body.
+title: "[route] "
+labels: ["bug", "route-detection"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please skim the [debugging guide](https://github.com/ehabterra/apispec/blob/main/docs/DEBUGGING.md) first — it walks the artifacts this form asks for, and often reveals the cause directly (excluded packages, budget truncation, an unsupported wiring style you can confirm by extending the config).
+  - type: input
+    id: version
+    attributes:
+      label: apispec version
+      description: Output of `apispec --version`
+      placeholder: v0.5.0
+    validations:
+      required: true
+  - type: dropdown
+    id: framework
+    attributes:
+      label: Framework
+      multiple: true
+      options:
+        - gin
+        - echo
+        - chi
+        - fiber
+        - gorilla/mux
+        - net/http (ServeMux)
+        - mixed / several in one binary
+        - other
+    validations:
+      required: true
+  - type: textarea
+    id: wiring
+    attributes:
+      label: How the route is registered
+      description: The minimal registration snippet — router setup plus the line that registers the missing route. Anonymized names are fine; the *shape* is what matters.
+      render: go
+      placeholder: |
+        r := chi.NewRouter()
+        r.Method(http.MethodGet, "/health", deps.Health)
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected vs. actual
+      placeholder: |
+        Expected: GET /health present
+        Actual: /health missing entirely (only /live documented)
+    validations:
+      required: true
+  - type: textarea
+    id: stagelog
+    attributes:
+      label: Stage log
+      description: The `[engine]` lines apispec printed (they show packages loaded, call edges, and paths mapped — and any truncation warning).
+      render: text
+  - type: textarea
+    id: usedconfig
+    attributes:
+      label: Effective config
+      description: Attach or paste the relevant part of `used-config.yaml` (from `apispec --output-config used-config.yaml`) — at minimum the `routePatterns` section.
+      render: yaml
+  - type: textarea
+    id: metadata
+    attributes:
+      label: Metadata excerpt
+      description: From `apispec --write-metadata` (writes `metadata.yaml`) — the entries for the handler and, if present, the registration call edge. Skip if the file is huge and nothing matches your handler name; say so instead.
+      render: yaml
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else
+      description: Insight report export (apispecui), diagram screenshot around the registration node, include/exclude flags used, build tags…

--- a/.github/ISSUE_TEMPLATE/2-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/2-bug-report.yml
@@ -1,0 +1,47 @@
+name: 🐛 Bug report
+description: Wrong schema, dangling $ref, crash, bad YAML/JSON — anything that isn't a missing route.
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For routes missing from the spec, please use the **Missing or wrong route** template instead — it collects the right artifacts.
+  - type: input
+    id: version
+    attributes:
+      label: apispec version
+      description: Output of `apispec --version`
+    validations:
+      required: true
+  - type: input
+    id: go-version
+    attributes:
+      label: Go version and OS
+      placeholder: go1.26.2, macOS 15
+  - type: textarea
+    id: command
+    attributes:
+      label: Command run
+      render: shell
+      placeholder: apispec -d . -o openapi.yaml
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: Expected vs. actual. For schema issues paste the relevant spec excerpt; for crashes the full panic/stack trace.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproduction
+      description: The smallest `main.go` (plus types) that reproduces it — the fixtures under `testdata/` are good templates. This is the single most useful thing you can provide.
+      render: go
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else
+      description: Config file used, `used-config.yaml`, insight export, related issues…

--- a/.github/ISSUE_TEMPLATE/3-framework-support.yml
+++ b/.github/ISSUE_TEMPLATE/3-framework-support.yml
@@ -1,0 +1,35 @@
+name: 🧩 Framework or wiring-style support
+description: Request support for a router/framework, or a registration style an existing framework config doesn't cover.
+title: "[support] "
+labels: ["enhancement", "framework-support"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Framework behavior in apispec is config-driven (regex patterns over call names and receiver types), so many wiring styles can be validated without code changes: run `apispec --output-config used-config.yaml`, extend the patterns by hand, and re-run with `--config used-config.yaml`. If that works, paste the pattern you added — it usually becomes the fix.
+  - type: input
+    id: framework
+    attributes:
+      label: Framework / router package
+      placeholder: github.com/example/router
+    validations:
+      required: true
+  - type: textarea
+    id: wiring
+    attributes:
+      label: Registration style
+      description: A representative snippet of how routes, bodies, and responses look in this framework.
+      render: go
+    validations:
+      required: true
+  - type: textarea
+    id: tried
+    attributes:
+      label: What you tried
+      description: Custom config patterns you experimented with (and whether they worked), or why the existing config can't express it.
+      render: yaml
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else
+      description: Popularity/links for the framework, related projects using this style…

--- a/.github/ISSUE_TEMPLATE/4-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/4-feature-request.yml
@@ -1,0 +1,24 @@
+name: 💡 Feature request
+description: New capability, CLI/UI improvement, or output enhancement.
+title: "[feature] "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do that apispec doesn't support today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What you'd like to happen — CLI flag, config option, output change, UI feature…
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you're using now, or other shapes the feature could take.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 📖 My route is missing — debugging guide
+    url: https://github.com/ehabterra/apispec/blob/main/docs/DEBUGGING.md
+    about: Work through the four failure classes first — the guide shows which artifact answers which question, and most gaps are diagnosable in minutes.
+  - name: 💬 Questions & help
+    url: https://github.com/ehabterra/apispec/discussions
+    about: Ask usage questions, share setups, or discuss ideas before they become issues.
+  - name: 📚 Documentation
+    url: https://github.com/ehabterra/apispec#documentation
+    about: README, installation, CLI reference, and design docs.


### PR DESCRIPTION
Adds GitHub issue forms + the template chooser config:

- **🕳️ Missing or wrong route** — the flagship (motivated by #34): asks for apispec version, framework(s), the registration snippet, and exactly the artifacts `docs/DEBUGGING.md` teaches — stage log, `used-config.yaml`, `metadata.yaml` excerpt — so reports arrive diagnosable without repo access.
- **🐛 Bug report** — schema/crash/output issues, with a minimal-repro field pointing at `testdata/` fixtures as templates.
- **🧩 Framework or wiring-style support** — points reporters at the config-driven self-serve loop (`--output-config` → extend patterns → `--config`) whose result usually becomes the fix.
- **💡 Feature request.**
- **config.yml** — help links: debugging guide, Discussions (enabled on the repo), docs index. Blank issues stay enabled.

Note: the debugging-guide links resolve once #136 (docs/DEBUGGING.md) merges — merging that first avoids a brief 404 window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)