### PR TITLE
fix(spec): gate response schema by destination provenance to the writer (#170)

### DIFF
--- a/generator/testdata_request_body_source_provenance_test.go
+++ b/generator/testdata_request_body_source_provenance_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	intspec "github.com/ehabterra/apispec/internal/spec"
+	"github.com/ehabterra/apispec/spec"
+)
+
+// TestTestdata_RequestBodySourceProvenance is the read-side mirror of the
+// response write-destination gating: a decode is a request body only when its
+// source traces to r.Body. The KEEP routes cover direct/helper/assign
+// provenance to r.Body (the io.Reader-helper case fixes a false negative); the
+// DROP routes decode non-request readers through the same helper and inline (no
+// false positive from the shared helper node). Config must never be a body.
+func TestTestdata_RequestBodySourceProvenance(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "request_body_source_provenance", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+	noUnresolvedPlaceholders(t, out)
+
+	// Config is only ever decoded from non-request readers — never a body.
+	for _, path := range []string{"/decode-buffer", "/decode-string"} {
+		post := opFor(out.Paths[path], "POST")
+		if post == nil {
+			t.Errorf("POST %s missing; have %v", path, mapPathKeys(out.Paths))
+			continue
+		}
+		if post.RequestBody != nil && requestBodyRefs(post.RequestBody, "Config") {
+			t.Errorf("POST %s: Config leaked as a request body — a non-request source was accepted", path)
+		}
+	}
+
+	// KEEP: source traces to r.Body → CreateUserRequest body present.
+	for _, path := range []string{"/direct", "/helper", "/assign"} {
+		post := opFor(out.Paths[path], "POST")
+		if post == nil {
+			t.Errorf("POST %s missing; have %v", path, mapPathKeys(out.Paths))
+			continue
+		}
+		if post.RequestBody == nil || !requestBodyRefs(post.RequestBody, "CreateUserRequest") {
+			t.Errorf("POST %s: expected a CreateUserRequest body (source traces to r.Body), got %v",
+				path, post.RequestBody)
+		}
+	}
+}
+
+func requestBodyRefs(rb *intspec.RequestBody, name string) bool {
+	for _, media := range rb.Content {
+		if media.Schema != nil && strings.Contains(media.Schema.Ref, name) {
+			return true
+		}
+	}
+	return false
+}

