### PR TITLE
test(tracker): reproducing end-to-end fixture for the #146 receiver-claim fix

### DIFF
--- a/generator/testdata_chi_middleware_recv_shadow_test.go
+++ b/generator/testdata_chi_middleware_recv_shadow_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/spec"
+)
+
+// TestTestdata_ChiMiddlewareRecvShadow guards the lazy-tracker regression where
+// a middleware that reassigns the request variable `r` (the canonical
+// `r = r.WithContext(ctx)` idiom) collided with the `r chi.Router` receiver at
+// the registration site. The callee-body `r` leaked into the caller-scope call
+// edge's AssignmentMap, and the tracker claimed the router's own receiver
+// registrations (a direct r.Get, a nested r.Group subtree) onto the middleware
+// producer — dropping them or re-homing them under the wrong path prefix
+// (e.g. /api/v1/tenant surfaced as /api/v1/auth/tenant). Every route must
+// appear at its correct path.
+func TestTestdata_ChiMiddlewareRecvShadow(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "chi_middleware_recv_shadow", spec.DefaultChiConfig())
+	noDanglingRefs(t, out)
+	noUnresolvedPlaceholders(t, out)
+
+	want := map[string][]string{
+		// Receiver-registered routes in the closure that installs the
+		// r-reassigning middleware — these regressed.
+		"/api/v1/tenant": {"GET"},
+		"/api/v1/users/": {"GET", "POST"}, // nested r.Group subtree
+		// Routes that always resolved (argument-passed helpers, sibling mounts).
+		"/api/v1/caps":          {"GET"},
+		"/api/v1/workflows":     {"GET"},
+		"/api/v1/notifications": {"GET"},
+		"/api/v1/auth/login":    {"POST"},
+		"/api/v1/auth/me":       {"GET"},
+	}
+	for path, methods := range want {
+		item, ok := out.Paths[path]
+		if !ok {
+			t.Errorf("path %q missing; have %v", path, mapPathKeys(out.Paths))
+			continue
+		}
+		for _, m := range methods {
+			if opFor(item, m) == nil {
+				t.Errorf("%s %s: expected operation, missing", m, path)
+			}
+		}
+	}
+
+	// The regression re-homed the receiver routes under the sibling mount's
+	// /auth prefix. Assert those wrong paths never appear.
+	for _, wrong := range []string{"/api/v1/auth/tenant", "/api/v1/auth/users/"} {
+		if _, ok := out.Paths[wrong]; ok {
+			t.Errorf("mis-prefixed path %q present — receiver-registration claim leaked", wrong)
+		}
+	}
+}

--- a/generator/testdata_chi_receiver_name_collision_test.go
+++ b/generator/testdata_chi_receiver_name_collision_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/spec"
+)
+
+func TestTestdata_ChiReceiverNameCollision(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "chi_receiver_name_collision", spec.DefaultChiConfig())
+	noDanglingRefs(t, out)
+	noUnresolvedPlaceholders(t, out)
+
+	for _, path := range []string{
+		"/api/v1/tenant",
+		"/api/v1/capabilities",
+		"/api/v1/users",
+	} {
+		item, ok := out.Paths[path]
+		if !ok {
+			t.Errorf("path %q missing; have %v", path, mapPathKeys(out.Paths))
+			continue
+		}
+		if opFor(item, "GET") == nil {
+			t.Errorf("GET %s: expected operation, missing", path)
+		}
+	}
+}

--- a/internal/spec/lazytree.go
+++ b/internal/spec/lazytree.go
@@ -246,8 +246,12 @@ func (t *LazyTree) buildRelations() {
 			pkg:  getString(meta, rel.Assignment.Pkg),
 			fn:   getString(meta, rel.Assignment.Func),
 		}] = producerKey
