### PR TITLE
fix(spec): resolve constructor-field status through a handler-factory closure

### DIFF
--- a/generator/testdata_status_via_constructor_closure_test.go
+++ b/generator/testdata_status_via_constructor_closure_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ehabterra/apispec/spec"
+)
+
+// TestTestdata_StatusViaConstructorClosure covers the constructor-field status
+// shape (#144) when the handler is a closure returned by a METHOD (the
+// handler-factory pattern). The `e := NewAPIError(msg, 401)` assignment lives
+// in the closure but is recorded on the enclosing method's AssignmentMap, and
+// methods live in Type.Methods, not file.Functions — so resolving the status
+// requires walking the edge's ParentFunction into the method table. The
+// plain-function variant (status_via_constructor) already worked; this pins the
+// method-closure variant, which previously collapsed the 401 to "default".
+func TestTestdata_StatusViaConstructorClosure(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "status_via_constructor_closure", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+
+	item, ok := out.Paths["/profile"]
+	if !ok {
+		t.Fatalf("path /profile missing; have %v", mapPathKeys(out.Paths))
+	}
+	get := opFor(item, "GET")
+	if get == nil {
+		t.Fatal("GET /profile missing")
+	}
+
+	// The 401 resolves through the constructor field even though the handler is
+	// a method-returned closure, and carries the APIError schema.
+	resp401, ok := get.Responses["401"]
+	if !ok {
+		t.Fatalf("GET /profile should resolve the 401 through the method-closure constructor field; have %v", keysOf(get.Responses))
+	}
+	ref := ""
+	if mt, ok := resp401.Content["application/json"]; ok && mt.Schema != nil {
+		ref = mt.Schema.Ref
+	}
+	if !strings.HasSuffix(ref, "_APIError") {
+		t.Errorf("401 response should carry the APIError schema, got %q", ref)
+	}
+
+	if _, ok := get.Responses["200"]; !ok {
+		t.Errorf("GET /profile lost its 200 response: %v", keysOf(get.Responses))
+	}
+	if _, ok := get.Responses["default"]; ok {
+		t.Errorf("GET /profile still has an unresolved default response: %v", keysOf(get.Responses))
+	}
+}

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -1812,6 +1812,64 @@ func findFunctionByName(meta *metadata.Metadata, pkg, name string) *metadata.Fun
 	return nil
 }
 
+// callerAssignmentMap returns the variable→assignments map of the function or
+// method that lexically contains a call edge's call site, preferring the map
+// that actually records varName. A plain call resolves via its caller function.
+// A call inside a returned closure (the handler-factory shape — a method
+// returning func(w, r){…}) flattens into the tree with a FuncLit caller, but
+// ast.Inspect records the closure's `err := NewX(…, status)` assignment on the
+// *enclosing* declared function or method (via the edge's ParentFunction).
+// Enclosing methods live in Type.Methods keyed by receiver, not in
+// file.Functions, so findFunctionByName alone would miss them.
+func callerAssignmentMap(impl *ContextProviderImpl, edge *metadata.CallGraphEdge, varName string) map[string][]metadata.Assignment {
+	if fn := findFunctionByName(impl.meta, impl.GetString(edge.Caller.Pkg), impl.GetString(edge.Caller.Name)); fn != nil {
+		if len(fn.AssignmentMap[varName]) > 0 {
+			return fn.AssignmentMap
+		}
+	}
+	pf := edge.ParentFunction
+	if pf == nil {
+		return nil
+	}
+	if fn := findFunctionByName(impl.meta, impl.GetString(pf.Pkg), impl.GetString(pf.Name)); fn != nil {
+		if len(fn.AssignmentMap[varName]) > 0 {
+			return fn.AssignmentMap
+		}
+	}
+	return methodAssignmentMap(impl.meta, impl.GetString(pf.Pkg), impl.GetString(pf.RecvType), impl.GetString(pf.Name), varName)
+}
+
+// methodAssignmentMap finds the AssignmentMap of the method (pkg, receiver,
+// name) whose map records varName. Methods are stored per-Type; receiver and
+// name are matched exactly (the same receiver string findParentFunction records
+// on ParentFunction), so an enclosing method's closure assignments resolve.
+func methodAssignmentMap(meta *metadata.Metadata, pkg, recv, name, varName string) map[string][]metadata.Assignment {
+	if meta == nil || name == "" {
+		return nil
+	}
+	p, ok := meta.Packages[pkg]
+	if !ok {
+		return nil
+	}
+	for _, file := range p.Files {
+		for _, t := range file.Types {
+			for i := range t.Methods {
+				m := &t.Methods[i]
+				if meta.StringPool.GetString(m.Name) != name {
+					continue
+				}
+				if recv != "" && meta.StringPool.GetString(m.Receiver) != recv {
+					continue
+				}
+				if len(m.AssignmentMap[varName]) > 0 {
+					return m.AssignmentMap
+				}
+			}
+		}
+	}
+	return nil
+}
+
 // handlerReachesAccessor reports whether the route's handler transitively calls
 // the map-key accessor described by pattern. Reachability is a precomputed
 // summary (reachSet, one bottom-up pass over the SCC condensation) rather
