### PR TITLE
fix(spec): resolve r.FormValue params to a valid OpenAPI location

### DIFF
--- a/generator/testdata_form_value_params_test.go
+++ b/generator/testdata_form_value_params_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"testing"
+
+	intspec "github.com/ehabterra/apispec/internal/spec"
+	"github.com/ehabterra/apispec/spec"
+)
+
+// TestTestdata_FormValueParams covers issue #171: r.FormValue reads must not be
+// emitted with the invalid OpenAPI parameter location `in: form`. GET form
+// values resolve to `in: query`; POST form values resolve to an
+// application/x-www-form-urlencoded request body. No parameter anywhere may
+// carry `in: form`.
+func TestTestdata_FormValueParams(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "form_value_params", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+	noUnresolvedPlaceholders(t, out)
+
+	// No operation may emit the invalid `in: form` location.
+	for path, item := range out.Paths {
+		for _, op := range []*intspec.Operation{item.Get, item.Post, item.Put, item.Delete, item.Patch} {
+			if op == nil {
+				continue
+			}
+			for _, p := range op.Parameters {
+				if p.In == "form" {
+					t.Errorf("%s: parameter %q emitted with invalid location in:form", path, p.Name)
+				}
+			}
+		}
+	}
+
+	// GET /search: form value resolves to an in:query parameter.
+	search := opFor(out.Paths["/search"], "GET")
+	if search == nil {
+		t.Fatalf("GET /search missing; have %v", mapPathKeys(out.Paths))
+	}
+	var queryParam *intspec.Parameter
+	for i := range search.Parameters {
+		if search.Parameters[i].Name == "query" {
+			queryParam = &search.Parameters[i]
+		}
+	}
+	if queryParam == nil {
+		t.Fatalf("GET /search missing 'query' parameter; have %+v", search.Parameters)
+	}
+	if queryParam.In != "query" {
+		t.Errorf("GET /search 'query' param: in=%q, want query", queryParam.In)
+	}
+
+	// POST /submit: form values resolve to a urlencoded request body.
+	submit := opFor(out.Paths["/submit"], "POST")
+	if submit == nil {
+		t.Fatalf("POST /submit missing; have %v", mapPathKeys(out.Paths))
+	}
+	if submit.RequestBody == nil {
+		t.Fatal("POST /submit: expected a form-urlencoded request body, got none")
+	}
+	media, ok := submit.RequestBody.Content["application/x-www-form-urlencoded"]
+	if !ok {
+		t.Fatalf("POST /submit: missing application/x-www-form-urlencoded body; have %v",
+			keysOf(submit.RequestBody.Content))
+	}
+	if media.Schema == nil || media.Schema.Type != "object" {
+		t.Fatalf("POST /submit: form body schema should be an object, got %+v", media.Schema)
+	}
+	for _, field := range []string{"name", "email"} {
+		if _, ok := media.Schema.Properties[field]; !ok {
+			t.Errorf("POST /submit: form body missing property %q; have %v",
+				field, keysOf(media.Schema.Properties))
+		}
+	}
+	// The form fields must not also leak out as `in: form` parameters.
+	for _, p := range submit.Parameters {
+		if p.Name == "name" || p.Name == "email" {
+			t.Errorf("POST /submit: form field %q leaked as a parameter (in=%q)", p.Name, p.In)
+		}
+	}
+}

