### PR TITLE
docs: pin .golangci.yml, add CONFIGURATION.md and CHANGELOG.md

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,29 @@
+# golangci-lint configuration.
+#
+# Pinned so local `make lint` and CI agree, and so a version bump of
+# golangci-lint cannot silently change the enabled rule set (issue #172).
+# This pins the v2 `standard` linter set — errcheck, govet, ineffassign,
+# staticcheck, unused — which is what CI (golangci-lint v2.11.4) already runs
+# by default. Enable additional linters in their own PR so each rule's churn
+# is reviewed on its own.
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  # `standard` is golangci-lint's default enabled set; naming it here makes the
+  # set explicit and version-stable rather than implicit.
+  default: standard
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+
+formatters:
+  # gofmt is enforced separately by the CI `gofmt -s -l` step; list it here so
+  # `golangci-lint fmt` stays consistent with that check.
+  enable:
+    - gofmt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,61 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `.golangci.yml` pinning the linter set (the golangci-lint v2 `standard` set)
+  so local `make lint` and CI agree and version bumps can't silently change the
+  rules. ([#172](https://github.com/ehabterra/apispec/issues/172))
+- `docs/CONFIGURATION.md` — field-by-field configuration reference.
+  ([#172](https://github.com/ehabterra/apispec/issues/172))
+- This `CHANGELOG.md`. ([#172](https://github.com/ehabterra/apispec/issues/172))
+
+## [0.5.1] - 2026-07-17
+
+### Fixed
+
+- Bodyless status codes (1xx, 204, 205, 304) are no longer emitted with an
+  invalid empty `content` block; the `content` block is omitted entirely per the
+  OpenAPI spec. ([#169](https://github.com/ehabterra/apispec/issues/169))
+
+## [0.5.0] - 2026-07-16
+
+### Added
+
+- Insight endpoint interface-decision reporting and an overview redesign.
+
+### Fixed
+
+- Lazy tracker no longer drops receiver-registered routes when middleware
+  reassigns an `r`-named variable. ([#146](https://github.com/ehabterra/apispec/issues/146))
+- Request bodies decoded through a `dec := json.NewDecoder(r.Body); dec.Decode(&dst)`
+  wrapper now resolve to a `$ref`. ([#153](https://github.com/ehabterra/apispec/issues/153))
+- Status codes threaded through helper chains, constructor fields, and
+  constructor closures now resolve to concrete responses instead of `default`.
+- chi `Method`/`Handle` route registration is now recognised.
+- HTTP-method name inference matches whole camelCase words only ("get" no longer
+  matches inside "widget").
+- `[]byte` fields map to `{type: string, format: byte}`.
+
+### Changed
+
+- Route-matcher edge memoisation and imports-only detector pass for faster
+  analysis on large projects.
+- Coverage ratcheted to ~95% with a CI floor check.
+
+## [0.4.0] - 2026-07-09
+
+Baseline release. Static-analysis OpenAPI 3.1 generation for gin, echo, chi,
+fiber, gorilla/mux, and net/http, with framework-agnostic auth detection, a
+structured type model, and the `apispecui`/`apidiag` companion tools.
+
+[Unreleased]: https://github.com/ehabterra/apispec/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/ehabterra/apispec/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/ehabterra/apispec/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/ehabterra/apispec/releases/tag/v0.4.0

--- a/README.md
+++ b/README.md
@@ -645,6 +645,8 @@ APISpec turns Go source into an OpenAPI document through a fixed sequence of sta
 
 APISpec uses YAML configuration files to describe framework patterns and OpenAPI metadata. For most projects the bundled defaults are enough; provide `--config` only when you need to extend or override them.
 
+📖 See [`docs/CONFIGURATION.md`](docs/CONFIGURATION.md) for the full field-by-field configuration reference.
+
 ### Minimal example (Gin)
 
 ```yaml

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,296 @@
+# Configuration reference
+
+APISpec is driven by a YAML configuration file. For most projects the bundled
+per-framework defaults are enough and no config is needed — pass `--config`
+only when you want to add OpenAPI metadata, map custom types, or teach the
+resolver about a framework/wiring style the defaults don't cover.
+
+This document is the field-by-field reference. For a task-oriented introduction
+with worked examples, see the [Configuration section of the
+README](../README.md#configuration).
+
+## How config is loaded and merged
+
+- **No `--config`** — APISpec detects the framework and loads its built-in
+  default config (`internal/spec/config_<framework>.go`).
+- **`--config path.yaml`** — your file is loaded *on top of* the detected
+  defaults. You only need to specify the keys you want to add or change; the
+  framework patterns you omit still apply.
+- **CLI flags win.** Values such as `--title`, `--api-version`, and
+  `--description` override the corresponding config-file values.
+- **Inspect the effective config.** `apispec --output-config used-config.yaml`
+  (or `-oc`) writes the fully merged config that was actually used, which is the
+  best starting point for a custom file.
+
+```bash
+apispec --config apispec.yaml --output openapi.yaml
+apispec --output-config used-config.yaml     # dump the effective config
+```
+
+## Top-level keys
+
+| Key | Type | Purpose |
+|-----|------|---------|
+| `info` | object | OpenAPI document metadata (title, version, contact, license). |
+| `servers` | list | OpenAPI `servers` entries. |
+| `tags` | list | OpenAPI `tags` definitions. |
+| `externalDocs` | object | OpenAPI `externalDocs` block. |
+| `typeMapping` | list | Map a Go type to a fixed OpenAPI schema. |
+| `externalTypes` | list | Give a package/external type a custom schema. |
+| `overrides` | list | Per-handler summary/description/response overrides. |
+| `include` / `exclude` | object | Filter which files/packages/functions/types are analysed. |
+| `defaults` | object | Fallback content types and response status. |
+| `security` | list | Document-level security requirements. |
+| `securitySchemes` | map | OpenAPI `securitySchemes` definitions. |
+| `securityMappings` | list | Map detected auth middleware to a scheme. |
+| `framework` | object | Framework detection/extraction patterns (advanced). |
+
+---
+
+## `info`
+
+OpenAPI document metadata. Also settable via CLI flags (`--title`,
+`--api-version`, `--description`, `--terms`).
+
+```yaml
+info:
+  title: My API
+  version: 1.0.0
+  description: User management service
+  termsOfService: https://example.com/terms
+  contact:
+    name: API Team
+    url: https://example.com/support
+    email: api@example.com
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `title` | string | API title. |
+| `version` | string | API version (required by OpenAPI). |
+| `description` | string | Longer description. |
+| `termsOfService` | string | URL. |
+| `contact` | object | `name`, `url`, `email`. |
+| `license` | object | `name`, `url`. |
+
+## `servers`
+
+```yaml
+servers:
+  - url: https://api.example.com/v1
+    description: Production
+  - url: http://localhost:8080
+    description: Local
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `url` | string | Server base URL (required). |
+| `description` | string | Human-readable label. |
+| `variables` | map | OpenAPI server-variable substitutions. |
+
+## `typeMapping`
+
+Replace a Go type — wherever it appears — with a fixed OpenAPI schema. Use this
+for well-known value types and for domain enums.
+
+```yaml
+typeMapping:
+  - goType: time.Time
+    openapiType: { type: string, format: date-time }
+  - goType: uuid.UUID
+    openapiType: { type: string, format: uuid }
+  - goType: domain.UserStatus
+    openapiType:
+      type: string
+      enum: [active, inactive, pending]
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `goType` | string | Go type name to match (as rendered by the analyser, e.g. `time.Time`). |
+| `openapiType` | schema | The OpenAPI schema to emit for it. |
+
+## `externalTypes`
+
+External package types are usually resolved automatically. Declare an
+`externalTypes` entry only when a third-party type needs a custom schema (for
+example one whose fields aren't exported, or that marshals to a scalar).
+
+```yaml
+externalTypes:
+  - name: github.com/gin-gonic/gin.H
+    description: Generic JSON object
+    openapiType:
+      type: object
+      additionalProperties: true
+  - name: go.mongodb.org/mongo-driver/bson/primitive.ObjectID
+    openapiType: { type: string }
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `name` | string | Fully-qualified type name (`pkgpath.TypeName`). |
+| `openapiType` | schema | Schema to emit for the type. |
+| `description` | string | Optional; copied into the schema. |
+
+> Layering note: type-to-schema decisions like these live in the spec layer, not
+> at metadata time — collapsing a type too early loses format information. See
+> [`TYPE_MODEL.md`](TYPE_MODEL.md).
+
+## `overrides`
+
+Manual, per-handler overrides applied by function name. Useful when static
+analysis can't recover a summary or the intended success response.
+
+```yaml
+overrides:
+  - functionName: GetUser
+    summary: Fetch a user by ID
+    description: Returns the user record for the given ID.
+    responseStatus: 200
+    responseType: models.User
+    tags: [users]
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `functionName` | string | Handler function name to match. |
+| `summary` | string | Operation summary. |
+| `description` | string | Operation description. |
+| `responseStatus` | int | Force a success status code. |
+| `responseType` | string | Force the success response Go type. |
+| `tags` | list | Operation tags. |
+
+## `include` / `exclude`
+
+Gitignore-style filters that restrict what is analysed. `exclude` takes
+precedence over `include`; empty lists mean "match everything".
+
+```yaml
+include:
+  packages:
+    - github.com/your-org/service/internal/api/**
+exclude:
+  files:
+    - "**/*_test.go"
+  functions:
+    - "^debug.*"
+```
+
+Each of `include` and `exclude` accepts `files`, `packages`, `functions`, and
+`types` lists.
+
+## `defaults`
+
+Fallbacks used when a request/response content type or status can't be inferred.
+
+```yaml
+defaults:
+  requestContentType: application/json
+  responseContentType: application/json
+  responseStatus: 200
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `requestContentType` | string | Default request body media type. |
+| `responseContentType` | string | Default response media type. |
+| `responseStatus` | int | Default success status when none is detected. |
+
+## Security: `security`, `securitySchemes`, `securityMappings`
+
+Most auth setups are detected with **no config** (see the README
+[Security & authentication detection](../README.md#security--authentication-detection)
+section). Add config only for custom middleware.
+
+```yaml
+# Document-level requirement (applies to all operations unless overridden)
+security:
+  - bearerAuth: []
+
+# Scheme definitions (only needed for schemes not auto-registered)
+securitySchemes:
+  bearerAuth:
+    type: http
+    scheme: bearer
+    bearerFormat: JWT
+
+# Map a detected middleware identity to a scheme
+securityMappings:
+  - functionNameRegex: ^authMiddleware$
+    schemes:
+      - { bearerAuth: [] }
+```
+
+`securityMappings` is framework-agnostic and works together with
+`framework.securityPatterns` (which describes *scope* — router / subtree / route
+/ wrapper). See [`AUTH_DETECTION_DESIGN.md`](AUTH_DETECTION_DESIGN.md) for the
+full model.
+
+## `framework` (advanced)
+
+The `framework` block holds the pattern system that drives route, request-body,
+response, parameter, mount, and security detection. The bundled defaults cover
+gin, echo, chi, fiber, gorilla/mux, and net/http; you normally extend this only
+to support a bespoke wrapper or an unsupported framework.
+
+```yaml
+framework:
+  routePatterns:
+    - callRegex: ^(?i)(GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD)$
+      recvTypeRegex: ^github\.com/gin-gonic/gin\.\*(Engine|RouterGroup)$
+      handlerArgIndex: 1
+      methodFromCall: true
+      pathFromArg: true
+      handlerFromArg: true
+  requestBodyPatterns:
+    - callRegex: ^(?i)(BindJSON|ShouldBindJSON|ShouldBind)$
+      typeFromArg: true
+      deref: true
+  responsePatterns:
+    - callRegex: ^(?i)(JSON|XML|String)$
+      typeArgIndex: 1
+      statusFromArg: true
+      typeFromArg: true
+  paramPatterns:
+    - callRegex: ^Param$
+      paramIn: path        # path | query | header | cookie
+    - callRegex: ^Query$
+      paramIn: query
+  requestContext:          # disambiguate generic decoders (json.Decode, etc.)
+    typeRegexes:
+      - ^net/http\.\*Request$
+    bodyAccessors:
+      - ^Body$
+```
+
+Sub-keys of `framework`:
+
+| Key | Purpose |
+|-----|---------|
+| `routePatterns` | How routes are registered (method/path/handler extraction). |
+| `requestBodyPatterns` | Calls that bind a request body to a Go type. |
+| `responsePatterns` | Calls that write a response (status + body type). |
+| `paramPatterns` | Calls that read a parameter, and its `in:` location. |
+| `mountPatterns` | Sub-router mounting (path-prefix composition). |
+| `securityPatterns` | Where/how auth middleware is applied (scope). |
+| `requestContext` | Which receivers/accessors mark a "request body" source. |
+
+Because these patterns are numerous and framework-specific, the authoritative
+reference is the in-repo default configs (`internal/spec/config_*.go`) and the
+struct definitions with doc comments in `internal/spec/config.go`. The quickest
+way to author a custom pattern is to dump the effective config with
+`--output-config` and edit the relevant block.
+
+---
+
+## See also
+
+- [README → Configuration](../README.md#configuration) — examples and quick start
+- [`TYPE_MODEL.md`](TYPE_MODEL.md) — how Go types become OpenAPI schemas
+- [`AUTH_DETECTION_DESIGN.md`](AUTH_DETECTION_DESIGN.md) — security detection model
+- [`INTERFACE_RESOLUTION.md`](INTERFACE_RESOLUTION.md) — interface/return resolution


### PR DESCRIPTION
## Summary

Closes #172 — the three repo-hygiene items from GAP §7.4:

- **`.golangci.yml`** — CI runs `golangci-lint` (v2.11.4) but nothing pinned the enabled linter set, so it was whatever that version defaults to. This commits a config that pins the v2 `standard` set (`errcheck`, `govet`, `ineffassign`, `staticcheck`, `unused`) — exactly what CI already runs — plus the `gofmt` formatter, so local `make lint` and CI agree and a version bump can't silently change the rules. Verified `golangci-lint config verify` passes and `golangci-lint run` reports **0 issues** against the current tree.
- **`docs/CONFIGURATION.md`** — a field-by-field reference for the config file (`info`, `servers`, `typeMapping`, `externalTypes`, `overrides`, `include`/`exclude`, `defaults`, security, and the advanced `framework` block), cross-linked with `TYPE_MODEL.md` / `AUTH_DETECTION_DESIGN.md` and linked from the README Configuration section.
- **`CHANGELOG.md`** — a [Keep a Changelog](https://keepachangelog.com/) file back-filled through v0.4.0, with an Unreleased section.

The GAP bullet's "move inlined HTML to templates" sub-item is intentionally **not** included — as the issue notes, only a test file contains inline HTML and `apispecui` already uses external assets, so it's effectively done.

## Notes

Docs/config-only — no Go source changed. `go build ./...` and the pinned lint both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)