### PR TITLE
ci: only run Go workflows when Go-related files change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,14 @@ name: CI
 on:
   push:
     branches: [ main, develop ]
+    paths: &go-paths
+      - '**.go'
+      - '**/go.mod'
+      - '**/go.sum'
+      - '.github/workflows/ci.yml'
   pull_request:
     branches: [ main, develop ]
+    paths: *go-paths
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,14 +3,18 @@ name: CI
 on:
   push:
     branches: [ main, develop ]
-    paths: &go-paths
+    paths:
       - '**.go'
       - '**/go.mod'
       - '**/go.sum'
       - '.github/workflows/ci.yml'
   pull_request:
     branches: [ main, develop ]
-    paths: *go-paths
+    paths:
+      - '**.go'
+      - '**/go.mod'
+      - '**/go.sum'
+      - '.github/workflows/ci.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,6 +3,12 @@ name: Coverage Badge
 on:
   push:
     branches: [ main ]
+    paths:
+      - '**.go'
+      - '**/go.mod'
+      - '**/go.sum'
+      - 'scripts/**'
+      - '.github/workflows/coverage.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,8 +3,16 @@ name: Lint
 on:
   push:
     branches: [ main, develop ]
+    paths: &go-paths
+      - '**.go'
+      - '**/go.mod'
+      - '**/go.sum'
+      - '.golangci.yml'
+      - '.golangci.yaml'
+      - '.github/workflows/lint.yml'
   pull_request:
     branches: [ main, develop ]
+    paths: *go-paths
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: Lint
 on:
   push:
     branches: [ main, develop ]
-    paths: &go-paths
+    paths:
       - '**.go'
       - '**/go.mod'
       - '**/go.sum'
@@ -12,7 +12,13 @@ on:
       - '.github/workflows/lint.yml'
   pull_request:
     branches: [ main, develop ]
-    paths: *go-paths
+    paths:
+      - '**.go'
+      - '**/go.mod'
+      - '**/go.sum'
+      - '.golangci.yml'
+      - '.golangci.yaml'
+      - '.github/workflows/lint.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 on:
   push:
     branches: [ main, develop ]
-    paths: &go-paths
+    paths:
       - '**.go'
       - '**/go.mod'
       - '**/go.sum'
@@ -11,7 +11,12 @@ on:
       - '.github/workflows/test.yml'
   pull_request:
     branches: [ main, develop ]
-    paths: *go-paths
+    paths:
+      - '**.go'
+      - '**/go.mod'
+      - '**/go.sum'
+      - 'scripts/**'
+      - '.github/workflows/test.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,15 @@ name: Test
 on:
   push:
     branches: [ main, develop ]
+    paths: &go-paths
+      - '**.go'
+      - '**/go.mod'
+      - '**/go.sum'
+      - 'scripts/**'
+      - '.github/workflows/test.yml'
   pull_request:
     branches: [ main, develop ]
+    paths: *go-paths
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## What

Adds `paths:` allowlists to the Go pipelines so they **don't run on commits/PRs that touch no Go-related files** (docs, coverage-badge commits, unrelated config).

| Workflow | Runs when these change |
|---|---|
| **CI** (build) | `**.go`, `**/go.mod`, `**/go.sum`, `.github/workflows/ci.yml` |
| **Lint** | above + `.golangci.yml`/`.yaml`, own file |
| **Test** (+ coverage-ratchet) | core + `scripts/**` (ratchet runs `scripts/check-coverage.sh`), own file |
| **Coverage Badge** | core + `scripts/**`, own file (push-to-main only) |

Each workflow lists only the files that actually affect its outcome, and includes **its own workflow file** so CI changes still re-validate (this PR self-runs for that reason).

## Why it's safe

`main` has **no required status checks** — its ruleset enforces only PR-required, non-fast-forward, and no-deletion. So a docs-only PR that skips these checks is **not** blocked from merging (the classic path-filter deadlock only happens when a *required* check is filtered out). `workflow_dispatch` is left unfiltered, so every workflow can still be triggered manually.

## Notes

- Side benefit: docs-only merges to `main` no longer recompute the coverage badge, so they stop producing `Update coverage badge [skip ci]` commits. This *reduces* — but does not fully eliminate — the `[skip ci]`-tip situation that blocks release tagging (Go-change merges still update the badge). The complete tag fix is the separate `create-release.sh` hardening.
- `**.go` covers `testdata/` fixtures; `**/go.mod`/`**/go.sum` cover nested fixture modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)