--- a/internal/spec/form_params_test.go
+++ b/internal/spec/form_params_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import "testing"
+
+func TestMethodTakesRequestBody(t *testing.T) {
+	body := []string{"POST", "PUT", "PATCH", "post", "put", "patch"}
+	for _, m := range body {
+		if !methodTakesRequestBody(m) {
+			t.Errorf("methodTakesRequestBody(%q) = false, want true", m)
+		}
+	}
+	noBody := []string{"GET", "HEAD", "DELETE", "OPTIONS", "TRACE", ""}
+	for _, m := range noBody {
+		if methodTakesRequestBody(m) {
+			t.Errorf("methodTakesRequestBody(%q) = true, want false", m)
+		}
+	}
+}
+
+// TestResolveFormParams pins issue #171: the invalid `in: form` sentinel must
+// never survive into the output — it becomes a query param or a urlencoded body
+// depending on the HTTP method.
+func TestResolveFormParams(t *testing.T) {
+	formParam := func(name string) Parameter {
+		return Parameter{Name: name, In: "form", Schema: &Schema{Type: "string"}}
+	}
+
+	t.Run("GET form params become query", func(t *testing.T) {
+		params, body := resolveFormParams("GET",
+			[]Parameter{formParam("query"), {Name: "id", In: "path"}}, false)
+		if body != nil {
+			t.Fatalf("GET should not synthesize a request body, got %+v", body)
+		}
+		for _, p := range params {
+			if p.In == "form" {
+				t.Errorf("param %q still has in:form", p.Name)
+			}
+		}
+		var q *Parameter
+		for i := range params {
+			if params[i].Name == "query" {
+				q = &params[i]
+			}
+		}
+		if q == nil || q.In != "query" {
+			t.Errorf("query param: got %+v, want in:query", q)
+		}
+	})
+
+	t.Run("POST form params become urlencoded body", func(t *testing.T) {
+		params, body := resolveFormParams("POST",
+			[]Parameter{formParam("name"), formParam("email")}, false)
+		if body == nil {
+			t.Fatal("POST should synthesize a request body")
+		}
+		media, ok := body.Content["application/x-www-form-urlencoded"]
+		if !ok {
+			t.Fatalf("missing urlencoded media type; have %v", body.Content)
+		}
+		if media.Schema.Type != "object" {
+			t.Errorf("body schema type = %q, want object", media.Schema.Type)
+		}
+		for _, f := range []string{"name", "email"} {
+			if _, ok := media.Schema.Properties[f]; !ok {
+				t.Errorf("body missing property %q", f)
+			}
+		}
+		// form params must be consumed, not left in the parameter list.
+		for _, p := range params {
+			if p.In == "form" {
+				t.Errorf("form param %q leaked into parameters", p.Name)
+			}
+		}
+	})
+
+	t.Run("POST with existing body falls back to query", func(t *testing.T) {
+		params, body := resolveFormParams("POST", []Parameter{formParam("name")}, true)
+		if body != nil {
+			t.Errorf("must not clobber an existing request body; got %+v", body)
+		}
+		if len(params) != 1 || params[0].In != "query" {
+			t.Errorf("form param should fall back to query, got %+v", params)
+		}
+	})
+
+	t.Run("no form params passes through untouched", func(t *testing.T) {
+		in := []Parameter{{Name: "id", In: "path"}, {Name: "q", In: "query"}}
+		params, body := resolveFormParams("POST", in, false)
+		if body != nil {
+			t.Errorf("no form params should not synthesize a body")
+		}
+		if len(params) != 2 {
+			t.Errorf("params changed unexpectedly: %+v", params)
+		}
+	})
+
+	t.Run("required form field is marked required in body", func(t *testing.T) {
+		req := formParam("token")
+		req.Required = true
+		_, body := resolveFormParams("PUT", []Parameter{req}, false)
+		if body == nil {
+			t.Fatal("expected a request body")
+		}
+		schema := body.Content["application/x-www-form-urlencoded"].Schema
+		if len(schema.Required) != 1 || schema.Required[0] != "token" {
+			t.Errorf("required = %v, want [token]", schema.Required)
+		}
+	})
+}

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -307,9 +307,22 @@ func buildPathsFromRoutes(routes []*RouteInfo) map[string]PathItem {
 			}
 		}
 
+		// r.FormValue-style reads carry the sentinel location "form", which is
+		// not a valid OpenAPI parameter location (issue #171). Resolve it to a
+		// real location from the HTTP method: for body-bearing methods
+		// (POST/PUT/PATCH) the values form an application/x-www-form-urlencoded
+		// request body; otherwise (GET/HEAD/DELETE/…) they are query params —
+		// Go's FormValue reads the URL query for those. A pre-existing request
+		// body (e.g. decoded JSON) is never clobbered: form params then fall
+		// back to query so we still emit a valid location.
+		params, formBody := resolveFormParams(route.Method, route.Params, operation.RequestBody != nil)
+		if formBody != nil {
+			operation.RequestBody = formBody
+		}
+
 		// Add parameters (deduplicated and ensure all path params)