-		// Claiming uses the exact-caller key: the assignment's producing edge
-		// carries the full identity of the function the assignment lives in.
+		// Claim receiver calls only when the assignment lives in the producing
+		// edge's caller. Callee-body assignments can leak through AssignmentMap;
+		// matching them by variable name would steal unrelated caller-scope edges.
+		if getString(meta, rel.Assignment.Func) != getString(meta, rel.Edge.Caller.Name) {
+			continue
+		}
 		edges := edgesByRecvVar[recvEdgeKey(getString(meta, rel.Assignment.VariableName), &rel.Edge.Caller)]
 		if len(edges) == 0 {
 			continue

--- a/internal/spec/lazytree_relations_test.go
+++ b/internal/spec/lazytree_relations_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+func TestLazyTreeBuildRelationsScopesReceiverClaimsToAssignmentFunction(t *testing.T) {
+	pool := metadata.NewStringPool()
+	meta := &metadata.Metadata{StringPool: pool}
+	pkg := pool.Get("example")
+	routesFunc := pool.Get("routes.func1")
+	middlewareFunc := pool.Get("middleware.func1")
+
+	call := func(name string, position string) metadata.Call {
+		return metadata.Call{
+			Meta:     meta,
+			Name:     pool.Get(name),
+			Pkg:      pkg,
+			Position: pool.Get(position),
+		}
+	}
+	assignment := func(variable string, function int, concreteType string) metadata.Assignment {
+		return metadata.Assignment{
+			VariableName: pool.Get(variable),
+			Pkg:          pkg,
+			ConcreteType: pool.Get(concreteType),
+			Func:         function,
+		}
+	}
+
+	meta.CallGraph = []metadata.CallGraphEdge{
+		{
+			Caller: call("routes.func1", "1"),
+			Callee: call("middleware", "2"),
+			AssignmentMap: map[string][]metadata.Assignment{
+				"r": {assignment("r", middlewareFunc, "*net/http.Request")},
+			},
+		},
+		{
+			Caller:        call("routes.func1", "3"),
+			Callee:        call("Get", "4"),
+			CalleeVarName: "r",
+		},
+		{
+			Caller: call("routes.func1", "5"),
+			Callee: call("Group", "6"),
+			AssignmentMap: map[string][]metadata.Assignment{
+				"g": {assignment("g", routesFunc, "chi.Router")},
+			},
+		},
+		{
+			Caller:        call("routes.func1", "7"),
+			Callee:        call("Get", "8"),
+			CalleeVarName: "g",
+		},
+	}
+	meta.BuildCallGraphMaps()
+
+	tree := &LazyTree{meta: meta}
+	tree.buildRelations()
+
+	if tree.claimed[&meta.CallGraph[1]] {
+		t.Fatal("cross-scope middleware assignment claimed the router receiver edge")
+	}
+	if !tree.claimed[&meta.CallGraph[3]] {
+		t.Fatal("same-scope group assignment did not claim its receiver edge")
+	}
+}

--- a/testdata/chi_middleware_recv_shadow/go.mod
+++ b/testdata/chi_middleware_recv_shadow/go.mod
@@ -1,0 +1,5 @@
+module github.com/ehabterra/apispec/testdata/chi_middleware_recv_shadow
+
+go 1.24.3
+
+require github.com/go-chi/chi/v5 v5.2.2

--- a/testdata/chi_middleware_recv_shadow/go.sum
+++ b/testdata/chi_middleware_recv_shadow/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=
+github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=

--- a/testdata/chi_middleware_recv_shadow/main.go
+++ b/testdata/chi_middleware_recv_shadow/main.go
@@ -1,0 +1,138 @@
+// Fixture: a chi router whose audit middleware reassigns the request variable
+// `r` (the canonical `r = r.WithContext(ctx)` idiom), shadowing the same name
+// used for the `r chi.Router` receiver at the registration site. This pins the
+// lazy-tracker regression where that cross-scope name collision made the
+// router's own receiver registrations — a direct r.Get, and a whole nested
+// r.Group subtree — get claimed onto the middleware producer and dropped from
+// the spec, while argument-passed mount helpers (mountUsers(r)) survived.
+//
+// The middleware is installed via r.Use(auditGuard(reporter())) — a CALL whose
+// returned closure carries the reassignment — because that is what records the
+// callee-body `r` in the caller-scope call edge's AssignmentMap and triggers
+// the mis-claim. Every route below must appear in the generated spec.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type Tenant struct {
+	ID string `json:"id"`
+}
+
+type User struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type Cap struct {
+	Name string `json:"name"`
+}
+
+// auditGuard returns a middleware whose handler reassigns `r`.
+func auditGuard(report func(method, path string)) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			r = r.WithContext(r.Context())
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func reporter() func(method, path string) {
+	return func(method, path string) {}
+}
+
+func plainMW(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(w, r)
+	})
+}
+
+func tenantHandler(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode(Tenant{})
+}
+
+type userHandler struct{}
+
+func (h *userHandler) list(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode([]User{})
+}
+
+func (h *userHandler) create(w http.ResponseWriter, r *http.Request) {
+	var u User
+	_ = json.NewDecoder(r.Body).Decode(&u)
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(u)
+}
+
+type capHandler struct{}
+
+func (h *capHandler) caps(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode([]Cap{})
+}
+
+// mountUsers registers on a router passed as an argument (this style always
+// survived); it is here so the fixture keeps both wiring styles side by side.
+func mountUsers(r chi.Router) {
+	h := &userHandler{}
+	r.Route("/users", func(r chi.Router) {
+		r.Get("/", h.list)
+		r.Post("/", h.create)
+	})
+}
+
+func mountCaps(r chi.Router) {
+	h := &capHandler{}
+	r.Get("/caps", h.caps)
+}
+
+func mountAuth(r chi.Router) {
+	h := &capHandler{}
+	r.Route("/auth", func(r chi.Router) {
+		r.Post("/login", h.caps)
+		r.Group(func(r chi.Router) {
+			r.Use(auditGuard(reporter()))
+			r.Get("/me", h.caps)
+		})
+	})
+}
+
+func mountWorkflow(r chi.Router) {
+	h := &capHandler{}
+	r.Get("/workflows", h.caps)
+}
+
+func mountNotify(r chi.Router) {
+	h := &capHandler{}
+	r.Get("/notifications", h.caps)
+}
+
+func main() {
+	r := chi.NewRouter()
+	r.Route("/api/v1", func(r chi.Router) {
+		r.Group(func(r chi.Router) {
+			r.Use(plainMW)
+			r.Use(auditGuard(reporter()))
+
+			// Direct receiver registration in the closure that installs the
+			// r-reassigning middleware — this regressed.
+			r.Get("/tenant", tenantHandler)
+
+			mountAuth(r)
+			mountWorkflow(r)
+			mountNotify(r)
+			mountCaps(r)
+
+			// Nested group whose whole subtree also regressed.
+			r.Group(func(r chi.Router) {
+				r.Use(plainMW)
+				mountUsers(r)
+			})
+		})
+	})
+	_ = http.ListenAndServe(":8080", r)
+}

