### PR TITLE
fix(spec): resolve response value type through 2+ helper hops (#180)

### DIFF
--- a/generator/testdata_multi_hop_value_type_test.go
+++ b/generator/testdata_multi_hop_value_type_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	intspec "github.com/ehabterra/apispec/internal/spec"
+	"github.com/ehabterra/apispec/spec"
+)
+
+// TestTestdata_MultiHopValueType covers issue #180: a concrete value forwarded
+// through two or more `any` helper hops must keep its concrete type. One hop was
+// the control that already worked; two and three hops previously erased to a
+// generic object. The request side (already multi-hop) guards symmetry.
+func TestTestdata_MultiHopValueType(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "multi_hop_value_type", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+	noUnresolvedPlaceholders(t, out)
+
+	for _, path := range []string{"/one-hop", "/two-hops", "/three-hops"} {
+		get := opFor(out.Paths[path], "GET")
+		if get == nil {
+			t.Errorf("GET %s missing; have %v", path, mapPathKeys(out.Paths))
+			continue
+		}
+		if !responseSchemaRefs(get.Responses, "User") {
+			t.Errorf("GET %s: expected a User response through the helper chain, got %v",
+				path, keysOf(get.Responses))
+		}
+	}
+
+	post := opFor(out.Paths["/create-two-hops"], "POST")
+	if post == nil {
+		t.Fatalf("POST /create-two-hops missing; have %v", mapPathKeys(out.Paths))
+	}
+	if post.RequestBody == nil || !bodySchemaRefs(post.RequestBody, "CreateUserRequest") {
+		t.Errorf("POST /create-two-hops: expected a CreateUserRequest body through the helper chain, got %v",
+			post.RequestBody)
+	}
+}
+
+func responseSchemaRefs(responses map[string]intspec.Response, name string) bool {
+	for _, resp := range responses {
+		for _, media := range resp.Content {
+			if media.Schema != nil && strings.Contains(media.Schema.Ref, name) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func bodySchemaRefs(rb *intspec.RequestBody, name string) bool {
+	for _, media := range rb.Content {
+		if media.Schema != nil && strings.Contains(media.Schema.Ref, name) {
+			return true
+		}
+	}
+	return false
+}

--- a/generator/testdata_multi_hop_value_type_test.go
+++ b/generator/testdata_multi_hop_value_type_test.go
@@ -43,6 +43,16 @@ func TestTestdata_MultiHopValueType(t *testing.T) {
 		}
 	}
 
+	// An interface-returning call forwarded through two hops must resolve to the
+	// concrete Dog — which needs the trace to carry the handler's scope, not the
+	// deepest helper's (CodeRabbit review on PR #183).
+	if get := opFor(out.Paths["/interface-return"], "GET"); get == nil {
+		t.Errorf("GET /interface-return missing; have %v", mapPathKeys(out.Paths))
+	} else if !responseSchemaRefs(get.Responses, "Dog") {
+		t.Errorf("GET /interface-return: expected the concrete Dog through the helper chain, got %v",
+			keysOf(get.Responses))
+	}
+
 	post := opFor(out.Paths["/create-two-hops"], "POST")
 	if post == nil {
 		t.Fatalf("POST /create-two-hops missing; have %v", mapPathKeys(out.Paths))
@@ -53,10 +63,18 @@ func TestTestdata_MultiHopValueType(t *testing.T) {
 	}
 }
 
+// refIsType reports whether a $ref points at the component for the exact type
+// `name`. Component names are the qualified path with the bare type as the last
+// underscore-delimited segment (…_User), so an exact "_"+name suffix avoids
+// matching "User" inside "CreateUserRequest".
+func refIsType(ref, name string) bool {
+	return ref != "" && strings.HasSuffix(ref, "_"+name)
+}
+
 func responseSchemaRefs(responses map[string]intspec.Response, name string) bool {
 	for _, resp := range responses {
 		for _, media := range resp.Content {
-			if media.Schema != nil && strings.Contains(media.Schema.Ref, name) {
+			if media.Schema != nil && refIsType(media.Schema.Ref, name) {
 				return true
 			}
 		}
@@ -66,7 +84,7 @@ func responseSchemaRefs(responses map[string]intspec.Response, name string) bool
 
 func bodySchemaRefs(rb *intspec.RequestBody, name string) bool {
 	for _, media := range rb.Content {
-		if media.Schema != nil && strings.Contains(media.Schema.Ref, name) {
+		if media.Schema != nil && refIsType(media.Schema.Ref, name) {
 			return true
 		}
 	}

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -2362,23 +2362,29 @@ func (r *ResponsePatternMatcherImpl) ExtractResponse(node TrackerNodeInterface, 
 	return []*ResponseInfo{respInfo}
 }
 
-// traceArgViaParent walks one step up the tracker tree to recover the
-// caller-site value of a parameter ident. When a response pattern matches
-// inside a helper (writeJSON-style) — e.g. WriteHeader(status) where
-// status is a parameter of writeJSON — the matched call's args reference
-// parameters, not literals. The parent tracker node represents the call
-// to the helper, and that edge's ParamArgMap maps callee parameter
+// traceArgViaParent walks up the tracker tree to recover the caller-site value
+// of a parameter ident. When a response pattern matches inside a helper
+// (writeJSON-style) — e.g. Encode(v) where v is a parameter of writeJSON — the
+// matched call's args reference parameters, not literals. Each parent tracker
+// node represents a call, and that edge's ParamArgMap maps callee parameter
 // names back to the caller's actual arguments.
 //
-// Returns nil when the arg isn't an ident, there is no parent node,
-// or the parameter name isn't present in the parent's ParamArgMap.
+// It follows the parameter across MULTIPLE hops (writeJSON -> render -> Encode),
+// stopping at the first non-parameter — the concrete value — via
+// resolveArgThroughParams. A single hop resolved only the outermost helper's
+// parameter, leaving `v any` at a generic object for two-hop helper chains
+// (issue #180). Returns nil when nothing resolves (the arg is unchanged).
 //
-// Per-route isolation in the tracker tree is what makes this sound:
-// each handler's path through the helper is a distinct tracker subtree,
-// so two routes that call writeJSON with different statuses each
-// resolve to their own value independently.
+// Per-route isolation in the tracker tree is what makes this sound: each
+// handler's path through the helpers is a distinct tracker subtree, so two
+// routes that call the same helper with different values each resolve to their
+// own value independently.
 func (r *ResponsePatternMatcherImpl) traceArgViaParent(arg *metadata.CallArgument, node TrackerNodeInterface) *metadata.CallArgument {
-	return argViaParent(arg, node)
+	resolved, _ := resolveArgThroughParams(arg, node)
+	if resolved == arg {
+		return nil
+	}
+	return resolved
 }
 
 // argViaParent recovers the caller-site value of a parameter ident by finding

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -2245,8 +2245,17 @@ func (r *ResponsePatternMatcherImpl) ExtractResponse(node TrackerNodeInterface, 
 		// concrete type — otherwise `v any` would resolve to a generic
 		// object. Per-route isolation in the tracker tree means each
 		// handler's response gets the type from its own call site.
-		if callerArg := r.traceArgViaParent(arg, node); callerArg != nil {
+		//
+		// typeNode follows arg to the scope where it was resolved, so the
+		// scope-dependent lookups below (concreteFromCalleeReturn,
+		// resolveTypeOrigin, collectWrapperOverrides) read the right function
+		// after a multi-hop trace, not the deepest helper's scope.
+		typeNode := node
+		if callerArg, callerNode := r.traceArgViaParent(arg, node); callerArg != nil {
 			arg = callerArg
+			if callerNode != nil {
+				typeNode = callerNode
+			}
 		}
 
 		// Type conversion like `[]byte(swaggerUIHTML)`: the *target* type of
@@ -2293,7 +2302,7 @@ func (r *ResponsePatternMatcherImpl) ExtractResponse(node TrackerNodeInterface, 
 					// makeAnimal() Animal { return Dog{} } → Dog). Mark it
 					// resolved so resolveTypeOrigin's GetResolvedType fast-path
 					// (which would restore the interface) is skipped.
-					if concrete := r.concreteFromCalleeReturn(arg, node.GetEdge(), t); concrete != "" {
+					if concrete := r.concreteFromCalleeReturn(arg, typeNode.GetEdge(), t); concrete != "" {
 						bodyType = concrete
 						resolvedConcrete = true
 					}
@@ -2302,7 +2311,7 @@ func (r *ResponsePatternMatcherImpl) ExtractResponse(node TrackerNodeInterface, 
 
 			// Trace type origin for non-literal arguments
 			if !resolvedConcrete {
-				bodyType = r.resolveTypeOrigin(arg, node, bodyType)
+				bodyType = r.resolveTypeOrigin(arg, typeNode, bodyType)
 			}
 
 			// Apply dereferencing if needed
@@ -2327,7 +2336,7 @@ func (r *ResponsePatternMatcherImpl) ExtractResponse(node TrackerNodeInterface, 
 		// concrete type for each bound field and compose an `allOf`
 		// override so per-route schemas reflect the actual payload
 		// type instead of the wrapper's declared `interface{}`.
-		if overrides := r.collectWrapperOverrides(arg, node); len(overrides) > 0 {
+		if overrides := r.collectWrapperOverrides(arg, typeNode); len(overrides) > 0 {
 			schema = specialiseWrapperSchema(schema, overrides, bodyType, route.UsedTypes, route.Metadata, r.cfg)
 		}
 
@@ -2379,12 +2388,12 @@ func (r *ResponsePatternMatcherImpl) ExtractResponse(node TrackerNodeInterface, 
 // handler's path through the helpers is a distinct tracker subtree, so two
 // routes that call the same helper with different values each resolve to their
 // own value independently.
-func (r *ResponsePatternMatcherImpl) traceArgViaParent(arg *metadata.CallArgument, node TrackerNodeInterface) *metadata.CallArgument {
-	resolved, _ := resolveArgThroughParams(arg, node)
+func (r *ResponsePatternMatcherImpl) traceArgViaParent(arg *metadata.CallArgument, node TrackerNodeInterface) (*metadata.CallArgument, TrackerNodeInterface) {
+	resolved, resolvedNode := resolveArgThroughParams(arg, node)
 	if resolved == arg {
-		return nil
+		return nil, nil
 	}
-	return resolved
+	return resolved, resolvedNode
 }
 
 // argViaParent recovers the caller-site value of a parameter ident by finding
@@ -2392,16 +2401,22 @@ func (r *ResponsePatternMatcherImpl) traceArgViaParent(arg *metadata.CallArgumen
 // ParamArgMap (callee parameter name → caller argument). Returns nil when the
 // arg isn't an ident or no such binding exists. Shared by the response and
 // request matchers.
-func argViaParent(arg *metadata.CallArgument, node TrackerNodeInterface) *metadata.CallArgument {
+// argViaParent recovers the caller-site value of a parameter ident and the
+// tracker node where it was resolved — the parent call node whose ParamArgMap
+// carried the argument. The returned node is the scope in which the resolved
+// argument lives, so downstream type resolution reads the right function
+// (issue #180 / CodeRabbit review on PR #183). Returns (nil, nil) when the arg
+// isn't a parameter reachable from the parent chain.
+func argViaParent(arg *metadata.CallArgument, node TrackerNodeInterface) (*metadata.CallArgument, TrackerNodeInterface) {
 	if arg == nil || arg.GetKind() != metadata.KindIdent || node == nil {
-		return nil
+		return nil, nil
 	}
 	// Fast path: the immediate parent is normally the call into the enclosing
-	// function. Kept as-is so existing resolutions are byte-for-byte unchanged.
+	// function.
 	if parent := node.GetParent(); parent != nil {
 		if pe := parent.GetEdge(); pe != nil && pe.ParamArgMap != nil {
 			if callerArg, ok := pe.ParamArgMap[arg.GetName()]; ok {
-				return &callerArg
+				return &callerArg, parent
 			}
 		}
 	}
@@ -2413,11 +2428,11 @@ func argViaParent(arg *metadata.CallArgument, node TrackerNodeInterface) *metada
 	// function and read its ParamArgMap. Mirrors concreteFromParamBinding.
 	edge := node.GetEdge()
 	if edge == nil {
-		return nil
+		return nil, nil
 	}
 	enclosing := edge.Caller.BaseID()
 	if enclosing == "" {
-		return nil
+		return nil, nil
 	}
 	for p := node.GetParent(); p != nil; p = p.GetParent() {
 		pe := p.GetEdge()
@@ -2425,14 +2440,14 @@ func argViaParent(arg *metadata.CallArgument, node TrackerNodeInterface) *metada
 			continue
 		}
 		if pe.ParamArgMap == nil {
-			return nil
+			return nil, nil
 		}
 		if callerArg, ok := pe.ParamArgMap[arg.GetName()]; ok {
-			return &callerArg
+			return &callerArg, p
 		}
-		return nil
+		return nil, nil
 	}
-	return nil
+	return nil, nil
 }
 
 // resolveArgThroughParams follows a parameter ident up through one or more
@@ -2447,12 +2462,20 @@ func resolveArgThroughParams(arg *metadata.CallArgument, node TrackerNodeInterfa
 	cur := node
 	const maxHops = 8
 	for i := 0; i < maxHops; i++ {
-		next := argViaParent(arg, cur)
+		next, nextNode := argViaParent(arg, cur)
 		if next == nil {
 			break
 		}
 		arg = next
-		cur = cur.GetParent()
+		// Advance to the node where the argument actually resolved, not blindly
+		// cur.GetParent(): on the re-homed fallback path argViaParent resolves at
+		// an ancestor several levels up, and cur.GetParent() would desync the
+		// scope from the resolved argument (CodeRabbit review on PR #183). On the
+		// fast path nextNode == cur.GetParent(), so this is unchanged there.
+		if nextNode == nil {
+			break
+		}
+		cur = nextNode
 	}
 	return arg, cur
 }

--- a/internal/spec/param_tracing_test.go
+++ b/internal/spec/param_tracing_test.go
@@ -85,7 +85,7 @@ func TestTraceArgViaParent_ResolvesParameterToCallerArg(t *testing.T) {
 		},
 	}
 
-	got := matcher.traceArgViaParent(statusIdent, child)
+	got, _ := matcher.traceArgViaParent(statusIdent, child)
 	if got == nil {
 		t.Fatal("expected to recover caller-site arg via parent's ParamArgMap, got nil")
 	}
@@ -110,7 +110,7 @@ func TestTraceArgViaParent_ReturnsNilForLiteral(t *testing.T) {
 		},
 	}
 
-	if got := matcher.traceArgViaParent(lit, &fakeNode{}); got != nil {
+	if got, _ := matcher.traceArgViaParent(lit, &fakeNode{}); got != nil {
 		t.Errorf("expected nil for literal arg, got %+v", got)
 	}
 }
@@ -139,7 +139,7 @@ func TestTraceArgViaParent_ReturnsNilWhenParamNotMapped(t *testing.T) {
 		},
 	}
 
-	if got := matcher.traceArgViaParent(ident, child); got != nil {
+	if got, _ := matcher.traceArgViaParent(ident, child); got != nil {
 		t.Errorf("expected nil when param not in ParamArgMap, got %+v", got)
 	}
 }

--- a/testdata/multi_hop_value_type/go.mod
+++ b/testdata/multi_hop_value_type/go.mod
@@ -1,0 +1,3 @@
+module github.com/ehabterra/apispec/testdata/multi_hop_value_type
+
+go 1.24.3

--- a/testdata/multi_hop_value_type/main.go
+++ b/testdata/multi_hop_value_type/main.go
@@ -23,6 +23,20 @@ type CreateUserRequest struct {
 	Email string `json:"email"`
 }
 
+// Animal is an interface returned by makeAnimal; Dog is the concrete value. When
+// makeAnimal() is forwarded through the helper chain, resolving the concrete Dog
+// requires reading the scope where makeAnimal is CALLED (the handler), not the
+// deepest helper's scope — the multi-hop trace must carry the resolved node.
+type Animal interface{ Sound() string }
+
+type Dog struct {
+	Name string `json:"name"`
+}
+
+func (Dog) Sound() string { return "woof" }
+
+func makeAnimal() Animal { return Dog{} }
+
 // Response helper chain: encThree -> encOuter -> encInner -> Encode(v).
 func encInner(dst io.Writer, v any) { _ = json.NewEncoder(dst).Encode(v) }
 func encOuter(dst io.Writer, v any) { encInner(dst, v) }
@@ -36,6 +50,10 @@ func getTwoHops(w http.ResponseWriter, r *http.Request) { encOuter(w, User{ID: 2
 
 // getThreeHops forwards User through three `any` parameter boundaries.
 func getThreeHops(w http.ResponseWriter, r *http.Request) { encThree(w, User{ID: 3}) }
+
+// getInterfaceReturn forwards an interface-returning CALL through two hops; the
+// concrete Dog resolves only if the trace carries the handler's scope.
+func getInterfaceReturn(w http.ResponseWriter, r *http.Request) { encOuter(w, makeAnimal()) }
 
 // Request helper chain: decOuter -> decInner -> Decode(v).
 func decInner(src io.Reader, v any) error { return json.NewDecoder(src).Decode(v) }
@@ -53,6 +71,7 @@ func main() {
 	mux.HandleFunc("GET /one-hop", getOneHop)
 	mux.HandleFunc("GET /two-hops", getTwoHops)
 	mux.HandleFunc("GET /three-hops", getThreeHops)
+	mux.HandleFunc("GET /interface-return", getInterfaceReturn)
 	mux.HandleFunc("POST /create-two-hops", createTwoHops)
 	_ = http.ListenAndServe(":8080", mux)
 }

--- a/testdata/multi_hop_value_type/main.go
+++ b/testdata/multi_hop_value_type/main.go
@@ -1,0 +1,58 @@
+// Fixture: a concrete value forwarded through TWO OR MORE helper hops typed
+// `any` must keep its concrete type in the response/request schema (issue #180).
+// The response value-type resolution previously walked only a single parameter
+// hop, so `encOuter(w, User{})` (which forwards to `encInner`) erased User to a
+// generic object. Multi-hop parameter tracing recovers the concrete type at any
+// depth. The request side (which already traced multi-hop) is included as a
+// symmetric guard.
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+type User struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+type CreateUserRequest struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+// Response helper chain: encThree -> encOuter -> encInner -> Encode(v).
+func encInner(dst io.Writer, v any) { _ = json.NewEncoder(dst).Encode(v) }
+func encOuter(dst io.Writer, v any) { encInner(dst, v) }
+func encThree(dst io.Writer, v any) { encOuter(dst, v) }
+
+// getOneHop resolves through a single helper hop (the control).
+func getOneHop(w http.ResponseWriter, r *http.Request) { encInner(w, User{ID: 1}) }
+
+// getTwoHops forwards User through two `any` parameter boundaries.
+func getTwoHops(w http.ResponseWriter, r *http.Request) { encOuter(w, User{ID: 2}) }
+
+// getThreeHops forwards User through three `any` parameter boundaries.
+func getThreeHops(w http.ResponseWriter, r *http.Request) { encThree(w, User{ID: 3}) }
+
+// Request helper chain: decOuter -> decInner -> Decode(v).
+func decInner(src io.Reader, v any) error { return json.NewDecoder(src).Decode(v) }
+func decOuter(src io.Reader, v any) error { return decInner(src, v) }
+
+// createTwoHops decodes the body through two `any` parameter boundaries.
+func createTwoHops(w http.ResponseWriter, r *http.Request) {
+	var req CreateUserRequest
+	_ = decOuter(r.Body, &req)
+	_ = req
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /one-hop", getOneHop)
+	mux.HandleFunc("GET /two-hops", getTwoHops)
+	mux.HandleFunc("GET /three-hops", getThreeHops)
+	mux.HandleFunc("POST /create-two-hops", createTwoHops)
+	_ = http.ListenAndServe(":8080", mux)
+}


### PR DESCRIPTION
## Summary

Fixes #180. A concrete value forwarded through **two or more** `any`-typed helper hops lost its type in the response schema:

```go
func encInner(dst io.Writer, v any) { json.NewEncoder(dst).Encode(v) }
func encOuter(dst io.Writer, v any) { encInner(dst, v) }        // 2nd hop
func h(w http.ResponseWriter, r *http.Request) { encOuter(w, User{}) }
// before: response schema = { type: object }   (User erased)
// after:  response schema = $ref User
```

## Root cause & fix

The response value-type resolution used `traceArgViaParent`, which walked a **single** `argViaParent` hop — enough to reach the outermost helper's parameter but not to follow it further. It now uses `resolveArgThroughParams`, the multi-hop tracer (max 8 hops, stops at the first non-parameter) that the **request-body side and status resolution already use**. One-symbol change; the request side already traced multi-hop and is unchanged.

| Depth | Before | After |
|---|---|---|
| 1 hop | `$ref User` | `$ref User` |
| 2 hops | `{type: object}` | `$ref User` |
| 3 hops | `{type: object}` | `$ref User` |

## Scope

Confirmed this is the multi-hop *forwarding* case only. The related **#163** (a value stored into a generic envelope `APIResponse[any]{Data: data}`) is a distinct generic-field-specialization problem and correctly **remains unfixed** by this change — verified it still erases, so #163 stays open.

## Tests

- `testdata/multi_hop_value_type/` — 1/2/3-hop response chains + a 2-hop request-body chain (symmetric guard).
- `generator/testdata_multi_hop_value_type_test.go` — asserts `User` / `CreateUserRequest` survive through the helper chains.

## Verification

Full `go test ./...` passes with **zero output drift**; `gofmt`, `go vet`, `golangci-lint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema type resolution when response matchers are used through multiple layers of helper functions.
  * Preserved concrete request and response types across multi-step forwarding, preventing unresolved placeholders and dangling references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->