-		if len(route.Params) > 0 {
-			operation.Parameters = deduplicateParameters(route.Params)
+		if len(params) > 0 {
+			operation.Parameters = deduplicateParameters(params)
 		} else {
 			operation.Parameters = nil
 		}
@@ -530,6 +543,82 @@ func isGenericObjectResponse(r *ResponseInfo) bool {
 		return false
 	}
 	return s.Type == "" || s.Type == "object"
+}
+
+// methodTakesRequestBody reports whether an HTTP method conventionally carries
+// a request body — the methods for which form values live in the body rather
+// than the query string.
+func methodTakesRequestBody(method string) bool {
+	switch strings.ToUpper(method) {
+	case "POST", "PUT", "PATCH":
+		return true
+	default:
+		return false
+	}
+}
+
+// resolveFormParams rewrites the sentinel "form" parameter location (emitted for
+// r.FormValue-style reads) into a valid OpenAPI shape (issue #171). Form values
+// are ambiguous in Go — FormValue reads the URL query for GET and the
+// urlencoded body for POST — so the HTTP method decides:
+//
+//   - body-bearing method (POST/PUT/PATCH) with no existing request body:
+//     the form params are folded into an application/x-www-form-urlencoded
+//     request body and removed from the parameter list.
+//   - otherwise: each form param is rewritten to `in: query`, a valid location.
+//
+// hasRequestBody guards against clobbering an already-detected body (e.g.
+// decoded JSON); in that case the query-param fallback is used. Non-form
+// params pass through untouched. The input slice is never mutated.
+func resolveFormParams(method string, params []Parameter, hasRequestBody bool) ([]Parameter, *RequestBody) {
+	hasForm := false
+	for i := range params {
+		if params[i].In == "form" {
+			hasForm = true
+			break
+		}
+	}
+	if !hasForm {
+		return params, nil
+	}
+
+	kept := make([]Parameter, 0, len(params))
+	var formParams []Parameter
+	for _, p := range params {
+		if p.In == "form" {
+			formParams = append(formParams, p)
+			continue
+		}
+		kept = append(kept, p)
+	}
+
+	if methodTakesRequestBody(method) && !hasRequestBody {
+		schema := &Schema{Type: "object", Properties: make(map[string]*Schema, len(formParams))}
+		for _, fp := range formParams {
+			s := fp.Schema
+			if s == nil {
+				s = &Schema{Type: "string"}
+			}
+			schema.Properties[fp.Name] = s
+			if fp.Required {
+				schema.Required = append(schema.Required, fp.Name)
+			}
+		}
+		sort.Strings(schema.Required)
+		body := &RequestBody{
+			Content: map[string]MediaType{
+				"application/x-www-form-urlencoded": {Schema: schema},
+			},
+		}
+		return kept, body
+	}
+
+	// Query-param fallback (non-body methods, or a body already exists).
+	for _, fp := range formParams {
+		fp.In = "query"
+		kept = append(kept, fp)
+	}
+	return kept, nil
 }
 
 func buildResponses(respInfo map[string]*ResponseInfo) map[string]Response {

--- a/testdata/form_value_params/go.mod
+++ b/testdata/form_value_params/go.mod
@@ -1,0 +1,3 @@
+module github.com/ehabterra/apispec/testdata/form_value_params
+
+go 1.24.3

--- a/testdata/form_value_params/main.go
+++ b/testdata/form_value_params/main.go
@@ -1,0 +1,36 @@
+// Fixture: r.FormValue reads must not be emitted with the invalid OpenAPI
+// parameter location `in: form` (issue #171). The location is ambiguous in Go —
+// FormValue reads the URL query for GET and the urlencoded body for POST — so
+// the resolver picks a valid shape from the HTTP method: GET form values become
+// `in: query`, and POST form values become an application/x-www-form-urlencoded
+// request body.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type Result struct {
+	Query string `json:"query"`
+}
+
+// search reads a form value on a GET — resolves to an `in: query` parameter.
+func search(w http.ResponseWriter, r *http.Request) {
+	q := r.FormValue("query")
+	_ = json.NewEncoder(w).Encode(Result{Query: q})
+}
+
+// submit reads form values on a POST — resolves to a form-urlencoded body.
+func submit(w http.ResponseWriter, r *http.Request) {
+	name := r.FormValue("name")
+	email := r.FormValue("email")
+	_ = json.NewEncoder(w).Encode(Result{Query: name + email})
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /search", search)
+	mux.HandleFunc("POST /submit", submit)
+	_ = http.ListenAndServe(":8080", mux)
+}


### PR DESCRIPTION
## Summary

Fixes #171. `r.FormValue("query")` was correctly detected as a parameter but emitted with `in: form` — not a valid OpenAPI parameter location (only `query`, `header`, `path`, `cookie` are allowed), which makes the generated spec fail strict validation.

Form values are inherently ambiguous in Go: `FormValue` reads the URL query for GET and the `application/x-www-form-urlencoded` body for POST. The fix resolves the sentinel `form` location from the route's HTTP method, in the mapper (so it's framework-agnostic — echo/chi/fiber/net/http all use the same `form` sentinel):

- **POST / PUT / PATCH** → an `application/x-www-form-urlencoded` request body, one property per form field. If a request body was already detected (e.g. decoded JSON), the fields fall back to `in: query` so a real body is never clobbered.
- **GET / HEAD / DELETE / …** → `in: query`.

## Before / After

```yaml
# Before (invalid)
parameters:
  - name: query
    in: form

# After — GET
parameters:
  - name: query
    in: query

# After — POST
requestBody:
  content:
    application/x-www-form-urlencoded:
      schema:
        type: object
        properties:
          name:  { type: string }
          email: { type: string }
```

## Tests & fixtures

- `testdata/form_value_params/` — a net/http server with a GET `search` (single form value) and a POST `submit` (two form values).
- `generator/testdata_form_value_params_test.go` — structural test: no operation emits `in: form`; GET resolves to `in: query`; POST resolves to a urlencoded body carrying both fields (and the fields don't leak as parameters).
- `internal/spec/form_params_test.go` — unit tests for `resolveFormParams` (GET→query, POST→body, existing-body fallback, pass-through, required-field) and `methodTakesRequestBody`.

## Verification

- `apispec --dir testdata/form_value_params` produces `in: query` for the GET and a form-urlencoded body for the POST — no `in: form` anywhere.
- Full `go test ./...` passes with **zero output drift** (no source fixture used `FormValue` before); `gofmt`, `go vet`, `golangci-lint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)