### PR TITLE
feat(insight): interface decisions on the endpoint resolution trace

### DIFF
--- a/cmd/apispecui/assets/js/components/charts.js
+++ b/cmd/apispecui/assets/js/components/charts.js
@@ -181,18 +181,23 @@ export function TraceDiagram({ trace }) {
     const p = pos[n.id];
     const isSel = selected && selected.node.id === n.id;
     const isFocus = focusId === n.id;
+    // A resolved node reached via an interface with >1 implementation is an
+    // ambiguous resolution — flag it in warn so it stands out from a clean
+    // single-implementation resolution.
+    const ambiguous = n.resolved && n.alternatives > 1;
+    const resCol = ambiguous ? "var(--warn)" : "var(--info)";
     return html`<g transform=${`translate(${p.x},${p.y})`} style="cursor:pointer" opacity=${nodeDim(n.id) ? 0.28 : 1}
       onMouseMove=${(e) => setHover({ node: n, x: e.clientX, y: e.clientY })}
       onMouseLeave=${() => setHover(null)}
       onClick=${(e) => setSelected({ node: n, x: e.clientX, y: e.clientY })}>
       <rect width=${NW} height=${NH} rx="6" fill=${nodeFill(n.kind)}
-        stroke=${isSel ? "var(--text)" : isFocus ? "var(--accent)" : n.resolved ? "var(--info)" : nodeColor(n.kind)}
+        stroke=${isSel ? "var(--text)" : isFocus ? "var(--accent)" : n.resolved ? resCol : nodeColor(n.kind)}
         stroke-width=${isSel || isFocus ? 2.5 : n.resolved ? 2 : n.kind === "handler" ? 2 : 1} />
-      <circle cx="11" cy=${NH / 2} r="3" fill=${n.resolved ? "var(--info)" : nodeColor(n.kind)} />
+      <circle cx="11" cy=${NH / 2} r="3" fill=${n.resolved ? resCol : nodeColor(n.kind)} />
       <text x="22" y=${NH / 2 + 4} font-size="11" fill="var(--text)" style="font-family:var(--font-mono)">${trunc(n.label, n.resolved ? 14 : 19)}</text>
       ${n.resolved
-        ? html`<text x=${NW - 6} y=${NH / 2 + 4} text-anchor="end" font-size="9" font-weight="700" fill="var(--info)"
-            ><title>resolved from an interface</title>⟐ impl</text
+        ? html`<text x=${NW - 6} y=${NH / 2 + 4} text-anchor="end" font-size="9" font-weight="700" fill=${resCol}
+            ><title>${n.resolvedFrom ? (ambiguous ? `one of ${n.alternatives} implementations of ${n.resolvedFrom}` : `sole implementation of ${n.resolvedFrom}`) : "resolved from an interface"}</title>⟐ ${ambiguous ? "1/" + n.alternatives : "impl"}</text
           >`
         : ""}
     </g>`;
@@ -218,7 +223,7 @@ export function TraceDiagram({ trace }) {
       </svg>
     </div>
     <p class="muted" style="font-size:var(--fs-xs);margin:6px 0 0">
-      Focus a node to highlight its edges: <span style="color:var(--accent)">▸ calls</span> · <span style="color:var(--warn)">◂ called by</span> · <span style="color:var(--info)">⟐ impl</span> = concrete resolved from an interface · hover to preview, click to pin.
+      Focus a node to highlight its edges: <span style="color:var(--accent)">▸ calls</span> · <span style="color:var(--warn)">◂ called by</span> · <span style="color:var(--info)">⟐ impl</span> = concrete resolved from an interface (sole impl) · <span style="color:var(--warn)">⟐ 1/N</span> = ambiguous, one of N implementations · hover to preview, click to pin.
     </p>
     ${selected ? html`<${TraceTip} key=${selected.node.id} node=${selected.node} x=${selected.x} y=${selected.y} pinned onClose=${() => setSelected(null)} />` : ""}
     ${hover && (!selected || selected.node.id !== hover.node.id) ? html`<${TraceTip} node=${hover.node} x=${hover.x} y=${hover.y} />` : ""}
@@ -354,9 +359,21 @@ function TraceTip({ node, x, y, pinned, onClose }) {
       <span class="tt-badge">${node.kind}</span>
       <span class="tt-badge">depth ${node.depth}</span>
       ${node.resolved
-        ? html`<span class="tt-badge" style="color:var(--info);border-color:var(--info)" title="Reached by resolving an interface call to its concrete implementation">⟐ resolved impl</span>`
+        ? html`<span
+            class="tt-badge"
+            style=${`color:${node.alternatives > 1 ? "var(--warn)" : "var(--info)"};border-color:${node.alternatives > 1 ? "var(--warn)" : "var(--info)"}`}
+            title="Reached by resolving an interface call to its concrete implementation"
+            >⟐ resolved impl</span
+          >`
         : ""}
     </div>
+    ${node.resolved && node.resolvedFrom
+      ? html`<div class="tt-meta">
+          ⟐ implements <b>${node.resolvedFrom}</b>${node.alternatives > 1
+            ? html` · <span style="color:var(--warn)">1 of ${node.alternatives} implementations — the type may be kept general (any)</span>`
+            : html` · <span style="color:var(--info)">sole implementation</span>`}
+        </div>`
+      : ""}
     <div class="tt-meta">
       <span style="color:var(--accent)">▸ ${node.calls} calls</span> · <span style="color:var(--warn)">◂ called by ${node.calledBy}</span>
     </div>

--- a/internal/insight/export.go
+++ b/internal/insight/export.go
@@ -175,12 +175,14 @@ func BuildEndpointExportMarkdown(rep *EndpointReport, opts ExportOptions) string
 
 	// scoped trace
 	if len(rep.Trace.Edges) > 0 {
-		// Node IDs whose target is a concrete implementation resolved from an
-		// interface call — annotated below so the AI sees the interface→impl hop.
-		resolved := make(map[string]bool, len(rep.Trace.Nodes))
+		// Nodes whose target is a concrete implementation resolved from an
+		// interface call — annotated below (with the interface and its
+		// implementation count) so the AI sees the interface→impl hop and any
+		// ambiguity behind it.
+		resolved := make(map[string]TraceNode, len(rep.Trace.Nodes))
 		for _, n := range rep.Trace.Nodes {
 			if n.Resolved {
-				resolved[n.ID] = true
+				resolved[n.ID] = n
 			}
 		}
 		b.WriteString("## Resolution trace (call subtree, this endpoint)\n")
@@ -192,8 +194,15 @@ func BuildEndpointExportMarkdown(rep *EndpointReport, opts ExportOptions) string
 				break
 			}
 			marker := ""
-			if resolved[e.Target] {
-				marker = "   ⟐ impl (resolved from interface)"
+			if rn, ok := resolved[e.Target]; ok {
+				switch {
+				case rn.ResolvedFrom != "" && rn.Alternatives > 1:
+					marker = fmt.Sprintf("   ⟐ impl (1 of %d implementations of %s — may be kept general)", rn.Alternatives, rn.ResolvedFrom)
+				case rn.ResolvedFrom != "":
+					marker = fmt.Sprintf("   ⟐ impl (sole implementation of %s)", rn.ResolvedFrom)
+				default:
+					marker = "   ⟐ impl (resolved from interface)"
+				}
 			}
 			fmt.Fprintf(&b, "%s → %s%s\n", red(shortLabel(e.Source)), red(shortLabel(e.Target)), marker)
 		}

--- a/internal/insight/metrics.go
+++ b/internal/insight/metrics.go
@@ -69,6 +69,13 @@ type TraceNode struct {
 	// interface method call to its implementer — the UI badges these so the
 	// "interface → impl" hop is visible.
 	Resolved bool `json:"resolved,omitempty"`
+	// ResolvedFrom / Alternatives describe the interface decision behind a
+	// Resolved node: the interface this concrete type satisfies and how many
+	// implementations that interface has. Alternatives > 1 flags an ambiguous
+	// resolution — the concrete type may be kept general (erased to any) at the
+	// schema boundary, so this is where interface ambiguity costs precision.
+	ResolvedFrom string `json:"resolvedFrom,omitempty"`
+	Alternatives int    `json:"alternatives,omitempty"`
 	// Sites lists every distinct location this function is called from within
 	// the trace (a function reached from several callers, or called more than
 	// once by the same caller, has multiple). The UI shows them all and lets
@@ -540,6 +547,10 @@ func analyzeTrackerSubtree(meta *metadata.Metadata, routeNode spec.TrackerNodeIn
 			if _, ok := info[caller]; !ok {
 				cm := traceMetaFromCall(meta, &ce.Caller)
 				cm.resolved = true // concrete impl reached via interface resolution
+				if iface, n := resolvedInterface(meta, sp.GetString(ce.Caller.RecvType)); iface != "" {
+					cm.resolvedFrom = iface
+					cm.alternatives = n
+				}
 				info[caller] = cm
 			}
 			parentID, d = caller, d+1
@@ -715,11 +726,13 @@ func enumeratePaths(adj map[string][]string, root string, cap int) [][]string {
 
 // traceMeta is per-node display metadata surfaced in the trace tooltip.
 type traceMeta struct {
-	pkg      string
-	symbol   string
-	pos      string
-	origin   string
-	resolved bool // concrete impl reached via interface resolution
+	pkg          string
+	symbol       string
+	pos          string
+	origin       string
+	resolved     bool // concrete impl reached via interface resolution
+	resolvedFrom string
+	alternatives int
 }
 
 func traceMetaFromCall(meta *metadata.Metadata, c *metadata.Call) traceMeta {
@@ -737,6 +750,83 @@ func traceMetaFromCall(meta *metadata.Metadata, c *metadata.Call) traceMeta {
 		pos:    extractFilePos(sp.GetString(c.Position)),
 		origin: classifyPkg(meta, pkg, recv),
 	}
+}
+
+// typeIndex builds and memoizes a name→*Type lookup over the metadata, keyed by
+// both the bare type name and the qualified "pkg.Name" form (matching how the
+// Implements/ImplementedBy pool strings are stored). Rebuilt only when the
+// metadata pointer changes.
+var (
+	typeIdxMu  sync.Mutex
+	typeIdxKey *metadata.Metadata
+	typeIdxVal map[string]*metadata.Type
+)
+
+func typeIndex(meta *metadata.Metadata) map[string]*metadata.Type {
+	typeIdxMu.Lock()
+	defer typeIdxMu.Unlock()
+	if typeIdxKey == meta && typeIdxVal != nil {
+		return typeIdxVal
+	}
+	sp := meta.StringPool
+	idx := map[string]*metadata.Type{}
+	add := func(t *metadata.Type) {
+		name := sp.GetString(t.Name)
+		if name == "" {
+			return
+		}
+		if _, ok := idx[name]; !ok {
+			idx[name] = t
+		}
+		if pkg := sp.GetString(t.Pkg); pkg != "" {
+			idx[pkg+"."+name] = t
+		}
+	}
+	for _, pkg := range meta.Packages {
+		for _, f := range pkg.Files {
+			for k := range f.Types {
+				add(f.Types[k])
+			}
+		}
+		for k := range pkg.Types {
+			add(pkg.Types[k])
+		}
+	}
+	typeIdxKey = meta
+	typeIdxVal = idx
+	return idx
+}
+
+// resolvedInterface reports, for a concrete receiver type reached by interface
+// resolution, the interface it satisfies and how many implementations that
+// interface has. When the concrete type satisfies several interfaces it returns
+// the most-implemented one (the strongest ambiguity signal). Both inputs come
+// from the precomputed Implements / ImplementedBy indexes — no traversal.
+func resolvedInterface(meta *metadata.Metadata, recvType string) (string, int) {
+	if meta == nil || meta.StringPool == nil {
+		return "", 0
+	}
+	recvType = strings.TrimPrefix(strings.TrimSpace(recvType), "*")
+	if recvType == "" {
+		return "", 0
+	}
+	idx := typeIndex(meta)
+	ct := idx[recvType]
+	if ct == nil {
+		return "", 0
+	}
+	sp := meta.StringPool
+	bestIface, bestN := "", 0
+	for _, impIdx := range ct.Implements {
+		it := idx[sp.GetString(impIdx)]
+		if it == nil {
+			continue
+		}
+		if n := len(it.ImplementedBy); n > bestN {
+			bestN, bestIface = n, sp.GetString(it.Name)
+		}
+	}
+	return bestIface, bestN
 }
 
 // countPaths counts root→leaf paths over the adjacency DAG, capping at
@@ -835,18 +925,20 @@ func buildTraceGraph(tg *TraceGraph, adj map[string][]string, depth map[string]i
 		}
 		md := info[n.id]
 		tg.Nodes = append(tg.Nodes, TraceNode{
-			ID:       n.id,
-			Label:    shortLabel(n.id),
-			Depth:    n.d,
-			Kind:     kind,
-			Pkg:      md.pkg,
-			Symbol:   md.symbol,
-			Pos:      md.pos,
-			Origin:   md.origin,
-			Resolved: md.resolved,
-			Sites:    sortedSites(sites[n.id]),
-			Calls:    len(adj[n.id]),
-			CalledBy: calledBy[n.id],
+			ID:           n.id,
+			Label:        shortLabel(n.id),
+			Depth:        n.d,
+			Kind:         kind,
+			Pkg:          md.pkg,
+			Symbol:       md.symbol,
+			Pos:          md.pos,
+			Origin:       md.origin,
+			Resolved:     md.resolved,
+			ResolvedFrom: md.resolvedFrom,
+			Alternatives: md.alternatives,
+			Sites:        sortedSites(sites[n.id]),
+			Calls:        len(adj[n.id]),
+			CalledBy:     calledBy[n.id],
 		})
 		included[n.id] = true
 	}

--- a/internal/insight/metrics_test.go
+++ b/internal/insight/metrics_test.go
@@ -145,3 +145,39 @@ func TestAnalyzers_Fixture(t *testing.T) {
 		t.Fatal("analyzeFromTrackerTree (echo cfg) should succeed")
 	}
 }
+
+// TestResolvedInterface checks the interface-decision helper: a concrete
+// receiver reached by resolution reports the interface it satisfies and how
+// many implementations that interface has (the ambiguity signal). It reads the
+// precomputed Implements / ImplementedBy indexes only.
+func TestResolvedInterface(t *testing.T) {
+	sp := metadata.NewStringPool()
+	iface := &metadata.Type{
+		Name: sp.Get("UserStore"), Pkg: sp.Get("app"), Kind: sp.Get("interface"),
+		ImplementedBy: []int{sp.Get("app.pgStore"), sp.Get("app.memStore")}, // 2 impls → ambiguous
+	}
+	concrete := &metadata.Type{
+		Name: sp.Get("pgStore"), Pkg: sp.Get("app"), Kind: sp.Get("struct"),
+		Implements: []int{sp.Get("app.UserStore")},
+	}
+	meta := &metadata.Metadata{
+		StringPool: sp,
+		Packages: map[string]*metadata.Package{
+			"app": {Files: map[string]*metadata.File{
+				"f.go": {Types: map[string]*metadata.Type{"UserStore": iface, "pgStore": concrete}},
+			}},
+		},
+	}
+	for _, recv := range []string{"pgStore", "*pgStore", "app.pgStore", "*app.pgStore"} {
+		name, n := resolvedInterface(meta, recv)
+		if name != "UserStore" || n != 2 {
+			t.Errorf("resolvedInterface(%q) = (%q, %d), want (UserStore, 2)", recv, name, n)
+		}
+	}
+	if _, n := resolvedInterface(meta, "nope"); n != 0 {
+		t.Errorf("unknown receiver should give 0 alternatives, got %d", n)
+	}
+	if _, n := resolvedInterface(nil, "x"); n != 0 {
+		t.Error("nil meta must be safe")
+	}
+}


### PR DESCRIPTION
## What

The per-endpoint resolution trace now surfaces **interface decisions**: when a concrete node was resolved from an interface call, the trace annotates it with the interface it satisfies and how many alternative implementations exist. More than one implementation is an ambiguity signal — apispec may have kept the general interface type rather than committing to one concrete option (per the "honest over wrong" invariant).

This is the cheap, high-value slice of the Endpoint-view tree overlay: it reads the precomputed `Type.ImplementedBy`/`Implements` facts already in metadata — **no additional tracker-tree build**.

## Changes

- **`metrics.go`** — `TraceNode.ResolvedFrom` / `Alternatives` fields; `resolvedInterface(meta, recvType)` + memoized `typeIndex(meta)` helpers (handle `*T`, `pkg.T`, `*pkg.T` receiver forms); hooked at the interface→impl resolution boundary in `analyzeTrackerSubtree`; `buildTraceGraph` copies the fields onto the graph node.
- **`charts.js`** — resolved nodes with >1 implementation render in the warn hue with a `⟐ 1/N` label; `TraceTip` gains an `implements <interface>` line noting alternatives; legend explains the ambiguity marker.
- **`export.go`** — the markdown resolution-trace marker names the interface and flags kept-general (ambiguous) resolutions for the AI bundle.
- **`metrics_test.go`** — `TestResolvedInterface` covers the pointer/qualified receiver forms and nil-safety.

## Notes

Independent of #156 (Overview redesign) — no file overlap. All Go tests pass; `gofmt`/`go vet`/`golangci-lint` clean; `node --check` on `charts.js` OK; apispecui builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)