### PR TITLE
feat(spec): resolve response status through nested response helpers (#144 follow-up)

### DIFF
--- a/generator/testdata_status_via_helper_chain_test.go
+++ b/generator/testdata_status_via_helper_chain_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/ehabterra/apispec/spec"
+)
+
+// TestTestdata_StatusViaHelperChain covers status codes threaded through nested
+// response helpers: respondError(w, http.StatusX, ...) -> respondJSON(w, status,
+// ...) -> w.WriteHeader(status). The status is a parameter across two (and, via
+// the shared writeError mapper, three) hops, so a single-hop parent lookup left
+// every error at "default"; multi-hop parameter resolution recovers the real
+// codes. Every branch's status must appear and none may fall into "default".
+func TestTestdata_StatusViaHelperChain(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "status_via_helper_chain", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+
+	item, ok := out.Paths["/widget"]
+	if !ok {
+		t.Fatalf("path /widget missing; have %v", mapPathKeys(out.Paths))
+	}
+	get := opFor(item, "GET")
+	if get == nil {
+		t.Fatal("GET /widget missing")
+	}
+
+	got := keysOf(get.Responses)
+	sort.Strings(got)
+	// 401/400 resolve through two helper hops; 404/403/500 through the shared
+	// writeError mapper (three hops); 200 through the single respondJSON hop.
+	for _, want := range []string{"200", "400", "401", "403", "404", "500"} {
+		if _, ok := get.Responses[want]; !ok {
+			t.Errorf("GET /widget missing status %s; have %v", want, got)
+		}
+	}
+	if _, ok := get.Responses["default"]; ok {
+		t.Errorf("GET /widget still has an unresolved default response; have %v", got)
+	}
+}

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -2057,12 +2057,17 @@ func (r *ResponsePatternMatcherImpl) ExtractResponse(node TrackerNodeInterface, 
 		if status, ok := r.schemaMapper.MapStatusCode(statusStr); ok {
 			statusResolved = true
 			respInfo.StatusCode = status
-		} else if callerArg := r.traceArgViaParent(statusArg, node); callerArg != nil {
-			// The status arg is a parameter of the enclosing function
-			// (e.g. WriteHeader(status) inside writeJSON(w, status, v)).
-			// Walk up to the caller's call site and read the actual value.
-			// Per-route tracker tree isolates each handler's path, so the
-			// status pairs correctly with the body resolved below.
+		} else if callerArg, _ := resolveArgThroughParams(statusArg, node); callerArg != statusArg {
+			// The status arg is a parameter threaded through one or more
+			// response helpers — e.g. WriteHeader(status) inside
+			// respondJSON(w, status, v), itself called from
+			// respondError(w, status, code, msg). Walk up EACH wrapper hop to
+			// the handler's actual literal; a single hop (the common
+			// writeJSON(w, status, v) shape) is just the one-iteration case.
+			// resolveArgThroughParams stops at the first non-parameter, so this
+			// is a strict superset of the single-hop lookup and never changes an
+			// already-resolved status. Per-route tracker isolation pairs each
+			// WriteHeader path with its handler's specific status.
 			callerStr := r.contextProvider.GetArgumentInfo(callerArg)
 			if status, ok := r.schemaMapper.MapStatusCode(callerStr); ok {
 				statusResolved = true

--- a/testdata/status_via_helper_chain/go.mod
+++ b/testdata/status_via_helper_chain/go.mod
@@ -1,0 +1,3 @@
+module github.com/ehabterra/apispec/testdata/status_via_helper_chain
+
+go 1.24.3

--- a/testdata/status_via_helper_chain/main.go
+++ b/testdata/status_via_helper_chain/main.go
@@ -1,0 +1,81 @@
+// Fixture: status codes threaded through a chain of response helpers. A handler
+// calls respondError(w, http.StatusX, ...) which forwards to
+// respondJSON(w, status, ...) which finally calls w.WriteHeader(status). The
+// status is a parameter across TWO hops, so a single-hop parent lookup leaves
+// every error at "default"; multi-hop parameter resolution recovers the real
+// codes. A shared error mapper (writeError) contributes its switch-branch
+// statuses to each caller (conservative but statically reachable).
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+)
+
+type errorBody struct {
+	Message string `json:"message"`
+}
+
+type Widget struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// respondJSON is the base writer — the only place WriteHeader is called.
+func respondJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if v != nil {
+		_ = json.NewEncoder(w).Encode(v)
+	}
+}
+
+// respondError forwards a status through to respondJSON (the second hop).
+func respondError(w http.ResponseWriter, status int, message string) {
+	respondJSON(w, status, errorBody{Message: message})
+}
+
+var (
+	errNotFound  = errors.New("not found")
+	errForbidden = errors.New("forbidden")
+)
+
+// writeError is a shared error→status mapper; each caller inherits every branch.
+func writeError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, errNotFound):
+		respondError(w, http.StatusNotFound, "not found")
+	case errors.Is(err, errForbidden):
+		respondError(w, http.StatusForbidden, "forbidden")
+	default:
+		respondError(w, http.StatusInternalServerError, "internal error")
+	}
+}
+
+func getWidget(w http.ResponseWriter, r *http.Request) {
+	if r.Header.Get("X-Token") == "" {
+		respondError(w, http.StatusUnauthorized, "no token") // 401 via 2 hops
+		return
+	}
+	if r.URL.Query().Get("id") == "" {
+		respondError(w, http.StatusBadRequest, "missing id") // 400 via 2 hops
+		return
+	}
+	widget, err := load(r)
+	if err != nil {
+		writeError(w, err) // 404 / 403 / 500 via 3 hops through the mapper
+		return
+	}
+	respondJSON(w, http.StatusOK, widget) // 200 via 1 hop
+}
+
+func load(r *http.Request) (Widget, error) {
+	return Widget{}, nil
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /widget", getWidget)
+	_ = http.ListenAndServe(":8080", mux)
+}


