### PR TITLE
fix(insight): keep stdlib calls in the handler trace — subtree must be complete

### DIFF
--- a/internal/insight/metrics.go
+++ b/internal/insight/metrics.go
@@ -106,17 +106,17 @@ var builtinFuncs = map[string]bool{
 	"println": true, "real": true, "recover": true,
 }
 
-// calleeIsStdOrBuiltin reports whether a callee is a Go builtin or lives
-// in the standard library, so the trace can skip it. Project packages
-// (under the current module path) and third-party dependencies (import
-// paths with a dotted domain, e.g. github.com/...) are kept — the latter
-// includes web frameworks, which are meaningful in a trace.
-func calleeIsStdOrBuiltin(meta *metadata.Metadata, c *metadata.Call) bool {
+// calleeIsBuiltin reports whether a callee is a Go builtin (len, append,
+// make, …), which never belongs in a call trace. Standard-library calls are
+// NOT filtered here: the endpoint trace is the handler's complete scoped
+// subtree, and metrics (reachable, fanout, paths, grade) are computed from
+// it — dropping stdlib calls like r.URL.Query().Get would silently
+// understate them. Stdlib callees are natural leaves (their bodies aren't
+// analyzed, so they have no outgoing edges) and carry Origin "standard" so
+// the UI can style or collapse them.
+func calleeIsBuiltin(meta *metadata.Metadata, c *metadata.Call) bool {
 	name := meta.StringPool.GetString(c.Name)
-	if builtinFuncs[name] { // robust against older metadata that mis-qualified builtins
-		return true
-	}
-	return classifyPkg(meta, meta.StringPool.GetString(c.Pkg), meta.StringPool.GetString(c.RecvType)) == "standard"
+	return builtinFuncs[name] // robust against older metadata that mis-qualified builtins
 }
 
 // classifyPkg buckets a callee's package into "project" (under the
@@ -189,11 +189,10 @@ func analyzeAdjacency(meta *metadata.Metadata, root string, callersOf func(strin
 		}
 		seen := map[string]bool{}
 		for _, e := range callersOf(cur) {
-			// Skip Go builtins (len, append, make, …) and standard-library
-			// calls (fmt, net/http, encoding/json, …) so the trace shows
-			// the project's own call flow (and third-party frameworks),
-			// not stdlib noise.
-			if calleeIsStdOrBuiltin(meta, &e.Callee) {
+			// Skip Go builtins (len, append, make, …) only. Stdlib calls stay
+			// in as leaves: the trace is the handler's complete subtree and
+			// the metrics depend on all of it.
+			if calleeIsBuiltin(meta, &e.Callee) {
 				continue
 			}
 			callee := e.Callee.BaseID()
@@ -352,7 +351,7 @@ func analyzeResolvedCallGraph(meta *metadata.Metadata, root string) (Metrics, Tr
 		}
 		seenCallee := map[string]bool{}
 		for _, e := range meta.Callers[cur] {
-			if calleeIsStdOrBuiltin(meta, &e.Callee) {
+			if calleeIsBuiltin(meta, &e.Callee) {
 				continue
 			}
 			callee := e.Callee.BaseID()
@@ -523,7 +522,7 @@ func analyzeTrackerSubtree(meta *metadata.Metadata, routeNode spec.TrackerNodeIn
 			}
 			continue
 		}
-		if calleeIsStdOrBuiltin(meta, &ce.Callee) {
+		if calleeIsBuiltin(meta, &ce.Callee) {
 			continue
 		}
 		callee := ce.Callee.BaseID()

--- a/internal/insight/metrics_sweep_test.go
+++ b/internal/insight/metrics_sweep_test.go
@@ -43,13 +43,19 @@ func sweepMeta() (*metadata.Metadata, func(pkg, recv, name, pos string) metadata
 	return meta, mk
 }
 
-func TestCalleeIsStdOrBuiltinAndClassifyPkg(t *testing.T) {
+func TestCalleeIsBuiltinAndClassifyPkg(t *testing.T) {
 	meta, mk := sweepMeta()
 	meta.CurrentModulePath = "example.com/app"
 
 	builtin := mk("", "", "append", "")
-	if !calleeIsStdOrBuiltin(meta, &builtin) {
+	if !calleeIsBuiltin(meta, &builtin) {
 		t.Error("append should be reported as builtin")
+	}
+	// Stdlib calls are NOT builtins: they stay in the trace as leaves so the
+	// handler subtree (and its metrics) is complete.
+	stdlib := mk("net/url", "Values", "Get", "")
+	if calleeIsBuiltin(meta, &stdlib) {
+		t.Error("net/url Values.Get must not be filtered as builtin")
 	}
 
 	cases := []struct {


### PR DESCRIPTION
Reported as "why can't I see `r.URL.Query().Get(\"user_id\")` in the tracker-tree graph view": the handler-scoped insight trace filtered out **every standard-library callee**, so those nodes never appeared — and because the endpoint metrics (reachable, fanout, call paths, grade) are computed from that same subtree, they silently understated it. The whole point of a handler-scoped view is that nothing in the subtree is missed.

## Change

`calleeIsStdOrBuiltin` → `calleeIsBuiltin`: only true Go builtins (`len`, `append`, `make`, …) are filtered. Stdlib callees join the trace as **natural leaves** (their bodies aren't analyzed, so they have no outgoing edges), carrying `Origin: "standard"` — which the UI's origin palette already styles (muted). Applied to all three walkers (tracker subtree, resolved call graph, raw handler BFS) so `tracker` and `callgraph` trace sources stay consistent.

## Verification

End-to-end through the apispecui insight API on a probe handler containing exactly the reported pattern:

before: trace shows only project nodes — no `Query`, no `Get`, no `WriteHeader`
after: `*URL.Query`, `Values.Get`, `ResponseWriter.WriteHeader` present as `standard`-origin leaves, `reachable: 4`

Full suite passes (no pinned metric expectations broke); lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Call-trace metrics and visualizations now retain standard-library calls instead of filtering them out.
  * Go built-in operations such as `append`, `len`, and `make` continue to be excluded from trace analysis.
  * Updated metrics improve accuracy for reachable nodes, fanout, and path counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->