### PR TITLE
fix(tracker): don't drop receiver routes on same-name middleware variable collision (#146)

### DIFF
--- a/generator/testdata_chi_middleware_recv_shadow_test.go
+++ b/generator/testdata_chi_middleware_recv_shadow_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/spec"
+)
+
+// TestTestdata_ChiMiddlewareRecvShadow guards the lazy-tracker regression where
+// a middleware that reassigns the request variable `r` (the canonical
+// `r = r.WithContext(ctx)` idiom) collided with the `r chi.Router` receiver at
+// the registration site. The callee-body `r` leaked into the caller-scope call
+// edge's AssignmentMap, and the tracker claimed the router's own receiver
+// registrations (a direct r.Get, a nested r.Group subtree) onto the middleware
+// producer — dropping them or re-homing them under the wrong path prefix
+// (e.g. /api/v1/tenant surfaced as /api/v1/auth/tenant). Every route must
+// appear at its correct path.
+func TestTestdata_ChiMiddlewareRecvShadow(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "chi_middleware_recv_shadow", spec.DefaultChiConfig())
+	noDanglingRefs(t, out)
+	noUnresolvedPlaceholders(t, out)
+
+	want := map[string][]string{
+		// Receiver-registered routes in the closure that installs the
+		// r-reassigning middleware — these regressed.
+		"/api/v1/tenant": {"GET"},
+		"/api/v1/users/": {"GET", "POST"}, // nested r.Group subtree
+		// Routes that always resolved (argument-passed helpers, sibling mounts).
+		"/api/v1/caps":          {"GET"},
+		"/api/v1/workflows":     {"GET"},
+		"/api/v1/notifications": {"GET"},
+		"/api/v1/auth/login":    {"POST"},
+		"/api/v1/auth/me":       {"GET"},
+	}
+	for path, methods := range want {
+		item, ok := out.Paths[path]
+		if !ok {
+			t.Errorf("path %q missing; have %v", path, mapPathKeys(out.Paths))
+			continue
+		}
+		for _, m := range methods {
+			if opFor(item, m) == nil {
+				t.Errorf("%s %s: expected operation, missing", m, path)
+			}
+		}
+	}
+
+	// The regression re-homed the receiver routes under the sibling mount's
+	// /auth prefix. Assert those wrong paths never appear.
+	for _, wrong := range []string{"/api/v1/auth/tenant", "/api/v1/auth/users/"} {
+		if _, ok := out.Paths[wrong]; ok {
+			t.Errorf("mis-prefixed path %q present — receiver-registration claim leaked", wrong)
+		}
+	}
+}

--- a/internal/spec/lazytree.go
+++ b/internal/spec/lazytree.go
@@ -248,6 +248,20 @@ func (t *LazyTree) buildRelations() {
 		}] = producerKey
 		// Claiming uses the exact-caller key: the assignment's producing edge
 		// carries the full identity of the function the assignment lives in.