--- a/generator/testdata_response_writer_provenance_test.go
+++ b/generator/testdata_response_writer_provenance_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	intspec "github.com/ehabterra/apispec/internal/spec"
+	"github.com/ehabterra/apispec/spec"
+)
+
+// TestTestdata_ResponseWriterProvenance covers issue #170: an encode is the
+// operation response only when its destination traces (through parameters,
+// assignments, and struct construction) to the handler's response-writer
+// parameter w. The KEEP routes cover direct/helper/assign/wrapper provenance to
+// w; the DROP routes cover buffer/hash/discard/constructor sinks. Secret must
+// never reach the spec.
+func TestTestdata_ResponseWriterProvenance(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "response_writer_provenance", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+	noUnresolvedPlaceholders(t, out)
+
+	// Secret is only ever encoded to non-writer sinks — it must not appear.
+	if blob, err := json.Marshal(out); err == nil && strings.Contains(string(blob), "Secret") {
+		t.Error("Secret leaked into the spec — a non-writer destination was treated as the response")
+	}
+
+	// KEEP: destination traces to w → User response present.
+	for _, path := range []string{"/direct", "/helper", "/assign", "/wrapper"} {
+		get := opFor(out.Paths[path], "GET")
+		if get == nil {
+			t.Errorf("GET %s missing; have %v", path, mapPathKeys(out.Paths))
+			continue
+		}
+		if !responseRefsType(get.Responses, "User") {
+			t.Errorf("GET %s: expected a User response (destination traces to w), got %v",
+				path, keysOf(get.Responses))
+		}
+	}
+
+	// DROP: destination is a sink → no struct/$ref response.
+	for _, path := range []string{"/leak-buffer", "/leak-hash", "/leak-discard", "/leak-constructed"} {
+		post := opFor(out.Paths[path], "POST")
+		if post == nil {
+			t.Errorf("POST %s missing; have %v", path, mapPathKeys(out.Paths))
+			continue
+		}
+		for status, resp := range post.Responses {
+			for ct, media := range resp.Content {
+				if media.Schema != nil && media.Schema.Ref != "" {
+					t.Errorf("POST %s [%s %s]: unexpected $ref response %q — a non-writer destination leaked",
+						path, status, ct, media.Schema.Ref)
+				}
+			}
+		}
+	}
+}
+
+func responseRefsType(responses map[string]intspec.Response, name string) bool {
+	for _, resp := range responses {
+		for _, media := range resp.Content {
+			if media.Schema != nil && strings.Contains(media.Schema.Ref, name) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/generator/testdata_response_writer_provenance_test.go
+++ b/generator/testdata_response_writer_provenance_test.go
@@ -53,7 +53,7 @@ func TestTestdata_ResponseWriterProvenance(t *testing.T) {
 	}
 
 	// DROP: destination is a sink → no struct/$ref response.
-	for _, path := range []string{"/leak-buffer", "/leak-hash", "/leak-discard", "/leak-constructed"} {
+	for _, path := range []string{"/leak-buffer", "/leak-hash", "/leak-discard", "/leak-constructed", "/leak-recorder"} {
 		post := opFor(out.Paths[path], "POST")
 		if post == nil {
 			t.Errorf("POST %s missing; have %v", path, mapPathKeys(out.Paths))

--- a/internal/spec/body_source.go
+++ b/internal/spec/body_source.go
@@ -152,8 +152,18 @@ func (r *bodySourceResolver) checkIdent(arg *metadata.CallArgument, edge *metada
 	callerName := r.contextProvider.GetString(edge.Caller.Name)
 	callerPkg := r.contextProvider.GetString(edge.Caller.Pkg)
 
-	// 1) Local assignments visible at this call site.
-	if assigns, ok := edge.AssignmentMap[name]; ok && len(assigns) > 0 {
+	// 1) Local assignments: src := r.Body. Check the call edge's map first, then
+	// the enclosing handler function's scope — a source assigned in the handler
+	// body lives on the Function, not on the Decode call edge.
+	assigns := edge.AssignmentMap[name]
+	if len(assigns) == 0 {
+		if impl, ok := r.contextProvider.(*ContextProviderImpl); ok {
+			if am := callerAssignmentMap(impl, edge, name); am != nil {
+				assigns = am[name]
+			}
+		}
+	}
+	if len(assigns) > 0 {
 		// Latest-wins, consistent with TraceVariableOrigin.
 		rhs := assigns[len(assigns)-1].Value
 		if rhs.Meta == nil {

--- a/internal/spec/body_source.go
+++ b/internal/spec/body_source.go
@@ -152,24 +152,15 @@ func (r *bodySourceResolver) checkIdent(arg *metadata.CallArgument, edge *metada
 	callerName := r.contextProvider.GetString(edge.Caller.Name)
 	callerPkg := r.contextProvider.GetString(edge.Caller.Pkg)
 
-	// 1) Local assignments: src := r.Body. Check the call edge's map first, then
-	// the enclosing handler function's scope — a source assigned in the handler
-	// body lives on the Function, not on the Decode call edge.
-	assigns := edge.AssignmentMap[name]
-	if len(assigns) == 0 {
-		if impl, ok := r.contextProvider.(*ContextProviderImpl); ok {
-			if am := callerAssignmentMap(impl, edge, name); am != nil {
-				assigns = am[name]
-			}
-		}
-	}
-	if len(assigns) > 0 {
-		// Latest-wins, consistent with TraceVariableOrigin.
-		rhs := assigns[len(assigns)-1].Value
+	// 1) Local assignments: src := r.Body. latestAssignment checks the call
+	// edge's map first, then the enclosing handler function's scope — a source
+	// assigned in the handler body lives on the Function, not on the Decode call
+	// edge. Latest-wins, consistent with TraceVariableOrigin.
+	if rhs := latestAssignment(r.contextProvider, edge, name); rhs != nil {
 		if rhs.Meta == nil {
 			rhs.Meta = arg.Meta
 		}
-		if r.check(&rhs, edge, visited) {
+		if r.check(rhs, edge, visited) {
 			return true
 		}
 	}

--- a/internal/spec/config.go
+++ b/internal/spec/config.go
@@ -59,6 +59,35 @@ type FrameworkConfig struct {
 	// so they are only treated as request-body extraction when the bytes
 	// actually originate from an HTTP request.
 	RequestContext RequestContextConfig `yaml:"requestContext,omitempty" json:"requestContext,omitempty"`
+
+	// ResponseContext is the write-side mirror of RequestContext: it identifies
+	// the HTTP response writer so a generic encoder (json.NewEncoder(x).Encode(v))
+	// is only treated as a response when x traces to the response writer. Used to
+	// gate ResponsePattern.RequireResponseDestination. See issue #170.
+	ResponseContext ResponseContextConfig `yaml:"responseContext,omitempty" json:"responseContext,omitempty"`
+}
+
+// ResponseContextConfig identifies the HTTP response writer for a framework so
+// an encoder's write destination can be traced to it — the write-side mirror of
+// RequestContextConfig (issue #170). Classification is by PROVENANCE, not type
+// guessing: the response writer is the handler's writer parameter (e.g.
+// net/http's `w`), and an encode is a response only when its destination traces
+// (through parameters, assignments, and struct construction) back to a value of
+// that type. Values that don't — a bytes.Buffer, a hash — are not the response.
+type ResponseContextConfig struct {
+	// WriterTypeRegexes match the (fully-qualified) types that ARE an HTTP
+	// response writer (the handler's writer parameter). A destination whose
+	// provenance reaches a value of one of these types is the response.
+	// Examples:
+	//   net/http -> "^net/http\\.ResponseWriter$"
+	//   gin      -> "^github\\.com/gin-gonic/gin\\.ResponseWriter$"
+	WriterTypeRegexes []string `yaml:"writerTypeRegexes,omitempty" json:"writerTypeRegexes,omitempty"`
+
+	// WriterCompatibleTypeRegexes match interface types a response writer
+	// satisfies (chiefly io.Writer). A destination that stays one of these —
+	// because it could not be resolved to a concrete value — could be the
+	// writer, so the response is kept (honest over wrong).
+	WriterCompatibleTypeRegexes []string `yaml:"writerCompatibleTypeRegexes,omitempty" json:"writerCompatibleTypeRegexes,omitempty"`
 }
 
 // RequestContextConfig describes the types and accessors that identify an
@@ -189,6 +218,18 @@ type ResponsePattern struct {
 	DefaultStatus int `yaml:"defaultStatus,omitempty" json:"defaultStatus,omitempty"`
 	// DefaultContentType overrides the config default content type when set
 	DefaultContentType string `yaml:"defaultContentType,omitempty" json:"defaultContentType,omitempty"`
+
+	// RequireResponseDestination gates the pattern on write-destination: the
+	// encoded value is only a response when its destination writer traces (via
+	// parameters, assignments, struct construction) to the HTTP response writer
+	// described by ResponseContext. Disambiguates generic encoders
+	// (json.NewEncoder(x).Encode(v)) that may write to a bytes.Buffer, a hash, a
+	// log — not the response. Symmetric with RequestBodyPattern.RequireRequestSource.
+	RequireResponseDestination bool `yaml:"requireResponseDestination,omitempty" json:"requireResponseDestination,omitempty"`
+	// DestFromReceiver resolves the write destination from the encoder factory
+	// receiver — for json.NewEncoder(x).Encode(v), the destination is
+	// NewEncoder's first argument x. Mirrors RequestBodyPattern.BodyFromReceiver.
+	DestFromReceiver bool `yaml:"destFromReceiver,omitempty" json:"destFromReceiver,omitempty"`
 
 	// Package/type filtering
 	CallerPkgPatterns      []string `yaml:"callerPkgPatterns,omitempty" json:"callerPkgPatterns,omitempty"`
@@ -775,6 +816,11 @@ func jsonEncodePattern(recvTypeRegex string) ResponsePattern {
 		TypeFromArg:   true,
 		Deref:         true,
 		RecvTypeRegex: recvTypeRegex,
+		// Gate on write destination: json.NewEncoder(x).Encode(v) is a response
+		// only when x traces to the response writer (issue #170). Inert unless
+		// the framework config populates ResponseContext.
+		RequireResponseDestination: true,
+		DestFromReceiver:           true,
 	}
 }
 

--- a/internal/spec/config_chi.go
+++ b/internal/spec/config_chi.go
@@ -79,7 +79,8 @@ func DefaultChiConfig() *APISpecConfig {
 					RecvTypeRegex:     "^github.com/go-chi/chi(/v\\d)?\\.\\*?(Router|Mux)$",
 				},
 			},
-			RequestContext: netHTTPRequestContext,
+			RequestContext:  netHTTPRequestContext,
+			ResponseContext: netHTTPResponseContext,
 			RequestBodyPatterns: []RequestBodyPattern{
 				{
 					CallRegex:            `^DecodeJSON$`,

--- a/internal/spec/config_http.go
+++ b/internal/spec/config_http.go
@@ -24,6 +24,25 @@ var netHTTPRequestContext = RequestContextConfig{
 	BodyAccessors: []string{`^Body$`},
 }
 
+// netHTTPResponseContext is the ResponseContext preset for the net/http family
+// (net/http, chi, mux — all encode to an http.ResponseWriter). The response
+// writer is the handler's `w http.ResponseWriter` parameter; an encode is a
+// response only when its destination traces back to it. The compatible list
+// keeps `func writeJSON(w io.Writer, v)` helpers whose destination stays an
+// io.Writer interface (could be the writer).
+var netHTTPResponseContext = ResponseContextConfig{
+	WriterTypeRegexes: []string{
+		`^net/http\.ResponseWriter$`,
+		`^\*?net/http\.response$`,
+		`^\*?net/http/httptest\.ResponseRecorder$`,
+	},
+	WriterCompatibleTypeRegexes: []string{
+		`^io\.Writer$`,
+		`^io\.WriteCloser$`,
+		`^io\.ReadWriter$`,
+	},
+}
+
 // DefaultHTTPConfig returns a default configuration for net/http.
 func DefaultHTTPConfig() *APISpecConfig {
 	// net/http response patterns come from netHTTPResponsePatterns(); the
@@ -67,6 +86,7 @@ func DefaultHTTPConfig() *APISpecConfig {
 			},
 			SecurityPatterns: httpSecurityPatterns(),
 			RequestContext:   netHTTPRequestContext,
+			ResponseContext:  netHTTPResponseContext,
 			RequestBodyPatterns: []RequestBodyPattern{
 				jsonDecodeRequestPattern(""),
 				jsonUnmarshalRequestPattern(""),

--- a/internal/spec/config_http.go
+++ b/internal/spec/config_http.go
@@ -31,10 +31,13 @@ var netHTTPRequestContext = RequestContextConfig{
 // keeps `func writeJSON(w io.Writer, v)` helpers whose destination stays an
 // io.Writer interface (could be the writer).
 var netHTTPResponseContext = ResponseContextConfig{
+	// Only the handler's parameter type. Independently-constructible concretes
+	// (httptest.ResponseRecorder, net/http.response) are intentionally NOT
+	// listed: a locally-built recorder is writer-typed but is not the handler's
+	// response writer, so encoding to it must not count as the response
+	// (provenance, not type — CodeRabbit review on PR #181).
 	WriterTypeRegexes: []string{
 		`^net/http\.ResponseWriter$`,
-		`^\*?net/http\.response$`,
-		`^\*?net/http/httptest\.ResponseRecorder$`,
 	},
 	WriterCompatibleTypeRegexes: []string{
 		`^io\.Writer$`,

--- a/internal/spec/config_mux.go
+++ b/internal/spec/config_mux.go
@@ -90,7 +90,8 @@ func DefaultMuxConfig() *APISpecConfig {
 					MethodExtraction:  DefaultMethodExtractionConfig(),
 				},
 			},
-			RequestContext: netHTTPRequestContext,
+			RequestContext:  netHTTPRequestContext,
+			ResponseContext: netHTTPResponseContext,
 			RequestBodyPatterns: []RequestBodyPattern{
 				jsonDecodeRequestPattern(".*json(iter)?\\.\\*?Decoder"),
 				jsonUnmarshalRequestPattern("json"),

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -1839,6 +1839,35 @@ func callerAssignmentMap(impl *ContextProviderImpl, edge *metadata.CallGraphEdge
 	return methodAssignmentMap(impl.meta, impl.GetString(pf.Pkg), impl.GetString(pf.RecvType), impl.GetString(pf.Name), varName)
 }
 
+// latestAssignment returns the right-hand side of the most recent assignment to
+// the variable `name` visible at the given call site — the Decode/Encode call
+// edge's own AssignmentMap first, then the enclosing handler function's scope
+// (via callerAssignmentMap) for a variable assigned in the handler body rather
+// than at the call edge. Returns nil when there is no such assignment.
+//
+// This is the shared variable-assignment lookup used by both the request-body
+// source resolver (src := r.Body) and the response-destination resolver
+// (dst := w, lw := &loggingWriter{w}); see issue #182 for consolidating it with
+// the other variable-resolution mechanisms.
+func latestAssignment(cp ContextProvider, edge *metadata.CallGraphEdge, name string) *metadata.CallArgument {
+	if name == "" || edge == nil {
+		return nil
+	}
+	assigns := edge.AssignmentMap[name]
+	if len(assigns) == 0 {
+		if impl, ok := cp.(*ContextProviderImpl); ok {
+			if am := callerAssignmentMap(impl, edge, name); am != nil {
+				assigns = am[name]
+			}
+		}
+	}
+	if len(assigns) == 0 {
+		return nil
+	}
+	rhs := assigns[len(assigns)-1].Value
+	return &rhs
+}
+
 // methodAssignmentMap finds the AssignmentMap of the method (pkg, receiver,
 // name) whose map records varName. Methods are stored per-Type; receiver and
 // name are matched exactly (the same receiver string findParentFunction records

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -2001,7 +2001,8 @@ func preprocessingBodyType(bodyType string) string {
 // ResponsePatternMatcherImpl implements ResponsePatternMatcher
 type ResponsePatternMatcherImpl struct {
 	*BasePatternMatcher
-	pattern ResponsePattern
+	pattern      ResponsePattern
+	destResolver *responseDestResolver
 }
 
 // NewResponsePatternMatcher creates a new response pattern matcher
@@ -2009,7 +2010,37 @@ func NewResponsePatternMatcher(pattern ResponsePattern, cfg *APISpecConfig, cont
 	return &ResponsePatternMatcherImpl{
 		BasePatternMatcher: NewBasePatternMatcher(cfg, contextProvider, typeResolver),
 		pattern:            pattern,
+		destResolver:       newResponseDestResolver(cfg, contextProvider),
 	}
+}
+
+// destination returns the encoder's write destination for the given node,
+// resolved per-route through the call graph to its concrete value, plus the
+// tracker edge in whose scope that value's provenance is read. For
+// json.NewEncoder(x).Encode(v) the raw destination is the factory's first
+// argument x; when x is a wrapper parameter (`func encodeTo(dst io.Writer, v)`)
+// it is followed to the caller's actual argument at this route's call site, so
+// the same helper resolves to the writer for `encodeTo(w, v)` and to a buffer
+// for `encodeTo(&buf, v)`. Returns (nil, nil) when the pattern carries no
+// receiver-based destination.
+func (r *ResponsePatternMatcherImpl) destination(node TrackerNodeInterface) (*metadata.CallArgument, *metadata.CallGraphEdge) {
+	if node == nil {
+		return nil, nil
+	}
+	edge := node.GetEdge()
+	if edge == nil || !r.pattern.DestFromReceiver {
+		return nil, nil
+	}
+	dst := resolveReceiverSource(edge, r.destResolver.metadata())
+	if dst == nil {
+		return nil, edge
+	}
+	resolved, resolvedNode := resolveArgThroughParams(dst, node)
+	dstEdge := edge
+	if resolvedNode != nil && resolvedNode.GetEdge() != nil {
+		dstEdge = resolvedNode.GetEdge()
+	}
+	return resolved, dstEdge
 }
 
 // MatchNode checks if a node matches the response pattern
@@ -2089,6 +2120,18 @@ func (r *ResponsePatternMatcherImpl) ExtractResponse(node TrackerNodeInterface, 
 	var (
 		statusResolved bool
 	)
+
+	// Write-destination gating (issue #170), done here — NOT in MatchNode, which
+	// is memoized per edge — because a generic encoder's destination is
+	// per-route: the same helper node writes to the response in one route and a
+	// buffer in another. Resolve the destination through the call graph to its
+	// concrete value at THIS route's call site and drop the encode only when
+	// that value provably does not trace to the response writer.
+	if r.pattern.RequireResponseDestination && r.destResolver != nil && r.destResolver.Enabled() {
+		if dst, dstEdge := r.destination(node); dst != nil && r.destResolver.ShouldDrop(dst, dstEdge) {
+			return nil
+		}
+	}
 
 	// Get least status code from response map
 	leastStatusCode := 0

--- a/internal/spec/extractor_sweep_test.go
+++ b/internal/spec/extractor_sweep_test.go
@@ -529,9 +529,9 @@ func TestSweepRequestBodySource(t *testing.T) {
 	cp := NewContextProvider(meta)
 	cfg := &APISpecConfig{}
 
-	t.Run("nil edge", func(t *testing.T) {
+	t.Run("nil node", func(t *testing.T) {
 		m := NewRequestPatternMatcher(RequestBodyPattern{}, cfg, cp, nil)
-		if m.bodySource(nil) != nil {
+		if got, _ := m.bodySource(nil); got != nil {
 			t.Error("bodySource(nil) != nil")
 		}
 	})
@@ -541,7 +541,8 @@ func TestSweepRequestBodySource(t *testing.T) {
 		src := sweepIdent(meta, "r")
 		edge := sweepEdge(meta, "h", "app", "Decode", "json", "Decoder", "")
 		edge.ChainParent = sweepEdge(meta, "h", "app", "NewDecoder", "json", "", "", src)
-		got := m.bodySource(edge)
+		// No parent node → resolveArgThroughParams returns the factory arg as-is.
+		got, _ := m.bodySource(sweepNode(edge))
 		if got != src {
 			t.Errorf("bodySource() = %v, want the chain-parent factory arg", got)
 		}

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -755,34 +755,50 @@ func (r *RequestPatternMatcherImpl) MatchNode(node TrackerNodeInterface) bool {
 		return false
 	}
 
-	// Body-source verification: only meaningful for ambiguous decoders
-	// (json.Decode, json.Unmarshal, render.DecodeJSON, ...). Receiver-based
-	// patterns like *gin.Context.BindJSON are already unambiguous because
-	// the receiver type IS the request.
-	if r.pattern.RequireRequestSource && r.bodyResolver != nil && r.bodyResolver.Enabled() {
-		src := r.bodySource(edge)
-		if src == nil || !r.bodyResolver.IsRequestSource(src, edge) {
-			return false
-		}
-	}
+	// NOTE: body-source verification (RequireRequestSource) is intentionally NOT
+	// done here. MatchNode is memoized per edge, but an ambiguous decoder's
+	// source is per-route — the same helper node decodes r.Body in one route and
+	// a non-request reader in another. The gate lives in ExtractRequest
+	// (per-route), where the source is resolved through the call graph to its
+	// concrete value. Mirror of the response-destination gating (issue #170).
 
 	return true
 }
 
-// bodySource returns the CallArgument that carries the decoder's input bytes
-// for the given call edge, according to the pattern configuration.
-func (r *RequestPatternMatcherImpl) bodySource(edge *metadata.CallGraphEdge) *metadata.CallArgument {
+// bodySource returns the decoder's input source for the given node, resolved
+// per-route through the call graph to its concrete value, plus the tracker edge
+// in whose scope that value is checked. For json.NewDecoder(x).Decode(v) the
+// raw source is the factory's first argument x; when x is a wrapper parameter
+// (`func decodeFrom(src io.Reader, v)`) it is followed to the caller's actual
+// argument at this route's call site, so the same helper resolves to r.Body for
+// decodeFrom(r.Body, &v) and to a non-request reader otherwise.
+func (r *RequestPatternMatcherImpl) bodySource(node TrackerNodeInterface) (*metadata.CallArgument, *metadata.CallGraphEdge) {
+	if node == nil {
+		return nil, nil
+	}
+	edge := node.GetEdge()
 	if edge == nil {
-		return nil
+		return nil, nil
 	}
+	var src *metadata.CallArgument
 	if r.pattern.BodyFromReceiver {
-		return resolveReceiverSource(edge, r.bodyResolver.metadata())
+		src = resolveReceiverSource(edge, r.bodyResolver.metadata())
+	} else {
+		idx := r.pattern.BodySourceArgIndex
+		if idx < 0 || idx >= len(edge.Args) {
+			return nil, edge
+		}
+		src = edge.Args[idx]
 	}
-	idx := r.pattern.BodySourceArgIndex
-	if idx < 0 || idx >= len(edge.Args) {
-		return nil
+	if src == nil {
+		return nil, edge
 	}
-	return edge.Args[idx]
+	resolved, resolvedNode := resolveArgThroughParams(src, node)
+	srcEdge := edge
+	if resolvedNode != nil && resolvedNode.GetEdge() != nil {
+		srcEdge = resolvedNode.GetEdge()
+	}
+	return resolved, srcEdge
 }
 
 // GetPattern returns the request pattern
@@ -807,6 +823,21 @@ func (r *RequestPatternMatcherImpl) GetPriority() int {
 
 // ExtractRequest extracts request information from a matched node
 func (r *RequestPatternMatcherImpl) ExtractRequest(node TrackerNodeInterface, route *RouteInfo) *RequestInfo {
+	// Body-source verification, done here — NOT in MatchNode, which is memoized
+	// per edge — because an ambiguous decoder's source is per-route. Resolve the
+	// source through the call graph to its concrete value at THIS route's call
+	// site and drop the body when it does not trace to an HTTP request. This
+	// recognises a decoder wrapped in a `func decodeFrom(src io.Reader, v)`
+	// helper called with r.Body (fixing the io.Reader-helper false negative)
+	// without the shared-node false positive of a per-edge gate. Mirror of the
+	// response-destination gating (issue #170).
+	if r.pattern.RequireRequestSource && r.bodyResolver != nil && r.bodyResolver.Enabled() {
+		src, srcEdge := r.bodySource(node)
+		if src == nil || !r.bodyResolver.IsRequestSource(src, srcEdge) {
+			return nil
+		}
+	}
+
 	reqInfo := &RequestInfo{
 		ContentType: r.cfg.Defaults.RequestContentType,
 	}

--- a/internal/spec/response_dest.go
+++ b/internal/spec/response_dest.go
@@ -149,7 +149,7 @@ func (r *responseDestResolver) reachesWriterIdent(arg *metadata.CallArgument, ed
 	// declared type. latestAssignment checks the call edge's map then the
 	// enclosing handler function's scope (a destination assigned in the handler
 	// body lives on the Function, not on the Encode call edge).
-	if rhs := r.latestAssignment(name, edge); rhs != nil {
+	if rhs := latestAssignment(r.contextProvider, edge, name); rhs != nil {
 		if rhs.Meta == nil {
 			rhs.Meta = arg.Meta
 		}
@@ -203,7 +203,7 @@ func (r *responseDestResolver) leafType(arg *metadata.CallArgument, edge *metada
 	case metadata.KindIdent:
 		if key := arg.ID(); !visited[key] {
 			visited[key] = true
-			if rhs := r.latestAssignment(arg.GetName(), edge); rhs != nil {
+			if rhs := latestAssignment(r.contextProvider, edge, arg.GetName()); rhs != nil {
 				if t := r.leafType(rhs, edge, visited); t != "" {
 					return t
 				}
@@ -222,28 +222,6 @@ func (r *responseDestResolver) leafType(arg *metadata.CallArgument, edge *metada
 		return r.contextProvider.GetArgumentInfo(arg)
 	}
 	return ""
-}
-
-// latestAssignment returns the RHS of the latest assignment to a variable
-// visible at this call site — the Encode call edge first, then the enclosing
-// handler function's scope — or nil when there is none.
-func (r *responseDestResolver) latestAssignment(name string, edge *metadata.CallGraphEdge) *metadata.CallArgument {
-	if name == "" || edge == nil {
-		return nil
-	}
-	assigns := edge.AssignmentMap[name]
-	if len(assigns) == 0 {
-		if impl, ok := r.contextProvider.(*ContextProviderImpl); ok {
-			if am := callerAssignmentMap(impl, edge, name); am != nil {
-				assigns = am[name]
-			}
-		}
-	}
-	if len(assigns) == 0 {
-		return nil
-	}
-	rhs := assigns[len(assigns)-1].Value
-	return &rhs
 }
 
 // identType returns the ident's declared type, preferring the resolved type.

--- a/internal/spec/response_dest.go
+++ b/internal/spec/response_dest.go
@@ -1,0 +1,285 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"regexp"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// responseDestResolver is the write-side counterpart of bodySourceResolver
+// (issue #170). It decides whether an encoder's write destination is the HTTP
+// response by PROVENANCE, not by guessing types: the response writer is the
+// handler's writer parameter, so an encode is a response only when its
+// destination traces — through parameters, local assignments, and struct
+// construction — back to a value of a response-writer type.
+//
+// The two resolvers are deliberately symmetric: request gating traces a
+// decoder's *source* bytes to a request body accessor (r.Body); response gating
+// traces an encoder's *destination* to the response writer (w).
+type responseDestResolver struct {
+	contextProvider ContextProvider
+	writerTypeREs   []*regexp.Regexp // types that ARE a response writer
+	compatibleREs   []*regexp.Regexp // interfaces a response writer satisfies (io.Writer, ...)
+}
+
+// newResponseDestResolver compiles the configured regexes once. Enabled()
+// reports false when no writer types are configured; callers then fall back to
+// prior (fully permissive) behaviour.
+func newResponseDestResolver(cfg *APISpecConfig, contextProvider ContextProvider) *responseDestResolver {
+	r := &responseDestResolver{contextProvider: contextProvider}
+	if cfg == nil {
+		return r
+	}
+	for _, p := range cfg.Framework.ResponseContext.WriterTypeRegexes {
+		if re, err := cachedRegex(p); err == nil {
+			r.writerTypeREs = append(r.writerTypeREs, re)
+		}
+	}
+	for _, p := range cfg.Framework.ResponseContext.WriterCompatibleTypeRegexes {
+		if re, err := cachedRegex(p); err == nil {
+			r.compatibleREs = append(r.compatibleREs, re)
+		}
+	}
+	return r
+}
+
+// Enabled reports whether writer types are configured. When false, the resolver
+// is skipped and matchers keep their prior behaviour.
+func (r *responseDestResolver) Enabled() bool {
+	return r != nil && len(r.writerTypeREs) > 0
+}
+
+// ShouldDrop reports whether an encode to this destination must NOT be treated
+// as the operation response. It drops only when the destination resolves to a
+// concrete value that does not trace to the response writer — a bytes.Buffer, a
+// hash, a log. A destination that reaches the writer (directly, through a
+// parameter, an assignment, or struct construction), stays a writer-compatible
+// interface (io.Writer), or cannot be resolved to a type is kept ("honest over
+// wrong").
+func (r *responseDestResolver) ShouldDrop(arg *metadata.CallArgument, edge *metadata.CallGraphEdge) bool {
+	if !r.Enabled() {
+		return false
+	}
+	if r.reachesWriter(arg, edge, make(map[string]bool, 4)) {
+		return false // provenance reaches the response writer — it's the response
+	}
+	t := r.leafType(arg, edge, make(map[string]bool, 4))
+	if t == "" || matchAny(r.compatibleREs, t) || matchAny(r.writerTypeREs, t) {
+		return false // unresolved, a writer-compatible interface, or a writer — keep
+	}
+	return true // a resolved concrete non-writer — drop
+}
+
+// reachesWriter reports whether the destination's provenance includes a value
+// of a response-writer type. It follows address-of/deref, local assignments
+// (dst := w), parameter boundaries (a helper's io.Writer param → the caller's
+// w), and struct construction (&loggingWriter{w} — the writer embedded in a
+// wrapper). This is the write-side mirror of bodySourceResolver.check.
+func (r *responseDestResolver) reachesWriter(arg *metadata.CallArgument, edge *metadata.CallGraphEdge, visited map[string]bool) bool {
+	if arg == nil || edge == nil {
+		return false
+	}
+	// Strip address-of and deref so &w and *w trace the same as w.
+	for arg != nil && (arg.GetKind() == metadata.KindUnary || arg.GetKind() == metadata.KindStar || arg.GetKind() == metadata.KindParen) {
+		arg = arg.X
+	}
+	if arg == nil {
+		return false
+	}
+
+	key := arg.ID()
+	if visited[key] {
+		return false
+	}
+	visited[key] = true
+
+	switch arg.GetKind() {
+	case metadata.KindIdent:
+		return r.reachesWriterIdent(arg, edge, visited)
+
+	case metadata.KindCompositeLit, metadata.KindKeyValue:
+		// A struct wrapping the writer: &loggingWriter{w} or
+		// loggingWriter{ResponseWriter: w}. Any element (or key-value value)
+		// that reaches the writer makes the wrapper a writer.
+		for _, el := range arg.Args {
+			if r.reachesWriter(el, edge, visited) {
+				return true
+			}
+		}
+		if arg.X != nil && r.reachesWriter(arg.X, edge, visited) {
+			return true
+		}
+		if arg.Sel != nil && r.reachesWriter(arg.Sel, edge, visited) {
+			return true
+		}
+		return false
+	}
+	return false
+}
+
+// reachesWriterIdent traces an ident through its own type, local assignments,
+// and parameter boundaries to a response-writer value.
+func (r *responseDestResolver) reachesWriterIdent(arg *metadata.CallArgument, edge *metadata.CallGraphEdge, visited map[string]bool) bool {
+	// The ident's own type IS a writer (the common `w` case, and the resolved
+	// writer at the end of a param/assignment chain).
+	if matchAny(r.writerTypeREs, r.identType(arg, edge)) {
+		return true
+	}
+
+	name := arg.GetName()
+	if name == "" {
+		return false
+	}
+
+	// Local assignments: dst := w, lw := &loggingWriter{w}. latestAssignment
+	// checks the call edge's map first, then the enclosing handler function's
+	// scope — a destination assigned in the handler body (the common wrapper
+	// case) lives on the Function, not on the Encode call edge.
+	if rhs := r.latestAssignment(name, edge); rhs != nil {
+		if rhs.Meta == nil {
+			rhs.Meta = arg.Meta
+		}
+		if r.reachesWriter(rhs, edge, visited) {
+			return true
+		}
+	}
+
+	// Parameter boundary: a helper's writer parameter traced up to the caller's
+	// argument. TraceVariableOrigin yields a synthesized ident with the origin's
+	// type; a writer type there means the destination is the response writer.
+	callerName := r.contextProvider.GetString(edge.Caller.Name)
+	if name == callerName {
+		return false // guard against pathological self-recursion
+	}
+	if meta := r.metadata(); meta != nil {
+		callerPkg := r.contextProvider.GetString(edge.Caller.Pkg)
+		_, _, originArg, _ := metadata.TraceVariableOrigin(name, callerName, callerPkg, meta)
+		if originArg != nil && originArg != arg {
+			if t := originArg.GetResolvedType(); t != "" && matchAny(r.writerTypeREs, t) {
+				return true
+			}
+			if matchAny(r.writerTypeREs, originArg.GetType()) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// leafType resolves the destination expression to the concrete type of its
+// underlying value, used to distinguish a resolved concrete non-writer (drop)
+// from an unresolved or interface destination (keep). Address-of/deref are
+// stripped, and an ident is followed through its latest local assignment so an
+// interface-typed variable reassigned to a concrete value (`var d io.Writer =
+// w; d = &bytes.Buffer{}`) is classified by that concrete value rather than its
+// declared interface type.
+func (r *responseDestResolver) leafType(arg *metadata.CallArgument, edge *metadata.CallGraphEdge, visited map[string]bool) string {
+	for arg != nil && (arg.GetKind() == metadata.KindUnary || arg.GetKind() == metadata.KindStar || arg.GetKind() == metadata.KindParen) {
+		arg = arg.X
+	}
+	if arg == nil {
+		return ""
+	}
+	switch arg.GetKind() {
+	case metadata.KindIdent:
+		if key := arg.ID(); !visited[key] {
+			visited[key] = true
+			if rhs := r.latestAssignment(arg.GetName(), edge); rhs != nil {
+				if t := r.leafType(rhs, edge, visited); t != "" {
+					return t
+				}
+			}
+		}
+		return r.identType(arg, edge)
+	case metadata.KindSelector, metadata.KindCall, metadata.KindCompositeLit:
+		if t := arg.GetResolvedType(); t != "" {
+			return t
+		}
+		if t := arg.GetType(); t != "" {
+			return t
+		}
+		// A composite literal (bytes.Buffer{}) carries its type on arg.X, not on
+		// Type/ResolvedType — render it via the context provider.
+		return r.contextProvider.GetArgumentInfo(arg)
+	}
+	return ""
+}
+
+// latestAssignment returns the RHS of the latest assignment to a variable
+// visible at this call site — the Encode call edge first, then the enclosing
+// handler function's scope — or nil when there is none.
+func (r *responseDestResolver) latestAssignment(name string, edge *metadata.CallGraphEdge) *metadata.CallArgument {
+	if name == "" || edge == nil {
+		return nil
+	}
+	assigns := edge.AssignmentMap[name]
+	if len(assigns) == 0 {
+		if impl, ok := r.contextProvider.(*ContextProviderImpl); ok {
+			if am := callerAssignmentMap(impl, edge, name); am != nil {
+				assigns = am[name]
+			}
+		}
+	}
+	if len(assigns) == 0 {
+		return nil
+	}
+	rhs := assigns[len(assigns)-1].Value
+	return &rhs
+}
+
+// identType returns the ident's declared type, preferring the resolved type.
+// Falls back to the concrete type recorded on a local assignment, then to a
+// call-graph origin trace. Mirrors bodySourceResolver.identType.
+func (r *responseDestResolver) identType(arg *metadata.CallArgument, edge *metadata.CallGraphEdge) string {
+	if arg == nil {
+		return ""
+	}
+	if t := arg.GetResolvedType(); t != "" {
+		return t
+	}
+	if t := arg.GetType(); t != "" {
+		return t
+	}
+	if edge != nil && len(edge.AssignmentMap) > 0 {
+		if assigns, ok := edge.AssignmentMap[arg.GetName()]; ok {
+			for i := len(assigns) - 1; i >= 0; i-- {
+				if t := r.contextProvider.GetString(assigns[i].ConcreteType); t != "" {
+					return t
+				}
+			}
+		}
+	}
+	if meta := r.metadata(); meta != nil && edge != nil {
+		callerName := r.contextProvider.GetString(edge.Caller.Name)
+		callerPkg := r.contextProvider.GetString(edge.Caller.Pkg)
+		_, _, originArg, _ := metadata.TraceVariableOrigin(arg.GetName(), callerName, callerPkg, meta)
+		if originArg != nil && originArg != arg {
+			if t := originArg.GetResolvedType(); t != "" {
+				return t
+			}
+			return originArg.GetType()
+		}
+	}
+	return ""
+}
+
+func (r *responseDestResolver) metadata() *metadata.Metadata {
+	if impl, ok := r.contextProvider.(*ContextProviderImpl); ok {
+		return impl.meta
+	}
+	return nil
+}

--- a/internal/spec/response_dest.go
+++ b/internal/spec/response_dest.go
@@ -75,13 +75,13 @@ func (r *responseDestResolver) ShouldDrop(arg *metadata.CallArgument, edge *meta
 		return false
 	}
 	if r.reachesWriter(arg, edge, make(map[string]bool, 4)) {
-		return false // provenance reaches the response writer — it's the response
+		return false // provenance reaches the handler's response writer — it's the response
 	}
 	t := r.leafType(arg, edge, make(map[string]bool, 4))
-	if t == "" || matchAny(r.compatibleREs, t) || matchAny(r.writerTypeREs, t) {
-		return false // unresolved, a writer-compatible interface, or a writer — keep
+	if t == "" || matchAny(r.compatibleREs, t) {
+		return false // unresolved, or a writer-compatible interface — keep
 	}
-	return true // a resolved concrete non-writer — drop
+	return true // resolved to something with no provenance to w — drop
 }
 
 // reachesWriter reports whether the destination's provenance includes a value
@@ -131,31 +131,36 @@ func (r *responseDestResolver) reachesWriter(arg *metadata.CallArgument, edge *m
 	return false
 }
 
-// reachesWriterIdent traces an ident through its own type, local assignments,
-// and parameter boundaries to a response-writer value.
+// reachesWriterIdent traces an ident to the handler's response-writer
+// PARAMETER — not merely to any writer-typed value. A writer type alone is not
+// provenance: a locally-constructed httptest.NewRecorder() is writer-typed but
+// is not the handler's `w` (CodeRabbit review on PR #181). So a local (an ident
+// with an assignment in scope) is judged by its assigned provenance, and only
+// an unassigned ident — the handler/helper parameter itself — is accepted on
+// its writer type.
 func (r *responseDestResolver) reachesWriterIdent(arg *metadata.CallArgument, edge *metadata.CallGraphEdge, visited map[string]bool) bool {
-	// The ident's own type IS a writer (the common `w` case, and the resolved
-	// writer at the end of a param/assignment chain).
-	if matchAny(r.writerTypeREs, r.identType(arg, edge)) {
-		return true
-	}
-
 	name := arg.GetName()
 	if name == "" {
 		return false
 	}
 
-	// Local assignments: dst := w, lw := &loggingWriter{w}. latestAssignment
-	// checks the call edge's map first, then the enclosing handler function's
-	// scope — a destination assigned in the handler body (the common wrapper
-	// case) lives on the Function, not on the Encode call edge.
+	// Local assignments come FIRST: dst := w, lw := &loggingWriter{w},
+	// rec := httptest.NewRecorder(). The local's provenance is its RHS, not its
+	// declared type. latestAssignment checks the call edge's map then the
+	// enclosing handler function's scope (a destination assigned in the handler
+	// body lives on the Function, not on the Encode call edge).
 	if rhs := r.latestAssignment(name, edge); rhs != nil {
 		if rhs.Meta == nil {
 			rhs.Meta = arg.Meta
 		}
-		if r.reachesWriter(rhs, edge, visited) {
-			return true
-		}
+		return r.reachesWriter(rhs, edge, visited)
+	}
+
+	// No local assignment: the ident is a parameter (or free var). The handler's
+	// writer parameter is accepted on its writer type — this is where provenance
+	// to `w` is seeded.
+	if matchAny(r.writerTypeREs, r.identType(arg, edge)) {
+		return true
 	}
 
 	// Parameter boundary: a helper's writer parameter traced up to the caller's

--- a/internal/spec/response_dest_test.go
+++ b/internal/spec/response_dest_test.go
@@ -1,0 +1,229 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+func newRespDestResolver(meta *metadata.Metadata) *responseDestResolver {
+	return newResponseDestResolver(&APISpecConfig{
+		Framework: FrameworkConfig{ResponseContext: netHTTPResponseContext},
+	}, NewContextProvider(meta))
+}
+
+// TestResponseDestResolver_Disabled: with no writer types configured the
+// resolver never drops, preserving prior behaviour (zero-drift guarantee).
+func TestResponseDestResolver_Disabled(t *testing.T) {
+	meta := newTestMeta()
+	r := newResponseDestResolver(&APISpecConfig{}, NewContextProvider(meta))
+	if r.Enabled() {
+		t.Fatal("expected resolver to be disabled with no writer types")
+	}
+	if r.ShouldDrop(mkIdent(meta, "buf", "*bytes.Buffer"), &metadata.CallGraphEdge{}) {
+		t.Fatal("disabled resolver must never drop")
+	}
+}
+
+// TestResponseDestResolver_DirectTypes: a bare destination whose type is a
+// writer / writer-compatible interface is kept; a concrete non-writer is
+// dropped; an unresolved destination is kept.
+func TestResponseDestResolver_DirectTypes(t *testing.T) {
+	meta := newTestMeta()
+	r := newRespDestResolver(meta)
+	if !r.Enabled() {
+		t.Fatal("resolver should be enabled with netHTTPResponseContext")
+	}
+
+	cases := []struct {
+		name string
+		arg  *metadata.CallArgument
+		drop bool
+	}{
+		{"response writer w", mkIdent(meta, "w", "net/http.ResponseWriter"), false},
+		{"httptest recorder", mkIdent(meta, "rec", "*net/http/httptest.ResponseRecorder"), false},
+		{"io.Writer helper param stays permissive", mkIdent(meta, "dst", "io.Writer"), false},
+		{"untyped ident stays permissive", mkIdent(meta, "x", ""), false},
+		{"bytes.Buffer is a sink", mkIdent(meta, "buf", "*bytes.Buffer"), true},
+		{"os.File is a sink", mkIdent(meta, "f", "*os.File"), true},
+		{"hash.Hash is a sink", mkIdent(meta, "h", "hash.Hash"), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := r.ShouldDrop(tc.arg, &metadata.CallGraphEdge{}); got != tc.drop {
+				t.Errorf("ShouldDrop(%s) = %v, want %v", tc.name, got, tc.drop)
+			}
+		})
+	}
+}
+
+// TestResponseDestResolver_AddressOf: &buf / &w strip to the underlying value.
+func TestResponseDestResolver_AddressOf(t *testing.T) {
+	meta := newTestMeta()
+	r := newRespDestResolver(meta)
+
+	addr := func(x *metadata.CallArgument) *metadata.CallArgument {
+		a := metadata.NewCallArgument(meta)
+		a.SetKind(metadata.KindUnary)
+		a.X = x
+		return a
+	}
+	if !r.ShouldDrop(addr(mkIdent(meta, "buf", "bytes.Buffer")), &metadata.CallGraphEdge{}) {
+		t.Error("&buf should be a sink")
+	}
+	if r.ShouldDrop(addr(mkIdent(meta, "w", "net/http.ResponseWriter")), &metadata.CallGraphEdge{}) {
+		t.Error("&w must not be dropped")
+	}
+}
+
+// TestResponseDestResolver_Assignment: a destination is traced through its
+// latest local assignment — dst := w keeps, dst := &bytes.Buffer{} drops, and
+// an interface var reassigned to a concrete sink drops by that sink.
+func TestResponseDestResolver_Assignment(t *testing.T) {
+	meta := newTestMeta()
+	r := newRespDestResolver(meta)
+
+	t.Run("dst := w traces to the writer", func(t *testing.T) {
+		w := mkIdent(meta, "w", "net/http.ResponseWriter")
+		edge := &metadata.CallGraphEdge{AssignmentMap: map[string][]metadata.Assignment{
+			"dst": {{Value: *w}},
+		}}
+		if r.ShouldDrop(mkIdent(meta, "dst", ""), edge) {
+			t.Error("dst := w must be kept")
+		}
+	})
+
+	t.Run("latest assignment wins: writer then buffer drops", func(t *testing.T) {
+		w := mkIdent(meta, "w", "net/http.ResponseWriter")
+		buf := mkIdent(meta, "buf", "bytes.Buffer")
+		edge := &metadata.CallGraphEdge{AssignmentMap: map[string][]metadata.Assignment{
+			"d": {{Value: *w}, {Value: *buf}}, // reassigned to a buffer
+		}}
+		if !r.ShouldDrop(mkIdent(meta, "d", "io.Writer"), edge) {
+			t.Error("an interface var reassigned to a buffer must drop by the buffer")
+		}
+	})
+
+	t.Run("latest assignment wins: buffer then writer keeps", func(t *testing.T) {
+		w := mkIdent(meta, "w", "net/http.ResponseWriter")
+		buf := mkIdent(meta, "buf", "bytes.Buffer")
+		edge := &metadata.CallGraphEdge{AssignmentMap: map[string][]metadata.Assignment{
+			"d": {{Value: *buf}, {Value: *w}}, // reassigned to the writer
+		}}
+		if r.ShouldDrop(mkIdent(meta, "d", "io.Writer"), edge) {
+			t.Error("an interface var reassigned to the writer must be kept")
+		}
+	})
+}
+
+// TestResponseDestResolver_Wrapper: a struct constructed around the writer
+// (&loggingWriter{w} / {ResponseWriter: w}) reaches the writer through the
+// composite literal.
+func TestResponseDestResolver_Wrapper(t *testing.T) {
+	meta := newTestMeta()
+	r := newRespDestResolver(meta)
+
+	w := mkIdent(meta, "w", "net/http.ResponseWriter")
+	comp := metadata.NewCallArgument(meta)
+	comp.SetKind(metadata.KindCompositeLit)
+	comp.Args = []*metadata.CallArgument{w}
+	addr := metadata.NewCallArgument(meta)
+	addr.SetKind(metadata.KindUnary)
+	addr.X = comp
+	edge := &metadata.CallGraphEdge{AssignmentMap: map[string][]metadata.Assignment{
+		"lw": {{Value: *addr}},
+	}}
+	if r.ShouldDrop(mkIdent(meta, "lw", "*app.loggingWriter"), edge) {
+		t.Error("a wrapper constructed around w must reach the writer and be kept")
+	}
+
+	// A wrapper built around a non-writer must NOT be rescued.
+	buf := mkIdent(meta, "buf", "bytes.Buffer")
+	comp2 := metadata.NewCallArgument(meta)
+	comp2.SetKind(metadata.KindCompositeLit)
+	comp2.Args = []*metadata.CallArgument{buf}
+	edge2 := &metadata.CallGraphEdge{AssignmentMap: map[string][]metadata.Assignment{
+		"x": {{Value: *comp2}},
+	}}
+	// The wrapper's own type is unknown here (empty) so it stays permissive, but
+	// it must not be *reported as reaching the writer*.
+	if r.reachesWriter(mkIdent(meta, "x", ""), edge2, map[string]bool{}) {
+		t.Error("a wrapper around a non-writer must not reach the writer")
+	}
+}
+
+// TestResponseDestResolver_CyclicAssignment: a := b; b := a terminates.
+func TestResponseDestResolver_CyclicAssignment(t *testing.T) {
+	meta := newTestMeta()
+	r := newRespDestResolver(meta)
+	a := mkIdent(meta, "a", "")
+	b := mkIdent(meta, "b", "")
+	edge := &metadata.CallGraphEdge{AssignmentMap: map[string][]metadata.Assignment{
+		"a": {{Value: *b}},
+		"b": {{Value: *a}},
+	}}
+	// Must terminate; neither reaches a writer nor resolves to a concrete sink.
+	if r.reachesWriter(mkIdent(meta, "a", ""), edge, map[string]bool{}) {
+		t.Error("cyclic non-writer assignment must not report reaching the writer")
+	}
+}
+
+// TestNewResponseDestResolver_EdgeCases covers nil-config and invalid-regex.
+func TestNewResponseDestResolver_EdgeCases(t *testing.T) {
+	cp := NewContextProvider(newTestMeta())
+	if newResponseDestResolver(nil, cp).Enabled() {
+		t.Error("nil cfg should yield a disabled resolver")
+	}
+	bad := &APISpecConfig{Framework: FrameworkConfig{ResponseContext: ResponseContextConfig{
+		WriterTypeRegexes: []string{"("}, // invalid, skipped
+	}}}
+	if newResponseDestResolver(bad, cp).Enabled() {
+		t.Error("an invalid writer regex should leave the resolver disabled")
+	}
+	mix := &APISpecConfig{Framework: FrameworkConfig{ResponseContext: ResponseContextConfig{
+		WriterTypeRegexes:           []string{"(", `^net/http\.ResponseWriter$`},
+		WriterCompatibleTypeRegexes: []string{"[", `^io\.Writer$`},
+	}}}
+	if !newResponseDestResolver(mix, cp).Enabled() {
+		t.Error("a valid writer regex should enable the resolver despite an invalid sibling")
+	}
+}
+
+// TestResponsePatternMatcher_Destination covers the receiver-based destination
+// resolution and its guards.
+func TestResponsePatternMatcher_Destination(t *testing.T) {
+	meta := newTestMeta()
+	cp := NewContextProvider(meta)
+	cfg := &APISpecConfig{Framework: FrameworkConfig{ResponseContext: netHTTPResponseContext}}
+
+	off := NewResponsePatternMatcher(ResponsePattern{DestFromReceiver: false}, cfg, cp, nil)
+	if got, _ := off.destination(&fakeNode{edge: &metadata.CallGraphEdge{}}); got != nil {
+		t.Errorf("DestFromReceiver=false should yield nil, got %v", got)
+	}
+	if got, _ := off.destination(nil); got != nil {
+		t.Errorf("destination(nil) should be nil, got %v", got)
+	}
+
+	on := NewResponsePatternMatcher(ResponsePattern{DestFromReceiver: true}, cfg, cp, nil)
+	w := mkIdent(meta, "w", "net/http.ResponseWriter")
+	edge := &metadata.CallGraphEdge{
+		ChainParent: &metadata.CallGraphEdge{Args: []*metadata.CallArgument{w}},
+	}
+	if got, _ := on.destination(&fakeNode{edge: edge}); got != w {
+		t.Errorf("destination should resolve to the factory's first arg, got %v", got)
+	}
+}

--- a/internal/spec/response_dest_test.go
+++ b/internal/spec/response_dest_test.go
@@ -54,8 +54,10 @@ func TestResponseDestResolver_DirectTypes(t *testing.T) {
 		arg  *metadata.CallArgument
 		drop bool
 	}{
-		{"response writer w", mkIdent(meta, "w", "net/http.ResponseWriter"), false},
-		{"httptest recorder", mkIdent(meta, "rec", "*net/http/httptest.ResponseRecorder"), false},
+		{"response writer w (handler param)", mkIdent(meta, "w", "net/http.ResponseWriter"), false},
+		// A recorder type alone is NOT provenance — a locally-built recorder is
+		// writer-shaped but is not the handler's w, so it must drop.
+		{"locally-typed recorder is not the handler writer", mkIdent(meta, "rec", "*net/http/httptest.ResponseRecorder"), true},
 		{"io.Writer helper param stays permissive", mkIdent(meta, "dst", "io.Writer"), false},
 		{"untyped ident stays permissive", mkIdent(meta, "x", ""), false},
 		{"bytes.Buffer is a sink", mkIdent(meta, "buf", "*bytes.Buffer"), true},

--- a/testdata/request_body_source_provenance/go.mod
+++ b/testdata/request_body_source_provenance/go.mod
@@ -1,0 +1,3 @@
+module github.com/ehabterra/apispec/testdata/request_body_source_provenance
+
+go 1.24.3

--- a/testdata/request_body_source_provenance/main.go
+++ b/testdata/request_body_source_provenance/main.go
@@ -1,0 +1,84 @@
+// Fixture: request-body source gating by PROVENANCE, moved to the per-route
+// extraction step (the read-side mirror of issue #170). A generic decoder
+// (json.NewDecoder(x).Decode(v)) is a request body only when its source x
+// traces — through parameters and assignments — back to the request's body
+// (r.Body). A decoder wrapped in a `func decodeFrom(src io.Reader, v)` helper
+// called with r.Body is recognised (no false negative); the same helper called
+// with a bytes.Buffer / strings.Reader is not a request body (no false
+// positive), because the source is resolved per-route.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+)
+
+type CreateUserRequest struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+// Config is decoded from non-request readers only — never a request body.
+type Config struct {
+	Debug bool `json:"debug"`
+}
+
+// decodeFrom is a generic helper whose source is an io.Reader parameter.
+func decodeFrom(src io.Reader, v any) error {
+	return json.NewDecoder(src).Decode(v)
+}
+
+// --- KEEP: the source traces to r.Body ---
+
+// createDirect decodes inline from r.Body.
+func createDirect(w http.ResponseWriter, r *http.Request) {
+	var req CreateUserRequest
+	_ = json.NewDecoder(r.Body).Decode(&req)
+	_ = req
+}
+
+// createViaHelper decodes through the io.Reader helper — source traces to r.Body.
+func createViaHelper(w http.ResponseWriter, r *http.Request) {
+	var req CreateUserRequest
+	_ = decodeFrom(r.Body, &req)
+	_ = req
+}
+
+// createViaAssign decodes through a local aliased to r.Body.
+func createViaAssign(w http.ResponseWriter, r *http.Request) {
+	var req CreateUserRequest
+	src := r.Body
+	_ = json.NewDecoder(src).Decode(&req)
+	_ = req
+}
+
+// --- DROP: the source is not the request ---
+
+// decodeBuffer decodes a Config from a buffer through the SAME helper — must NOT
+// be a request body (per-route resolution distinguishes it from createViaHelper).
+func decodeBuffer(w http.ResponseWriter, r *http.Request) {
+	var cfg Config
+	buf := bytes.NewBufferString("{}")
+	_ = decodeFrom(buf, &cfg)
+	_ = cfg
+}
+
+// decodeString decodes a Config from a strings.Reader — not a request body.
+func decodeString(w http.ResponseWriter, r *http.Request) {
+	var cfg Config
+	_ = json.NewDecoder(strings.NewReader("{}")).Decode(&cfg)
+	_ = cfg
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /direct", createDirect)
+	mux.HandleFunc("POST /helper", createViaHelper)
+	mux.HandleFunc("POST /assign", createViaAssign)
+	mux.HandleFunc("POST /decode-buffer", decodeBuffer)
+	mux.HandleFunc("POST /decode-string", decodeString)
+	_ = http.ListenAndServe(":8080", mux)
+}

--- a/testdata/response_writer_provenance/go.mod
+++ b/testdata/response_writer_provenance/go.mod
@@ -1,0 +1,3 @@
+module github.com/ehabterra/apispec/testdata/response_writer_provenance
+
+go 1.24.3

--- a/testdata/response_writer_provenance/main.go
+++ b/testdata/response_writer_provenance/main.go
@@ -1,0 +1,102 @@
+// Fixture: write-destination gating by PROVENANCE (issue #170). An encode is the
+// operation response only when its destination traces back — through parameters,
+// assignments, and struct construction — to the handler's response-writer
+// parameter `w`. A value encoded to any other sink (a bytes.Buffer, a hash,
+// io.Discard) is not the response. The response writer's identity is already in
+// the code (the `w` parameter); classification is value-flow tracking, not type
+// guessing. Mirror of the request-body source gating (#153, which traces a
+// decoder's source to r.Body).
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+// User is the real response body; Secret must never reach the response.
+type User struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type Secret struct {
+	Token string `json:"token"`
+}
+
+// loggingWriter is a custom ResponseWriter wrapper embedding the real writer.
+type loggingWriter struct {
+	http.ResponseWriter
+}
+
+// encodeTo is a generic helper whose destination is an io.Writer parameter.
+func encodeTo(dst io.Writer, v any) { _ = json.NewEncoder(dst).Encode(v) }
+
+func makeBuffer() *bytes.Buffer { return &bytes.Buffer{} }
+
+// --- KEEP: the destination traces to the response writer w ---
+
+// getDirect writes straight to w.
+func getDirect(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode(User{ID: "1"})
+}
+
+// getViaHelper threads w through an io.Writer helper parameter.
+func getViaHelper(w http.ResponseWriter, r *http.Request) {
+	encodeTo(w, User{ID: "2"})
+}
+
+// getViaAssign encodes through a local aliased to w.
+func getViaAssign(w http.ResponseWriter, r *http.Request) {
+	dst := w
+	_ = json.NewEncoder(dst).Encode(User{ID: "3"})
+}
+
+// getViaWrapper encodes to a wrapper struct constructed around w.
+func getViaWrapper(w http.ResponseWriter, r *http.Request) {
+	lw := &loggingWriter{w}
+	_ = json.NewEncoder(lw).Encode(User{ID: "4"})
+}
+
+// --- DROP: the destination is a sink unrelated to w ---
+
+// leakBuffer encodes to a bytes.Buffer.
+func leakBuffer(w http.ResponseWriter, r *http.Request) {
+	var buf bytes.Buffer
+	encodeTo(&buf, Secret{Token: "shh"})
+	_, _ = w.Write([]byte("ok"))
+}
+
+// leakHash encodes into a hash.
+func leakHash(w http.ResponseWriter, r *http.Request) {
+	h := sha256.New()
+	_ = json.NewEncoder(h).Encode(Secret{Token: "shh"})
+	_, _ = w.Write([]byte("ok"))
+}
+
+// leakDiscard encodes to io.Discard.
+func leakDiscard(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(io.Discard).Encode(Secret{Token: "shh"})
+	_, _ = w.Write([]byte("ok"))
+}
+
+// leakConstructed encodes to a buffer returned by a constructor.
+func leakConstructed(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(makeBuffer()).Encode(Secret{Token: "shh"})
+	_, _ = w.Write([]byte("ok"))
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /direct", getDirect)
+	mux.HandleFunc("GET /helper", getViaHelper)
+	mux.HandleFunc("GET /assign", getViaAssign)
+	mux.HandleFunc("GET /wrapper", getViaWrapper)
+	mux.HandleFunc("POST /leak-buffer", leakBuffer)
+	mux.HandleFunc("POST /leak-hash", leakHash)
+	mux.HandleFunc("POST /leak-discard", leakDiscard)
+	mux.HandleFunc("POST /leak-constructed", leakConstructed)
+	_ = http.ListenAndServe(":8080", mux)
+}

--- a/testdata/response_writer_provenance/main.go
+++ b/testdata/response_writer_provenance/main.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/http/httptest"
 )
 
 // User is the real response body; Secret must never reach the response.
@@ -88,6 +89,14 @@ func leakConstructed(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write([]byte("ok"))
 }
 
+// leakRecorder encodes to a locally-built httptest recorder — writer-typed but
+// NOT the handler's w, so it has no response provenance.
+func leakRecorder(w http.ResponseWriter, r *http.Request) {
+	rec := httptest.NewRecorder()
+	_ = json.NewEncoder(rec).Encode(Secret{Token: "shh"})
+	_, _ = w.Write([]byte("ok"))
+}
+
 func main() {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /direct", getDirect)
@@ -98,5 +107,6 @@ func main() {
 	mux.HandleFunc("POST /leak-hash", leakHash)
 	mux.HandleFunc("POST /leak-discard", leakDiscard)
 	mux.HandleFunc("POST /leak-constructed", leakConstructed)
+	mux.HandleFunc("POST /leak-recorder", leakRecorder)
 	_ = http.ListenAndServe(":8080", mux)
 }


### PR DESCRIPTION
## Summary

Fixes #170. A value encoded to a non-response `io.Writer` — a `bytes.Buffer`, a hash, `io.Discard` — was wrongly emitted as the operation's response.

The key reframing (thanks to review feedback): **the response writer's concrete identity is already in the code** — it is the handler's `w http.ResponseWriter` parameter. So this is a **provenance question**, not a type-relationship computation (no VTA, no `go/types.Implements`, no denylist). An encode is a response only when its destination traces — through **parameters, assignments, and struct construction** — back to a writer-typed value. This is the exact mirror of the request-body source gating (#153, which traces a decoder's source to `r.Body`).

## Design

- `responseDestResolver` is the structural twin of `bodySourceResolver`.
- The gate lives in the **per-route `ExtractResponse`**, *not* the per-edge-memoized `MatchNode` — a helper shared by several routes resolves its destination to the actual argument at each route's call site (`encodeTo(w,v)` → `w`, `encodeTo(&buf,v)` → `&buf`).
- Config is framework-agnostic (`ResponseContext.WriterTypeRegexes` / `WriterCompatibleTypeRegexes`), populated for the net/http family (net/http, chi, mux); gin/echo/fiber stay permissive until their writer types are declared.

## Extensively tested — assignment & parameter matrix

| Shape | Result |
|---|---|
| `NewEncoder(w)` | **keep** ✓ |
| `encodeTo(w, v)` (io.Writer helper param) | **keep** ✓ |
| `dst := w` | **keep** ✓ |
| `a := w; b := a` (multi-assign) | **keep** ✓ |
| `var d io.Writer = …; d = w` (reassign to writer) | **keep** ✓ |
| `&loggingWriter{w}` / `{ResponseWriter: w}` (wrapper) | **keep** ✓ |
| `var buf bytes.Buffer; NewEncoder(&buf)` | **drop** ✓ |
| `encodeTo(&buf, v)` | **drop** ✓ |
| `buf := &bytes.Buffer{}` | **drop** ✓ |
| `sha256.New()` (hash) | **drop** ✓ |
| `io.Discard` | **drop** ✓ |
| `var d io.Writer = &bytes.Buffer{}` | **drop** ✓ |
| `var d io.Writer = w; d = &bytes.Buffer{}` (reassign to sink) | **drop** ✓ |
| `NewEncoder(makeBuffer())` (constructor-returned) | **drop** ✓ |

All 14 shapes classify correctly; unresolved/interface destinations stay permissive ("honest over wrong").

## Issue filed during testing

Per the "fix the root cause or file an issue, never a workaround" rule, extensive testing surfaced a **pre-existing** value-tracing gap (unrelated to this gate): a value forwarded through **2+** `any`-typed helper hops loses its concrete type (`{type: object}`). Reproduced identically on `main`. Filed as **#180**. This gate correctly *keeps* such responses (it only drops provable non-writers).

## Tests

- `testdata/response_writer_provenance/` — 4 keep + 4 drop shapes.
- `generator/testdata_response_writer_provenance_test.go` — structural: KEEP routes ref `User`, DROP routes carry no `$ref`, `Secret` never appears.
- `internal/spec/response_dest_test.go` — unit tests for direct types, address-of, latest-wins assignments, wrapper construction, and cyclic-assignment termination.

## Verification

Original #170 reproduction (`json.NewEncoder(&buf).Encode(Secret{})`) no longer leaks. Full `go test ./...` passes with **zero output drift**; `gofmt`, `go vet`, `golangci-lint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API response detection to distinguish actual HTTP responses from writes to unrelated destinations.
  * Prevented leaked or indirect data from being incorrectly included in generated response schemas.
  * Added support for tracing response destinations through assignments, wrappers, pointers, and receiver-based encoders.

* **Tests**
  * Added coverage for response provenance, writer detection, assignment handling, and edge cases across supported HTTP configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->