### PR TITLE
fix(spec): omit content block for bodyless status codes (204/304/1xx)

### DIFF
--- a/generator/testdata_bodyless_status_test.go
+++ b/generator/testdata_bodyless_status_test.go
@@ -28,6 +28,7 @@ import (
 func TestTestdata_BodylessStatus(t *testing.T) {
 	out := loadTestdataWithFixtureConfig(t, "bodyless_status", spec.DefaultHTTPConfig())
 	noDanglingRefs(t, out)
+	noUnresolvedPlaceholders(t, out)
 
 	// (path, method, status) -> whether a content block is expected.
 	cases := []struct {

--- a/generator/testdata_bodyless_status_test.go
+++ b/generator/testdata_bodyless_status_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/spec"
+)
+
+// TestTestdata_BodylessStatus covers issue #169 (GAP §7.3): bodyless status
+// codes — 1xx, 204, and 304 — must be emitted with NO `content` block, since
+// the OpenAPI spec forbids a body for these codes. Any body the handler appears
+// to write (deleteWidget writes a spurious one alongside its 204) must be
+// stripped. Non-bodyless responses (200) must keep their content untouched.
+func TestTestdata_BodylessStatus(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "bodyless_status", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+
+	// (path, method, status) -> whether a content block is expected.
+	cases := []struct {
+		path, method, status string
+		wantContent          bool
+	}{
+		{"/widget/{id}", "DELETE", "204", false}, // No Content — spurious body dropped
+		{"/widget/{id}", "HEAD", "304", false},   // Not Modified
+		{"/upload", "POST", "100", false},        // 1xx informational
+		{"/widget/{id}", "GET", "200", true},     // normal body — unaffected
+	}
+
+	for _, tc := range cases {
+		item, ok := out.Paths[tc.path]
+		if !ok {
+			t.Errorf("path %s missing; have %v", tc.path, mapPathKeys(out.Paths))
+			continue
+		}
+		op := opFor(item, tc.method)
+		if op == nil {
+			t.Errorf("%s %s missing", tc.method, tc.path)
+			continue
+		}
+		resp, ok := op.Responses[tc.status]
+		if !ok {
+			t.Errorf("%s %s: status %s missing; have %v",
+				tc.method, tc.path, tc.status, keysOf(op.Responses))
+			continue
+		}
+		hasContent := len(resp.Content) > 0
+		if hasContent != tc.wantContent {
+			t.Errorf("%s %s status %s: content present=%v, want %v (content=%v)",
+				tc.method, tc.path, tc.status, hasContent, tc.wantContent, resp.Content)
+		}
+	}
+}

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -595,6 +595,15 @@ func buildResponses(respInfo map[string]*ResponseInfo) map[string]Response {
 			description = "Status code could not be determined"
 		}
 
+		// Bodyless status codes (204, 304, 1xx) must not carry a response body
+		// per the OpenAPI spec — emit them with no `content` block. Any body the
+		// handler appears to write is spurious for these codes and would produce
+		// an invalid document.
+		if isBodylessStatus(resp.StatusCode) {
+			responses[statusCode] = Response{Description: description}
+			continue
+		}
+
 		responses[statusCode] = Response{
 			Description: description,
 			Content: map[string]MediaType{
@@ -606,6 +615,14 @@ func buildResponses(respInfo map[string]*ResponseInfo) map[string]Response {
 	}
 
 	return responses
+}
+
+// isBodylessStatus reports whether an HTTP status code must not carry a
+// response body per RFC 7231 / the OpenAPI spec: 1xx (informational), 204
+// (No Content), and 304 (Not Modified). Responses for these codes must omit
+// the `content` block entirely.
+func isBodylessStatus(code int) bool {
+	return (code >= 100 && code < 200) || code == 204 || code == 304
 }
 
 // setOperationOnPathItem sets an operation on a path item based on HTTP method

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -618,11 +618,11 @@ func buildResponses(respInfo map[string]*ResponseInfo) map[string]Response {
 }
 
 // isBodylessStatus reports whether an HTTP status code must not carry a
-// response body per RFC 7231 / the OpenAPI spec: 1xx (informational), 204
-// (No Content), and 304 (Not Modified). Responses for these codes must omit
-// the `content` block entirely.
+// response body per RFC 9110 / the OpenAPI spec: 1xx (informational), 204
+// (No Content), 205 (Reset Content), and 304 (Not Modified). Responses for
+// these codes must omit the `content` block entirely.
 func isBodylessStatus(code int) bool {
-	return (code >= 100 && code < 200) || code == 204 || code == 304
+	return (code >= 100 && code < 200) || code == 204 || code == 205 || code == 304
 }
 
 // setOperationOnPathItem sets an operation on a path item based on HTTP method

--- a/internal/spec/response_bodyless_test.go
+++ b/internal/spec/response_bodyless_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import "testing"
+
+func TestIsBodylessStatus(t *testing.T) {
+	bodyless := []int{100, 101, 102, 199, 204, 304}
+	for _, code := range bodyless {
+		if !isBodylessStatus(code) {
+			t.Errorf("isBodylessStatus(%d) = false, want true", code)
+		}
+	}
+	withBody := []int{200, 201, 202, 203, 205, 206, 300, 301, 400, 404, 500}
+	for _, code := range withBody {
+		if isBodylessStatus(code) {
+			t.Errorf("isBodylessStatus(%d) = true, want false", code)
+		}
+	}
+}
+
+// TestBuildResponses_BodylessOmitsContent pins issue #169: 1xx/204/304 must be
+// emitted with no `content` block even when a body was resolved for them, while
+// ordinary statuses keep their content.
+func TestBuildResponses_BodylessOmitsContent(t *testing.T) {
+	ref := func(name string) *Schema { return &Schema{Ref: "#/components/schemas/" + name} }
+
+	r := buildResponses(map[string]*ResponseInfo{
+		// A spurious body is attached to each bodyless status to prove it is
+		// dropped regardless.
+		"100": {StatusCode: 100, ContentType: "application/json", BodyType: "Widget", Schema: ref("Widget")},
+		"204": {StatusCode: 204, ContentType: "application/json", BodyType: "Widget", Schema: ref("Widget")},
+		"304": {StatusCode: 304, ContentType: "application/json", BodyType: "Widget", Schema: ref("Widget")},
+		"200": {StatusCode: 200, ContentType: "application/json", BodyType: "Widget", Schema: ref("Widget")},
+	})
+
+	for _, status := range []string{"100", "204", "304"} {
+		resp, ok := r[status]
+		if !ok {
+			t.Errorf("status %s missing from responses", status)
+			continue
+		}
+		if len(resp.Content) != 0 {
+			t.Errorf("status %s must have no content, got %v", status, resp.Content)
+		}
+		if resp.Description == "" {
+			t.Errorf("status %s should retain a description", status)
+		}
+	}
+
+	if ok := r["200"]; len(ok.Content) == 0 {
+		t.Error("status 200 must keep its content block")
+	}
+}

--- a/internal/spec/response_bodyless_test.go
+++ b/internal/spec/response_bodyless_test.go
@@ -17,13 +17,13 @@ package spec
 import "testing"
 
 func TestIsBodylessStatus(t *testing.T) {
-	bodyless := []int{100, 101, 102, 199, 204, 304}
+	bodyless := []int{100, 101, 102, 199, 204, 205, 304}
 	for _, code := range bodyless {
 		if !isBodylessStatus(code) {
 			t.Errorf("isBodylessStatus(%d) = false, want true", code)
 		}
 	}
-	withBody := []int{200, 201, 202, 203, 205, 206, 300, 301, 400, 404, 500}
+	withBody := []int{200, 201, 202, 203, 206, 300, 301, 400, 404, 500}
 	for _, code := range withBody {
 		if isBodylessStatus(code) {
 			t.Errorf("isBodylessStatus(%d) = true, want false", code)
@@ -60,7 +60,7 @@ func TestBuildResponses_BodylessOmitsContent(t *testing.T) {
 		}
 	}
 
-	if ok := r["200"]; len(ok.Content) == 0 {
+	if resp, ok := r["200"]; !ok || len(resp.Content) == 0 {
 		t.Error("status 200 must keep its content block")
 	}
 }

--- a/testdata/bodyless_status/go.mod
+++ b/testdata/bodyless_status/go.mod
@@ -1,0 +1,3 @@
+module github.com/ehabterra/apispec/testdata/bodyless_status
+
+go 1.24.3

--- a/testdata/bodyless_status/main.go
+++ b/testdata/bodyless_status/main.go
@@ -1,0 +1,49 @@
+// Fixture: bodyless status codes (204/304/1xx) must be emitted with no
+// `content` block per the OpenAPI spec (issue #169, GAP §7.3). Handlers here
+// return 204 No Content, 304 Not Modified, and 100 Continue — none may carry a
+// response body. getWidget returns a real 200 body to prove that non-bodyless
+// responses are unaffected, and deleteWidget deliberately writes a spurious
+// body alongside its 204 to prove the body is stripped anyway.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type Widget struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// deleteWidget writes a 204 — and a stray body — to prove the body is dropped.
+func deleteWidget(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNoContent) // 204 — must have no content
+	_ = json.NewEncoder(w).Encode(Widget{ID: "deleted"})
+}
+
+// checkWidget returns 304 Not Modified — bodyless.
+func checkWidget(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotModified) // 304 — must have no content
+}
+
+// continueUpload returns 100 Continue — a 1xx informational code, bodyless.
+func continueUpload(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusContinue) // 100 — must have no content
+}
+
+// getWidget returns a normal 200 body — unaffected by the bodyless rule.
+func getWidget(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK) // 200 — keeps its content block
+	_ = json.NewEncoder(w).Encode(Widget{ID: "1", Name: "gadget"})
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("DELETE /widget/{id}", deleteWidget)
+	mux.HandleFunc("HEAD /widget/{id}", checkWidget)
+	mux.HandleFunc("POST /upload", continueUpload)
+	mux.HandleFunc("GET /widget/{id}", getWidget)
+	_ = http.ListenAndServe(":8080", mux)
+}


### PR DESCRIPTION
## Summary

Fixes #169. Responses for status codes that must not carry a body — 1xx (informational), 204 (No Content), and 304 (Not Modified) — were emitted with an invalid empty `content: { application/json: {} }` placeholder. Per RFC 7231 / the OpenAPI spec these must have no `content` block at all (GAP §7.3).

## Change

- `internal/spec/mapper.go` — `buildResponses` now skips the `content` block for bodyless statuses, emitting `description` only. Any body the handler appears to write is dropped for these codes. New helper `isBodylessStatus(code)` encodes the rule (`1xx || 204 || 304`).

## Before / After

```yaml
# Before (invalid)
"204":
  description: No Content
  content: { application/json: {} }

# After
"204":
  description: No Content
```

## Tests & fixtures

- `testdata/bodyless_status/` — net/http server exercising:
  - `DELETE /widget/{id}` → **204**, deliberately writing a stray body (proves it's stripped)
  - `HEAD /widget/{id}` → **304**
  - `POST /upload` → **100** (1xx)
  - `GET /widget/{id}` → **200** with a real body (proves non-bodyless responses are unaffected)
- `generator/testdata_bodyless_status_test.go` — structural test asserting content presence/absence per (path, method, status); no dangling refs.
- `internal/spec/response_bodyless_test.go` — unit tests for `isBodylessStatus` (boundary codes) and `buildResponses`.

## Verification

- `apispec --dir testdata/bodyless_status` confirms 100/204/304 emit `description` only; 200 keeps its `$ref` content.
- Full `go test ./...` passes with **zero output drift**; `gofmt`, `go vet`, `golangci-lint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected generated API specifications so bodyless HTTP responses—including informational statuses, `204`, and `304`—no longer include an incorrect response content block.
  * Preserved response content for statuses that support response bodies, such as `200`.
  * Added validation covering bodyless status handling across generated test data and specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->