### PR TITLE
perf(core): DetectAll parses imports only, stops when all frameworks found

### DIFF
--- a/internal/core/detector.go
+++ b/internal/core/detector.go
@@ -62,9 +62,14 @@ func (d *FrameworkDetector) DetectAll(dir string) ([]string, error) {
 		}
 	}
 
+	// ImportsOnly: parsing stops after the import block, which is all this
+	// scan reads — a full parse of every file (the pre-DetectAll code at
+	// least early-returned on the first hit) costs hundreds of ms on large
+	// projects. The loop also stops once every known framework is seen.
+	const knownFrameworks = 5
 	fset := token.NewFileSet()
 	for _, filePath := range goFiles {
-		f, err := parser.ParseFile(fset, filePath, nil, parser.ParseComments)
+		f, err := parser.ParseFile(fset, filePath, nil, parser.ImportsOnly)
 		if err != nil {
 			continue // Skip files that can't be parsed
 		}
@@ -83,6 +88,9 @@ func (d *FrameworkDetector) DetectAll(dir string) ([]string, error) {
 			case strings.Contains(importPath, "gorilla/mux"):
 				add("mux")
 			}
+		}
+		if len(frameworks) == knownFrameworks {
+			break
 		}
 	}
 


### PR DESCRIPTION
Follow-up to #135. `DetectAll` fully parsed every Go file with `parser.ParseComments`, where the old `Detect` at least early-returned on the first framework hit — a small but real regression on large projects (the detector phase isn't covered by the `[engine]` stage logs, so it hides in total wall time).

Two semantics-preserving changes:
- **`parser.ImportsOnly`** — parsing stops after the import block, which is all this scan reads.
- **Early exit** once every known framework has been seen (the set can't grow further).

Measured per-run detection cost on two large private projects (5-iteration Go benchmark):

| Project | before | after |
|---|---|---|
| ~100-pkg project | 146ms | 53ms |
| ~40-pkg project | 66ms | 9.5ms |

Same files considered, same first-seen order, full suite passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved framework detection speed by analyzing only required file information.
  * Stops scanning once all supported frameworks are identified, reducing unnecessary processing.
  * Preserved existing detection order and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->