### PR TITLE
fix(spec): gate response schema on write destination (issue #170)

### DIFF
--- a/generator/testdata_response_dest_gating_test.go
+++ b/generator/testdata_response_dest_gating_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	intspec "github.com/ehabterra/apispec/internal/spec"
+	"github.com/ehabterra/apispec/spec"
+)
+
+// TestTestdata_ResponseDestGating covers issue #170: a value encoded to some
+// other io.Writer (a bytes.Buffer, a hash) must not be attributed as the
+// operation response — only a value whose encoder destination traces to the
+// HTTP response writer counts. User (encoded to w, directly and through a
+// wrapper) must appear; Secret/Audit (encoded to a buffer/hash) must not appear
+// anywhere in the document.
+func TestTestdata_ResponseDestGating(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "response_dest_gating", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+	noUnresolvedPlaceholders(t, out)
+
+	// The whole document must never mention the leaked types.
+	blob, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("marshal spec: %v", err)
+	}
+	doc := string(blob)
+	for _, leaked := range []string{"Secret", "Audit"} {
+		if strings.Contains(doc, leaked) {
+			t.Errorf("leaked type %q reached the spec — write-destination gating failed", leaked)
+		}
+	}
+	if !strings.Contains(doc, "User") {
+		t.Error("expected the real response type User to be present")
+	}
+
+	// The two writer-destination routes carry a User response ref.
+	for _, path := range []string{"/user", "/user-helper"} {
+		get := opFor(out.Paths[path], "GET")
+		if get == nil {
+			t.Errorf("GET %s missing; have %v", path, mapPathKeys(out.Paths))
+			continue
+		}
+		if !responseRefsUser(get.Responses) {
+			t.Errorf("GET %s: expected a User response, got %v", path, keysOf(get.Responses))
+		}
+	}
+
+	// The leak routes must NOT carry any object/$ref response — their only
+	// write is the plain w.Write, so a struct body would be the false positive.
+	for _, path := range []string{"/leak-buffer", "/leak-hash"} {
+		post := opFor(out.Paths[path], "POST")
+		if post == nil {
+			t.Errorf("POST %s missing; have %v", path, mapPathKeys(out.Paths))
+			continue
+		}
+		for status, resp := range post.Responses {
+			for ct, media := range resp.Content {
+				if media.Schema != nil && media.Schema.Ref != "" {
+					t.Errorf("POST %s [%s %s]: unexpected $ref response %q — a non-writer encode leaked",
+						path, status, ct, media.Schema.Ref)
+				}
+			}
+		}
+	}
+}
+
+func responseRefsUser(responses map[string]intspec.Response) bool {
+	for _, resp := range responses {
+		for _, media := range resp.Content {
+			if media.Schema != nil && strings.Contains(media.Schema.Ref, "User") {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/generator/testdata_response_dest_gating_test.go
+++ b/generator/testdata_response_dest_gating_test.go
@@ -49,8 +49,10 @@ func TestTestdata_ResponseDestGating(t *testing.T) {
 		t.Error("expected the real response type User to be present")
 	}
 
-	// The two writer-destination routes carry a User response ref.
-	for _, path := range []string{"/user", "/user-helper"} {
+	// The writer-destination routes carry a User response ref — including the
+	// io.Writer-typed helper, whose destination can't be proven to be the
+	// writer but could be, so the response must be kept (regression guard).
+	for _, path := range []string{"/user", "/user-helper", "/user-iowriter"} {
 		get := opFor(out.Paths[path], "GET")
 		if get == nil {
 			t.Errorf("GET %s missing; have %v", path, mapPathKeys(out.Paths))

--- a/internal/spec/config.go
+++ b/internal/spec/config.go
@@ -93,21 +93,19 @@ type RequestContextConfig struct {
 // write-side mirror of RequestContextConfig (issue #170).
 type ResponseContextConfig struct {
 	// WriterTypeRegexes match the (fully-qualified) types that ARE an HTTP
-	// response writer. The root of a write-destination expression must have one
-	// of these types for the write to count as a response. Examples:
+	// response writer. A destination resolving to one of these keeps the
+	// response. Examples:
 	//   net/http -> "^net/http\\.ResponseWriter$"
 	//   gin      -> "^github\\.com/gin-gonic/gin\\.ResponseWriter$"
 	WriterTypeRegexes []string `yaml:"writerTypeRegexes,omitempty" json:"writerTypeRegexes,omitempty"`
 
-	// WriterAccessors are regexes matched against the dot-joined accessor chain
-	// applied to a response-writer root, for frameworks whose writer is reached
-	// through the request context rather than being a bare parameter. The chain
-	// is rendered like RequestContextConfig.BodyAccessors (method calls as
-	// "Name()"). An empty chain (the writer IS the root, e.g. net/http's `w`)
-	// always qualifies. Examples:
-	//   gin  -> "^Writer$"          (c.Writer)
-	//   echo -> "^Response\\(\\)$"  (c.Response())
-	WriterAccessors []string `yaml:"writerAccessors,omitempty" json:"writerAccessors,omitempty"`
+	// WriterCompatibleTypeRegexes match interface types that an HTTP response
+	// writer SATISFIES — most importantly io.Writer, the parameter type of the
+	// ubiquitous `func writeJSON(w io.Writer, v any)` helper. A destination of
+	// such a type could dynamically be the response writer, so the response is
+	// kept (the gate rejects only destinations that provably cannot be the
+	// writer). Leave empty to treat every non-writer type as disqualifying.
+	WriterCompatibleTypeRegexes []string `yaml:"writerCompatibleTypeRegexes,omitempty" json:"writerCompatibleTypeRegexes,omitempty"`
 }
 
 // MethodMapping defines how to extract HTTP methods from function names

--- a/internal/spec/config.go
+++ b/internal/spec/config.go
@@ -88,24 +88,26 @@ type RequestContextConfig struct {
 	BodyAccessors []string `yaml:"bodyAccessors,omitempty" json:"bodyAccessors,omitempty"`
 }
 
-// ResponseContextConfig describes how to recognise the HTTP response writer,
-// so a generic encoder's write destination can be traced to it. It is the
-// write-side mirror of RequestContextConfig (issue #170).
+// ResponseContextConfig gates generic encoders (json.NewEncoder(x).Encode(v))
+// on their write destination, so a value written somewhere OTHER than the HTTP
+// response — a bytes.Buffer, a hash, a log sink — is not mistaken for the
+// operation response (issue #170). It is the write-side mirror of
+// RequestContextConfig.
+//
+// The gate is deliberately PERMISSIVE ("honest over wrong", golden rule #7):
+// the encoder destination is first resolved through the call graph to its
+// concrete value, then dropped ONLY when that value's type matches a configured
+// known-sink pattern. A destination that is the response writer, a custom
+// writer, an interface (io.Writer), or simply unresolved is kept — a real
+// response is never dropped just because it could not be proven to be a writer.
 type ResponseContextConfig struct {
-	// WriterTypeRegexes match the (fully-qualified) types that ARE an HTTP
-	// response writer. A destination resolving to one of these keeps the
-	// response. Examples:
-	//   net/http -> "^net/http\\.ResponseWriter$"
-	//   gin      -> "^github\\.com/gin-gonic/gin\\.ResponseWriter$"
-	WriterTypeRegexes []string `yaml:"writerTypeRegexes,omitempty" json:"writerTypeRegexes,omitempty"`
-
-	// WriterCompatibleTypeRegexes match interface types that an HTTP response
-	// writer SATISFIES — most importantly io.Writer, the parameter type of the
-	// ubiquitous `func writeJSON(w io.Writer, v any)` helper. A destination of
-	// such a type could dynamically be the response writer, so the response is
-	// kept (the gate rejects only destinations that provably cannot be the
-	// writer). Leave empty to treat every non-writer type as disqualifying.
-	WriterCompatibleTypeRegexes []string `yaml:"writerCompatibleTypeRegexes,omitempty" json:"writerCompatibleTypeRegexes,omitempty"`
+	// WriterExcludeTypeRegexes match the (fully-qualified) types of write
+	// destinations that are PROVABLY not the HTTP response — standard-library
+	// sinks a handler encodes into for reasons unrelated to the response. A
+	// destination resolving to one of these disqualifies the encoded value.
+	// Everything else is kept. Examples:
+	//   "^\\*?bytes\\.Buffer$", "^\\*?strings\\.Builder$", "^hash\\.Hash$"
+	WriterExcludeTypeRegexes []string `yaml:"writerExcludeTypeRegexes,omitempty" json:"writerExcludeTypeRegexes,omitempty"`
 }
 
 // MethodMapping defines how to extract HTTP methods from function names
@@ -217,15 +219,16 @@ type ResponsePattern struct {
 	// DefaultContentType overrides the config default content type when set
 	DefaultContentType string `yaml:"defaultContentType,omitempty" json:"defaultContentType,omitempty"`
 
-	// RequireResponseDestination gates the pattern on write-destination: the
-	// encoded/written value only becomes a response when its destination writer
-	// provably traces to the HTTP response writer (see ResponseContext). This
-	// is the symmetric counterpart of RequestBodyPattern.RequireRequestSource
-	// and disambiguates generic encoders (json.NewEncoder(x).Encode(v)) that
-	// may write to some other io.Writer — a bytes.Buffer, a hash, a log — rather
-	// than the response. Only meaningful for destination-carrying encoders;
-	// receiver-based writers (net/http.ResponseWriter.Write) are already
-	// unambiguous because their receiver IS the writer.
+	// RequireResponseDestination gates the pattern on write-destination: a
+	// generic encoder (json.NewEncoder(x).Encode(v)) is dropped as a response
+	// ONLY when x provably resolves to a known sink (see ResponseContext) — a
+	// bytes.Buffer, a hash, a log. A destination that is the response writer, a
+	// custom writer, an interface, or unresolved is kept, so a real response is
+	// never dropped (permissive; "honest over wrong"). Symmetric counterpart of
+	// RequestBodyPattern.RequireRequestSource. Only meaningful for
+	// destination-carrying encoders; receiver-based writers
+	// (net/http.ResponseWriter.Write) are already unambiguous because their
+	// receiver IS the writer.
 	RequireResponseDestination bool `yaml:"requireResponseDestination,omitempty" json:"requireResponseDestination,omitempty"`
 	// DestFromReceiver resolves the write destination from the encoder factory
 	// receiver — for json.NewEncoder(w).Encode(v), the destination is

--- a/internal/spec/config.go
+++ b/internal/spec/config.go
@@ -59,6 +59,13 @@ type FrameworkConfig struct {
 	// so they are only treated as request-body extraction when the bytes
 	// actually originate from an HTTP request.
 	RequestContext RequestContextConfig `yaml:"requestContext,omitempty" json:"requestContext,omitempty"`
+
+	// ResponseContext is the symmetric counterpart of RequestContext for the
+	// write side: it describes how to recognise the HTTP response writer so
+	// generic encoders (json.NewEncoder(x).Encode(v)) are only treated as a
+	// response when x provably traces to the response writer. Used together
+	// with ResponsePattern.RequireResponseDestination.
+	ResponseContext ResponseContextConfig `yaml:"responseContext,omitempty" json:"responseContext,omitempty"`
 }
 
 // RequestContextConfig describes the types and accessors that identify an
@@ -79,6 +86,28 @@ type RequestContextConfig struct {
 	//   echo     -> "^Request\\(\\)\\.Body$"
 	//   fiber    -> "^Body\\(\\)$"
 	BodyAccessors []string `yaml:"bodyAccessors,omitempty" json:"bodyAccessors,omitempty"`
+}
+
+// ResponseContextConfig describes how to recognise the HTTP response writer,
+// so a generic encoder's write destination can be traced to it. It is the
+// write-side mirror of RequestContextConfig (issue #170).
+type ResponseContextConfig struct {
+	// WriterTypeRegexes match the (fully-qualified) types that ARE an HTTP
+	// response writer. The root of a write-destination expression must have one
+	// of these types for the write to count as a response. Examples:
+	//   net/http -> "^net/http\\.ResponseWriter$"
+	//   gin      -> "^github\\.com/gin-gonic/gin\\.ResponseWriter$"
+	WriterTypeRegexes []string `yaml:"writerTypeRegexes,omitempty" json:"writerTypeRegexes,omitempty"`
+
+	// WriterAccessors are regexes matched against the dot-joined accessor chain
+	// applied to a response-writer root, for frameworks whose writer is reached
+	// through the request context rather than being a bare parameter. The chain
+	// is rendered like RequestContextConfig.BodyAccessors (method calls as
+	// "Name()"). An empty chain (the writer IS the root, e.g. net/http's `w`)
+	// always qualifies. Examples:
+	//   gin  -> "^Writer$"          (c.Writer)
+	//   echo -> "^Response\\(\\)$"  (c.Response())
+	WriterAccessors []string `yaml:"writerAccessors,omitempty" json:"writerAccessors,omitempty"`
 }
 
 // MethodMapping defines how to extract HTTP methods from function names
@@ -189,6 +218,21 @@ type ResponsePattern struct {
 	DefaultStatus int `yaml:"defaultStatus,omitempty" json:"defaultStatus,omitempty"`
 	// DefaultContentType overrides the config default content type when set
 	DefaultContentType string `yaml:"defaultContentType,omitempty" json:"defaultContentType,omitempty"`
+
+	// RequireResponseDestination gates the pattern on write-destination: the
+	// encoded/written value only becomes a response when its destination writer
+	// provably traces to the HTTP response writer (see ResponseContext). This
+	// is the symmetric counterpart of RequestBodyPattern.RequireRequestSource
+	// and disambiguates generic encoders (json.NewEncoder(x).Encode(v)) that
+	// may write to some other io.Writer — a bytes.Buffer, a hash, a log — rather
+	// than the response. Only meaningful for destination-carrying encoders;
+	// receiver-based writers (net/http.ResponseWriter.Write) are already
+	// unambiguous because their receiver IS the writer.
+	RequireResponseDestination bool `yaml:"requireResponseDestination,omitempty" json:"requireResponseDestination,omitempty"`
+	// DestFromReceiver resolves the write destination from the encoder factory
+	// receiver — for json.NewEncoder(w).Encode(v), the destination is
+	// NewEncoder's first argument. Mirrors RequestBodyPattern.BodyFromReceiver.
+	DestFromReceiver bool `yaml:"destFromReceiver,omitempty" json:"destFromReceiver,omitempty"`
 
 	// Package/type filtering
 	CallerPkgPatterns      []string `yaml:"callerPkgPatterns,omitempty" json:"callerPkgPatterns,omitempty"`
@@ -775,6 +819,11 @@ func jsonEncodePattern(recvTypeRegex string) ResponsePattern {
 		TypeFromArg:   true,
 		Deref:         true,
 		RecvTypeRegex: recvTypeRegex,
+		// Gate on write destination: json.NewEncoder(x).Encode(v) is only a
+		// response when x traces to the response writer (issue #170). Inert
+		// unless the framework config populates ResponseContext.
+		RequireResponseDestination: true,
+		DestFromReceiver:           true,
 	}
 }
 

--- a/internal/spec/config_chi.go
+++ b/internal/spec/config_chi.go
@@ -79,7 +79,8 @@ func DefaultChiConfig() *APISpecConfig {
 					RecvTypeRegex:     "^github.com/go-chi/chi(/v\\d)?\\.\\*?(Router|Mux)$",
 				},
 			},
-			RequestContext: netHTTPRequestContext,
+			RequestContext:  netHTTPRequestContext,
+			ResponseContext: netHTTPResponseContext,
 			RequestBodyPatterns: []RequestBodyPattern{
 				{
 					CallRegex:            `^DecodeJSON$`,

--- a/internal/spec/config_http.go
+++ b/internal/spec/config_http.go
@@ -24,22 +24,21 @@ var netHTTPRequestContext = RequestContextConfig{
 	BodyAccessors: []string{`^Body$`},
 }
 
-// netHTTPResponseContext is the ResponseContext preset for plain net/http
-// handlers: the response writer is the http.ResponseWriter parameter. Chi and
-// Mux share it (their handlers also take an http.ResponseWriter). The
-// compatible list keeps the ubiquitous `func writeJSON(w io.Writer, v any)`
-// helper shape — an io.Writer parameter could dynamically be the response
-// writer, so responses written through it must not be dropped.
+// netHTTPResponseContext is the ResponseContext preset shared by the net/http
+// family (net/http, chi, mux — all encode to an http.ResponseWriter). It lists
+// standard-library sinks a handler encodes into for reasons unrelated to the
+// response, so a value written to one of them is not mistaken for the response.
+// Only known sinks are listed: an unrecognised destination (a custom writer,
+// an io.Writer parameter that could be the writer) is kept.
 var netHTTPResponseContext = ResponseContextConfig{
-	WriterTypeRegexes: []string{
-		`^net/http\.ResponseWriter$`,
-		`^\*?net/http\.response$`,
-		`^\*?net/http/httptest\.ResponseRecorder$`,
-	},
-	WriterCompatibleTypeRegexes: []string{
-		`^io\.Writer$`,
-		`^io\.WriteCloser$`,
-		`^io\.ReadWriter$`,
+	WriterExcludeTypeRegexes: []string{
+		`^\*?bytes\.Buffer$`,
+		`^\*?strings\.Builder$`,
+		`^\*?bufio\.Writer$`,
+		`^\*?os\.File$`,
+		`^hash\.Hash$`,
+		`^hash/.*\.Hash.*$`,
+		`^\*?crypto/.*$`, // e.g. *crypto/sha256.digest from sha256.New()
 	},
 }
 

--- a/internal/spec/config_http.go
+++ b/internal/spec/config_http.go
@@ -26,15 +26,20 @@ var netHTTPRequestContext = RequestContextConfig{
 
 // netHTTPResponseContext is the ResponseContext preset for plain net/http
 // handlers: the response writer is the http.ResponseWriter parameter. Chi and
-// Mux share it (their handlers also take an http.ResponseWriter). Concrete
-// implementations of ResponseWriter (http.ResponseWriter itself resolves to the
-// interface, but wrappers may surface as *http.response) are covered by the
-// interface match plus the httptest recorder used in tests.
+// Mux share it (their handlers also take an http.ResponseWriter). The
+// compatible list keeps the ubiquitous `func writeJSON(w io.Writer, v any)`
+// helper shape — an io.Writer parameter could dynamically be the response
+// writer, so responses written through it must not be dropped.
 var netHTTPResponseContext = ResponseContextConfig{
 	WriterTypeRegexes: []string{
 		`^net/http\.ResponseWriter$`,
 		`^\*?net/http\.response$`,
 		`^\*?net/http/httptest\.ResponseRecorder$`,
+	},
+	WriterCompatibleTypeRegexes: []string{
+		`^io\.Writer$`,
+		`^io\.WriteCloser$`,
+		`^io\.ReadWriter$`,
 	},
 }
 

--- a/internal/spec/config_http.go
+++ b/internal/spec/config_http.go
@@ -24,6 +24,20 @@ var netHTTPRequestContext = RequestContextConfig{
 	BodyAccessors: []string{`^Body$`},
 }
 
+// netHTTPResponseContext is the ResponseContext preset for plain net/http
+// handlers: the response writer is the http.ResponseWriter parameter. Chi and
+// Mux share it (their handlers also take an http.ResponseWriter). Concrete
+// implementations of ResponseWriter (http.ResponseWriter itself resolves to the
+// interface, but wrappers may surface as *http.response) are covered by the
+// interface match plus the httptest recorder used in tests.
+var netHTTPResponseContext = ResponseContextConfig{
+	WriterTypeRegexes: []string{
+		`^net/http\.ResponseWriter$`,
+		`^\*?net/http\.response$`,
+		`^\*?net/http/httptest\.ResponseRecorder$`,
+	},
+}
+
 // DefaultHTTPConfig returns a default configuration for net/http.
 func DefaultHTTPConfig() *APISpecConfig {
 	// net/http response patterns come from netHTTPResponsePatterns(); the
@@ -67,6 +81,7 @@ func DefaultHTTPConfig() *APISpecConfig {
 			},
 			SecurityPatterns: httpSecurityPatterns(),
 			RequestContext:   netHTTPRequestContext,
+			ResponseContext:  netHTTPResponseContext,
 			RequestBodyPatterns: []RequestBodyPattern{
 				jsonDecodeRequestPattern(""),
 				jsonUnmarshalRequestPattern(""),

--- a/internal/spec/config_mux.go
+++ b/internal/spec/config_mux.go
@@ -90,7 +90,8 @@ func DefaultMuxConfig() *APISpecConfig {
 					MethodExtraction:  DefaultMethodExtractionConfig(),
 				},
 			},
-			RequestContext: netHTTPRequestContext,
+			RequestContext:  netHTTPRequestContext,
+			ResponseContext: netHTTPResponseContext,
 			RequestBodyPatterns: []RequestBodyPattern{
 				jsonDecodeRequestPattern(".*json(iter)?\\.\\*?Decoder"),
 				jsonUnmarshalRequestPattern("json"),

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -2057,15 +2057,20 @@ func (r *ResponsePatternMatcherImpl) MatchNode(node TrackerNodeInterface) bool {
 	}
 
 	// Write-destination gating: only meaningful for destination-carrying
-	// encoders (json.NewEncoder(x).Encode(v)). Drop the response only when x
-	// provably resolves to a concrete non-writer — a bytes.Buffer, a hash, a log
-	// sink. A proven writer, a writer-compatible interface (io.Writer helper
-	// param), or an unresolvable destination all stay permissive, so a real
-	// response is never dropped ("honest over wrong"). Mirrors the request-source
-	// gating on RequestBodyPattern. See issue #170.
+	// encoders (json.NewEncoder(x).Encode(v)). Drop the response only when the
+	// direct destination x is a known sink — a bytes.Buffer, a hash, a log. A
+	// writer, a custom writer, an interface (io.Writer helper parameter), or an
+	// unresolved destination stay permissive, so a real response is never
+	// dropped ("honest over wrong").
+	//
+	// The destination is NOT resolved per-route through wrapper parameters here:
+	// a helper shared by several routes is a single tracker node, so resolving
+	// its argument at this once-evaluated gate would attribute one route's
+	// destination to all. The direct check plus per-route response attribution
+	// already handles the helper case (each route only sees its own encode).
+	// Mirrors the request-source gating on RequestBodyPattern. See issue #170.
 	if r.pattern.RequireResponseDestination && r.destResolver != nil && r.destResolver.Enabled() {
-		dst := r.destination(edge)
-		if dst != nil && r.destResolver.IsProvablyNonWriter(dst, edge) {
+		if dst := r.destination(edge); dst != nil && r.destResolver.IsProvablyNonWriter(dst, edge) {
 			return false
 		}
 	}
@@ -2074,15 +2079,14 @@ func (r *ResponsePatternMatcherImpl) MatchNode(node TrackerNodeInterface) bool {
 }
 
 // destination returns the CallArgument that carries the encoder's write
-// destination for the given call edge, according to the pattern configuration.
+// destination for the given call edge — for json.NewEncoder(x).Encode(v) the
+// factory's first argument x. Returns nil when the pattern carries no
+// receiver-based destination.
 func (r *ResponsePatternMatcherImpl) destination(edge *metadata.CallGraphEdge) *metadata.CallArgument {
-	if edge == nil {
+	if edge == nil || !r.pattern.DestFromReceiver {
 		return nil
 	}
-	if r.pattern.DestFromReceiver {
-		return resolveReceiverSource(edge, r.destResolver.metadata())
-	}
-	return nil
+	return resolveReceiverSource(edge, r.destResolver.metadata())
 }
 
 // GetPattern returns the response pattern

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -2057,13 +2057,15 @@ func (r *ResponsePatternMatcherImpl) MatchNode(node TrackerNodeInterface) bool {
 	}
 
 	// Write-destination gating: only meaningful for destination-carrying
-	// encoders (json.NewEncoder(x).Encode(v)). The encoded value is a response
-	// only when x provably traces to the response writer — otherwise it was
-	// written to some other io.Writer (a bytes.Buffer, a hash, a log). Mirrors
-	// the request-source gating on RequestBodyPattern. See issue #170.
+	// encoders (json.NewEncoder(x).Encode(v)). Drop the response only when x
+	// provably resolves to a concrete non-writer — a bytes.Buffer, a hash, a log
+	// sink. A proven writer, a writer-compatible interface (io.Writer helper
+	// param), or an unresolvable destination all stay permissive, so a real
+	// response is never dropped ("honest over wrong"). Mirrors the request-source
+	// gating on RequestBodyPattern. See issue #170.
 	if r.pattern.RequireResponseDestination && r.destResolver != nil && r.destResolver.Enabled() {
 		dst := r.destination(edge)
-		if dst == nil || !r.destResolver.IsResponseDest(dst, edge) {
+		if dst != nil && r.destResolver.IsProvablyNonWriter(dst, edge) {
 			return false
 		}
 	}

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -2001,7 +2001,8 @@ func preprocessingBodyType(bodyType string) string {
 // ResponsePatternMatcherImpl implements ResponsePatternMatcher
 type ResponsePatternMatcherImpl struct {
 	*BasePatternMatcher
-	pattern ResponsePattern
+	pattern      ResponsePattern
+	destResolver *responseDestResolver
 }
 
 // NewResponsePatternMatcher creates a new response pattern matcher
@@ -2009,6 +2010,7 @@ func NewResponsePatternMatcher(pattern ResponsePattern, cfg *APISpecConfig, cont
 	return &ResponsePatternMatcherImpl{
 		BasePatternMatcher: NewBasePatternMatcher(cfg, contextProvider, typeResolver),
 		pattern:            pattern,
+		destResolver:       newResponseDestResolver(cfg, contextProvider),
 	}
 }
 
@@ -2054,7 +2056,31 @@ func (r *ResponsePatternMatcherImpl) MatchNode(node TrackerNodeInterface) bool {
 		return false
 	}
 
+	// Write-destination gating: only meaningful for destination-carrying
+	// encoders (json.NewEncoder(x).Encode(v)). The encoded value is a response
+	// only when x provably traces to the response writer — otherwise it was
+	// written to some other io.Writer (a bytes.Buffer, a hash, a log). Mirrors
+	// the request-source gating on RequestBodyPattern. See issue #170.
+	if r.pattern.RequireResponseDestination && r.destResolver != nil && r.destResolver.Enabled() {
+		dst := r.destination(edge)
+		if dst == nil || !r.destResolver.IsResponseDest(dst, edge) {
+			return false
+		}
+	}
+
 	return true
+}
+
+// destination returns the CallArgument that carries the encoder's write
+// destination for the given call edge, according to the pattern configuration.
+func (r *ResponsePatternMatcherImpl) destination(edge *metadata.CallGraphEdge) *metadata.CallArgument {
+	if edge == nil {
+		return nil
+	}
+	if r.pattern.DestFromReceiver {
+		return resolveReceiverSource(edge, r.destResolver.metadata())
+	}
+	return nil
 }
 
 // GetPattern returns the response pattern

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -759,6 +759,14 @@ func (r *RequestPatternMatcherImpl) MatchNode(node TrackerNodeInterface) bool {
 	// (json.Decode, json.Unmarshal, render.DecodeJSON, ...). Receiver-based
 	// patterns like *gin.Context.BindJSON are already unambiguous because
 	// the receiver type IS the request.
+	//
+	// Note: this gate is evaluated once per tracker node, and a decoder helper
+	// shared by several routes has a single node — so the source cannot be
+	// resolved per-route HERE without attributing one route's argument to all
+	// (an io.Reader helper decoding r.Body in one route and a buffer in another
+	// would otherwise leak the body into the second). The known io.Reader-helper
+	// false negative is left to a per-route gate rather than risk that false
+	// positive. See the discussion on issue #170's response counterpart.
 	if r.pattern.RequireRequestSource && r.bodyResolver != nil && r.bodyResolver.Enabled() {
 		src := r.bodySource(edge)
 		if src == nil || !r.bodyResolver.IsRequestSource(src, edge) {

--- a/internal/spec/response_dest.go
+++ b/internal/spec/response_dest.go
@@ -20,25 +20,29 @@ import (
 	"github.com/ehabterra/apispec/internal/metadata"
 )
 
-// responseDestResolver is the write-side mirror of bodySourceResolver
-// (issue #170). It determines whether an encoder's write destination can be
-// traced back to the HTTP response writer as configured by
-// FrameworkConfig.ResponseContext. This is the "response-destination gating"
-// that stops a value encoded to some other io.Writer — a bytes.Buffer, a hash,
-// a log sink — from being mistaken for the operation's response.
+// responseDestResolver is the write-side counterpart of bodySourceResolver
+// (issue #170). It decides whether an encoder's write destination disqualifies
+// the encoded value from being the operation's response — i.e. whether the
+// value was written somewhere OTHER than the HTTP response writer (a
+// bytes.Buffer, a hash, a log sink).
 //
-// The two resolvers are deliberately symmetric: request gating traces a
-// decoder's *source* bytes to a request-body accessor; response gating traces
-// an encoder's *destination* writer to a response writer.
+// It is deliberately CONSERVATIVE ("honest over wrong", golden rule #7): it
+// rejects a destination only when it can PROVE the destination is a concrete
+// non-writer. A proven writer, a writer-compatible interface (io.Writer — the
+// ubiquitous `func writeJSON(w io.Writer, v any)` helper shape), or a
+// destination it cannot resolve all stay permissive, so a legitimate response
+// is never dropped. The narrower risk it accepts is missing a false positive
+// that hides behind an interface indirection — preferable to regressing real
+// responses.
 type responseDestResolver struct {
 	contextProvider ContextProvider
-	writerTypeREs   []*regexp.Regexp
-	accessorREs     []*regexp.Regexp
+	writerTypeREs   []*regexp.Regexp // types that ARE a response writer
+	compatibleREs   []*regexp.Regexp // interfaces a response writer satisfies (io.Writer, ...)
 }
 
 // newResponseDestResolver compiles the configured regexes once. Enabled()
 // reports false when no ResponseContext writer types are configured; callers
-// then fall back to prior (permissive) behaviour.
+// then fall back to prior (fully permissive) behaviour.
 func newResponseDestResolver(cfg *APISpecConfig, contextProvider ContextProvider) *responseDestResolver {
 	r := &responseDestResolver{contextProvider: contextProvider}
 	if cfg == nil {
@@ -49,9 +53,9 @@ func newResponseDestResolver(cfg *APISpecConfig, contextProvider ContextProvider
 			r.writerTypeREs = append(r.writerTypeREs, re)
 		}
 	}
-	for _, p := range cfg.Framework.ResponseContext.WriterAccessors {
+	for _, p := range cfg.Framework.ResponseContext.WriterCompatibleTypeRegexes {
 		if re, err := cachedRegex(p); err == nil {
-			r.accessorREs = append(r.accessorREs, re)
+			r.compatibleREs = append(r.compatibleREs, re)
 		}
 	}
 	return r
@@ -63,131 +67,59 @@ func (r *responseDestResolver) Enabled() bool {
 	return r != nil && len(r.writerTypeREs) > 0
 }
 
-// IsResponseDest returns true if the destination argument at the given call
-// site can be traced through selectors, idents, assignments and parameter
-// boundaries to a response-writer root.
+// IsProvablyNonWriter reports whether the destination argument resolves to a
+// concrete type that is definitely NOT the response writer, and so the encoded
+// value must not be treated as the response. It returns false — permissive —
+// whenever the destination:
+//   - is a configured response-writer type, or
+//   - is a writer-compatible interface (io.Writer, ...), or
+//   - cannot be resolved to a concrete type.
 //
-// When Enabled() is false it returns true (permissive) so callers can use it
-// unconditionally.
-func (r *responseDestResolver) IsResponseDest(arg *metadata.CallArgument, edge *metadata.CallGraphEdge) bool {
+// Only a destination that resolves to a specific, non-writer, non-compatible
+// type (bytes.Buffer, os.File, a hash, ...) is reported as provably non-writer.
+func (r *responseDestResolver) IsProvablyNonWriter(arg *metadata.CallArgument, edge *metadata.CallGraphEdge) bool {
 	if !r.Enabled() {
-		return true
-	}
-	visited := make(map[string]bool, 4)
-	return r.check(arg, edge, visited)
-}
-
-func (r *responseDestResolver) check(arg *metadata.CallArgument, edge *metadata.CallGraphEdge, visited map[string]bool) bool {
-	if arg == nil || edge == nil {
 		return false
 	}
+	t := r.leafType(arg, edge)
+	if t == "" {
+		return false // unresolved — stay permissive
+	}
+	if matchAny(r.writerTypeREs, t) {
+		return false // it IS a writer
+	}
+	if matchAny(r.compatibleREs, t) {
+		return false // could be the writer (e.g. an io.Writer parameter)
+	}
+	return true
+}
 
-	// Strip address-of and deref so &w and *w trace the same as w.
+// leafType resolves the destination expression to the type of its underlying
+// value. Address-of and deref are stripped (&buf and buf resolve alike); a bare
+// ident yields its (possibly traced) type; a selector/call yields its recorded
+// result type when available. Returns "" when the type cannot be determined.
+func (r *responseDestResolver) leafType(arg *metadata.CallArgument, edge *metadata.CallGraphEdge) string {
 	for arg != nil && (arg.GetKind() == metadata.KindUnary || arg.GetKind() == metadata.KindStar) {
 		arg = arg.X
 	}
 	if arg == nil {
-		return false
+		return ""
 	}
-
-	key := arg.ID()
-	if visited[key] {
-		return false
-	}
-	visited[key] = true
-
 	switch arg.GetKind() {
-	case metadata.KindSelector, metadata.KindCall:
-		root, segs := peelAccessorChain(arg)
-		if root != nil && r.chainMatches(root, segs, edge) {
-			return true
-		}
-		// The root may itself be a variable whose origin is the writer —
-		// e.g. dst := w; json.NewEncoder(dst).Encode(v).
-		if root != nil && root.GetKind() == metadata.KindIdent {
-			return r.checkIdent(root, edge, visited)
-		}
-		return false
-
 	case metadata.KindIdent:
-		return r.checkIdent(arg, edge, visited)
-	}
-	return false
-}
-
-// chainMatches reports whether the (root, segs) chain points at a response
-// writer: the root's type must match a WriterTypeRegex when segs is empty
-// (the writer IS the root, e.g. net/http's `w`), otherwise the dotted accessor
-// chain must match a WriterAccessor applied to a writer-typed context root.
-func (r *responseDestResolver) chainMatches(root *metadata.CallArgument, segs []chainSegment, edge *metadata.CallGraphEdge) bool {
-	if root == nil || root.GetKind() != metadata.KindIdent {
-		return false
-	}
-	rootType := r.identType(root, edge)
-	if rootType == "" {
-		return false
-	}
-	// Bare writer parameter (no accessor chain): the root's own type decides.
-	if len(segs) == 0 {
-		return matchAny(r.writerTypeREs, rootType)
-	}
-	// Writer reached through a context accessor (e.g. c.Writer): the accessor
-	// chain must match. WriterAccessors is optional; when unset, only bare
-	// writer roots qualify.
-	return matchAny(r.accessorREs, accessorString(segs))
-}
-
-// checkIdent traces an ident through local assignments and parameter
-// boundaries to see whether its value is the response writer.
-func (r *responseDestResolver) checkIdent(arg *metadata.CallArgument, edge *metadata.CallGraphEdge, visited map[string]bool) bool {
-	if arg == nil || arg.GetKind() != metadata.KindIdent || edge == nil {
-		return false
-	}
-	name := arg.GetName()
-	if name == "" {
-		return false
-	}
-
-	// A bare ident whose own type is already a writer qualifies directly —
-	// this is the common `json.NewEncoder(w).Encode(v)` case.
-	if t := r.identType(arg, edge); t != "" && matchAny(r.writerTypeREs, t) {
-		return true
-	}
-
-	// 1) Local assignments visible at this call site (dst := w).
-	if assigns, ok := edge.AssignmentMap[name]; ok && len(assigns) > 0 {
-		rhs := assigns[len(assigns)-1].Value
-		if rhs.Meta == nil {
-			rhs.Meta = arg.Meta
+		return r.identType(arg, edge)
+	case metadata.KindSelector, metadata.KindCall:
+		if t := arg.GetResolvedType(); t != "" {
+			return t
 		}
-		if r.check(&rhs, edge, visited) {
-			return true
-		}
+		return arg.GetType()
 	}
-
-	// 2) The ident may be a parameter of a helper — trace it up the call graph
-	// to the caller's argument so writeJSON(w, v) { enc(w) } resolves from its
-	// caller passing the real response writer.
-	callerName := r.contextProvider.GetString(edge.Caller.Name)
-	callerPkg := r.contextProvider.GetString(edge.Caller.Pkg)
-	if name == callerName {
-		return false // guard against pathological self-recursion
-	}
-	if meta := r.metadata(); meta != nil {
-		_, _, originArg, _ := metadata.TraceVariableOrigin(name, callerName, callerPkg, meta)
-		if originArg != nil && originArg != arg {
-			if t := originArg.GetType(); t != "" && matchAny(r.writerTypeREs, t) {
-				return true
-			}
-		}
-	}
-
-	return false
+	return ""
 }
 
 // identType returns the ident's declared type, preferring the resolved type.
-// Falls back to local assignments and a call-graph origin trace. Mirrors
-// bodySourceResolver.identType.
+// Falls back to the concrete type recorded on a local assignment, then to a
+// call-graph origin trace. Mirrors bodySourceResolver.identType.
 func (r *responseDestResolver) identType(arg *metadata.CallArgument, edge *metadata.CallGraphEdge) string {
 	if arg == nil {
 		return ""
@@ -211,7 +143,7 @@ func (r *responseDestResolver) identType(arg *metadata.CallArgument, edge *metad
 		callerName := r.contextProvider.GetString(edge.Caller.Name)
 		callerPkg := r.contextProvider.GetString(edge.Caller.Pkg)
 		_, _, originArg, _ := metadata.TraceVariableOrigin(arg.GetName(), callerName, callerPkg, meta)
-		if originArg != nil {
+		if originArg != nil && originArg != arg {
 			return originArg.GetType()
 		}
 	}

--- a/internal/spec/response_dest.go
+++ b/internal/spec/response_dest.go
@@ -23,60 +23,49 @@ import (
 // responseDestResolver is the write-side counterpart of bodySourceResolver
 // (issue #170). It decides whether an encoder's write destination disqualifies
 // the encoded value from being the operation's response — i.e. whether the
-// value was written somewhere OTHER than the HTTP response writer (a
-// bytes.Buffer, a hash, a log sink).
+// value was written to a known sink (a bytes.Buffer, a hash, a log) rather than
+// to the HTTP response.
 //
-// It is deliberately CONSERVATIVE ("honest over wrong", golden rule #7): it
-// rejects a destination only when it can PROVE the destination is a concrete
-// non-writer. A proven writer, a writer-compatible interface (io.Writer — the
-// ubiquitous `func writeJSON(w io.Writer, v any)` helper shape), or a
-// destination it cannot resolve all stay permissive, so a legitimate response
-// is never dropped. The narrower risk it accepts is missing a false positive
-// that hides behind an interface indirection — preferable to regressing real
-// responses.
+// It is deliberately PERMISSIVE ("honest over wrong", golden rule #7). The
+// destination is first resolved through the call graph to its concrete value
+// (see ResponsePatternMatcherImpl.destination), then rejected ONLY when that
+// value's type matches a configured known-sink pattern. A destination that is
+// the response writer, a custom writer type, an interface (io.Writer), or one
+// that cannot be resolved is kept — the gate never drops a real response merely
+// because it could not prove the destination is a writer.
 type responseDestResolver struct {
 	contextProvider ContextProvider
-	writerTypeREs   []*regexp.Regexp // types that ARE a response writer
-	compatibleREs   []*regexp.Regexp // interfaces a response writer satisfies (io.Writer, ...)
+	excludeREs      []*regexp.Regexp // types that are provably NOT the response
 }
 
 // newResponseDestResolver compiles the configured regexes once. Enabled()
-// reports false when no ResponseContext writer types are configured; callers
-// then fall back to prior (fully permissive) behaviour.
+// reports false when no exclude patterns are configured; callers then fall back
+// to prior (fully permissive) behaviour.
 func newResponseDestResolver(cfg *APISpecConfig, contextProvider ContextProvider) *responseDestResolver {
 	r := &responseDestResolver{contextProvider: contextProvider}
 	if cfg == nil {
 		return r
 	}
-	for _, p := range cfg.Framework.ResponseContext.WriterTypeRegexes {
+	for _, p := range cfg.Framework.ResponseContext.WriterExcludeTypeRegexes {
 		if re, err := cachedRegex(p); err == nil {
-			r.writerTypeREs = append(r.writerTypeREs, re)
-		}
-	}
-	for _, p := range cfg.Framework.ResponseContext.WriterCompatibleTypeRegexes {
-		if re, err := cachedRegex(p); err == nil {
-			r.compatibleREs = append(r.compatibleREs, re)
+			r.excludeREs = append(r.excludeREs, re)
 		}
 	}
 	return r
 }
 
-// Enabled reports whether ResponseContext writer types are configured. When
-// false, the resolver is skipped and matchers keep their prior behaviour.
+// Enabled reports whether any exclude patterns are configured. When false, the
+// resolver is skipped and matchers keep their prior behaviour.
 func (r *responseDestResolver) Enabled() bool {
-	return r != nil && len(r.writerTypeREs) > 0
+	return r != nil && len(r.excludeREs) > 0
 }
 
 // IsProvablyNonWriter reports whether the destination argument resolves to a
-// concrete type that is definitely NOT the response writer, and so the encoded
-// value must not be treated as the response. It returns false — permissive —
-// whenever the destination:
-//   - is a configured response-writer type, or
-//   - is a writer-compatible interface (io.Writer, ...), or
-//   - cannot be resolved to a concrete type.
-//
-// Only a destination that resolves to a specific, non-writer, non-compatible
-// type (bytes.Buffer, os.File, a hash, ...) is reported as provably non-writer.
+// type that is a configured known sink and therefore definitely NOT the HTTP
+// response. It returns false — permissive — whenever the destination cannot be
+// resolved to a type or that type is not on the exclude list, so a proven
+// writer, a custom writer, an io.Writer interface, or an unknown destination
+// are all kept.
 func (r *responseDestResolver) IsProvablyNonWriter(arg *metadata.CallArgument, edge *metadata.CallGraphEdge) bool {
 	if !r.Enabled() {
 		return false
@@ -85,13 +74,7 @@ func (r *responseDestResolver) IsProvablyNonWriter(arg *metadata.CallArgument, e
 	if t == "" {
 		return false // unresolved — stay permissive
 	}
-	if matchAny(r.writerTypeREs, t) {
-		return false // it IS a writer
-	}
-	if matchAny(r.compatibleREs, t) {
-		return false // could be the writer (e.g. an io.Writer parameter)
-	}
-	return true
+	return matchAny(r.excludeREs, t)
 }
 
 // leafType resolves the destination expression to the type of its underlying
@@ -144,6 +127,11 @@ func (r *responseDestResolver) identType(arg *metadata.CallArgument, edge *metad
 		callerPkg := r.contextProvider.GetString(edge.Caller.Pkg)
 		_, _, originArg, _ := metadata.TraceVariableOrigin(arg.GetName(), callerName, callerPkg, meta)
 		if originArg != nil && originArg != arg {
+			// Prefer the resolved (concrete/instantiated) type so a traced
+			// generic or wrapper argument keeps its real type for gating.
+			if t := originArg.GetResolvedType(); t != "" {
+				return t
+			}
 			return originArg.GetType()
 		}
 	}

--- a/internal/spec/response_dest.go
+++ b/internal/spec/response_dest.go
@@ -1,0 +1,226 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"regexp"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// responseDestResolver is the write-side mirror of bodySourceResolver
+// (issue #170). It determines whether an encoder's write destination can be
+// traced back to the HTTP response writer as configured by
+// FrameworkConfig.ResponseContext. This is the "response-destination gating"
+// that stops a value encoded to some other io.Writer — a bytes.Buffer, a hash,
+// a log sink — from being mistaken for the operation's response.
+//
+// The two resolvers are deliberately symmetric: request gating traces a
+// decoder's *source* bytes to a request-body accessor; response gating traces
+// an encoder's *destination* writer to a response writer.
+type responseDestResolver struct {
+	contextProvider ContextProvider
+	writerTypeREs   []*regexp.Regexp
+	accessorREs     []*regexp.Regexp
+}
+
+// newResponseDestResolver compiles the configured regexes once. Enabled()
+// reports false when no ResponseContext writer types are configured; callers
+// then fall back to prior (permissive) behaviour.
+func newResponseDestResolver(cfg *APISpecConfig, contextProvider ContextProvider) *responseDestResolver {
+	r := &responseDestResolver{contextProvider: contextProvider}
+	if cfg == nil {
+		return r
+	}
+	for _, p := range cfg.Framework.ResponseContext.WriterTypeRegexes {
+		if re, err := cachedRegex(p); err == nil {
+			r.writerTypeREs = append(r.writerTypeREs, re)
+		}
+	}
+	for _, p := range cfg.Framework.ResponseContext.WriterAccessors {
+		if re, err := cachedRegex(p); err == nil {
+			r.accessorREs = append(r.accessorREs, re)
+		}
+	}
+	return r
+}
+
+// Enabled reports whether ResponseContext writer types are configured. When
+// false, the resolver is skipped and matchers keep their prior behaviour.
+func (r *responseDestResolver) Enabled() bool {
+	return r != nil && len(r.writerTypeREs) > 0
+}
+
+// IsResponseDest returns true if the destination argument at the given call
+// site can be traced through selectors, idents, assignments and parameter
+// boundaries to a response-writer root.
+//
+// When Enabled() is false it returns true (permissive) so callers can use it
+// unconditionally.
+func (r *responseDestResolver) IsResponseDest(arg *metadata.CallArgument, edge *metadata.CallGraphEdge) bool {
+	if !r.Enabled() {
+		return true
+	}
+	visited := make(map[string]bool, 4)
+	return r.check(arg, edge, visited)
+}
+
+func (r *responseDestResolver) check(arg *metadata.CallArgument, edge *metadata.CallGraphEdge, visited map[string]bool) bool {
+	if arg == nil || edge == nil {
+		return false
+	}
+
+	// Strip address-of and deref so &w and *w trace the same as w.
+	for arg != nil && (arg.GetKind() == metadata.KindUnary || arg.GetKind() == metadata.KindStar) {
+		arg = arg.X
+	}
+	if arg == nil {
+		return false
+	}
+
+	key := arg.ID()
+	if visited[key] {
+		return false
+	}
+	visited[key] = true
+
+	switch arg.GetKind() {
+	case metadata.KindSelector, metadata.KindCall:
+		root, segs := peelAccessorChain(arg)
+		if root != nil && r.chainMatches(root, segs, edge) {
+			return true
+		}
+		// The root may itself be a variable whose origin is the writer —
+		// e.g. dst := w; json.NewEncoder(dst).Encode(v).
+		if root != nil && root.GetKind() == metadata.KindIdent {
+			return r.checkIdent(root, edge, visited)
+		}
+		return false
+
+	case metadata.KindIdent:
+		return r.checkIdent(arg, edge, visited)
+	}
+	return false
+}
+
+// chainMatches reports whether the (root, segs) chain points at a response
+// writer: the root's type must match a WriterTypeRegex when segs is empty
+// (the writer IS the root, e.g. net/http's `w`), otherwise the dotted accessor
+// chain must match a WriterAccessor applied to a writer-typed context root.
+func (r *responseDestResolver) chainMatches(root *metadata.CallArgument, segs []chainSegment, edge *metadata.CallGraphEdge) bool {
+	if root == nil || root.GetKind() != metadata.KindIdent {
+		return false
+	}
+	rootType := r.identType(root, edge)
+	if rootType == "" {
+		return false
+	}
+	// Bare writer parameter (no accessor chain): the root's own type decides.
+	if len(segs) == 0 {
+		return matchAny(r.writerTypeREs, rootType)
+	}
+	// Writer reached through a context accessor (e.g. c.Writer): the accessor
+	// chain must match. WriterAccessors is optional; when unset, only bare
+	// writer roots qualify.
+	return matchAny(r.accessorREs, accessorString(segs))
+}
+
+// checkIdent traces an ident through local assignments and parameter
+// boundaries to see whether its value is the response writer.
+func (r *responseDestResolver) checkIdent(arg *metadata.CallArgument, edge *metadata.CallGraphEdge, visited map[string]bool) bool {
+	if arg == nil || arg.GetKind() != metadata.KindIdent || edge == nil {
+		return false
+	}
+	name := arg.GetName()
+	if name == "" {
+		return false
+	}
+
+	// A bare ident whose own type is already a writer qualifies directly —
+	// this is the common `json.NewEncoder(w).Encode(v)` case.
+	if t := r.identType(arg, edge); t != "" && matchAny(r.writerTypeREs, t) {
+		return true
+	}
+
+	// 1) Local assignments visible at this call site (dst := w).
+	if assigns, ok := edge.AssignmentMap[name]; ok && len(assigns) > 0 {
+		rhs := assigns[len(assigns)-1].Value
+		if rhs.Meta == nil {
+			rhs.Meta = arg.Meta
+		}
+		if r.check(&rhs, edge, visited) {
+			return true
+		}
+	}
+
+	// 2) The ident may be a parameter of a helper — trace it up the call graph
+	// to the caller's argument so writeJSON(w, v) { enc(w) } resolves from its
+	// caller passing the real response writer.
+	callerName := r.contextProvider.GetString(edge.Caller.Name)
+	callerPkg := r.contextProvider.GetString(edge.Caller.Pkg)
+	if name == callerName {
+		return false // guard against pathological self-recursion
+	}
+	if meta := r.metadata(); meta != nil {
+		_, _, originArg, _ := metadata.TraceVariableOrigin(name, callerName, callerPkg, meta)
+		if originArg != nil && originArg != arg {
+			if t := originArg.GetType(); t != "" && matchAny(r.writerTypeREs, t) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// identType returns the ident's declared type, preferring the resolved type.
+// Falls back to local assignments and a call-graph origin trace. Mirrors
+// bodySourceResolver.identType.
+func (r *responseDestResolver) identType(arg *metadata.CallArgument, edge *metadata.CallGraphEdge) string {
+	if arg == nil {
+		return ""
+	}
+	if t := arg.GetResolvedType(); t != "" {
+		return t
+	}
+	if t := arg.GetType(); t != "" {
+		return t
+	}
+	if edge != nil && len(edge.AssignmentMap) > 0 {
+		if assigns, ok := edge.AssignmentMap[arg.GetName()]; ok {
+			for i := len(assigns) - 1; i >= 0; i-- {
+				if t := r.contextProvider.GetString(assigns[i].ConcreteType); t != "" {
+					return t
+				}
+			}
+		}
+	}
+	if meta := r.metadata(); meta != nil && edge != nil {
+		callerName := r.contextProvider.GetString(edge.Caller.Name)
+		callerPkg := r.contextProvider.GetString(edge.Caller.Pkg)
+		_, _, originArg, _ := metadata.TraceVariableOrigin(arg.GetName(), callerName, callerPkg, meta)
+		if originArg != nil {
+			return originArg.GetType()
+		}
+	}
+	return ""
+}
+
+func (r *responseDestResolver) metadata() *metadata.Metadata {
+	if impl, ok := r.contextProvider.(*ContextProviderImpl); ok {
+		return impl.meta
+	}
+	return nil
+}

--- a/internal/spec/response_dest_test.go
+++ b/internal/spec/response_dest_test.go
@@ -20,14 +20,14 @@ import (
 	"github.com/ehabterra/apispec/internal/metadata"
 )
 
-// TestResponseDestResolver_Disabled: with no ResponseContext configured the
+// TestResponseDestResolver_Disabled: with no exclude patterns configured the
 // resolver never rejects, preserving prior behaviour (zero-drift guarantee).
 func TestResponseDestResolver_Disabled(t *testing.T) {
 	meta := newTestMeta()
 	cp := NewContextProvider(meta)
 	r := newResponseDestResolver(&APISpecConfig{}, cp)
 	if r.Enabled() {
-		t.Fatal("expected resolver to be disabled with no WriterTypeRegexes")
+		t.Fatal("expected resolver to be disabled with no exclude patterns")
 	}
 	// Even a clearly-non-writer destination is not rejected when disabled.
 	if r.IsProvablyNonWriter(mkIdent(meta, "buf", "*bytes.Buffer"), &metadata.CallGraphEdge{}) {
@@ -35,10 +35,10 @@ func TestResponseDestResolver_Disabled(t *testing.T) {
 	}
 }
 
-// TestResponseDestResolver_ProvablyNonWriter: once ResponseContext is
-// configured, only a destination that resolves to a concrete non-writer type is
-// rejected; writers, writer-compatible interfaces, and unresolvable
-// destinations are all kept.
+// TestResponseDestResolver_ProvablyNonWriter: once exclude patterns are
+// configured, only a destination whose resolved type matches a known-sink
+// pattern is rejected; writers, custom/unknown types, interfaces, and
+// unresolvable destinations are all kept (permissive, honest over wrong).
 func TestResponseDestResolver_ProvablyNonWriter(t *testing.T) {
 	meta := newTestMeta()
 	cp := NewContextProvider(meta)
@@ -54,17 +54,16 @@ func TestResponseDestResolver_ProvablyNonWriter(t *testing.T) {
 		arg     *metadata.CallArgument
 		nonWrit bool // want IsProvablyNonWriter
 	}{
-		// Writers — kept.
+		// Known sinks — rejected.
+		{"bytes.Buffer", mkIdent(meta, "buf", "*bytes.Buffer"), true},
+		{"strings.Builder", mkIdent(meta, "b", "*strings.Builder"), true},
+		{"os.File", mkIdent(meta, "f", "*os.File"), true},
+		{"hash.Hash", mkIdent(meta, "h", "hash.Hash"), true},
+		// Response writer and writer-compatible/unknown — kept.
 		{"response writer param w", mkIdent(meta, "w", "net/http.ResponseWriter"), false},
-		{"httptest recorder", mkIdent(meta, "rec", "*net/http/httptest.ResponseRecorder"), false},
-		// Writer-compatible interfaces — kept (could be the writer).
 		{"io.Writer helper param", mkIdent(meta, "dst", "io.Writer"), false},
-		{"io.WriteCloser", mkIdent(meta, "wc", "io.WriteCloser"), false},
-		// Concrete non-writers — rejected.
-		{"bytes.Buffer is a non-writer", mkIdent(meta, "buf", "*bytes.Buffer"), true},
-		{"os.File is a non-writer", mkIdent(meta, "f", "*os.File"), true},
-		{"a named hash type is a non-writer", mkIdent(meta, "h", "crypto/sha256.digest"), true},
-		// Unresolvable — kept (permissive).
+		{"custom writer type", mkIdent(meta, "cw", "example.com/app.LoggingWriter"), false},
+		// Unresolvable — kept.
 		{"untyped ident stays permissive", mkIdent(meta, "x", ""), false},
 	}
 	for _, tc := range cases {
@@ -78,7 +77,7 @@ func TestResponseDestResolver_ProvablyNonWriter(t *testing.T) {
 }
 
 // TestResponseDestResolver_AddressOf: &buf strips to buf, so a concrete buffer
-// is still recognised as a non-writer, while &w stays a writer.
+// is still recognised as a sink, while &w (a writer) is kept.
 func TestResponseDestResolver_AddressOf(t *testing.T) {
 	meta := newTestMeta()
 	cp := NewContextProvider(meta)
@@ -88,9 +87,9 @@ func TestResponseDestResolver_AddressOf(t *testing.T) {
 
 	addrBuf := metadata.NewCallArgument(meta)
 	addrBuf.SetKind(metadata.KindUnary)
-	addrBuf.X = mkIdent(meta, "buf", "*bytes.Buffer")
+	addrBuf.X = mkIdent(meta, "buf", "bytes.Buffer")
 	if !r.IsProvablyNonWriter(addrBuf, &metadata.CallGraphEdge{}) {
-		t.Error("&buf should be recognised as a concrete non-writer")
+		t.Error("&buf should be recognised as a sink")
 	}
 
 	addrW := metadata.NewCallArgument(meta)
@@ -102,8 +101,9 @@ func TestResponseDestResolver_AddressOf(t *testing.T) {
 }
 
 // TestResponseDestResolver_TypeTracing covers identType's fallbacks: a variable
-// whose concrete type is recorded on a local assignment resolves through, and a
-// selector/call destination uses its recorded result type.
+// whose concrete type is recorded on a local assignment resolves through, a
+// selector/call destination uses its recorded result type, and an unsupported
+// kind stays permissive.
 func TestResponseDestResolver_TypeTracing(t *testing.T) {
 	meta := newTestMeta()
 	cp := NewContextProvider(meta)
@@ -111,18 +111,18 @@ func TestResponseDestResolver_TypeTracing(t *testing.T) {
 		Framework: FrameworkConfig{ResponseContext: netHTTPResponseContext},
 	}, cp)
 
-	t.Run("concrete type recovered from assignment ConcreteType", func(t *testing.T) {
+	t.Run("sink type recovered from assignment ConcreteType", func(t *testing.T) {
 		edge := &metadata.CallGraphEdge{
 			AssignmentMap: map[string][]metadata.Assignment{
 				"buf": {{ConcreteType: meta.StringPool.Get("bytes.Buffer")}},
 			},
 		}
 		if !r.IsProvablyNonWriter(mkIdent(meta, "buf", ""), edge) {
-			t.Error("buf whose assignment ConcreteType is bytes.Buffer should be a non-writer")
+			t.Error("buf whose assignment ConcreteType is bytes.Buffer should be a sink")
 		}
 	})
 
-	t.Run("writer type recovered from assignment keeps the response", func(t *testing.T) {
+	t.Run("writer type from assignment keeps the response", func(t *testing.T) {
 		edge := &metadata.CallGraphEdge{
 			AssignmentMap: map[string][]metadata.Assignment{
 				"rw": {{ConcreteType: meta.StringPool.Get("net/http.ResponseWriter")}},
@@ -134,10 +134,10 @@ func TestResponseDestResolver_TypeTracing(t *testing.T) {
 	})
 
 	t.Run("selector destination uses its resolved type", func(t *testing.T) {
-		sel := mkSelector(meta, mkIdent(meta, "c", "*gin.Context"), mkIdent(meta, "buf", ""))
+		sel := mkSelector(meta, mkIdent(meta, "s", "app.Server"), mkIdent(meta, "buf", ""))
 		sel.ResolvedType = meta.StringPool.Get("bytes.Buffer")
 		if !r.IsProvablyNonWriter(sel, &metadata.CallGraphEdge{}) {
-			t.Error("a selector resolving to bytes.Buffer should be a non-writer")
+			t.Error("a selector resolving to bytes.Buffer should be a sink")
 		}
 	})
 
@@ -145,16 +145,16 @@ func TestResponseDestResolver_TypeTracing(t *testing.T) {
 		lit := metadata.NewCallArgument(meta)
 		lit.SetKind(metadata.KindLiteral)
 		if r.IsProvablyNonWriter(lit, &metadata.CallGraphEdge{}) {
-			t.Error("a literal destination is not provably a non-writer")
+			t.Error("a literal destination is not provably a sink")
 		}
 		if r.IsProvablyNonWriter(nil, &metadata.CallGraphEdge{}) {
-			t.Error("a nil destination is not provably a non-writer")
+			t.Error("a nil destination is not provably a sink")
 		}
 	})
 }
 
 // TestNewResponseDestResolver_EdgeCases covers the constructor's nil-config and
-// invalid-regex handling for both regex lists.
+// invalid-regex handling.
 func TestNewResponseDestResolver_EdgeCases(t *testing.T) {
 	cp := NewContextProvider(newTestMeta())
 
@@ -163,29 +163,27 @@ func TestNewResponseDestResolver_EdgeCases(t *testing.T) {
 	}
 
 	bad := &APISpecConfig{Framework: FrameworkConfig{ResponseContext: ResponseContextConfig{
-		WriterTypeRegexes: []string{"("}, // invalid regex, skipped
+		WriterExcludeTypeRegexes: []string{"("}, // invalid regex, skipped
 	}}}
 	if newResponseDestResolver(bad, cp).Enabled() {
-		t.Error("an invalid writer regex should be skipped, leaving the resolver disabled")
+		t.Error("an invalid regex should be skipped, leaving the resolver disabled")
 	}
 
 	mix := &APISpecConfig{Framework: FrameworkConfig{ResponseContext: ResponseContextConfig{
-		WriterTypeRegexes:           []string{"(", `^net/http\.ResponseWriter$`}, // one bad, one good
-		WriterCompatibleTypeRegexes: []string{"[", `^io\.Writer$`},               // one bad, one good
+		WriterExcludeTypeRegexes: []string{"(", `^\*?bytes\.Buffer$`}, // one bad, one good
 	}}}
 	r := newResponseDestResolver(mix, cp)
 	if !r.Enabled() {
-		t.Error("a valid writer regex should enable the resolver despite an invalid sibling")
+		t.Error("a valid exclude regex should enable the resolver despite an invalid sibling")
 	}
-	// The valid compatible regex still applies.
 	m := newTestMeta()
-	if r2 := newResponseDestResolver(mix, NewContextProvider(m)); r2.IsProvablyNonWriter(mkIdent(m, "dst", "io.Writer"), &metadata.CallGraphEdge{}) {
-		t.Error("io.Writer should be kept via the valid compatible regex")
+	if r2 := newResponseDestResolver(mix, NewContextProvider(m)); !r2.IsProvablyNonWriter(mkIdent(m, "buf", "*bytes.Buffer"), &metadata.CallGraphEdge{}) {
+		t.Error("the valid exclude regex should still reject bytes.Buffer")
 	}
 }
 
 // TestResponsePatternMatcher_Destination covers ResponsePatternMatcherImpl.
-// destination across its branches: nil edge, DestFromReceiver off, and the
+// destination across its branches: nil node, DestFromReceiver off, and the
 // receiver-chain resolution that yields the encoder factory's first argument.
 func TestResponsePatternMatcher_Destination(t *testing.T) {
 	meta := newTestMeta()

--- a/internal/spec/response_dest_test.go
+++ b/internal/spec/response_dest_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 // TestResponseDestResolver_Disabled: with no ResponseContext configured the
-// resolver is permissive, preserving prior behaviour (zero-drift guarantee).
+// resolver never rejects, preserving prior behaviour (zero-drift guarantee).
 func TestResponseDestResolver_Disabled(t *testing.T) {
 	meta := newTestMeta()
 	cp := NewContextProvider(meta)
@@ -29,15 +29,17 @@ func TestResponseDestResolver_Disabled(t *testing.T) {
 	if r.Enabled() {
 		t.Fatal("expected resolver to be disabled with no WriterTypeRegexes")
 	}
-	// Even a clearly-non-writer destination is accepted when disabled.
-	if !r.IsResponseDest(mkIdent(meta, "buf", "*bytes.Buffer"), &metadata.CallGraphEdge{}) {
-		t.Fatal("disabled resolver must be permissive")
+	// Even a clearly-non-writer destination is not rejected when disabled.
+	if r.IsProvablyNonWriter(mkIdent(meta, "buf", "*bytes.Buffer"), &metadata.CallGraphEdge{}) {
+		t.Fatal("disabled resolver must never report a non-writer")
 	}
 }
 
-// TestResponseDestResolver_WriterTypes: once ResponseContext is configured, a
-// bare writer-typed destination qualifies and a non-writer destination does not.
-func TestResponseDestResolver_WriterTypes(t *testing.T) {
+// TestResponseDestResolver_ProvablyNonWriter: once ResponseContext is
+// configured, only a destination that resolves to a concrete non-writer type is
+// rejected; writers, writer-compatible interfaces, and unresolvable
+// destinations are all kept.
+func TestResponseDestResolver_ProvablyNonWriter(t *testing.T) {
 	meta := newTestMeta()
 	cp := NewContextProvider(meta)
 	r := newResponseDestResolver(&APISpecConfig{
@@ -48,28 +50,35 @@ func TestResponseDestResolver_WriterTypes(t *testing.T) {
 	}
 
 	cases := []struct {
-		name string
-		arg  *metadata.CallArgument
-		want bool
+		name    string
+		arg     *metadata.CallArgument
+		nonWrit bool // want IsProvablyNonWriter
 	}{
-		{"response writer param w", mkIdent(meta, "w", "net/http.ResponseWriter"), true},
-		{"httptest recorder", mkIdent(meta, "rec", "*net/http/httptest.ResponseRecorder"), true},
-		{"bytes.Buffer is not a writer", mkIdent(meta, "buf", "*bytes.Buffer"), false},
-		{"hash is not a writer", mkIdent(meta, "h", "hash.Hash"), false},
-		{"untyped ident is not a writer", mkIdent(meta, "x", ""), false},
+		// Writers — kept.
+		{"response writer param w", mkIdent(meta, "w", "net/http.ResponseWriter"), false},
+		{"httptest recorder", mkIdent(meta, "rec", "*net/http/httptest.ResponseRecorder"), false},
+		// Writer-compatible interfaces — kept (could be the writer).
+		{"io.Writer helper param", mkIdent(meta, "dst", "io.Writer"), false},
+		{"io.WriteCloser", mkIdent(meta, "wc", "io.WriteCloser"), false},
+		// Concrete non-writers — rejected.
+		{"bytes.Buffer is a non-writer", mkIdent(meta, "buf", "*bytes.Buffer"), true},
+		{"os.File is a non-writer", mkIdent(meta, "f", "*os.File"), true},
+		{"a named hash type is a non-writer", mkIdent(meta, "h", "crypto/sha256.digest"), true},
+		// Unresolvable — kept (permissive).
+		{"untyped ident stays permissive", mkIdent(meta, "x", ""), false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := r.IsResponseDest(tc.arg, &metadata.CallGraphEdge{})
-			if got != tc.want {
-				t.Errorf("IsResponseDest(%s) = %v, want %v", tc.name, got, tc.want)
+			got := r.IsProvablyNonWriter(tc.arg, &metadata.CallGraphEdge{})
+			if got != tc.nonWrit {
+				t.Errorf("IsProvablyNonWriter(%s) = %v, want %v", tc.name, got, tc.nonWrit)
 			}
 		})
 	}
 }
 
-// TestResponseDestResolver_AddressOf: &w traces the same as w (address-of is
-// stripped), matching how json.NewEncoder(&buf) / (w) appear.
+// TestResponseDestResolver_AddressOf: &buf strips to buf, so a concrete buffer
+// is still recognised as a non-writer, while &w stays a writer.
 func TestResponseDestResolver_AddressOf(t *testing.T) {
 	meta := newTestMeta()
 	cp := NewContextProvider(meta)
@@ -77,17 +86,126 @@ func TestResponseDestResolver_AddressOf(t *testing.T) {
 		Framework: FrameworkConfig{ResponseContext: netHTTPResponseContext},
 	}, cp)
 
-	addr := metadata.NewCallArgument(meta)
-	addr.SetKind(metadata.KindUnary)
-	addr.X = mkIdent(meta, "w", "net/http.ResponseWriter")
-	if !r.IsResponseDest(addr, &metadata.CallGraphEdge{}) {
-		t.Error("&w should trace to the response writer")
-	}
-
 	addrBuf := metadata.NewCallArgument(meta)
 	addrBuf.SetKind(metadata.KindUnary)
 	addrBuf.X = mkIdent(meta, "buf", "*bytes.Buffer")
-	if r.IsResponseDest(addrBuf, &metadata.CallGraphEdge{}) {
-		t.Error("&buf must not trace to the response writer")
+	if !r.IsProvablyNonWriter(addrBuf, &metadata.CallGraphEdge{}) {
+		t.Error("&buf should be recognised as a concrete non-writer")
+	}
+
+	addrW := metadata.NewCallArgument(meta)
+	addrW.SetKind(metadata.KindUnary)
+	addrW.X = mkIdent(meta, "w", "net/http.ResponseWriter")
+	if r.IsProvablyNonWriter(addrW, &metadata.CallGraphEdge{}) {
+		t.Error("&w must not be rejected — it is the writer")
+	}
+}
+
+// TestResponseDestResolver_TypeTracing covers identType's fallbacks: a variable
+// whose concrete type is recorded on a local assignment resolves through, and a
+// selector/call destination uses its recorded result type.
+func TestResponseDestResolver_TypeTracing(t *testing.T) {
+	meta := newTestMeta()
+	cp := NewContextProvider(meta)
+	r := newResponseDestResolver(&APISpecConfig{
+		Framework: FrameworkConfig{ResponseContext: netHTTPResponseContext},
+	}, cp)
+
+	t.Run("concrete type recovered from assignment ConcreteType", func(t *testing.T) {
+		edge := &metadata.CallGraphEdge{
+			AssignmentMap: map[string][]metadata.Assignment{
+				"buf": {{ConcreteType: meta.StringPool.Get("bytes.Buffer")}},
+			},
+		}
+		if !r.IsProvablyNonWriter(mkIdent(meta, "buf", ""), edge) {
+			t.Error("buf whose assignment ConcreteType is bytes.Buffer should be a non-writer")
+		}
+	})
+
+	t.Run("writer type recovered from assignment keeps the response", func(t *testing.T) {
+		edge := &metadata.CallGraphEdge{
+			AssignmentMap: map[string][]metadata.Assignment{
+				"rw": {{ConcreteType: meta.StringPool.Get("net/http.ResponseWriter")}},
+			},
+		}
+		if r.IsProvablyNonWriter(mkIdent(meta, "rw", ""), edge) {
+			t.Error("rw whose ConcreteType is the writer must be kept")
+		}
+	})
+
+	t.Run("selector destination uses its resolved type", func(t *testing.T) {
+		sel := mkSelector(meta, mkIdent(meta, "c", "*gin.Context"), mkIdent(meta, "buf", ""))
+		sel.ResolvedType = meta.StringPool.Get("bytes.Buffer")
+		if !r.IsProvablyNonWriter(sel, &metadata.CallGraphEdge{}) {
+			t.Error("a selector resolving to bytes.Buffer should be a non-writer")
+		}
+	})
+
+	t.Run("unsupported kind and nil stay permissive", func(t *testing.T) {
+		lit := metadata.NewCallArgument(meta)
+		lit.SetKind(metadata.KindLiteral)
+		if r.IsProvablyNonWriter(lit, &metadata.CallGraphEdge{}) {
+			t.Error("a literal destination is not provably a non-writer")
+		}
+		if r.IsProvablyNonWriter(nil, &metadata.CallGraphEdge{}) {
+			t.Error("a nil destination is not provably a non-writer")
+		}
+	})
+}
+
+// TestNewResponseDestResolver_EdgeCases covers the constructor's nil-config and
+// invalid-regex handling for both regex lists.
+func TestNewResponseDestResolver_EdgeCases(t *testing.T) {
+	cp := NewContextProvider(newTestMeta())
+
+	if newResponseDestResolver(nil, cp).Enabled() {
+		t.Error("nil cfg should yield a disabled resolver")
+	}
+
+	bad := &APISpecConfig{Framework: FrameworkConfig{ResponseContext: ResponseContextConfig{
+		WriterTypeRegexes: []string{"("}, // invalid regex, skipped
+	}}}
+	if newResponseDestResolver(bad, cp).Enabled() {
+		t.Error("an invalid writer regex should be skipped, leaving the resolver disabled")
+	}
+
+	mix := &APISpecConfig{Framework: FrameworkConfig{ResponseContext: ResponseContextConfig{
+		WriterTypeRegexes:           []string{"(", `^net/http\.ResponseWriter$`}, // one bad, one good
+		WriterCompatibleTypeRegexes: []string{"[", `^io\.Writer$`},               // one bad, one good
+	}}}
+	r := newResponseDestResolver(mix, cp)
+	if !r.Enabled() {
+		t.Error("a valid writer regex should enable the resolver despite an invalid sibling")
+	}
+	// The valid compatible regex still applies.
+	m := newTestMeta()
+	if r2 := newResponseDestResolver(mix, NewContextProvider(m)); r2.IsProvablyNonWriter(mkIdent(m, "dst", "io.Writer"), &metadata.CallGraphEdge{}) {
+		t.Error("io.Writer should be kept via the valid compatible regex")
+	}
+}
+
+// TestResponsePatternMatcher_Destination covers ResponsePatternMatcherImpl.
+// destination across its branches: nil edge, DestFromReceiver off, and the
+// receiver-chain resolution that yields the encoder factory's first argument.
+func TestResponsePatternMatcher_Destination(t *testing.T) {
+	meta := newTestMeta()
+	cp := NewContextProvider(meta)
+	cfg := &APISpecConfig{Framework: FrameworkConfig{ResponseContext: netHTTPResponseContext}}
+
+	off := NewResponsePatternMatcher(ResponsePattern{DestFromReceiver: false}, cfg, cp, nil)
+	if got := off.destination(&metadata.CallGraphEdge{}); got != nil {
+		t.Errorf("DestFromReceiver=false should yield nil destination, got %v", got)
+	}
+	if got := off.destination(nil); got != nil {
+		t.Errorf("destination(nil) should be nil, got %v", got)
+	}
+
+	on := NewResponsePatternMatcher(ResponsePattern{DestFromReceiver: true}, cfg, cp, nil)
+	w := mkIdent(meta, "w", "net/http.ResponseWriter")
+	edge := &metadata.CallGraphEdge{
+		ChainParent: &metadata.CallGraphEdge{Args: []*metadata.CallArgument{w}},
+	}
+	if got := on.destination(edge); got != w {
+		t.Errorf("destination should resolve to the factory's first arg, got %v", got)
 	}
 }

--- a/internal/spec/response_dest_test.go
+++ b/internal/spec/response_dest_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// TestResponseDestResolver_Disabled: with no ResponseContext configured the
+// resolver is permissive, preserving prior behaviour (zero-drift guarantee).
+func TestResponseDestResolver_Disabled(t *testing.T) {
+	meta := newTestMeta()
+	cp := NewContextProvider(meta)
+	r := newResponseDestResolver(&APISpecConfig{}, cp)
+	if r.Enabled() {
+		t.Fatal("expected resolver to be disabled with no WriterTypeRegexes")
+	}
+	// Even a clearly-non-writer destination is accepted when disabled.
+	if !r.IsResponseDest(mkIdent(meta, "buf", "*bytes.Buffer"), &metadata.CallGraphEdge{}) {
+		t.Fatal("disabled resolver must be permissive")
+	}
+}
+
+// TestResponseDestResolver_WriterTypes: once ResponseContext is configured, a
+// bare writer-typed destination qualifies and a non-writer destination does not.
+func TestResponseDestResolver_WriterTypes(t *testing.T) {
+	meta := newTestMeta()
+	cp := NewContextProvider(meta)
+	r := newResponseDestResolver(&APISpecConfig{
+		Framework: FrameworkConfig{ResponseContext: netHTTPResponseContext},
+	}, cp)
+	if !r.Enabled() {
+		t.Fatal("resolver should be enabled with netHTTPResponseContext")
+	}
+
+	cases := []struct {
+		name string
+		arg  *metadata.CallArgument
+		want bool
+	}{
+		{"response writer param w", mkIdent(meta, "w", "net/http.ResponseWriter"), true},
+		{"httptest recorder", mkIdent(meta, "rec", "*net/http/httptest.ResponseRecorder"), true},
+		{"bytes.Buffer is not a writer", mkIdent(meta, "buf", "*bytes.Buffer"), false},
+		{"hash is not a writer", mkIdent(meta, "h", "hash.Hash"), false},
+		{"untyped ident is not a writer", mkIdent(meta, "x", ""), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := r.IsResponseDest(tc.arg, &metadata.CallGraphEdge{})
+			if got != tc.want {
+				t.Errorf("IsResponseDest(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResponseDestResolver_AddressOf: &w traces the same as w (address-of is
+// stripped), matching how json.NewEncoder(&buf) / (w) appear.
+func TestResponseDestResolver_AddressOf(t *testing.T) {
+	meta := newTestMeta()
+	cp := NewContextProvider(meta)
+	r := newResponseDestResolver(&APISpecConfig{
+		Framework: FrameworkConfig{ResponseContext: netHTTPResponseContext},
+	}, cp)
+
+	addr := metadata.NewCallArgument(meta)
+	addr.SetKind(metadata.KindUnary)
+	addr.X = mkIdent(meta, "w", "net/http.ResponseWriter")
+	if !r.IsResponseDest(addr, &metadata.CallGraphEdge{}) {
+		t.Error("&w should trace to the response writer")
+	}
+
+	addrBuf := metadata.NewCallArgument(meta)
+	addrBuf.SetKind(metadata.KindUnary)
+	addrBuf.X = mkIdent(meta, "buf", "*bytes.Buffer")
+	if r.IsResponseDest(addrBuf, &metadata.CallGraphEdge{}) {
+		t.Error("&buf must not trace to the response writer")
+	}
+}

--- a/testdata/response_dest_gating/go.mod
+++ b/testdata/response_dest_gating/go.mod
@@ -1,0 +1,3 @@
+module github.com/ehabterra/apispec/testdata/response_dest_gating
+
+go 1.24.3

--- a/testdata/response_dest_gating/main.go
+++ b/testdata/response_dest_gating/main.go
@@ -1,0 +1,69 @@
+// Fixture: write-destination gating (issue #170). A value encoded to some other
+// io.Writer — a bytes.Buffer, a hash — must NOT be attributed as the operation
+// response. Only a value whose encoder destination provably traces to the HTTP
+// response writer becomes the response. This mirrors the request-side source
+// gating (issue #153): request gating traces a decoder's source to r.Body;
+// response gating traces an encoder's destination to w.
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"net/http"
+)
+
+// User is the real response body.
+type User struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// Secret is encoded only to a local buffer — it must never surface as a response.
+type Secret struct {
+	Token string `json:"token"`
+}
+
+// Audit is encoded to a hash writer — also never a response.
+type Audit struct {
+	Event string `json:"event"`
+}
+
+// getUser encodes User straight to the response writer — the real response.
+func getUser(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode(User{ID: "1", Name: "a"})
+}
+
+// getUserViaHelper threads w through a wrapper before encoding — still a
+// response (the destination traces to w across the parameter boundary).
+func getUserViaHelper(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, User{ID: "2", Name: "b"})
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// leakBuffer encodes Secret to a bytes.Buffer, not to w — must be ignored. The
+// real response is the plain w.Write below.
+func leakBuffer(w http.ResponseWriter, r *http.Request) {
+	var buf bytes.Buffer
+	_ = json.NewEncoder(&buf).Encode(Secret{Token: "shh"})
+	_, _ = w.Write([]byte("ok"))
+}
+
+// leakHash encodes Audit into a hash — must be ignored.
+func leakHash(w http.ResponseWriter, r *http.Request) {
+	h := sha256.New()
+	_ = json.NewEncoder(h).Encode(Audit{Event: "login"})
+	_, _ = w.Write([]byte("ok"))
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /user", getUser)
+	mux.HandleFunc("GET /user-helper", getUserViaHelper)
+	mux.HandleFunc("POST /leak-buffer", leakBuffer)
+	mux.HandleFunc("POST /leak-hash", leakHash)
+	_ = http.ListenAndServe(":8080", mux)
+}

--- a/testdata/response_dest_gating/main.go
+++ b/testdata/response_dest_gating/main.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/json"
+	"io"
 	"net/http"
 )
 
@@ -44,6 +45,19 @@ func writeJSON(w http.ResponseWriter, v any) {
 	_ = json.NewEncoder(w).Encode(v)
 }
 
+// getUserViaIOWriter threads w through a helper whose parameter is typed
+// io.Writer — the destination can't be PROVEN to be the response writer, but it
+// could be (a writer satisfies io.Writer), so the response must be kept. This
+// is the ubiquitous writeJSON(w io.Writer, v) shape; dropping it was the
+// regression the conservative gate avoids.
+func getUserViaIOWriter(w http.ResponseWriter, r *http.Request) {
+	encodeTo(w, User{ID: "3", Name: "c"})
+}
+
+func encodeTo(dst io.Writer, v any) {
+	_ = json.NewEncoder(dst).Encode(v)
+}
+
 // leakBuffer encodes Secret to a bytes.Buffer, not to w — must be ignored. The
 // real response is the plain w.Write below.
 func leakBuffer(w http.ResponseWriter, r *http.Request) {
@@ -63,6 +77,7 @@ func main() {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /user", getUser)
 	mux.HandleFunc("GET /user-helper", getUserViaHelper)
+	mux.HandleFunc("GET /user-iowriter", getUserViaIOWriter)
 	mux.HandleFunc("POST /leak-buffer", leakBuffer)
 	mux.HandleFunc("POST /leak-hash", leakHash)
 	_ = http.ListenAndServe(":8080", mux)


### PR DESCRIPTION
## Summary

Fixes #170. A value encoded to some **other** `io.Writer` — a `bytes.Buffer`, a hash, a log sink — was wrongly emitted as the operation's response, because the `json.Encoder.Encode` response pattern matched regardless of *where* the encoder writes. There was no write-destination gating.

```go
func leak(w http.ResponseWriter, r *http.Request) {
    var buf bytes.Buffer
    json.NewEncoder(&buf).Encode(Secret{})  // encoded to buf, NOT to w
    w.Write([]byte("ok"))
}
```
Before, `Secret` surfaced as the `/leak` response. After, it does not.

## This is the response-side mirror of the request-body fix (#153)

The request side already solved the symmetric problem: a generic decoder is only treated as a request body when its **source** bytes trace to `r.Body` — gated by `RequestBodyPattern.RequireRequestSource` + `FrameworkConfig.RequestContext` + `bodySourceResolver` (issue #153). This PR adds the write-side counterpart:

| | Request side (#153) | Response side (this PR) |
|---|---|---|
| Pattern flag | `RequireRequestSource` | `RequireResponseDestination` |
| Config | `RequestContext` (`TypeRegexes` / `BodyAccessors`) | `ResponseContext` (`WriterTypeRegexes` / `WriterAccessors`) |
| Resolver | `bodySourceResolver.IsRequestSource` | `responseDestResolver.IsResponseDest` |
| Traces | decoder source → `r.Body` | encoder destination → `w` |

`responseDestResolver` reuses the request resolver's shared helpers (`resolveReceiverSource`, `peelAccessorChain`, ident/assignment/param tracing), so:

- `json.NewEncoder(w).Encode(v)` → **kept** (destination is `w`)
- `writeJSON(w, v)` where `writeJSON(w http.ResponseWriter, v any) { json.NewEncoder(w).Encode(v) }` → **kept** (destination traces to `w` across the parameter boundary)
- `json.NewEncoder(&buf).Encode(v)` / `json.NewEncoder(hash).Encode(v)` → **dropped**

## Framework-agnostic & config-driven

The mechanism is generic. `ResponseContext.WriterTypeRegexes` is populated for the net/http family (net/http, chi, mux — which all pass the `http.ResponseWriter` parameter). gin/echo/fiber leave it empty, so the resolver is **permissive** there (exactly like an unconfigured `RequestContext`), guaranteeing zero drift; their writer types can be declared in a follow-up.

## Tests & fixtures

- `testdata/response_dest_gating/` — writer / wrapper-param / buffer / hash handlers.
- `generator/testdata_response_dest_gating_test.go` — asserts the leaked types (`Secret`, `Audit`) never appear anywhere in the document, while `User` (direct + via wrapper) is the response, and the leak routes carry no `$ref` body.
- `internal/spec/response_dest_test.go` — unit tests for `responseDestResolver` (disabled/permissive, writer-type matching, address-of stripping).

## Verification

- `apispec` on the fixture: `/user` & `/user-helper` → `User`; `/leak-buffer` & `/leak-hash` → the plain `w.Write` byte string, no struct.
- Full `go test ./...` passes with **zero output drift**; `gofmt`, `go vet`, `golangci-lint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved API specification generation to distinguish genuine HTTP responses from writes to unrelated destinations.
  - Prevented non-response data types, including sensitive or audit-related types, from leaking into generated response schemas.
  - Improved response detection for encoders writing through standard HTTP writers and compatible writer interfaces.
  - Applied consistent response handling across supported HTTP frameworks.

- **Tests**
  - Added coverage for valid response detection, excluded leak scenarios, type tracing, and unresolved destinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->