### PR TITLE
test: pin known gaps — cli-action routes (#143), constructor status (#144)

### DIFF
--- a/generator/testdata_known_gaps_test.go
+++ b/generator/testdata_known_gaps_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ehabterra/apispec/spec"
+)
+
+// This file pins KNOWN GAPS: each test asserts today's (incomplete) output
+// so the gap is documented, reproducible, and fails LOUD the day the
+// capability lands — at which point the assertions must flip to the
+// commented expectations and the tracking issue closes.
+
+// TestTestdata_CLIActionRoutes pins issue #143: route registration reached
+// from main only through a function value stored in a composite-literal
+// field (`Command{Action: runWeb}`, the urfave/cli shape used by gitea) is
+// invisible — tracker roots are main functions and no static edge crosses
+// the dispatcher hop, even though the registration edges exist in metadata.
+//
+// When #143 lands, this fixture must document /users GET+POST and this test
+// must assert exactly that.
+func TestTestdata_CLIActionRoutes(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "cli_action_routes", nil)
+
+	if len(out.Paths) != 0 {
+		t.Errorf("cli_action_routes now documents %d paths (%v) — the #143 gap "+
+			"seems fixed: flip this test to assert /users GET+POST and close the issue",
+			len(out.Paths), mapPathKeys(out.Paths))
+	}
+}
+
+// TestTestdata_StatusViaConstructor pins issue #144: a status carried
+// through a constructor struct field (`e := NewAPIError(msg, 401);
+// RespondWithError(w, e)` → `w.WriteHeader(err.Code)`) is not resolved.
+// Parameter tracing and assignment tracing both exist; the missing link is
+// return-field ↔ constructor-parameter provenance. The response IS detected
+// with the right body schema — only its status falls into "default".
+//
+// When #144 lands, the 401 must appear as a real response (keeping the
+// APIError schema) and "default" must no longer carry this write.
+func TestTestdata_StatusViaConstructor(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "status_via_constructor", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+
+	item, ok := out.Paths["/profile"]
+	if !ok {
+		t.Fatalf("path /profile missing; have %v", mapPathKeys(out.Paths))
+	}
+	get := opFor(item, "GET")
+	if get == nil {
+		t.Fatal("GET /profile missing")
+	}
+
+	if _, ok := get.Responses["401"]; ok {
+		t.Errorf("GET /profile now resolves the 401 — the #144 gap seems fixed: " +
+			"flip this test to assert 401 (APIError schema) and close the issue")
+	}
+
+	// The parts that DO work today must not regress: the success body and
+	// the detected-but-unresolved error write with its correct schema.
+	if _, ok := get.Responses["200"]; !ok {
+		t.Errorf("GET /profile lost its 200 response: %v", keysOf(get.Responses))
+	}
+	def, ok := get.Responses["default"]
+	if !ok {
+		t.Fatalf("GET /profile lost the default (unresolved-status) response: %v", keysOf(get.Responses))
+	}
+	ref := ""
+	if mt, ok := def.Content["application/json"]; ok && mt.Schema != nil {
+		ref = mt.Schema.Ref
+	}
+	if !strings.HasSuffix(ref, "_APIError") {
+		t.Errorf("default response should carry the APIError schema, got %q", ref)
+	}
+}
+
+func keysOf[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/testdata/cli_action_routes/go.mod
+++ b/testdata/cli_action_routes/go.mod
@@ -1,0 +1,5 @@
+module github.com/ehabterra/apispec/testdata/cli_action_routes
+
+go 1.24.3
+
+require github.com/go-chi/chi/v5 v5.2.2

--- a/testdata/cli_action_routes/go.sum
+++ b/testdata/cli_action_routes/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=
+github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=

--- a/testdata/cli_action_routes/main.go
+++ b/testdata/cli_action_routes/main.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// This fixture mirrors the urfave/cli wiring style (gitea, many CLIs):
+// route registration is reachable from main ONLY through a function value
+// stored in a composite-literal field, invoked by a dispatcher. Static
+// call-graph tracing stops at app.Run — there is no direct call edge from
+// main's subtree to runWeb.
+
+// Command mirrors cli.Command: the handler wiring hides in Action.
+type Command struct {
+	Name   string
+	Action func() error
+}
+
+// App mirrors cli.App.
+type App struct {
+	Commands []*Command
+}
+
+// Run dispatches to the named command's Action — the dynamic hop.
+func (a *App) Run(name string) error {
+	for _, c := range a.Commands {
+		if c.Name == name {
+			return c.Action()
+		}
+	}
+	return nil
+}
+
+// User is the API resource.
+type User struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+func listUsers(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode([]User{})
+}
+
+func createUser(w http.ResponseWriter, r *http.Request) {
+	var u User
+	_ = json.NewDecoder(r.Body).Decode(&u)
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(u)
+}
+
+// runWeb registers the routes — plain chi, no wrapper router, so the ONLY
+// obstacle between main and these registrations is the Action field hop.
+func runWeb() error {
+	r := chi.NewRouter()
+	r.Get("/users", listUsers)
+	r.Post("/users", createUser)
+	return http.ListenAndServe(":8080", r)
+}
+
+func main() {
+	app := &App{Commands: []*Command{{Name: "web", Action: runWeb}}}
+	_ = app.Run("web")
+}

--- a/testdata/status_via_constructor/go.mod
+++ b/testdata/status_via_constructor/go.mod
@@ -1,0 +1,3 @@
+module github.com/ehabterra/apispec/testdata/status_via_constructor
+
+go 1.24.3

--- a/testdata/status_via_constructor/main.go
+++ b/testdata/status_via_constructor/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// This fixture pins the "status through a constructor field" shape common
+// in error-helper packages:
+//
+//	e := NewAPIError("missing token", http.StatusUnauthorized)
+//	RespondWithError(w, e)          // does w.WriteHeader(err.Code)
+//
+// Resolving the 401 requires following err.Code (a selector on a parameter)
+// back through the caller's argument, the assignment from the constructor
+// call, and the constructor's composite-literal field Code: code — the last
+// hop (return-field ↔ constructor-parameter provenance) is the missing link.
+
+// APIError is the error body every failure path encodes.
+type APIError struct {
+	Message string `json:"message"`
+	Code    int    `json:"code"`
+}
+
+// NewAPIError is the constructor carrying the status into a struct field.
+func NewAPIError(message string, code int) *APIError {
+	return &APIError{Message: message, Code: code}
+}
+
+// RespondWithError writes the error with its embedded status.
+func RespondWithError(w http.ResponseWriter, err *APIError) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(err.Code)
+	_ = json.NewEncoder(w).Encode(err)
+}
+
+// Profile is the success body.
+type Profile struct {
+	Email string `json:"email"`
+}
+
+func getProfile(w http.ResponseWriter, r *http.Request) {
+	if r.Header.Get("X-Token") == "" {
+		e := NewAPIError("missing token", http.StatusUnauthorized)
+		RespondWithError(w, e)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(Profile{Email: "a@b.c"})
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /profile", getProfile)
+	_ = http.ListenAndServe(":8080", mux)
+}


### PR DESCRIPTION
Two fixtures reduced from this week's real-project investigations, each with a structural test that **asserts today's incomplete output**. The pattern: the gap stays documented and reproducible, the working parts are protected against regression, and the day either capability lands the pin fails loudly with instructions to flip the expectations and close the issue.

## `testdata/cli_action_routes` → #143

The urfave/cli shape that makes gitea produce **0 routes**: plain chi registrations reached from `main` only through `Command{Action: runWeb}` + a dispatcher method. The metadata records the registration edges; the tracker tree (rooted at `main` functions) never crosses the composite-literal function-field hop. Test pins `0 paths`.

## `testdata/status_via_constructor` → #144

The error-helper shape (`e := NewAPIError(msg, http.StatusUnauthorized); RespondWithError(w, e)` → `w.WriteHeader(err.Code)`). Test pins: `200` present, **no `401`**, and — protecting what already works — the `default` response *must* carry the `APIError` schema (the body resolves today; only the status is unresolved, because return-field ↔ constructor-parameter provenance is the single missing link, detailed in the issue).

Full suite passes; both fixtures build; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)