--- a/testdata/chi_receiver_name_collision/go.mod
+++ b/testdata/chi_receiver_name_collision/go.mod
@@ -1,0 +1,5 @@
+module github.com/ehabterra/apispec/testdata/chi_receiver_name_collision
+
+go 1.24.3
+
+require github.com/go-chi/chi/v5 v5.2.2

--- a/testdata/chi_receiver_name_collision/go.sum
+++ b/testdata/chi_receiver_name_collision/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=
+github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=

--- a/testdata/chi_receiver_name_collision/main.go
+++ b/testdata/chi_receiver_name_collision/main.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func requestContext(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r = r.WithContext(r.Context())
+		next.ServeHTTP(w, r)
+	})
+}
+
+func routes() http.Handler {
+	r := chi.NewRouter()
+	r.Route("/api/v1", func(r chi.Router) {
+		r.Group(func(r chi.Router) {
+			r.Use(requestContext)
+			r.Get("/tenant", tenantHandler)
+			mountCapabilities(r)
+			r.Group(func(r chi.Router) {
+				r.Use(requestContext)
+				mountUsers(r)
+			})
+		})
+	})
+	return r
+}
+
+func mountCapabilities(r chi.Router) {
+	r.Get("/capabilities", capabilitiesHandler)
+}
+
+func mountUsers(r chi.Router) {
+	r.Get("/users", usersHandler)
+}
+
+func tenantHandler(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func capabilitiesHandler(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func usersHandler(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func main() {
+	http.ListenAndServe(":8080", routes())
+}


### PR DESCRIPTION
## Summary

Adds a fixture that **actually reproduces #146 end-to-end**, strengthening the coverage of the fix in #147.

Stacks on **#147** — it contains that fix's commit until #147 merges, after which this reduces to just the fixture. Merge **after** #147.

## Why

#147's fixture (`chi_receiver_name_collision`) does not reproduce the drop: it installs the middleware as a bare func value (`r.Use(requestContext)`), which is too shallow to trigger the mis-claim, so its structural test passes **even without the fix**. #147's unit test guards the fix at the claim-map level, but nothing guards the full pipeline.

`chi_middleware_recv_shadow` closes that gap: it installs the `r`-reassigning middleware as a **call** (`r.Use(auditGuard(reporter()))`) with enough nested-group density that, without the guard, `/api/v1/tenant` and the nested users subtree drop — or surface mis-prefixed as `/api/v1/auth/tenant`. `TestTestdata_ChiMiddlewareRecvShadow` asserts every route at its correct path and **fails on the pre-fix code** (verified by removing the guard).

## Validation

- Passes on #147's base; fails with the guard removed (real regression guard).
- Full `go test ./...` green; zero golden drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)