+		//
+		// Guard against a cross-scope name collision: a callee's internal
+		// reassignment of a same-named variable (the canonical middleware
+		// `r = r.WithContext(ctx)`, where `r` is a *http.Request) is recorded
+		// in the call edge's AssignmentMap, so the link's Edge.Caller is the
+		// *caller's* scope (which may have its own `r`, e.g. a chi.Router
+		// receiver) while the assignment actually lives in the callee. Claiming
+		// then would steal the caller's receiver route registrations (r.Get,
+		// r.Group) onto the callee's producer, where they are never re-emitted
+		// — dropping those routes. The assignment must genuinely live in the
+		// scope whose receiver calls we claim.
+		if getString(meta, rel.Assignment.Func) != getString(meta, rel.Edge.Caller.Name) {
+			continue
+		}
 		edges := edgesByRecvVar[recvEdgeKey(getString(meta, rel.Assignment.VariableName), &rel.Edge.Caller)]
 		if len(edges) == 0 {
 			continue

--- a/testdata/chi_middleware_recv_shadow/go.mod
+++ b/testdata/chi_middleware_recv_shadow/go.mod
@@ -1,0 +1,5 @@
+module github.com/ehabterra/apispec/testdata/chi_middleware_recv_shadow
+
+go 1.24.3
+
+require github.com/go-chi/chi/v5 v5.2.2

--- a/testdata/chi_middleware_recv_shadow/go.sum
+++ b/testdata/chi_middleware_recv_shadow/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=
+github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=

--- a/testdata/chi_middleware_recv_shadow/main.go
+++ b/testdata/chi_middleware_recv_shadow/main.go
@@ -1,0 +1,138 @@
+// Fixture: a chi router whose audit middleware reassigns the request variable
+// `r` (the canonical `r = r.WithContext(ctx)` idiom), shadowing the same name
+// used for the `r chi.Router` receiver at the registration site. This pins the
+// lazy-tracker regression where that cross-scope name collision made the
+// router's own receiver registrations — a direct r.Get, and a whole nested
+// r.Group subtree — get claimed onto the middleware producer and dropped from
+// the spec, while argument-passed mount helpers (mountUsers(r)) survived.
+//
+// The middleware is installed via r.Use(auditGuard(reporter())) — a CALL whose
+// returned closure carries the reassignment — because that is what records the
+// callee-body `r` in the caller-scope call edge's AssignmentMap and triggers
+// the mis-claim. Every route below must appear in the generated spec.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type Tenant struct {
+	ID string `json:"id"`
+}
+
+type User struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type Cap struct {
+	Name string `json:"name"`
+}
+
+// auditGuard returns a middleware whose handler reassigns `r`.
+func auditGuard(report func(method, path string)) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			r = r.WithContext(r.Context())
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func reporter() func(method, path string) {
+	return func(method, path string) {}
+}
+
+func plainMW(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(w, r)
+	})
+}
+
+func tenantHandler(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode(Tenant{})
+}
+
+type userHandler struct{}
+
+func (h *userHandler) list(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode([]User{})
+}
+
+func (h *userHandler) create(w http.ResponseWriter, r *http.Request) {
+	var u User
+	_ = json.NewDecoder(r.Body).Decode(&u)
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(u)
+}
+
+type capHandler struct{}
+
+func (h *capHandler) caps(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode([]Cap{})
+}
+
+// mountUsers registers on a router passed as an argument (this style always
+// survived); it is here so the fixture keeps both wiring styles side by side.
+func mountUsers(r chi.Router) {
+	h := &userHandler{}
+	r.Route("/users", func(r chi.Router) {
+		r.Get("/", h.list)
+		r.Post("/", h.create)
+	})
+}
+
+func mountCaps(r chi.Router) {
+	h := &capHandler{}
+	r.Get("/caps", h.caps)
+}
+
+func mountAuth(r chi.Router) {
+	h := &capHandler{}
+	r.Route("/auth", func(r chi.Router) {
+		r.Post("/login", h.caps)
+		r.Group(func(r chi.Router) {
+			r.Use(auditGuard(reporter()))
+			r.Get("/me", h.caps)
+		})
+	})
+}
+
+func mountWorkflow(r chi.Router) {
+	h := &capHandler{}
+	r.Get("/workflows", h.caps)
+}
+
+func mountNotify(r chi.Router) {
+	h := &capHandler{}
+	r.Get("/notifications", h.caps)
+}
+
+func main() {
+	r := chi.NewRouter()
+	r.Route("/api/v1", func(r chi.Router) {
+		r.Group(func(r chi.Router) {
+			r.Use(plainMW)
+			r.Use(auditGuard(reporter()))
+
+			// Direct receiver registration in the closure that installs the
+			// r-reassigning middleware — this regressed.
+			r.Get("/tenant", tenantHandler)
+
+			mountAuth(r)
+			mountWorkflow(r)
+			mountNotify(r)
+			mountCaps(r)
+
+			// Nested group whose whole subtree also regressed.
+			r.Group(func(r chi.Router) {
+				r.Use(plainMW)
+				mountUsers(r)
+			})
+		})
+	})
+	_ = http.ListenAndServe(":8080", r)
+}


### PR DESCRIPTION
## Summary

Fixes #146 — a v0.5.0 release blocker. The default lazy tracker dropped (or mis-prefixed) routes registered directly on a router receiver variable (`r.Get`, nested `r.Group`) when a middleware installed in the same closure reassigned an identically-named variable. This is the canonical `r = r.WithContext(ctx)` middleware idiom, where the inner `r` is a `*http.Request` colliding with the `r chi.Router` receiver at the registration site.

On a real chi app this lost roughly **half** the routes (22 of 50 ops vs 43 with `--legacy-tracker`). The eager tracker was never affected; the regression surfaced when `LazyTree` became the default after v0.4.0.

## Root cause

1. The middleware body's `r = r.WithContext(ctx)` is recorded in the `r.Use(mw(...))` call edge's `AssignmentMap` (built from the callee body).
2. `Metadata.BuildAssignmentRelationships` pairs that callee-body assignment (`ConcreteType: *net/http.Request`) with the **caller's** `r chi.Router` — same name, different scope.
3. `LazyTree.buildRelations` then **claims** the caller's receiver registrations onto the middleware producer node, where they are re-homed under the wrong path prefix or dropped.

## Fix

Gate the assignment-claim on the assignment genuinely living in the edge's caller scope (`rel.Assignment.Func == rel.Edge.Caller.Name`), which rejects the cross-scope name collision. One guard, in `internal/spec/lazytree.go` `buildRelations`.

## Validation

- New fixture `testdata/chi_middleware_recv_shadow` + `TestTestdata_ChiMiddlewareRecvShadow` — **fails pre-fix** (routes appear as `/api/v1/auth/tenant` / `/api/v1/auth/users/` or missing), passes with the fix.
- Full `go test ./...`: 0 failures (metadata goldens are byte-compared → zero drift).
- `gofmt`, `go vet`, `golangci-lint` clean.
- A/B on a 245-path real project: **byte-identical** output old vs fixed; timing unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)