### PR TITLE
fix(spec): follow constructor-function response-writer wrappers (regression from #181)

### DIFF
--- a/generator/testdata_response_writer_provenance_test.go
+++ b/generator/testdata_response_writer_provenance_test.go
@@ -40,7 +40,7 @@ func TestTestdata_ResponseWriterProvenance(t *testing.T) {
 	}
 
 	// KEEP: destination traces to w → User response present.
-	for _, path := range []string{"/direct", "/helper", "/assign", "/wrapper"} {
+	for _, path := range []string{"/direct", "/helper", "/assign", "/wrapper", "/ctor-wrapper"} {
 		get := opFor(out.Paths[path], "GET")
 		if get == nil {
 			t.Errorf("GET %s missing; have %v", path, mapPathKeys(out.Paths))

--- a/internal/spec/response_dest.go
+++ b/internal/spec/response_dest.go
@@ -127,6 +127,19 @@ func (r *responseDestResolver) reachesWriter(arg *metadata.CallArgument, edge *m
 			return true
 		}
 		return false
+
+	case metadata.KindCall:
+		// A constructor-function wrapper: ww := newResponseWriter(w). If any
+		// argument reaches the writer, the constructed value wraps it, so the
+		// call reaches the writer too. A sink constructor with no writer argument
+		// (bytes.NewBufferString("{}"), sha256.New()) does not, and still drops.
+		// Provenance-consistent with the composite-literal wrapper above.
+		for _, a := range arg.Args {
+			if r.reachesWriter(a, edge, visited) {
+				return true
+			}
+		}
+		return false
 	}
 	return false
 }

--- a/internal/spec/response_dest_test.go
+++ b/internal/spec/response_dest_test.go
@@ -168,6 +168,40 @@ func TestResponseDestResolver_Wrapper(t *testing.T) {
 	}
 }
 
+// TestResponseDestResolver_ConstructorWrapper covers the constructor-function
+// wrapper: ww := newWrapped(w) — the writer flows through the call argument, so
+// the result reaches the writer; a sink constructor with no writer argument
+// does not.
+func TestResponseDestResolver_ConstructorWrapper(t *testing.T) {
+	meta := newTestMeta()
+	r := newRespDestResolver(meta)
+
+	// ww := newWrapped(w) — a call whose arg is the writer.
+	w := mkIdent(meta, "w", "net/http.ResponseWriter")
+	ctorCall := metadata.NewCallArgument(meta)
+	ctorCall.SetKind(metadata.KindCall)
+	ctorCall.Fun = mkIdent(meta, "newWrapped", "")
+	ctorCall.Args = []*metadata.CallArgument{w}
+	edge := &metadata.CallGraphEdge{AssignmentMap: map[string][]metadata.Assignment{
+		"ww": {{Value: *ctorCall}},
+	}}
+	if r.ShouldDrop(mkIdent(meta, "ww", "*app.wrappedWriter"), edge) {
+		t.Error("a constructor wrapper receiving w must reach the writer and be kept")
+	}
+
+	// buf := bytes.NewBufferString("{}") — a call with no writer argument.
+	lit := metadata.NewCallArgument(meta)
+	lit.SetKind(metadata.KindLiteral)
+	lit.SetValue(`"{}"`)
+	sinkCall := metadata.NewCallArgument(meta)
+	sinkCall.SetKind(metadata.KindCall)
+	sinkCall.Fun = mkIdent(meta, "NewBufferString", "")
+	sinkCall.Args = []*metadata.CallArgument{lit}
+	if r.reachesWriter(sinkCall, &metadata.CallGraphEdge{}, map[string]bool{}) {
+		t.Error("a constructor with no writer argument must not reach the writer")
+	}
+}
+
 // TestResponseDestResolver_CyclicAssignment: a := b; b := a terminates.
 func TestResponseDestResolver_CyclicAssignment(t *testing.T) {
 	meta := newTestMeta()

--- a/testdata/response_writer_provenance/main.go
+++ b/testdata/response_writer_provenance/main.go
@@ -37,6 +37,10 @@ func encodeTo(dst io.Writer, v any) { _ = json.NewEncoder(dst).Encode(v) }
 
 func makeBuffer() *bytes.Buffer { return &bytes.Buffer{} }
 
+// newLoggingWriter is a CONSTRUCTOR-FUNCTION wrapper around w (the common
+// middleware pattern). The writer flows into the call, so the result wraps it.
+func newLoggingWriter(w http.ResponseWriter) *loggingWriter { return &loggingWriter{w} }
+
 // --- KEEP: the destination traces to the response writer w ---
 
 // getDirect writes straight to w.
@@ -59,6 +63,14 @@ func getViaAssign(w http.ResponseWriter, r *http.Request) {
 func getViaWrapper(w http.ResponseWriter, r *http.Request) {
 	lw := &loggingWriter{w}
 	_ = json.NewEncoder(lw).Encode(User{ID: "4"})
+}
+
+// getViaCtorWrapper encodes to a wrapper built by a CONSTRUCTOR FUNCTION — the
+// writer flows through the call argument, so the response must be kept (the
+// regression that dropped these was surfacing as spurious `default` statuses).
+func getViaCtorWrapper(w http.ResponseWriter, r *http.Request) {
+	lw := newLoggingWriter(w)
+	_ = json.NewEncoder(lw).Encode(User{ID: "5"})
 }
 
 // --- DROP: the destination is a sink unrelated to w ---
@@ -103,6 +115,7 @@ func main() {
 	mux.HandleFunc("GET /helper", getViaHelper)
 	mux.HandleFunc("GET /assign", getViaAssign)
 	mux.HandleFunc("GET /wrapper", getViaWrapper)
+	mux.HandleFunc("GET /ctor-wrapper", getViaCtorWrapper)
 	mux.HandleFunc("POST /leak-buffer", leakBuffer)
 	mux.HandleFunc("POST /leak-hash", leakHash)
 	mux.HandleFunc("POST /leak-discard", leakDiscard)


### PR DESCRIPTION
## Summary

Fixes a regression from #181 that surfaces as an **increase in `default` (unresolved-status) responses** on routes that wrap the response writer via a constructor function.

The write-destination gating (#170/#181) followed **composite-literal** wrappers (`&loggingWriter{w}`) but not **constructor-function** wrappers:

```go
func newWrapped(w http.ResponseWriter) *wrappedWriter { return &wrappedWriter{ResponseWriter: w} }
func respond(w http.ResponseWriter, data any) { ww := newWrapped(w); json.NewEncoder(ww).Encode(data) }
```

`ww`'s provenance is a *call* (`newWrapped(w)`), which `reachesWriter` didn't follow — so the encode was dropped as a non-writer. Real success responses degraded to a generic `object` / unresolved status, pushing affected routes to `default`. This is a very common middleware pattern (logging/gzip/status-capturing writers).

### Reproduction (pre-#181 vs main)

```
GET /assets
  pre-#181:  { type: array, items: $ref Asset }
  main:      { type: object }                     ← concrete response lost
```

## Fix

`reachesWriter` now handles `KindCall` by recursing into the call's arguments — a constructor whose argument reaches the writer produces a value that wraps it, so the call reaches the writer. A sink constructor with **no** writer argument (`bytes.NewBufferString("{}")`, `sha256.New()`, `makeBuffer()`) still drops. Provenance-consistent with the composite-literal wrapper case, and it also correctly keeps `io.MultiWriter(w, buf)`.

| Destination | Result |
|---|---|
| `ww := newWrapped(w)` (constructor wrapper) | **keep** ✅ (was dropped) |
| `&loggingWriter{w}` (composite wrapper) | keep ✅ |
| `bytes.NewBufferString("{}")` / `sha256.New()` / `makeBuffer()` | drop ✅ |

## Tests

- `response_writer_provenance` fixture: added `/ctor-wrapper` (keep) alongside the existing `/leak-constructed` (drop), so the writer-wrapping constructor and the sink constructor are distinguished.
- Unit test `TestResponseDestResolver_ConstructorWrapper`.

## Verification

Reproduction now keeps `[]Asset`; sinks still drop with no `Secret` leak. Full `go test ./...` passes with **zero drift**; fmt/vet/lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)