### PR TITLE
docs(claude): file an issue instead of building a workaround

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,20 @@ make metrics-view         # interactive metrics viewer (scripts/view_metrics.sh)
    splitting; the POST default gates name inference off for plain
    registrations but does *not* block dispatch splitting
    (`testdata/method_switch` guards this).
+9. **Fix the root cause or file an issue — never a workaround.** When a
+   feature is blocked by a real precision gap in a lower layer (assignment,
+   parameter, variable, type, chain, generics, or interface resolution;
+   metadata facts; the tracker), do **not** paper over it in the upper layer
+   with a heuristic — a type-name denylist/allowlist, a hardcoded special
+   case, or a "good enough" guess. Fix the actual limitation, or if that's out
+   of scope, **open a GitHub issue** describing the root cause (with a
+   reproduction) and mark the dependent work blocked on it. A heuristic that
+   trades one wrong answer for another (a false negative for a false positive)
+   is not progress. This is the operational form of #7: when resolution is
+   genuinely blocked, the honest move is to report the gap, not to guess around
+   it. (Origin: issue #178 — `Type.Implements` omitting stdlib interfaces
+   blocked the #170 write-destination gate; the denylist attempt was reverted
+   and the metadata gap was filed instead.)
 
 ## Testing conventions
 


### PR DESCRIPTION
## Summary

Adds golden rule #9 to `CLAUDE.md`:

> **Fix the root cause or file an issue — never a workaround.** When a feature is blocked by a real precision gap in a lower layer (assignment, parameter, variable, type, chain, generics, or interface resolution; metadata facts; the tracker), don't paper over it with a heuristic (type-name denylist/allowlist, hardcoded special case, or guess). Fix the limitation, or open a GitHub issue with a reproduction and mark the dependent work blocked on it.

This is the operational form of the existing rule #7 ("honest over wrong / never guess one concrete option"): when resolution is genuinely blocked, report the gap rather than guessing around it.

**Origin:** #178 — `Type.Implements` omitting standard-library interfaces blocked the #170 write-destination gate; the denylist heuristic (PR #177) was reverted and the metadata gap was filed instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance to address underlying precision issues directly or report them, rather than relying on heuristics or special cases.
  * Documented the background and rationale for this development guideline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->