@@ -2361,11 +2419,11 @@ func (r *ResponsePatternMatcherImpl) statusFromConstructorField(arg *metadata.Ca
 	}
 
 	// 2. That local's latest assignment, which must come from a constructor call.
-	fn := findFunctionByName(impl.meta, impl.GetString(callerEdge.Caller.Pkg), impl.GetString(callerEdge.Caller.Name))
-	if fn == nil {
+	assignMap := callerAssignmentMap(impl, callerEdge, baseVar.GetName())
+	if assignMap == nil {
 		return 0, false
 	}
-	assigns, ok := fn.AssignmentMap[baseVar.GetName()]
+	assigns, ok := assignMap[baseVar.GetName()]
 	if !ok || len(assigns) == 0 {
 		return 0, false
 	}

--- a/testdata/status_via_constructor_closure/go.mod
+++ b/testdata/status_via_constructor_closure/go.mod
@@ -1,0 +1,3 @@
+module github.com/ehabterra/apispec/testdata/status_via_constructor_closure
+
+go 1.24.3

--- a/testdata/status_via_constructor_closure/main.go
+++ b/testdata/status_via_constructor_closure/main.go
@@ -1,0 +1,70 @@
+// Fixture: status through a constructor field, where the handler is a closure
+// returned by a METHOD (the handler-factory shape common in clean-architecture
+// Go):
+//
+//	func (h *handler) Login() http.HandlerFunc {
+//	    return func(w, r) {
+//	        e := NewAPIError("missing token", http.StatusUnauthorized)
+//	        RespondWithError(w, e)          // w.WriteHeader(err.Code)
+//	    }
+//	}
+//
+// The `e := NewAPIError(...)` assignment lives inside the closure, but the
+// metadata records it on the *enclosing method's* AssignmentMap (ast.Inspect
+// descends into the literal). The status resolver used to look the assignment
+// up only via the FuncLit caller's function record — which doesn't exist for a
+// method — so the 401 collapsed to `default`. It must resolve through the
+// edge's ParentFunction, including methods (Type.Methods, not file.Functions).
+// The plain-function variant already worked (testdata/status_via_constructor);
+// this fixture pins the method-closure variant.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// APIError is the error body every failure path encodes.
+type APIError struct {
+	Message string `json:"message"`
+	Code    int    `json:"code"`
+}
+
+// NewAPIError is the constructor carrying the status into a struct field.
+func NewAPIError(message string, code int) *APIError {
+	return &APIError{Message: message, Code: code}
+}
+
+// RespondWithError writes the error with its embedded status.
+func RespondWithError(w http.ResponseWriter, err *APIError) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(err.Code)
+	_ = json.NewEncoder(w).Encode(err)
+}
+
+// Profile is the success body.
+type Profile struct {
+	Email string `json:"email"`
+}
+
+type handler struct{}
+
+// Login returns the actual handler as a closure (handler-factory).
+func (h *handler) Login() func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Token") == "" {
+			e := NewAPIError("missing token", http.StatusUnauthorized)
+			RespondWithError(w, e)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(Profile{Email: "a@b.c"})
+	}
+}
+
+func main() {
+	h := &handler{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /profile", h.Login())
+	_ = http.ListenAndServe(":8080", mux)
+}


### PR DESCRIPTION
## Problem

The #144 constructor-field status resolver — `RespondWithError(w, NewErr(msg, 401))` → `w.WriteHeader(err.Code)` — recovered the status for **plain-function** handlers but collapsed it to `default` when the handler was a **closure returned by a method** (the handler-factory shape idiomatic in clean-architecture Go):

```go
func (h *handler) Login() http.HandlerFunc {
    return func(w, r) {
        e := NewAPIError("missing token", http.StatusUnauthorized)
        RespondWithError(w, e)  // w.WriteHeader(err.Code)
    }
}
```

## Root cause

The `e := NewAPIError(...)` assignment lives in the closure, but `ast.Inspect` records it on the **enclosing method's** `AssignmentMap`. `statusFromConstructorField` looked the assignment up only via the FuncLit caller's function record (which doesn't exist), and even resolving the enclosing declared function wouldn't help — **methods live in `Type.Methods` keyed by receiver, not in `file.Functions`**, which `findFunctionByName` never searches. So the base variable's constructor assignment was never found and the status defaulted.

## Fix

New helper `callerAssignmentMap` resolves the assignment map of the function **or method** that lexically contains a call, preferring the map that actually records the variable: the direct caller → (for a flattened closure) the edge's `ParentFunction` as a declared function → as a method via `methodAssignmentMap` (matched by receiver + name, both carried on `ParentFunction`). The constructor call itself still lives under the FuncLit caller, so step 4 is unchanged.

**Additive by construction:** `callerAssignmentMap` returns the same map the old `findFunctionByName` path did whenever that path resolved, so no already-resolved status changes — it only converts former `default`s into concrete codes.

## Validation

- Fixture `testdata/status_via_constructor_closure/` + `TestTestdata_StatusViaConstructorClosure` pin it (the 401 was `default` pre-fix, resolves with the fix). Dependency-free (net/http).
- Full `go test ./...` passes with **zero golden drift**.
- A 245-path real project is **byte-identical** before/after.
- On a real chi API this recovers **26 previously-missing error statuses** (`400`s that were `default`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)