### PR TITLE
fix(spec): resolve request body through a variable-receiver decoder wrapper

### DIFF
--- a/generator/testdata_request_body_var_decoder_test.go
+++ b/generator/testdata_request_body_var_decoder_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ehabterra/apispec/spec"
+)
+
+// TestTestdata_RequestBodyVarDecoder covers a request body decoded through a
+// helper that assigns the decoder to a local variable (dec := json.NewDecoder(
+// r.Body); dec.Decode(dst)). The intermediate variable re-homes dec.Decode
+// under the json.NewDecoder producer, so the wrapper's dst parameter could not
+// be traced to the caller's concrete request type — the body collapsed to a
+// generic object. It must resolve to a $ref instead.
+func TestTestdata_RequestBodyVarDecoder(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "request_body_var_decoder", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+	noUnresolvedPlaceholders(t, out)
+
+	cases := []struct {
+		path, method, wantSuffix string
+	}{
+		{"/users", "POST", "_CreateUserRequest"},
+		{"/users/{id}", "PUT", "_UpdateUserRequest"},
+	}
+	for _, c := range cases {
+		item, ok := out.Paths[c.path]
+		if !ok {
+			t.Errorf("path %q missing; have %v", c.path, mapPathKeys(out.Paths))
+			continue
+		}
+		op := opFor(item, c.method)
+		if op == nil {
+			t.Errorf("%s %s missing", c.method, c.path)
+			continue
+		}
+		if op.RequestBody == nil {
+			t.Errorf("%s %s: no requestBody", c.method, c.path)
+			continue
+		}
+		mt, ok := op.RequestBody.Content["application/json"]
+		if !ok || mt.Schema == nil {
+			t.Errorf("%s %s: no application/json schema", c.method, c.path)
+			continue
+		}
+		if !strings.HasSuffix(mt.Schema.Ref, c.wantSuffix) {
+			t.Errorf("%s %s: request body should $ref a schema ending %q, got ref=%q type=%q",
+				c.method, c.path, c.wantSuffix, mt.Schema.Ref, mt.Schema.Type)
+		}
+	}
+}

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -2246,26 +2246,50 @@ func (r *ResponsePatternMatcherImpl) traceArgViaParent(arg *metadata.CallArgumen
 	return argViaParent(arg, node)
 }
 