### PR DESCRIPTION
## Summary

Follow-up to #149 (merged). That PR resolved the constructor-field status shape; this handles the far more common **plain multi-helper** shape, which still collapsed to `default`:

```go
respondError(w, http.StatusBadRequest, code, msg)
  -> respondJSON(w, status, body)   // status is a parameter (2nd hop)
    -> w.WriteHeader(status)          // ...and here (final hop)
```

The status resolver walked only **one** parameter hop, so any handler reaching `WriteHeader` through two helpers (or three, via a shared error→status mapper) left every error at `default`. On a real chi API this was **23 of ~50 operations**.

## Fix

Swap the single-hop `traceArgViaParent` for the existing multi-hop `resolveArgThroughParams`. It stops at the first non-parameter, so it's a **strict superset** of the single hop and never changes an already-resolved status (the common `writeJSON(w, status, v)` shape is just the one-iteration case). Per-route tracker isolation pairs each `WriteHeader` path with its handler's specific status, so multi-branch handlers get one operation status per branch; a shared error mapper contributes its switch-branch statuses to each caller (conservative but statically reachable).

## Validation

- New fixture `status_via_helper_chain` + `TestTestdata_StatusViaHelperChain` — **fails pre-change** (only `[200, default]`), asserts `200/400/401/403/404/500` with no `default`.
- Full `go test ./...`: 0 failures, **zero golden drift**.
- `gofmt`/`vet`/`golangci-lint` clean.
- A/B on a 245-path real project: **byte-identical** (it resolves status in ≤1 hop, so it's unaffected — confirms the strict-superset property).
- The motivating chi API: **23 `default` responses → 0**, each verified against its handler's branches (e.g. `GET /auth/me` → `200/401/500`; `POST /auth/login` → `200/400/401/403/429/500`, matching its `writeAuthError` switch exactly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP response status detection when status values are passed through multiple helper or wrapper layers.
  * Correctly resolves status responses including 200, 400, 401, 403, 404, and 500.
  * Prevents unresolved default responses from appearing when a specific status code can be determined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->