### PR TITLE
feat(apispecui): redesign the Insight Overview as a diagnostic cockpit

### DIFF
--- a/cmd/apispecui/assets/css/components.css
+++ b/cmd/apispecui/assets/css/components.css
@@ -1376,3 +1376,212 @@ h3 + .info {
   font-size: var(--fs-sm);
   height: auto;
 }
+
+/* ============================================================
+   Insight Overview redesign — alerts, resolution quality,
+   coverage meters, tree-insight stat blocks.
+   ============================================================ */
+
+.sec-head {
+  display: flex;
+  align-items: baseline;
+  gap: var(--sp-3);
+  margin: var(--sp-5) 0 var(--sp-3);
+}
+.sec-head .eyebrow {
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--faint);
+  font-weight: 600;
+}
+.sec-head h3 {
+  margin: 0;
+  font-size: var(--fs-lg);
+}
+.sec-head .note {
+  margin-left: auto;
+  color: var(--muted);
+  font-size: var(--fs-sm);
+}
+
+/* alert strip */
+.alert-strip {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+}
+.alert {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  padding: 10px var(--sp-3);
+  border: 1px solid var(--border);
+  border-left-width: 3px;
+  border-radius: var(--r-2);
+  background: var(--panel);
+}
+.alert.crit {
+  border-left-color: var(--danger);
+}
+.alert.warn {
+  border-left-color: var(--warn);
+}
+.alert.info {
+  border-left-color: var(--info);
+}
+.alert .a-sev {
+  font-size: var(--fs-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 2px 7px;
+  border-radius: var(--r-1);
+  flex: 0 0 auto;
+}
+.alert.crit .a-sev {
+  color: var(--danger);
+  background: var(--danger-bg);
+}
+.alert.warn .a-sev {
+  color: var(--warn);
+  background: var(--warn-bg);
+}
+.alert.info .a-sev {
+  color: var(--info);
+  background: var(--info-bg);
+}
+.alert .a-count {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  font-size: var(--fs-lg);
+  min-width: 26px;
+  text-align: right;
+  flex: 0 0 auto;
+}
+.alert .a-msg {
+  flex: 1;
+  min-width: 0;
+  font-size: var(--fs-sm);
+}
+.alert .a-msg b {
+  font-weight: 600;
+}
+.alert .a-msg .a-det {
+  color: var(--muted);
+}
+
+/* resolution segmented bar */
+.resbar {
+  display: flex;
+  height: 26px;
+  border-radius: var(--r-2);
+  overflow: hidden;
+  border: 1px solid var(--border);
+}
+.resbar > span {
+  display: block;
+  height: 100%;
+}
+.res-legend {
+  display: flex;
+  gap: var(--sp-4);
+  flex-wrap: wrap;
+  margin-top: var(--sp-3);
+  font-size: var(--fs-sm);
+}
+.res-legend .it {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--muted);
+}
+.res-legend .sw {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+}
+.res-legend b {
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+
+/* coverage meters */
+.meters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--sp-4);
+}
+.meter .mtop {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 6px;
+}
+.meter .mtop .mt {
+  font-size: var(--fs-sm);
+}
+.meter .mtop .mp {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+}
+.meter .mtrack {
+  position: relative;
+  height: 10px;
+  background: var(--panel-3);
+  border-radius: var(--r-pill);
+  overflow: hidden;
+}
+.meter .mfill {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  border-radius: var(--r-pill);
+}
+.meter .mfoot {
+  color: var(--faint);
+  font-size: var(--fs-xs);
+  margin-top: 5px;
+}
+
+/* mini quad stat (interface resolution) */
+.miniquad {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--sp-2);
+  margin-bottom: var(--sp-3);
+}
+.miniquad .q {
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-2);
+  padding: 8px 10px;
+}
+.miniquad .q .v {
+  font-size: var(--fs-lg);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+.miniquad .q .k {
+  color: var(--muted);
+  font-size: var(--fs-xs);
+}
+
+/* verb dispatch rows */
+.disp-list {
+  display: flex;
+  flex-direction: column;
+}
+.disp-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--sp-3);
+  padding: 7px 0;
+  border-top: 1px solid var(--border);
+  font-size: var(--fs-sm);
+}
+.disp-row:first-child {
+  border-top: 0;
+}

--- a/cmd/apispecui/assets/js/insight.js
+++ b/cmd/apispecui/assets/js/insight.js
@@ -10,25 +10,33 @@ import { Donut, Gauge, Info, TraceDiagram } from "/assets/js/components/charts.j
 
 function normalizeReport(d) {
   d = d || {};
-  for (const k of ["issues", "endpoints", "byMethod", "byStatus", "byContentType", "byTag", "topTypes"]) {
+  for (const k of ["issues", "endpoints", "byMethod", "byStatus", "byContentType", "byTag", "topTypes", "taxonomy", "verbDispatch"]) {
     if (!Array.isArray(d[k])) d[k] = [];
   }
   d.health = d.health || { score: 0, cleanRoutes: 0, totalRoutes: 0 };
   d.callGraph = d.callGraph || { packages: 0, functions: 0, edges: 0 };
   d.security = d.security || { schemesDefined: 0, schemes: [], protected: 0, public: 0, unsecured: 0, bySchemeUsage: [] };
+  d.resolution = d.resolution || { full: 0, partial: 0, broken: 0 };
+  d.coverage = d.coverage || {};
+  for (const k of ["requestBody", "errorResponses", "protected"]) {
+    d.coverage[k] = d.coverage[k] || { have: 0, total: 0 };
+  }
+  d.interfaces = d.interfaces || { total: 0, singleImpl: 0, ambiguous: 0, unimplemented: 0, ambiguousList: [] };
+  if (!Array.isArray(d.interfaces.ambiguousList)) d.interfaces.ambiguousList = [];
   return d;
 }
 
 function Bars({ data, color }) {
   const max = Math.max(1, ...data.map((d) => d.count));
   return html`<div class="bars">
-    ${data.map(
-      (d) => html`<div class="bar-row" title=${`${d.name}: ${d.count}`}>
+    ${data.map((d) => {
+      const col = d.color || color;
+      return html`<div class="bar-row" title=${`${d.name}: ${d.count}`}>
         <span style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${d.name}</span>
-        <div class="bar-track"><div class="bar-fill" style=${`width:${(d.count / max) * 100}%${color ? ";background:" + color : ""}`}></div></div>
+        <div class="bar-track"><div class="bar-fill" style=${`width:${(d.count / max) * 100}%${col ? ";background:" + col : ""}`}></div></div>
         <span class="muted" style="text-align:right">${d.count}</span>
-      </div>`,
-    )}
+      </div>`;
+    })}
   </div>`;
 }
 
@@ -72,6 +80,18 @@ const INFO = {
   chain: "Fluent method-chain depth at the handler (e.g. r.Group().Use()).",
   grade:
     "Heuristic complexity grade (A best … D worst) blending call-path fan-out, depth, mutations and unresolved types. A readability indicator — NOT a correctness or performance guarantee (built on AST, not SSA). The bars below are NOT a percent of a total: each gauges its metric against a fixed reference ceiling (a 'notably high' value, e.g. fan-out 8, depth 12, paths 200), so a full bar means 'at or above that ceiling'. Hover any bar to see its ceiling. The pointer:value bar is the exception — a true proportion.",
+  alerts:
+    "The issues that need you, grouped by cause and ranked by severity. Each is the count of operations affected — the per-route breakdown is in 'Needs attention' below.",
+  resolution:
+    "Every operation by how completely it resolved. Fully resolved = no issues. Partial = it works but a detail is missing (a defaulted status, a generic request body). Broken = a dangling $ref, an unresolved/external type, or no responses reaches the generated spec.",
+  taxonomy:
+    "The root cause behind each unresolved detail — one operation can appear in more than one bucket. This is what to fix to raise resolution health.",
+  coverage:
+    "How completely common facets are documented, as a share of the operations they apply to: request bodies on write operations, a 4xx/5xx on every operation, and authentication.",
+  interfaces:
+    "Interface method calls resolved to concrete implementations, read from the analyzer's implementation index (no extra traversal). Interfaces with several implementations may be kept general (erased to any) when the concrete type is ambiguous — those are the ones that cost schema precision.",
+  verbdispatch:
+    "Handlers that serve several HTTP methods from one function via a switch r.Method (or if r.Method ==). apispec splits each into its own operation.",
 };
 
 /* ---- root ----------------------------------------------------------- */
@@ -129,6 +149,170 @@ const Title = (text, info) =>
 
 /* ---- overview ------------------------------------------------------- */
 
+const SEV_ORDER = { crit: 0, warn: 1, info: 2 };
+
+// ALERT_META maps an issue kind to how it reads as an alert: its severity
+// (which can differ from the issue's own — a defaulted status is info-level as
+// an issue but actionable as an alert) and a plain-language cause.
+const ALERT_META = {
+  "dangling-ref": { sev: "crit", label: "Dangling schema references", det: "reference a component with no definition" },
+  "unresolved-type": { sev: "crit", label: "Unresolved / external types", det: "resolve to an external or placeholder type" },
+  "no-responses": { sev: "crit", label: "Operations with no responses", det: "no responses were detected" },
+  "missing-body": { sev: "warn", label: "Request body not resolved", det: "the body resolves to a generic object" },
+  "default-status": { sev: "warn", label: "Status falls back to default", det: "an error status could not be determined" },
+  "wrapper-specialised": { sev: "info", label: "Wrapper-specialised responses", det: "envelope types with an inlined data payload" },
+};
+
+const TAXO_META = {
+  "default-status": { label: "Status defaulted", color: "var(--warn)" },
+  "missing-body": { label: "Body not resolved", color: "var(--warn)" },
+  "unresolved-type": { label: "External / unresolved type", color: "var(--faint)" },
+  "dangling-ref": { label: "Dangling $ref", color: "var(--danger)" },
+  "no-responses": { label: "No responses", color: "var(--danger)" },
+  "wrapper-specialised": { label: "Wrapper specialised", color: "var(--info)" },
+};
+
+const SectionHead = (eyebrow, title, note, info) => html`
+  <div class="sec-head">
+    <span class="eyebrow">${eyebrow}</span>
+    <h3>${title}</h3>
+    ${info ? html`<${Info} text=${info} />` : ""}
+    ${note ? html`<span class="note">${note}</span>` : ""}
+  </div>
+`;
+
+// Alerts aggregates the per-route issues into a prioritized, severity-striped
+// strip — the triage entry point. The granular per-route list ("Needs
+// attention") remains below as the drill-down.
+function Alerts({ rep }) {
+  const s = useStore();
+  const unresolvedSec = (s.unresolvedSecurity || []).length;
+  const byKind = {};
+  for (const i of rep.issues) byKind[i.kind] = (byKind[i.kind] || 0) + 1;
+  const alerts = [];
+  for (const kind in byKind) {
+    const m = ALERT_META[kind];
+    if (m) alerts.push({ sev: m.sev, count: byKind[kind], label: m.label, det: m.det });
+  }
+  if (unresolvedSec > 0)
+    alerts.push({ sev: "warn", count: unresolvedSec, label: "Unmapped auth middleware", det: "middleware guards routes but isn't mapped to a security scheme", action: "configure" });
+  alerts.sort((a, b) => SEV_ORDER[a.sev] - SEV_ORDER[b.sev] || b.count - a.count);
+
+  return html`
+    ${SectionHead("What needs you", "Alerts", alerts.length ? "prioritized — critical first" : "all clear", INFO.alerts)}
+    ${alerts.length === 0
+      ? html`<div class="card"><p class="muted" style="margin:0">No issues detected — every reference resolves and every status is documented.</p></div>`
+      : html`<div class="alert-strip">
+          ${alerts.map((a) => {
+            const sevLabel = a.sev === "crit" ? "critical" : a.sev === "warn" ? "warning" : "info";
+            return html`<div class=${"alert " + a.sev}>
+              <span class="a-sev">${sevLabel}</span>
+              <span class="a-count">${a.count}</span>
+              <span class="a-msg"><b>${a.label}</b> <span class="a-det">— ${a.det}.</span></span>
+              ${a.action === "configure" ? html`<button class="btn sm" onClick=${() => setState({ mode: "configure" })}>Map them →</button>` : ""}
+            </div>`;
+          })}
+        </div>`}
+  `;
+}
+
+// Meter — a coverage bar coloured by how complete it is.
+function Meter({ label, m, foot }) {
+  const pct = m.total ? Math.round((m.have / m.total) * 100) : 0;
+  const col = pct >= 85 ? "var(--accent-2)" : pct >= 60 ? "var(--warn)" : "var(--danger)";
+  return html`<div class="meter">
+    <div class="mtop"><span class="mt">${label}</span><span class="mp" style=${"color:" + col}>${pct}%</span></div>
+    <div class="mtrack"><span class="mfill" style=${`width:${pct}%;background:${col}`}></span></div>
+    <div class="mfoot">${foot}</div>
+  </div>`;
+}
+
+// ResolutionQuality decomposes the health score: the full/partial/broken split,
+// the root-cause taxonomy, and documentation-coverage meters.
+function ResolutionQuality({ rep }) {
+  const r = rep.resolution;
+  const tot = Math.max(1, r.full + r.partial + r.broken);
+  const c = rep.coverage;
+  const taxo = rep.taxonomy
+    .map((t) => ({ name: (TAXO_META[t.name] || {}).label || t.name, count: t.count, color: (TAXO_META[t.name] || {}).color }))
+    .filter((t) => t.count > 0);
+  return html`
+    ${SectionHead("Resolution quality", "How the spec resolved", "why it looks the way it does")}
+    <div class="grid-cards" style="grid-template-columns:1.3fr 1fr;margin-bottom:var(--sp-3)">
+      <div class="card">
+        <div class="row" style="gap:6px"><h3 style="margin:0">Operations by state</h3><${Info} text=${INFO.resolution} /></div>
+        <div class="resbar" style="margin-top:var(--sp-3)" role="img" aria-label=${`${r.full} fully resolved, ${r.partial} partial, ${r.broken} broken`}>
+          ${r.full ? html`<span style=${`width:${(r.full / tot) * 100}%;background:var(--accent-2)`}></span>` : ""}
+          ${r.partial ? html`<span style=${`width:${(r.partial / tot) * 100}%;background:var(--warn)`}></span>` : ""}
+          ${r.broken ? html`<span style=${`width:${(r.broken / tot) * 100}%;background:var(--danger)`}></span>` : ""}
+        </div>
+        <div class="res-legend">
+          <span class="it"><span class="sw" style="background:var(--accent-2)"></span>Fully resolved <b>${r.full}</b></span>
+          <span class="it"><span class="sw" style="background:var(--warn)"></span>Partial <b>${r.partial}</b></span>
+          <span class="it"><span class="sw" style="background:var(--danger)"></span>Broken <b>${r.broken}</b></span>
+        </div>
+      </div>
+      <div class="card">
+        <div class="row" style="gap:6px"><h3 style="margin:0">Why not resolved</h3><${Info} text=${INFO.taxonomy} /></div>
+        ${taxo.length ? html`<div style="margin-top:var(--sp-2)"><${Bars} data=${taxo} /></div>` : html`<p class="muted" style="margin-top:var(--sp-2)">Nothing unresolved.</p>`}
+      </div>
+    </div>
+    <div class="card" style="margin-bottom:var(--sp-3)">
+      <div class="row" style="gap:6px"><h3 style="margin:0">Documentation coverage</h3><${Info} text=${INFO.coverage} /></div>
+      <div class="meters" style="margin-top:var(--sp-3)">
+        ${Meter({ label: "Request body documented", m: c.requestBody, foot: `${c.requestBody.have} of ${c.requestBody.total} write operations declare a body` })}
+        ${Meter({ label: "Error responses documented", m: c.errorResponses, foot: `${c.errorResponses.have} of ${c.errorResponses.total} operations declare a 4xx/5xx` })}
+        ${Meter({ label: "Operations protected", m: c.protected, foot: `${c.protected.have} of ${c.protected.total} require authentication` })}
+      </div>
+    </div>
+  `;
+}
+
+// TreeInsights surfaces whole-API facts read straight from the analyzer's
+// precomputed indexes (no per-request tracker-tree build): interface
+// resolution and verb-dispatch splits.
+function TreeInsights({ rep }) {
+  const itf = rep.interfaces;
+  const vd = rep.verbDispatch;
+  if (!itf.total && !vd.length) return "";
+  const ambig = (itf.ambiguousList || []).map((a) => ({ name: a.name, count: a.count, color: "var(--warn)" }));
+  return html`
+    ${SectionHead("Tree insights", "Resolution internals", "from the analyzer — interfaces & verb dispatch")}
+    <div class="grid-cards" style="grid-template-columns:repeat(auto-fit,minmax(300px,1fr));margin-bottom:var(--sp-3)">
+      ${itf.total
+        ? html`<div class="card">
+            <div class="row" style="gap:6px"><h3 style="margin:0">Interface resolution</h3><${Info} text=${INFO.interfaces} /></div>
+            <div class="miniquad" style="margin-top:var(--sp-3)">
+              <div class="q"><div class="v">${itf.total}</div><div class="k">interfaces</div></div>
+              <div class="q"><div class="v" style="color:var(--accent-2)">${itf.singleImpl}</div><div class="k">single impl</div></div>
+              <div class="q"><div class="v" style=${itf.ambiguous ? "color:var(--warn)" : ""}>${itf.ambiguous}</div><div class="k">ambiguous</div></div>
+              <div class="q"><div class="v" style="color:var(--faint)">${itf.unimplemented}</div><div class="k">unimplemented</div></div>
+            </div>
+            ${ambig.length
+              ? html`<div class="shape-h">Ambiguous — may erase to <code>any</code></div><${Bars} data=${ambig} />`
+              : html`<p class="muted" style="font-size:var(--fs-sm);margin:0">Every interface resolves to a single implementation.</p>`}
+          </div>`
+        : ""}
+      ${vd.length
+        ? html`<div class="card">
+            <div class="row" style="gap:6px"><h3 style="margin:0">Verb dispatch</h3><${Info} text=${INFO.verbdispatch} /></div>
+            <p class="muted" style="font-size:var(--fs-xs);margin:4px 0 var(--sp-2)">
+              ${vd.length} handler${vd.length === 1 ? "" : "s"} split into multiple operations from one function
+            </p>
+            <div class="disp-list">
+              ${vd.map(
+                (d) => html`<div class="disp-row">
+                  <span class="mono" style="color:var(--accent)">${d.handler}</span>
+                  <span class="muted">${(d.methods || []).join("  ")}</span>
+                </div>`,
+              )}
+            </div>
+          </div>`
+        : ""}
+    </div>
+  `;
+}
+
 function Overview({ rep, onTag }) {
   const [exportOpen, setExportOpen] = useState(false);
   const warns = rep.issues.filter((i) => i.severity === "warn");
@@ -156,6 +340,11 @@ function Overview({ rep, onTag }) {
       <div class="stat"><div class="num">${rep.components}</div><div class="lbl">components <${Info} text=${INFO.components} /></div></div>
     </div>
 
+    <${Alerts} rep=${rep} />
+    <${ResolutionQuality} rep=${rep} />
+    <${TreeInsights} rep=${rep} />
+
+    ${SectionHead("API shape", "Requests & responses")}
     <div class="grid-cards" style="grid-template-columns:repeat(auto-fit,minmax(300px,1fr));margin-bottom:var(--sp-3)">
       ${rep.byMethod.length ? html`<div class="card">${Title("Methods", INFO.methods)}<${Bars} data=${rep.byMethod} /></div>` : ""}
       ${rep.byStatus.length ? html`<div class="card">${Title("Status codes", INFO.status)}<${Donut} data=${rep.byStatus.map((d) => ({ ...d, color: statusColor(d.name) }))} centerLabel=${rep.byStatus.reduce((a, b) => a + b.count, 0)} centerSub="responses" /></div>` : ""}

--- a/docs/INSIGHT_ROADMAP.md
+++ b/docs/INSIGHT_ROADMAP.md
@@ -13,6 +13,18 @@
 > (correctness gaps) — this doc is about **observability of the pipeline's
 > reasoning**, not about resolving more types.
 
+> **Status (updated as work lands).** The Overview redesign in this PR shipped
+> the whole-API aggregate layer of §4.5: the resolution funnel + failure
+> taxonomy, coverage meters, the **interface inventory** (single-impl /
+> ambiguous / unimplemented, from `ImplementedBy`), and the **verb-dispatch**
+> explainer — all as lightweight precomputed reads (`interfaceStats`,
+> `verbDispatch`, `classifyResolution` in `overview.go`), no tracker-tree build.
+> The per-endpoint **interface-decision** overlay (§4.2) followed on its own
+> branch. Sections 1, 3, 4.5, and 5 below describe the *original* pre-redesign
+> state and the full plan; items marked **✔ shipped** are done. The remaining
+> frontier is the per-endpoint "why" — provenance (§4.1), param/generic flow
+> (§4.3), and registration chains (§4.4).
+
 ---
 
 ## 1. The core reframe: the dashboard shows *what*, not *why*
@@ -75,11 +87,11 @@ data-model audit.
 | Fact | Struct (file:line) | Dashboard today | Diagram viewer |
 |---|---|---|---|
 | Assignment provenance | `Assignment` (`internal/metadata/types.go:518`); `AssignmentMap` on `Function`/`Method`/`CallGraphEdge` (`types.go:470`, `449`, `981`) | **No** | count-only (`RootAssignments`) |
-| Interface impl set | `Type.ImplementedBy` / `Implements` / `Embeds` (`types.go:403-408`) | badge only (`Resolved`) | via trace |
+| Interface impl set | `Type.ImplementedBy` / `Implements` / `Embeds` (`types.go:403-408`) | **✔ Overview inventory** (single/ambiguous/unimplemented) + per-node badge | via trace |
 | Param→arg binding | `CallGraphEdge.ParamArgMap` (`types.go:984`) | **No** | yes (popup) |
 | Generic instantiation | `CallGraphEdge.TypeParamMap` (`types.go:985`) | **No** | yes (popup) |
 | Fluent-chain shape | `CallGraphEdge.ChainParent`/`ChainRoot` (`types.go:991-992`) | depth scalar only | indirect |
-| Verb dispatch arms | `Function.MethodDispatch` / `MethodBranch` (`types.go:476-482`) | **No** | **No** |
+| Verb dispatch arms | `Function.MethodDispatch` / `MethodBranch` (`types.go:476-482`) | **✔ Overview** (verb-dispatch explainer) | **No** |
 | Return-value origins | `Method`/`Function.ReturnVars` (`types.go:446-467`) | **No** | **No** |
 | External-type facts | `Metadata.ExternalTypes` / `ExternalTypeFact` (`types.go:169-191`) | string-marker only | **No** |
 | Go signatures | `SignatureStr` / `Signature` (`types.go:434-457`) | **No** (uses spec schema summary) | partial |
@@ -180,22 +192,23 @@ dashboard today.
 
 These lift the per-endpoint facts into API-level signals:
 
-- **Resolution funnel + failure taxonomy.** Replace the flat "needs attention"
-  list with *categorized* causes: external type, interface-erased-to-`any`,
-  **status defaulted (dynamic/switch)**, wrapper-not-matched,
-  request-body-unresolved — each linking to the exact nodes. A "status
-  defaulted" bucket would have surfaced the #155 case at a glance instead of
-  eyeballing 21 `default`s. Generalizes every gap we file.
+- **✔ shipped — Resolution funnel + failure taxonomy.** Replaces the flat
+  "needs attention" list with *categorized* causes: external type,
+  interface-erased-to-`any`, **status defaulted (dynamic/switch)**,
+  wrapper-not-matched, request-body-unresolved — each linking to the exact
+  nodes. A "status defaulted" bucket would have surfaced the #155 case at a
+  glance instead of eyeballing 21 `default`s. Generalizes every gap we file.
 - **Resolution confidence per endpoint** (beside the complexity grade): did
   body / status / params resolve via a *literal*, via *N-hop param threading*,
   or *default/fallback*? A "defaulted status" / "body = object" / "synthesized
   param" badge is the single highest-signal addition.
-- **Interface inventory:** interfaces by implementation count, unimplemented
-  interfaces, and ambiguous (multi-impl) interfaces — from `ImplementedBy` /
-  `Implements`.
-- **Verb-dispatch explainer:** where a `switch r.Method` split one handler into
-  several operations (`MethodDispatch`, `types.go:476`) — read by no UI today —
-  answers "where did this extra operation come from?" (golden-rule #8).
+- **✔ shipped — Interface inventory:** interfaces by implementation count,
+  unimplemented interfaces, and ambiguous (multi-impl) interfaces — from
+  `ImplementedBy` / `Implements` (`interfaceStats`, `overview.go`).
+- **✔ shipped — Verb-dispatch explainer:** where a `switch r.Method` split one
+  handler into several operations (`MethodDispatch`, `types.go:476`) — answers
+  "where did this extra operation come from?" (golden-rule #8) (`verbDispatch`,
+  `overview.go`).
 - **Generation diff / regression view.** Compare two runs (lazy vs legacy, or
   before/after a code change): which routes / statuses / bodies changed. This is
   the A/B done by hand in every validation session; valuable as a feature and as
@@ -209,8 +222,8 @@ shippable and testable.
 **Phase 0 — unlock what exists (cheap, high value)**
 - Add **resolution-confidence badges** to the endpoint report (defaulted status,
   generic-object body, synthesized param) — small `internal/insight` additions.
-- **Failure taxonomy** on the Overview (re-bucket issues already collected in
-  `collectOperationIssues` + a few metadata-derived causes).
+- **✔ shipped — Failure taxonomy** on the Overview (re-bucket issues already
+  collected in `collectOperationIssues` + a few metadata-derived causes).
 - (The endpoint view already exposes a tracker-tree ↔ call-graph toggle
   (`insight.js` trace-source segment), so the tree substrate is already
   user-reachable there; wiring the separate `/diagram` page's `tracker-tree`
@@ -218,12 +231,13 @@ shippable and testable.
 
 **Phase 1 — the differentiators**
 - **Param/generic type-flow overlay** (§4.3) — extraction already exists.
-- **Interface-decision panel** with alternatives + ambiguity flag (§4.2).
+- **✔ shipped — Interface-decision panel** with alternatives + ambiguity flag
+  (§4.2) — the per-endpoint trace now annotates each interface→impl hop.
 
 **Phase 2 — deeper provenance**
 - Fix `Assignment.ReturnIndex` (§4.1 prerequisite), then the **value-provenance
   panel** (§4.1).
-- **Verb-dispatch explainer** and **interface inventory** (§4.5).
+- **✔ shipped — Verb-dispatch explainer** and **interface inventory** (§4.5).
 
 **Phase 3 — bigger bets**
 - **Registration-chain inspector** (§4.4).
@@ -233,11 +247,16 @@ shippable and testable.
 
 - **`Assignment.ReturnIndex == 0` (hardcoded, `metadata.go:1428`).** Multi-return
   provenance is lossy; must be fixed before §4.1 is correct.
-- **Tracker tree is transient.** LazyTree nodes are expanded on demand and not
-  serialized (`internal/spec/lazytree.go`); insights that need the tree build it
-  via `cachedTrackerTree` (`internal/insight/metrics.go:624`), as the endpoint
-  metrics already do. No new persistence is required, but the cost is a tree
-  build per request — keep the existing cache.
+- **Tracker tree is transient — but the Overview must not build it.** The
+  whole-API Overview aggregation (`BuildOverview`) is deliberately restricted to
+  lightweight precomputed reads (spec walk + `ImplementedBy` / `MethodDispatch`
+  / issue tallies) and builds **no** tracker tree, so it stays cheap on large
+  projects. LazyTree nodes are expanded on demand and not serialized
+  (`internal/spec/lazytree.go`); the per-request tree build via
+  `cachedTrackerTree` (`internal/insight/metrics.go:624`) applies only to the
+  per-**endpoint** resolution/tree-inspector features (§4.1–4.4), as the
+  endpoint metrics already do. No new persistence is required; keep the existing
+  cache, and keep any new Overview-level insight tree-free.
 - **Determinism.** Any new insight that ranges maps whose order can reach the
   API response must sort (golden rule #1). The existing insight code already
   does this (`sortedCounts`, stable issue sort); match it.

--- a/docs/INSIGHT_ROADMAP.md
+++ b/docs/INSIGHT_ROADMAP.md
@@ -1,0 +1,271 @@
+# Insight Dashboard Roadmap — From "What" to "Why"
+
+> A plan to enrich the apispecui **Insight** dashboard (`cmd/apispecui`,
+> `internal/insight`) with resolution-reasoning insights: how a type / route /
+> status / body was actually resolved, and — when it wasn't — exactly where the
+> chain broke. The organizing idea is to surface the **tracker-tree facts**
+> (assignments, interface decisions, parameter bindings, fluent chains) that the
+> pipeline already computes but the dashboard does not show.
+>
+> Written 2026-07-16, based on the state of `internal/insight/*`,
+> `internal/diagserver/*`, `internal/spec/visualization.go`, and
+> `cmd/apispecui/assets/js/*` at that time. Companion to `GAP_ANALYSIS.md`
+> (correctness gaps) — this doc is about **observability of the pipeline's
+> reasoning**, not about resolving more types.
+
+---
+
+## 1. The core reframe: the dashboard shows *what*, not *why*
+
+Today the Insight dashboard answers two questions well:
+
+- **"What did we produce?"** — the Overview is almost entirely derived from the
+  generated OpenAPI spec (`insight.BuildOverview`, `internal/insight/overview.go:138`):
+  route/method/status/content histograms, a resolution-health score, a
+  "needs attention" issue list, component/type stats, security posture.
+- **"How big is the graph?"** — the only metadata-derived block is
+  `CallGraphStats` (`overview.go:412`): package/function/edge counts, edge
+  composition, fan-in hot functions, busiest packages.
+
+It does **not** answer the question every user of a static-analysis tool
+actually asks: **"*Why* did this resolve the way it did — and where did it
+break?"** That question is what turned every recent correctness investigation
+(the lazy-tracker route drop / #146, the status `default`s / #144·#155, the
+wrapper-decoded request bodies / #153) into a manual trace of `AssignmentMap`,
+`ParamArgMap`, and `ChainParent`. The dashboard should make that trace
+self-service.
+
+The insight is structural: **the call graph shows *who calls whom*; the tracker
+tree shows *how a value/type/route was resolved*.** The call graph is
+well-covered by the current UI. The tracker tree — the structure apispec
+actually walks to build the spec — and its facts are the untapped value.
+
+## 2. What already exists (build on this, do not rebuild)
+
+Three capabilities are already present and materially reduce the work:
+
+1. **The per-endpoint resolution trace already walks the tracker tree.**
+   `EndpointReport.Trace` (`internal/insight/metrics.go:90`) is built by
+   `analyzeFromTrackerTree` (`metrics.go:270`) by default, and it already marks
+   interface→concrete hops with `TraceNode.Resolved` (`metrics.go:71`) — the
+   `⟐ impl` badge in the UI (`cmd/apispecui/assets/js/charts.js`). The substrate
+   for "why" is there; it is under-labelled, not missing.
+
+2. **The diagram server already has a full `tracker-tree` mode** with popups for
+   argument type, resolved type, root assignments, generics, and per-call-path
+   parameter/generic values — `CytoscapeNodeData` fields `ArgType`,
+   `ArgResolvedType`, `RootAssignments`, `Generics`, and `CallPathInfo`
+   (`internal/spec/visualization.go:57-98`). **But apispecui hard-codes
+   `DiagramType:"call-graph"`** (`cmd/apispecui/main.go:311`), so the "Call
+   graph ↗" tab never renders the tree or any of those resolution facts. A mode
+   toggle unlocks work that is already written.
+
+3. **The insight layer already holds the full `*metadata.Metadata`** (both
+   `/api/insight/overview` and `/api/insight/endpoint` cache `s.currentMeta`,
+   `cmd/apispecui/main.go`). It consumes only a thin slice today, so most new
+   insights are **new reads over data already in hand**, not new analysis.
+
+## 3. The facts we compute but do not surface
+
+Every item below is present and rich in `internal/metadata`, serialized in the
+metadata goldens, and read by *no* dashboard endpoint (some are read only by the
+separate diagram viewer). Source: the metadata-fact inventory + insight
+data-model audit.
+
+| Fact | Struct (file:line) | Dashboard today | Diagram viewer |
+|---|---|---|---|
+| Assignment provenance | `Assignment` (`internal/metadata/types.go:518`); `AssignmentMap` on `Function`/`Method`/`CallGraphEdge` (`types.go:470`, `449`, `981`) | **No** | count-only (`RootAssignments`) |
+| Interface impl set | `Type.ImplementedBy` / `Implements` / `Embeds` (`types.go:403-408`) | badge only (`Resolved`) | via trace |
+| Param→arg binding | `CallGraphEdge.ParamArgMap` (`types.go:984`) | **No** | yes (popup) |
+| Generic instantiation | `CallGraphEdge.TypeParamMap` (`types.go:985`) | **No** | yes (popup) |
+| Fluent-chain shape | `CallGraphEdge.ChainParent`/`ChainRoot` (`types.go:991-992`) | depth scalar only | indirect |
+| Verb dispatch arms | `Function.MethodDispatch` / `MethodBranch` (`types.go:476-482`) | **No** | **No** |
+| Return-value origins | `Method`/`Function.ReturnVars` (`types.go:446-467`) | **No** | **No** |
+| External-type facts | `Metadata.ExternalTypes` / `ExternalTypeFact` (`types.go:169-191`) | string-marker only | **No** |
+| Go signatures | `SignatureStr` / `Signature` (`types.go:434-457`) | **No** (uses spec schema summary) | partial |
+
+The four highest-value untapped facts — the ones this roadmap is built around —
+are **assignments, interface impl sets, param/generic bindings, and chain
+shape**, i.e. exactly the categories named in the original request.
+
+## 4. The insights to add
+
+The unifying deliverable is a **Resolution ("Why") view**: the tracker tree for
+an endpoint, where every node explains *how* it resolved and every failure is a
+clickable dead-end with a jump-to-source. The four fact categories are four
+overlays on that view; §4.5 adds whole-API aggregates.
+
+### 4.1 Value provenance (assignments)
+
+**Show:** for a resolved (or *unresolved*) request body / response schema /
+status, the assignment chain that produced it —
+`var req X` → `decodeJSON(w, r, &req)` → param `dst` → `dec.Decode(dst)`.
+Render as an ordered provenance list per node, with each hop's `file:line`.
+
+**Why it's crucial:** this is exactly the hand-trace behind #153 (request body
+lost through a variable-receiver decoder). It converts "the body is a generic
+`object`" into "resolution stopped *here*, at this assignment," which the user
+can act on.
+
+**Data:** `AssignmentMap` (`types.go:470/449/981`), `Assignment{VariableName,
+Value, CalleeFunc, CalleePkg, ReturnIndex}` (`types.go:518`);
+`BuildAssignmentRelationships` (`internal/metadata/metadata.go:466`) and
+`traceVariableOriginHelper` (`internal/metadata/analysis.go:506`) already do the
+walk internally.
+
+**Prerequisite:** `Assignment.ReturnIndex` is hardcoded to `0`
+(`metadata.go:1428`), so multi-return provenance (`h, err := factory()`)
+mis-binds to the first return. Fix this before the provenance panel can be
+*correct* for multi-return producers. Small change; own PR + fixture.
+
+**Effort:** medium (new insight-layer plumbing + a UI panel). Prerequisite is
+small but real.
+
+### 4.2 Interface decisions
+
+**Show:** at each interface→concrete hop, *which* implementation was chosen and
+the **alternatives** (`ImplementedBy`). When the set has >1 concrete impl and
+the type was kept general (erased to `any`), **flag it**: "resolved to `any` —
+2 concrete types assigned to this interface."
+
+**Why it's crucial:** it surfaces golden-rule-#7 honesty *at the exact point it
+cost precision*, so the user can disambiguate via config instead of guessing why
+a payload is generic. It also makes the existing `⟐ impl` badge explain itself.
+
+**Data:** `Type.ImplementedBy` is a slice that honestly keeps *all* impls
+(`types.go:403`), so the ambiguity flag is a straight read — no new resolution
+logic. Forward `Implements` and `Embeds` (`types.go:405-408`) enable an
+interface-inventory card (§4.5).
+
+**Effort:** low–medium (data is a direct read; UI is a panel + a badge state).
+
+### 4.3 Parameter / generic type-flow
+
+**Show:** an overlay on the endpoint trace where edges are labelled param→arg
+(`ParamArgMap`), so the user can watch a concrete type thread from a call site
+through wrapper parameters to the encode/decode site; plus the concrete generic
+instantiation (`TypeParamMap`) on each node.
+
+**Why it's crucial:** the param binding *is* the request-body/status resolution
+mechanism (the multi-hop `resolveArgThroughParams` path). Making it visible
+turns a black box into an inspectable data-flow.
+
+**Data:** `CallGraphEdge.ParamArgMap` / `TypeParamMap` (`types.go:984-985`).
+**The diagram viewer already extracts both** — `extractParameterInfo` reads
+`ParamArgMap` (`visualization.go:660`) and `TypeParamMap` feeds the generics
+popup (`visualization.go:406`) — so extraction is proven trivial; this is
+lifting it into the dashboard trace (or reusing the tracker-tree diagram mode).
+
+**Effort:** low (extraction exists; wire to the dashboard).
+
+### 4.4 Registration chains
+
+**Show:** the fluent chain that decides route/middleware/security scope —
+`r.With(mw).Get(...)`, `r.Group(func(r){ r.Use(auth); r.Get(...) })` — as a
+small chain diagram per route (`ChainParent` → `ChainRoot`).
+
+**Why it's crucial:** the SecurityCard shows the *outcome* (protected / public /
+no-auth) but never *why*. Chain shape is how you debug "why is this route
+unsecured / mis-prefixed" — the #146 class of bug — and how a reviewer verifies
+that a group's middleware actually reaches its routes.
+
+**Data:** `CallGraphEdge.ChainParent`/`ChainRoot` (`types.go:991-992`); the
+LazyTree already indexes chain relations (`chainChildren`,
+`internal/spec/lazytree.go:66`). Only the scalar `ChainDepth` reaches the
+dashboard today.
+
+**Effort:** medium (chain reconstruction for display + a small diagram).
+
+### 4.5 Whole-API aggregates (Overview)
+
+These lift the per-endpoint facts into API-level signals:
+
+- **Resolution funnel + failure taxonomy.** Replace the flat "needs attention"
+  list with *categorized* causes: external type, interface-erased-to-`any`,
+  **status defaulted (dynamic/switch)**, wrapper-not-matched,
+  request-body-unresolved — each linking to the exact nodes. A "status
+  defaulted" bucket would have surfaced the #155 case at a glance instead of
+  eyeballing 21 `default`s. Generalizes every gap we file.
+- **Resolution confidence per endpoint** (beside the complexity grade): did
+  body / status / params resolve via a *literal*, via *N-hop param threading*,
+  or *default/fallback*? A "defaulted status" / "body = object" / "synthesized
+  param" badge is the single highest-signal addition.
+- **Interface inventory:** interfaces by implementation count, unimplemented
+  interfaces, and ambiguous (multi-impl) interfaces — from `ImplementedBy` /
+  `Implements`.
+- **Verb-dispatch explainer:** where a `switch r.Method` split one handler into
+  several operations (`MethodDispatch`, `types.go:476`) — read by no UI today —
+  answers "where did this extra operation come from?" (golden-rule #8).
+- **Generation diff / regression view.** Compare two runs (lazy vs legacy, or
+  before/after a code change): which routes / statuses / bodies changed. This is
+  the A/B done by hand in every validation session; valuable as a feature and as
+  a release gate.
+
+## 5. Phasing
+
+Sequenced by value-to-effort, cheapest-first. Each phase is independently
+shippable and testable.
+
+**Phase 0 — unlock what exists (cheap, high value)**
+- Add **resolution-confidence badges** to the endpoint report (defaulted status,
+  generic-object body, synthesized param) — small `internal/insight` additions.
+- **Failure taxonomy** on the Overview (re-bucket issues already collected in
+  `collectOperationIssues` + a few metadata-derived causes).
+- (The endpoint view already exposes a tracker-tree ↔ call-graph toggle
+  (`insight.js` trace-source segment), so the tree substrate is already
+  user-reachable there; wiring the separate `/diagram` page's `tracker-tree`
+  mode (`cmd/apispecui/main.go:311`) is optional and lower priority.)
+
+**Phase 1 — the differentiators**
+- **Param/generic type-flow overlay** (§4.3) — extraction already exists.
+- **Interface-decision panel** with alternatives + ambiguity flag (§4.2).
+
+**Phase 2 — deeper provenance**
+- Fix `Assignment.ReturnIndex` (§4.1 prerequisite), then the **value-provenance
+  panel** (§4.1).
+- **Verb-dispatch explainer** and **interface inventory** (§4.5).
+
+**Phase 3 — bigger bets**
+- **Registration-chain inspector** (§4.4).
+- **Generation diff** view (§4.5).
+
+## 6. Prerequisites & known data limitations
+
+- **`Assignment.ReturnIndex == 0` (hardcoded, `metadata.go:1428`).** Multi-return
+  provenance is lossy; must be fixed before §4.1 is correct.
+- **Tracker tree is transient.** LazyTree nodes are expanded on demand and not
+  serialized (`internal/spec/lazytree.go`); insights that need the tree build it
+  via `cachedTrackerTree` (`internal/insight/metrics.go:624`), as the endpoint
+  metrics already do. No new persistence is required, but the cost is a tree
+  build per request — keep the existing cache.
+- **Determinism.** Any new insight that ranges maps whose order can reach the
+  API response must sort (golden rule #1). The existing insight code already
+  does this (`sortedCounts`, stable issue sort); match it.
+- **Layering.** Insights are read-only projections; keep `internal/insight`
+  side-effect free (its package doc states this) so it stays unit-testable with
+  hand-built inputs.
+
+## 7. What not to do
+
+- **Do not add more call-graph-shaped charts** (fan-in/fan-out variants). That
+  dimension is well-covered; the marginal value is entirely in resolution
+  reasoning, not more graph statistics.
+- **Do not collapse the honest general type** to show a single "winner" when an
+  interface has multiple impls. Surface the ambiguity (§4.2) — do not hide it
+  (golden rule #7).
+- **Do not duplicate the diagram viewer.** Where the diagram already extracts a
+  fact (param bindings, generics), reuse that extraction rather than reimplement.
+
+## 8. Open questions
+
+- **Rendering model for the "Why" view:** extend the existing layered
+  `TraceDiagram` (`charts.js`) with per-node provenance panels, or render the
+  tracker structure as a literal collapsible tree widget? The trace diagram is
+  proven and interactive; a tree widget may read more naturally for deep chains.
+  (To be decided with the maintainer.)
+- **Scope of the generation diff:** same-project two-run diff only, or persist a
+  baseline spec for release-gate comparison?
+- **Redaction:** the export flow already redacts identifiers
+  (`internal/insight/export.go`); provenance panels expose more source
+  structure, so confirm the redaction story extends to them before shipping any
+  share/export of the "Why" view.

--- a/internal/insight/e2e_test.go
+++ b/internal/insight/e2e_test.go
@@ -57,6 +57,24 @@ func TestEndToEnd_TrackerTraceFromTestdata(t *testing.T) {
 		t.Skip("no endpoints in overview")
 	}
 
+	// The redesigned Overview aggregations must hold their invariants on real
+	// generated metadata (exercises interfaceStats/verbDispatch/coverage/
+	// resolution over actual data, not just hand-built inputs).
+	if got := rep.Resolution.Full + rep.Resolution.Partial + rep.Resolution.Broken; got != rep.Operations {
+		t.Errorf("resolution split %+v sums to %d, want operations %d", rep.Resolution, got, rep.Operations)
+	}
+	if rep.Coverage.Protected.Total != rep.Operations {
+		t.Errorf("protected coverage total = %d, want operations %d", rep.Coverage.Protected.Total, rep.Operations)
+	}
+	if rep.Interfaces.Total != rep.Interfaces.SingleImpl+rep.Interfaces.Ambiguous+rep.Interfaces.Unimplemented {
+		t.Errorf("interface stats don't add up: %+v", rep.Interfaces)
+	}
+	for _, vd := range rep.VerbDispatch {
+		if len(vd.Methods) < 2 {
+			t.Errorf("verb dispatch %q should be a multi-method split, got %v", vd.Handler, vd.Methods)
+		}
+	}
+
 	tracker, callgraph, handlerFound := 0, 0, 0
 	for _, ep := range rep.Endpoints {
 		tr := BuildEndpointWithSource(out, meta, cfg, ep.Method, ep.Path, TraceSourceTracker)

--- a/internal/insight/overview.go
+++ b/internal/insight/overview.go
@@ -389,7 +389,17 @@ func interfaceStats(meta *metadata.Metadata) InterfaceStats {
 			st.SingleImpl++
 		default:
 			st.Ambiguous++
-			ambig[sp.GetString(t.Name)] = n
+			// Qualify the display label the same way `seen` qualifies its
+			// dedupe key: two ambiguous interfaces with the same bare name in
+			// different packages (Store, Repository, Handler … are common)
+			// would otherwise overwrite each other's count, and — because map
+			// iteration order is randomized — which one survived would vary
+			// run to run, breaking output determinism.
+			label := sp.GetString(t.Name)
+			if p := sp.GetString(t.Pkg); p != "" {
+				label = lastSegment(p) + "." + label
+			}
+			ambig[label] = n
 		}
 	}
 	for _, pkg := range meta.Packages {

--- a/internal/insight/overview.go
+++ b/internal/insight/overview.go
@@ -89,6 +89,49 @@ type SecurityStats struct {
 	BySchemeUsage  []Count  `json:"bySchemeUsage"`  // operations requiring each scheme
 }
 
+// CoverMetric is a have-of-total coverage tally.
+type CoverMetric struct {
+	Have  int `json:"have"`
+	Total int `json:"total"`
+}
+
+// Coverage summarises how completely common facets are documented across the
+// API. All fields are derived from the generated spec (cheap — no call-graph or
+// tracker-tree traversal).
+type Coverage struct {
+	RequestBody    CoverMetric `json:"requestBody"`    // write ops (POST/PUT/PATCH) that declare a body schema
+	ErrorResponses CoverMetric `json:"errorResponses"` // ops that declare at least one 4xx/5xx
+	Protected      CoverMetric `json:"protected"`      // ops that require authentication
+}
+
+// Resolution splits operations by how completely they resolved: full (no
+// issues), partial (works but a detail is missing — a defaulted status or a
+// generic body), broken (a dangling ref / unresolved type / no responses
+// reaches the output).
+type Resolution struct {
+	Full    int `json:"full"`
+	Partial int `json:"partial"`
+	Broken  int `json:"broken"`
+}
+
+// InterfaceStats summarises interface→implementation resolution, read directly
+// from the metadata's precomputed ImplementedBy index (no tracker-tree build).
+type InterfaceStats struct {
+	Total         int     `json:"total"`
+	SingleImpl    int     `json:"singleImpl"`    // exactly one implementation — unambiguous
+	Ambiguous     int     `json:"ambiguous"`     // more than one — may be kept general (erased to any)
+	Unimplemented int     `json:"unimplemented"` // no implementation found
+	AmbiguousList []Count `json:"ambiguousList"` // ambiguous interface name -> implementation count
+}
+
+// VerbDispatch is one handler that serves several HTTP methods from a single
+// function via a `switch r.Method` / `if r.Method ==` dispatch (from the
+// metadata's precomputed MethodDispatch arms).
+type VerbDispatch struct {
+	Handler string   `json:"handler"`
+	Methods []string `json:"methods"`
+}
+
 // OverviewReport is the whole-API insight payload.
 type OverviewReport struct {
 	Routes        int            `json:"routes"`     // distinct path templates
@@ -101,8 +144,13 @@ type OverviewReport struct {
 	Components    int            `json:"components"`
 	TopTypes      []Count        `json:"topTypes"`
 	Health        Health         `json:"health"`
+	Resolution    Resolution     `json:"resolution"`
+	Coverage      Coverage       `json:"coverage"`
+	Taxonomy      []Count        `json:"taxonomy"` // issue kind -> count (the "why not resolved" breakdown)
 	Security      SecurityStats  `json:"security"`
 	Issues        []Issue        `json:"issues"`
+	Interfaces    InterfaceStats `json:"interfaces"`   // tree insight: interface resolution (cheap read)
+	VerbDispatch  []VerbDispatch `json:"verbDispatch"` // tree insight: handlers split by verb (cheap read)
 	CallGraph     CallGraphStats `json:"callGraph"`
 }
 
@@ -182,6 +230,27 @@ func BuildOverview(s *spec.OpenAPISpec, meta *metadata.Metadata) *OverviewReport
 			if !hasWarn(routeIssues) {
 				clean++
 			}
+
+			// Resolution state + documentation coverage — both cheap, from the
+			// spec we're already walking.
+			switch classifyResolution(routeIssues) {
+			case "broken":
+				rep.Resolution.Broken++
+			case "partial":
+				rep.Resolution.Partial++
+			default:
+				rep.Resolution.Full++
+			}
+			if isWriteMethod(mo.Method) {
+				rep.Coverage.RequestBody.Total++
+				if hasBodySchema(mo.Op) {
+					rep.Coverage.RequestBody.Have++
+				}
+			}
+			rep.Coverage.ErrorResponses.Total++
+			if hasErrorResponse(mo.Op) {
+				rep.Coverage.ErrorResponses.Have++
+			}
 		}
 	}
 
@@ -217,8 +286,165 @@ func BuildOverview(s *spec.OpenAPISpec, meta *metadata.Metadata) *OverviewReport
 	}
 
 	rep.Security = securityStats(s)
+	// Protected coverage reuses the security classification (cheap).
+	rep.Coverage.Protected = CoverMetric{
+		Have:  rep.Security.Protected,
+		Total: rep.Security.Protected + rep.Security.Public + rep.Security.Unsecured,
+	}
+	// Taxonomy: the "why not resolved" breakdown — a tally of every issue kind
+	// (all severities), so the UI can rank the causes.
+	kindC := map[string]int{}
+	for _, is := range rep.Issues {
+		kindC[is.Kind]++
+	}
+	rep.Taxonomy = sortedCounts(kindC, true)
+
+	// Tree insights — precomputed metadata reads only (no tracker-tree build,
+	// so the Overview stays lightweight).
+	rep.Interfaces = interfaceStats(meta)
+	rep.VerbDispatch = verbDispatch(meta)
+
 	rep.CallGraph = callGraphStats(meta)
 	return rep
+}
+
+// classifyResolution maps an operation's issues to a resolution state:
+// broken (a dangling ref / unresolved type / no responses reaches the output),
+// partial (works but a detail is missing — a generic body or a defaulted
+// status), or full (no issues).
+func classifyResolution(issues []Issue) string {
+	partial := false
+	for _, is := range issues {
+		switch is.Kind {
+		case "dangling-ref", "unresolved-type", "no-responses":
+			return "broken"
+		case "missing-body", "default-status":
+			partial = true
+		}
+	}
+	if partial {
+		return "partial"
+	}
+	return "full"
+}
+
+func isWriteMethod(m string) bool {
+	switch m {
+	case "POST", "PUT", "PATCH":
+		return true
+	}
+	return false
+}
+
+// hasBodySchema reports whether an operation declares a request body with a
+// schema (any content type).
+func hasBodySchema(op *spec.Operation) bool {
+	if op.RequestBody == nil {
+		return false
+	}
+	for _, mt := range op.RequestBody.Content {
+		if mt.Schema != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// hasErrorResponse reports whether an operation declares any 4xx or 5xx
+// response (a documented failure path), as opposed to only 2xx and/or default.
+func hasErrorResponse(op *spec.Operation) bool {
+	for status := range op.Responses {
+		if len(status) > 0 && (status[0] == '4' || status[0] == '5') {
+			return true
+		}
+	}
+	return false
+}
+
+// interfaceStats reads the metadata's precomputed ImplementedBy index to
+// summarise interface resolution. Cheap: a single pass over declared types, no
+// call-graph or tracker traversal.
+func interfaceStats(meta *metadata.Metadata) InterfaceStats {
+	st := InterfaceStats{AmbiguousList: []Count{}}
+	if meta == nil || meta.StringPool == nil {
+		return st
+	}
+	sp := meta.StringPool
+	ambig := map[string]int{}
+	seen := map[string]bool{} // dedupe types that appear under both file- and package-scope
+	visit := func(t *metadata.Type) {
+		if sp.GetString(t.Kind) != "interface" {
+			return
+		}
+		key := sp.GetString(t.Pkg) + "." + sp.GetString(t.Name)
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		st.Total++
+		switch n := len(t.ImplementedBy); n {
+		case 0:
+			st.Unimplemented++
+		case 1:
+			st.SingleImpl++
+		default:
+			st.Ambiguous++
+			ambig[sp.GetString(t.Name)] = n
+		}
+	}
+	for _, pkg := range meta.Packages {
+		for _, f := range pkg.Files {
+			for i := range f.Types {
+				visit(f.Types[i])
+			}
+		}
+		for i := range pkg.Types {
+			visit(pkg.Types[i])
+		}
+	}
+	st.AmbiguousList = topN(sortedCounts(ambig, true), 8)
+	return st
+}
+
+// verbDispatch reads the metadata's precomputed MethodDispatch arms to list
+// handlers that serve several HTTP methods from one function. Cheap: a single
+// pass over declared functions.
+func verbDispatch(meta *metadata.Metadata) []VerbDispatch {
+	out := []VerbDispatch{}
+	if meta == nil || meta.StringPool == nil {
+		return out
+	}
+	sp := meta.StringPool
+	for _, pkg := range meta.Packages {
+		for _, f := range pkg.Files {
+			for name, fn := range f.Functions {
+				if len(fn.MethodDispatch) == 0 {
+					continue
+				}
+				methods := []string{}
+				seen := map[string]bool{}
+				for _, b := range fn.MethodDispatch {
+					for _, m := range b.Methods {
+						if m != "" && !seen[m] {
+							seen[m] = true
+							methods = append(methods, m)
+						}
+					}
+				}
+				if len(methods) < 2 {
+					continue // a single-method dispatch isn't a split worth surfacing
+				}
+				sort.Strings(methods)
+				handler := name
+				if p := sp.GetString(fn.Pkg); p != "" {
+					handler = lastSegment(p) + "." + name
+				}
+				out = append(out, VerbDispatch{Handler: handler, Methods: methods})
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Handler < out[j].Handler })
+	return out
 }
 
 // securityStats classifies every operation as protected / public / unsecured,
@@ -318,6 +544,16 @@ func collectOperationIssues(method, path string, op *spec.Operation, comps map[s
 				})
 			}
 		}
+	}
+
+	// A `default` response means apispec could not pin the status to a concrete
+	// code — the real 4xx/5xx isn't documented. Info-level (the route still
+	// works), but it feeds the resolution taxonomy and the "partial" bucket.
+	if _, ok := op.Responses["default"]; ok {
+		issues = append(issues, Issue{
+			Severity: "info", Kind: "default-status", Method: method, Path: path,
+			Detail: "an error status could not be determined (e.g. computed dynamically); the concrete 4xx/5xx isn't documented",
+		})
 	}
 
 	// parameter schemas can also reference components

--- a/internal/insight/overview_test.go
+++ b/internal/insight/overview_test.go
@@ -135,6 +135,113 @@ func TestBuildOverview_IssuesNeverNil(t *testing.T) {
 	}
 }
 
+func TestBuildOverview_ResolutionCoverageTaxonomy(t *testing.T) {
+	s := &spec.OpenAPISpec{
+		Paths: map[string]spec.PathItem{
+			// clean write op: has a body + a documented 400 → full, body+error covered
+			"/a": {Post: &spec.Operation{
+				RequestBody: &spec.RequestBody{Content: map[string]spec.MediaType{"application/json": {Schema: ref("In")}}},
+				Responses: map[string]spec.Response{
+					"201": {Content: map[string]spec.MediaType{"application/json": {Schema: ref("Out")}}},
+					"400": {},
+				},
+			}},
+			// only 200 + default → partial (default-status), no documented error
+			"/b": {Get: &spec.Operation{Responses: map[string]spec.Response{
+				"200":     {Content: map[string]spec.MediaType{"application/json": {Schema: ref("Out")}}},
+				"default": {},
+			}}},
+			// dangling ref → broken
+			"/c": {Get: &spec.Operation{Responses: jsonResp("200", ref("Missing"))}},
+		},
+		Components: &spec.Components{Schemas: map[string]*spec.Schema{"In": {Type: "object"}, "Out": {Type: "object"}}},
+	}
+	rep := BuildOverview(s, nil)
+
+	if rep.Resolution.Full != 1 || rep.Resolution.Partial != 1 || rep.Resolution.Broken != 1 {
+		t.Errorf("resolution = %+v, want full1 partial1 broken1", rep.Resolution)
+	}
+	if rep.Coverage.RequestBody.Have != 1 || rep.Coverage.RequestBody.Total != 1 {
+		t.Errorf("request-body coverage = %+v, want 1/1", rep.Coverage.RequestBody)
+	}
+	if rep.Coverage.ErrorResponses.Have != 1 || rep.Coverage.ErrorResponses.Total != 3 {
+		t.Errorf("error-response coverage = %+v, want 1/3", rep.Coverage.ErrorResponses)
+	}
+	if countOf(rep.Taxonomy, "default-status") != 1 {
+		t.Errorf("taxonomy default-status = %d, want 1 (%+v)", countOf(rep.Taxonomy, "default-status"), rep.Taxonomy)
+	}
+	if countOf(rep.Taxonomy, "dangling-ref") != 1 {
+		t.Errorf("taxonomy dangling-ref = %d, want 1 (%+v)", countOf(rep.Taxonomy, "dangling-ref"), rep.Taxonomy)
+	}
+	// default-status is info-level, so /b stays "clean"; health counts /a and /b.
+	if rep.Health.Score != 67 {
+		t.Errorf("health = %d, want 67 (default-status must not drop the score)", rep.Health.Score)
+	}
+}
+
+func TestInterfaceStats(t *testing.T) {
+	sp := metadata.NewStringPool()
+	iface := sp.Get("interface")
+	mkIface := func(name string, impls int) *metadata.Type {
+		by := make([]int, impls)
+		for i := range by {
+			by[i] = sp.Get(name + "Impl" + string(rune('a'+i)))
+		}
+		return &metadata.Type{Name: sp.Get(name), Pkg: sp.Get("pkg"), Kind: iface, ImplementedBy: by}
+	}
+	meta := &metadata.Metadata{
+		StringPool: sp,
+		Packages: map[string]*metadata.Package{
+			"pkg": {Files: map[string]*metadata.File{
+				"f.go": {Types: map[string]*metadata.Type{
+					"Store": mkIface("Store", 2), // ambiguous
+					"Clock": mkIface("Clock", 1), // single
+					"Empty": mkIface("Empty", 0), // unimplemented
+					"Foo":   {Name: sp.Get("Foo"), Pkg: sp.Get("pkg"), Kind: sp.Get("struct")},
+				}},
+			}},
+		},
+	}
+	st := interfaceStats(meta)
+	if st.Total != 3 || st.SingleImpl != 1 || st.Ambiguous != 1 || st.Unimplemented != 1 {
+		t.Errorf("interface stats = %+v, want total3 single1 ambiguous1 unimpl1", st)
+	}
+	if len(st.AmbiguousList) != 1 || st.AmbiguousList[0].Name != "Store" || st.AmbiguousList[0].Count != 2 {
+		t.Errorf("ambiguous list = %+v, want [Store:2]", st.AmbiguousList)
+	}
+	if interfaceStats(nil).Total != 0 {
+		t.Error("nil meta should be zero stats")
+	}
+}
+
+func TestVerbDispatch(t *testing.T) {
+	sp := metadata.NewStringPool()
+	pkg := "github.com/x/httpapi"
+	meta := &metadata.Metadata{
+		StringPool: sp,
+		Packages: map[string]*metadata.Package{
+			pkg: {Files: map[string]*metadata.File{
+				"h.go": {Functions: map[string]*metadata.Function{
+					"Widget": {Name: sp.Get("Widget"), Pkg: sp.Get(pkg),
+						MethodDispatch: []metadata.MethodBranch{{Methods: []string{"POST"}}, {Methods: []string{"GET"}}}},
+					"Plain":  {Name: sp.Get("Plain"), Pkg: sp.Get(pkg)},
+					"Single": {Name: sp.Get("Single"), Pkg: sp.Get(pkg), MethodDispatch: []metadata.MethodBranch{{Methods: []string{"GET"}}}},
+				}},
+			}},
+		},
+	}
+	vd := verbDispatch(meta)
+	if len(vd) != 1 {
+		t.Fatalf("verb dispatch = %+v, want exactly 1 (multi-method only)", vd)
+	}
+	if vd[0].Handler != "httpapi.Widget" {
+		t.Errorf("handler = %q, want httpapi.Widget", vd[0].Handler)
+	}
+	if len(vd[0].Methods) != 2 || vd[0].Methods[0] != "GET" || vd[0].Methods[1] != "POST" {
+		t.Errorf("methods = %v, want sorted [GET POST]", vd[0].Methods)
+	}
+}
+
 func TestSchemaRefs_DedupAndNested(t *testing.T) {
 	s := &spec.Schema{
 		Properties: map[string]*spec.Schema{

--- a/internal/insight/overview_test.go
+++ b/internal/insight/overview_test.go
@@ -206,11 +206,49 @@ func TestInterfaceStats(t *testing.T) {
 	if st.Total != 3 || st.SingleImpl != 1 || st.Ambiguous != 1 || st.Unimplemented != 1 {
 		t.Errorf("interface stats = %+v, want total3 single1 ambiguous1 unimpl1", st)
 	}
-	if len(st.AmbiguousList) != 1 || st.AmbiguousList[0].Name != "Store" || st.AmbiguousList[0].Count != 2 {
-		t.Errorf("ambiguous list = %+v, want [Store:2]", st.AmbiguousList)
+	if len(st.AmbiguousList) != 1 || st.AmbiguousList[0].Name != "pkg.Store" || st.AmbiguousList[0].Count != 2 {
+		t.Errorf("ambiguous list = %+v, want [pkg.Store:2]", st.AmbiguousList)
 	}
 	if interfaceStats(nil).Total != 0 {
 		t.Error("nil meta should be zero stats")
+	}
+}
+
+// Two ambiguous interfaces sharing a bare name in different packages must both
+// survive as distinct, package-qualified entries — a bare-name ambig key would
+// let one overwrite the other, and map-iteration order would decide which,
+// producing non-deterministic output (golden rule #1).
+func TestInterfaceStats_SameNameDifferentPackages(t *testing.T) {
+	sp := metadata.NewStringPool()
+	iface := sp.Get("interface")
+	mkIface := func(pkg, name string, impls int) *metadata.Type {
+		by := make([]int, impls)
+		for i := range by {
+			by[i] = sp.Get(pkg + name + "Impl" + string(rune('a'+i)))
+		}
+		return &metadata.Type{Name: sp.Get(name), Pkg: sp.Get(pkg), Kind: iface, ImplementedBy: by}
+	}
+	meta := &metadata.Metadata{
+		StringPool: sp,
+		Packages: map[string]*metadata.Package{
+			"github.com/me/app/orders": {Types: map[string]*metadata.Type{
+				"Store": mkIface("github.com/me/app/orders", "Store", 2),
+			}},
+			"github.com/me/app/users": {Types: map[string]*metadata.Type{
+				"Store": mkIface("github.com/me/app/users", "Store", 3),
+			}},
+		},
+	}
+	st := interfaceStats(meta)
+	if st.Ambiguous != 2 {
+		t.Fatalf("ambiguous = %d, want 2 (both Store interfaces)", st.Ambiguous)
+	}
+	got := map[string]int{}
+	for _, c := range st.AmbiguousList {
+		got[c.Name] = c.Count
+	}
+	if got["orders.Store"] != 2 || got["users.Store"] != 3 {
+		t.Errorf("ambiguous list = %+v, want orders.Store:2 users.Store:3", st.AmbiguousList)
 	}
 }
 


### PR DESCRIPTION
Reframes the Insight **Overview** from *"what did we produce?"* to also answer *"why did it resolve this way, and what needs attention?"* — a **strict superset** of today's Overview (nothing removed).

## What's kept
Every existing element: health gauge + counts, Methods / Status / Content-type / Tags charts (with tag→endpoint click), the full Security card, the route-level **Needs attention** list, Most-referenced types, the Call-graph card, **Export to AI**, and every ⓘ tooltip.

## What's new
Added above/around the existing charts, grouped by section eyebrows:
- **Alerts** — a prioritized, severity-striped strip (critical → warning → info) as the triage entry point; the per-route list below is the drill-down.
- **Resolution quality** — operations by **full / partial / broken**, a **"why not resolved"** taxonomy, and **documentation-coverage** meters (request body, error responses, protected).
- **Tree insights** — **interface resolution** (single-impl / ambiguous / unimplemented, with the ambiguous ones that erase to `any`) and **verb dispatch** (`switch r.Method` splits).

## Lightweight by design
The constraint was that the Overview must stay cheap. All new backend data is **precomputed reads with no tracker-tree build**:
- `Resolution`, `Coverage`, `Taxonomy` — from the spec walk already happening.
- `Interfaces` — one pass over the precomputed `ImplementedBy` index.
- `VerbDispatch` — one pass over the precomputed `MethodDispatch` arms.
- A `default-status` **info** signal (never lowers the health score) that feeds alerts / taxonomy / the "partial" bucket.

**Deliberately excluded** from the Overview because they'd force a per-request tracker-tree build: the type-flow mechanism breakdown, resolution hotspots, type-flow depth, and middleware/registration chains — those live in the per-endpoint view. Rationale + the full plan in `docs/INSIGHT_ROADMAP.md` (included).

## Tests & checks
- `overview_test.go` — resolution / coverage / taxonomy / `interfaceStats` / `verbDispatch`.
- `e2e_test.go` — asserts the aggregations' invariants on **real generated metadata** (`testdata/echo`).
- Existing insight tests unchanged (health-score behavior preserved).
- gofmt / vet / golangci-lint clean; `insight.js` syntax-checked; apispecui builds.
- `normalizeReport` guards every new field, so an older backend response can't break the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned the Insight Overview dashboard with resolution summaries (full/partial/broken), coverage meters, taxonomy breakdowns, interface insights, and verb-dispatch details.
  * Added clearer health alerts (critical/warning/info), resolution/coverage legends, and improved chart coloring for per-item emphasis.
* **Documentation**
  * Added an Insight Dashboard Roadmap focused on moving from “what” to “why” resolution.
* **Bug Fixes**
  * Improved robustness of report shaping so insight sections render with safe defaults when data is missing.
  * Added handling to surface and classify operations that define default responses.
* **Tests**
  * Expanded Insight Overview validation with new resolution/coverage/taxonomy, interface, and verb-dispatch assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->