-// argViaParent walks one step up the tracker tree to recover the caller-site
-// value of a parameter ident. The parent tracker node represents the call into
-// the function the matched call lives in, and that edge's ParamArgMap maps
-// callee parameter names back to the caller's actual arguments. Returns nil
-// when the arg isn't an ident, there's no parent, or the name isn't a mapped
-// parameter. Shared by the response and request matchers.
+// argViaParent recovers the caller-site value of a parameter ident by finding
+// the call into the function the matched call lives in and reading that edge's
+// ParamArgMap (callee parameter name → caller argument). Returns nil when the
+// arg isn't an ident or no such binding exists. Shared by the response and
+// request matchers.
 func argViaParent(arg *metadata.CallArgument, node TrackerNodeInterface) *metadata.CallArgument {
 	if arg == nil || arg.GetKind() != metadata.KindIdent || node == nil {
 		return nil
 	}
-	parent := node.GetParent()
-	if parent == nil {
+	// Fast path: the immediate parent is normally the call into the enclosing
+	// function. Kept as-is so existing resolutions are byte-for-byte unchanged.
+	if parent := node.GetParent(); parent != nil {
+		if pe := parent.GetEdge(); pe != nil && pe.ParamArgMap != nil {
+			if callerArg, ok := pe.ParamArgMap[arg.GetName()]; ok {
+				return &callerArg
+			}
+		}
+	}
+	// Fallback: the node may be re-homed under a receiver-variable producer
+	// rather than under its call site — e.g. `dec := json.NewDecoder(r.Body);
+	// dec.Decode(dst)` parents Decode under NewDecoder, so the immediate parent
+	// is not the call into the enclosing wrapper and the wrapper's param (dst)
+	// never resolves. Walk ancestors for the edge whose callee IS the enclosing
+	// function and read its ParamArgMap. Mirrors concreteFromParamBinding.
+	edge := node.GetEdge()
+	if edge == nil {
 		return nil
 	}
-	parentEdge := parent.GetEdge()
-	if parentEdge == nil || parentEdge.ParamArgMap == nil {
+	enclosing := edge.Caller.BaseID()
+	if enclosing == "" {
 		return nil
 	}
-	if callerArg, ok := parentEdge.ParamArgMap[arg.GetName()]; ok {
-		return &callerArg
+	for p := node.GetParent(); p != nil; p = p.GetParent() {
+		pe := p.GetEdge()
+		if pe == nil || pe.Callee.BaseID() != enclosing {
+			continue
+		}
+		if pe.ParamArgMap == nil {
+			return nil
+		}
+		if callerArg, ok := pe.ParamArgMap[arg.GetName()]; ok {
+			return &callerArg
+		}
+		return nil
 	}
 	return nil
 }

--- a/testdata/request_body_var_decoder/go.mod
+++ b/testdata/request_body_var_decoder/go.mod
@@ -1,0 +1,3 @@
+module github.com/ehabterra/apispec/testdata/request_body_var_decoder
+
+go 1.24.3

--- a/testdata/request_body_var_decoder/main.go
+++ b/testdata/request_body_var_decoder/main.go
@@ -1,0 +1,61 @@
+// Fixture: request body decoded through a helper that assigns the decoder to a
+// local variable before calling Decode — the common
+//
+//	dec := json.NewDecoder(r.Body)
+//	dec.DisallowUnknownFields()
+//	dec.Decode(dst)
+//
+// shape (e.g. a project's decodeJSON(w, r, &req) wrapper). The intermediate
+// `dec` variable re-homes dec.Decode under the json.NewDecoder producer in the
+// tracker tree, so a single-hop parent lookup could not reach the wrapper's
+// `dst` parameter and the body collapsed to a generic object. The concrete
+// type must resolve through the wrapper to a $ref. An inline decoder (no
+// variable) already worked and is kept here as the control.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type CreateUserRequest struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+type UpdateUserRequest struct {
+	Name string `json:"name"`
+}
+
+// decodeJSON assigns the decoder to a variable (the regressed shape).
+func decodeJSON(w http.ResponseWriter, r *http.Request, dst any) error {
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	return dec.Decode(dst)
+}
+
+func createUser(w http.ResponseWriter, r *http.Request) {
+	var req CreateUserRequest
+	if err := decodeJSON(w, r, &req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+}
+
+func updateUser(w http.ResponseWriter, r *http.Request) {
+	var req UpdateUserRequest
+	if err := decodeJSON(w, r, &req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /users", createUser)
+	mux.HandleFunc("PUT /users/{id}", updateUser)
+	_ = http.ListenAndServe(":8080", mux)
+}


### PR DESCRIPTION
## Problem

A decode helper that assigns the decoder to a local before calling it — the common `decodeJSON(w, r, &req)` shape:

```go
func decodeJSON(w http.ResponseWriter, r *http.Request, dst any) error {
    r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
    dec := json.NewDecoder(r.Body)
    dec.DisallowUnknownFields()
    return dec.Decode(dst)
}
```

left the request body as a generic `object` instead of a `$ref` to the concrete request type. An **inline** decoder (`json.NewDecoder(r.Body).Decode(dst)`) already worked — which is why only *some* bodies resolved.

## Root cause

The intermediate `dec` variable re-homes `dec.Decode` under the `json.NewDecoder` producer node in the tracker tree (the LazyTree receiver-claiming mechanism). `argViaParent`'s single immediate-parent `ParamArgMap` lookup could therefore not reach the wrapper's `dst` parameter, so the concrete type was never traced back from the caller's `&req`.

## Fix

`argViaParent` keeps its immediate-parent fast path (every existing resolution is byte-for-byte unchanged) and adds a fallback: when the parent is *not* the call into the enclosing function, walk ancestors for the edge whose callee **is** the enclosing function and read its `ParamArgMap` — the same ancestor walk `concreteFromParamBinding` already uses for interface-typed parameters.

## Validation

- New fixture `testdata/request_body_var_decoder/` + `TestTestdata_RequestBodyVarDecoder` pin it (fails pre-fix with a generic `object`, passes with the fix).
- Full `go test ./...` passes with **zero golden drift**.
- A 245-path real project is **byte-identical** before/after (no regression, no perf change).
- On the motivating chi API, all 25 request bodies now resolve to a `$ref` (was 0 through this wrapper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #153