### PR TITLE
fix(spec): fan branched status through an error constructor to concrete codes (#155)

### DIFF
--- a/generator/testdata_branched_status_constructor_test.go
+++ b/generator/testdata_branched_status_constructor_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/ehabterra/apispec/spec"
+)
+
+// TestTestdata_BranchedStatusConstructor covers issue #155: a status assigned
+// across switch/if branches then handed to an error constructor must resolve to
+// the concrete branch codes, not a single `default`.
+func TestTestdata_BranchedStatusConstructor(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "branched_status_constructor", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+	noUnresolvedPlaceholders(t, out)
+
+	// GET /thing reports errors through writeError (inline constructor); its
+	// switch sets {404, 400, 500}.
+	get := opFor(out.Paths["/thing"], "GET")
+	if get == nil {
+		t.Fatalf("GET /thing missing; have %v", mapPathKeys(out.Paths))
+	}
+	got := keysOf(get.Responses)
+	sort.Strings(got)
+	for _, want := range []string{"400", "404", "500"} {
+		if _, ok := get.Responses[want]; !ok {
+			t.Errorf("GET /thing missing status %s; have %v", want, got)
+		}
+	}
+	if _, ok := get.Responses["default"]; ok {
+		t.Errorf("GET /thing still has an unresolved default; the branch statuses should be concrete; have %v", got)
+	}
+
+	// GET /other uses the variable form (e := NewAPIError(...)); its if sets
+	// {404, 500}.
+	other := opFor(out.Paths["/other"], "GET")
+	if other == nil {
+		t.Fatalf("GET /other missing; have %v", mapPathKeys(out.Paths))
+	}
+	for _, want := range []string{"404", "500"} {
+		if _, ok := other.Responses[want]; !ok {
+			t.Errorf("GET /other missing status %s; have %v", want, keysOf(other.Responses))
+		}
+	}
+}

--- a/generator/testdata_branched_status_constructor_test.go
+++ b/generator/testdata_branched_status_constructor_test.go
@@ -57,4 +57,22 @@ func TestTestdata_BranchedStatusConstructor(t *testing.T) {
 			t.Errorf("GET /other missing status %s; have %v", want, keysOf(other.Responses))
 		}
 	}
+
+	// GET /mixed has a constant branch (404) and a computed branch (residue).
+	// The concrete 404 must survive — it must NOT collapse to only a `default`.
+	// (The residue's own default is emitted then pruned as redundant with 404's
+	// body; the concrete code surviving is the observable guarantee.)
+	mixed := opFor(out.Paths["/mixed"], "GET")
+	if mixed == nil {
+		t.Fatalf("GET /mixed missing; have %v", mapPathKeys(out.Paths))
+	}
+	if _, ok := mixed.Responses["404"]; !ok {
+		t.Errorf("GET /mixed: the concrete 404 branch must survive alongside the computed residue; have %v",
+			keysOf(mixed.Responses))
+	}
+	if len(mixed.Responses) == 1 {
+		if _, only := mixed.Responses["default"]; only {
+			t.Errorf("GET /mixed collapsed to only `default`; the 404 branch was lost")
+		}
+	}
 }

--- a/internal/spec/branched_status_constructor_test.go
+++ b/internal/spec/branched_status_constructor_test.go
@@ -164,3 +164,113 @@ func TestStatusCodeOfValue(t *testing.T) {
 		}
 	})
 }
+
+// TestFindCallEdge covers the call-site position match, the first-match
+// fallback, and the no-match case.
+func TestFindCallEdge(t *testing.T) {
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	impl := NewContextProvider(meta)
+	caller := metadata.Call{Name: meta.StringPool.Get("h"), Pkg: meta.StringPool.Get("app")}
+	e := func(pos string) metadata.CallGraphEdge {
+		return metadata.CallGraphEdge{
+			Caller:   caller,
+			Callee:   metadata.Call{Name: meta.StringPool.Get("New")},
+			Position: meta.StringPool.Get(pos),
+		}
+	}
+	meta.CallGraph = []metadata.CallGraphEdge{e("pos1"), e("pos2")}
+	callerID := caller.ID()
+
+	if got := findCallEdge(impl, callerID, "New", "pos2"); got == nil || impl.GetString(got.Position) != "pos2" {
+		t.Errorf("valPos match should return the pos2 edge, got %v", got)
+	}
+	if got := findCallEdge(impl, callerID, "New", ""); got == nil || impl.GetString(got.Position) != "pos1" {
+		t.Errorf("no valPos should return the first match (pos1), got %v", got)
+	}
+	if got := findCallEdge(impl, callerID, "New", "nope"); got == nil || impl.GetString(got.Position) != "pos1" {
+		t.Errorf("unmatched valPos should fall back to the first match, got %v", got)
+	}
+	if got := findCallEdge(impl, callerID, "Missing", ""); got != nil {
+		t.Errorf("unknown callee should return nil, got %v", got)
+	}
+}
+
+// TestStatusesFromConstructorField_Guards covers the early-out guards.
+func TestStatusesFromConstructorField_Guards(t *testing.T) {
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	m := branchStatusMatcher(meta)
+
+	sel := func(base, field string) *metadata.CallArgument {
+		a := metadata.NewCallArgument(meta)
+		a.SetKind(metadata.KindSelector)
+		x := metadata.NewCallArgument(meta)
+		x.SetKind(metadata.KindIdent)
+		x.SetName(base)
+		f := metadata.NewCallArgument(meta)
+		f.SetKind(metadata.KindIdent)
+		f.SetName(field)
+		a.X, a.Sel = x, f
+		return a
+	}
+	node := &fakeNode{edge: &metadata.CallGraphEdge{
+		Caller: metadata.Call{Name: meta.StringPool.Get("h"), Pkg: meta.StringPool.Get("app")},
+	}}
+
+	cases := []struct {
+		name string
+		arg  *metadata.CallArgument
+		node TrackerNodeInterface
+	}{
+		{"nil arg", nil, node},
+		{"non-selector", mkIdent(meta, "x", ""), node},
+		{"selector, empty field", sel("e", ""), node},
+		{"selector, unresolvable base scope", sel("e", "Code"), node},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			codes, residue := m.statusesFromConstructorField(tc.arg, tc.node)
+			if codes != nil || residue {
+				t.Errorf("guard %q should yield (nil,false); got (%v,%v)", tc.name, codes, residue)
+			}
+		})
+	}
+}
+
+// TestConstructorFieldParam covers resolving a return composite-literal field to
+// its source parameter (and the no-match / non-composite cases).
+func TestConstructorFieldParam(t *testing.T) {
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+
+	kv := func(field, param string) *metadata.CallArgument {
+		e := metadata.NewCallArgument(meta)
+		e.SetKind(metadata.KindKeyValue)
+		key := metadata.NewCallArgument(meta)
+		key.SetKind(metadata.KindIdent)
+		key.SetName(field)
+		val := metadata.NewCallArgument(meta)
+		val.SetKind(metadata.KindIdent)
+		val.SetName(param)
+		e.X, e.Fun = key, val
+		return e
+	}
+	// return &APIError{Message: message, Code: code}
+	lit := metadata.NewCallArgument(meta)
+	lit.SetKind(metadata.KindCompositeLit)
+	lit.Args = []*metadata.CallArgument{kv("Message", "message"), kv("Code", "code")}
+	addr := metadata.NewCallArgument(meta)
+	addr.SetKind(metadata.KindUnary)
+	addr.X = lit
+	ctor := &metadata.Function{ReturnVars: []metadata.CallArgument{*addr}}
+
+	if got := constructorFieldParam(ctor, "Code"); got != "code" {
+		t.Errorf(`constructorFieldParam(_, "Code") = %q, want "code"`, got)
+	}
+	if got := constructorFieldParam(ctor, "Missing"); got != "" {
+		t.Errorf(`constructorFieldParam(_, "Missing") = %q, want ""`, got)
+	}
+	// A non-composite return contributes no field param.
+	plain := &metadata.Function{ReturnVars: []metadata.CallArgument{*mkIdent(meta, "x", "")}}
+	if got := constructorFieldParam(plain, "Code"); got != "" {
+		t.Errorf(`non-composite return should yield "", got %q`, got)
+	}
+}

--- a/internal/spec/branched_status_constructor_test.go
+++ b/internal/spec/branched_status_constructor_test.go
@@ -1,0 +1,166 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+func branchStatusMatcher(meta *metadata.Metadata) *ResponsePatternMatcherImpl {
+	cfg := &APISpecConfig{Defaults: Defaults{ResponseContentType: "application/json"}}
+	return &ResponsePatternMatcherImpl{
+		BasePatternMatcher: &BasePatternMatcher{
+			cfg:             cfg,
+			contextProvider: NewContextProvider(meta),
+			schemaMapper:    NewSchemaMapper(cfg),
+		},
+	}
+}
+
+// httpStatusSelector builds `http.StatusXxx` as a selector CallArgument.
+func httpStatusSelector(meta *metadata.Metadata, name string) metadata.CallArgument {
+	x := metadata.NewCallArgument(meta)
+	x.SetKind(metadata.KindIdent)
+	x.SetName("http")
+	sel := metadata.NewCallArgument(meta)
+	sel.SetKind(metadata.KindIdent)
+	sel.SetName(name)
+	a := metadata.NewCallArgument(meta)
+	a.SetKind(metadata.KindSelector)
+	a.X = x
+	a.Sel = sel
+	return *a
+}
+
+// TestExpandVarStatuses_Constants covers issue #155's core: a variable set to
+// constant statuses across branches (statusCode = http.StatusNotFound), not
+// through constructor calls, fans out to the concrete codes.
+func TestExpandVarStatuses_Constants(t *testing.T) {
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	m := branchStatusMatcher(meta)
+	cp := m.contextProvider.(*ContextProviderImpl)
+
+	fn := &metadata.Function{AssignmentMap: map[string][]metadata.Assignment{
+		"statusCode": {
+			{Value: httpStatusSelector(meta, "StatusNotFound")},
+			{Value: httpStatusSelector(meta, "StatusBadRequest")},
+			{Value: httpStatusSelector(meta, "StatusInternalServerError")},
+		},
+	}}
+	codes, residue := m.expandVarStatuses("statusCode", fn, cp)
+	sort.Ints(codes)
+	if want := []int{400, 404, 500}; len(codes) != 3 || codes[0] != want[0] || codes[1] != want[1] || codes[2] != want[2] {
+		t.Errorf("codes = %v, want %v", codes, want)
+	}
+	if residue {
+		t.Error("all-constant branches must not report a residue")
+	}
+}
+
+// TestExpandVarStatuses_Residue: a non-constant branch (a computed status)
+// yields the constant codes plus residue=true, so the caller keeps an honest
+// default.
+func TestExpandVarStatuses_Residue(t *testing.T) {
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	m := branchStatusMatcher(meta)
+	cp := m.contextProvider.(*ContextProviderImpl)
+
+	// A call with no status literal — a computed/dynamic status.
+	dyn := metadata.NewCallArgument(meta)
+	dyn.SetKind(metadata.KindCall)
+	fun := metadata.NewCallArgument(meta)
+	fun.SetKind(metadata.KindIdent)
+	fun.SetName("statusFor")
+	dyn.Fun = fun
+
+	fn := &metadata.Function{AssignmentMap: map[string][]metadata.Assignment{
+		"statusCode": {
+			{Value: httpStatusSelector(meta, "StatusNotFound")},
+			{Value: *dyn},
+		},
+	}}
+	codes, residue := m.expandVarStatuses("statusCode", fn, cp)
+	if len(codes) != 1 || codes[0] != 404 {
+		t.Errorf("codes = %v, want [404]", codes)
+	}
+	if !residue {
+		t.Error("a non-constant branch must report a residue")
+	}
+}
+
+// TestExpandVarStatuses_SingleAssignmentNoFanOut: a single assignment is left
+// to the normal latest-wins path (no fan-out).
+func TestExpandVarStatuses_SingleAssignmentNoFanOut(t *testing.T) {
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	m := branchStatusMatcher(meta)
+	cp := m.contextProvider.(*ContextProviderImpl)
+
+	fn := &metadata.Function{AssignmentMap: map[string][]metadata.Assignment{
+		"statusCode": {{Value: httpStatusSelector(meta, "StatusOK")}},
+	}}
+	if codes, residue := m.expandVarStatuses("statusCode", fn, cp); codes != nil || residue {
+		t.Errorf("single assignment must not fan out; got codes=%v residue=%v", codes, residue)
+	}
+}
+
+// TestStatusCodeOfValue covers the constant, constructor-call, and
+// non-constant shapes.
+func TestStatusCodeOfValue(t *testing.T) {
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	m := branchStatusMatcher(meta)
+	cp := m.contextProvider.(*ContextProviderImpl)
+
+	t.Run("constant selector", func(t *testing.T) {
+		v := httpStatusSelector(meta, "StatusNotFound")
+		if s, ok := m.statusCodeOfValue(&v, cp); !ok || s != 404 {
+			t.Errorf("got (%d,%v), want (404,true)", s, ok)
+		}
+	})
+
+	t.Run("constructor call carrying a status literal", func(t *testing.T) {
+		call := metadata.NewCallArgument(meta)
+		call.SetKind(metadata.KindCall)
+		fun := metadata.NewCallArgument(meta)
+		fun.SetKind(metadata.KindIdent)
+		fun.SetName("NewError")
+		call.Fun = fun
+		msg := metadata.NewCallArgument(meta)
+		msg.SetKind(metadata.KindIdent)
+		msg.SetName("msg")
+		st := httpStatusSelector(meta, "StatusBadRequest")
+		call.Args = []*metadata.CallArgument{msg, &st}
+		if s, ok := m.statusCodeOfValue(call, cp); !ok || s != 400 {
+			t.Errorf("got (%d,%v), want (400,true)", s, ok)
+		}
+	})
+
+	t.Run("non-constant is not a status", func(t *testing.T) {
+		call := metadata.NewCallArgument(meta)
+		call.SetKind(metadata.KindCall)
+		fun := metadata.NewCallArgument(meta)
+		fun.SetKind(metadata.KindIdent)
+		fun.SetName("statusFor")
+		call.Fun = fun
+		if s, ok := m.statusCodeOfValue(call, cp); ok {
+			t.Errorf("got (%d,true), want (_,false)", s)
+		}
+		if _, ok := m.statusCodeOfValue(nil, cp); ok {
+			t.Error("nil value must be false")
+		}
+	})
+}

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -2350,11 +2350,29 @@ func (r *ResponsePatternMatcherImpl) ExtractResponse(node TrackerNodeInterface, 
 	// patterns whose status arg is an opaque ident (e.g. RespondWithError(w,
 	// err)) still produce responses when the branches encode the codes.
 	if r.pattern.StatusFromArg && len(edge.Args) > r.pattern.StatusArgIndex {
-		if expanded := r.expandStatusesFromIdent(edge.Args[r.pattern.StatusArgIndex], edge); len(expanded) > 1 {
-			out := make([]*ResponseInfo, 0, len(expanded))
+		statusArg := edge.Args[r.pattern.StatusArgIndex]
+		expanded := r.expandStatusesFromIdent(statusArg, edge)
+		residue := false
+		if len(expanded) == 0 {
+			// The status arg wasn't a directly branch-assigned local. It may be
+			// a constructor field (err.Code) whose value was set across branches
+			// then handed to the error constructor — issue #155.
+			expanded, residue = r.statusesFromConstructorField(statusArg, node)
+		}
+		if len(expanded) > 1 || (len(expanded) == 1 && residue) {
+			out := make([]*ResponseInfo, 0, len(expanded)+1)
 			for _, st := range expanded {
 				out = append(out, &ResponseInfo{
 					StatusCode:  st,
+					ContentType: respInfo.ContentType,
+					BodyType:    respInfo.BodyType,
+					Schema:      respInfo.Schema,
+				})
+			}
+			// A non-constant branch keeps an honest `default` for the residue.
+			if residue {
+				out = append(out, &ResponseInfo{
+					StatusCode:  respInfo.StatusCode,
 					ContentType: respInfo.ContentType,
 					BodyType:    respInfo.BodyType,
 					Schema:      respInfo.Schema,
@@ -2580,6 +2598,107 @@ func constructorFieldParam(ctor *metadata.Function, fieldName string) string {
 	return ""
 }
 
+// statusesFromConstructorField is the one→many counterpart of
+// statusFromConstructorField (issue #155): when the WriteHeader status argument
+// (`err.Code`) resolves through the error constructor to a local variable whose
+// value is set across switch/if branches, it fans that variable out to the set
+// of concrete status codes the branches assign. residue is true when a branch
+// is non-constant, so the caller keeps an honest `default` alongside the codes.
+// Returns nil codes when the status is a single value (handled by the existing
+// single-status path) or cannot be resolved to a branch variable.
+func (r *ResponsePatternMatcherImpl) statusesFromConstructorField(arg *metadata.CallArgument, node TrackerNodeInterface) (codes []int, residue bool) {
+	if arg == nil || arg.GetKind() != metadata.KindSelector || arg.X == nil || arg.Sel == nil {
+		return nil, false
+	}
+	fieldName := arg.Sel.GetName()
+	if fieldName == "" {
+		return nil, false
+	}
+	impl, ok := r.contextProvider.(*ContextProviderImpl)
+	if !ok || impl.meta == nil {
+		return nil, false
+	}
+
+	// The selector base up to its concrete producer (through wrapper params):
+	// either the constructor call itself (inline `Respond(w, NewErr(...))`) or a
+	// local variable assigned from it (`e := NewErr(...); Respond(w, e)`). The
+	// tracker node's caller is the scope where the branch variable lives.
+	base, baseNode := resolveArgThroughParams(arg.X, node)
+	if base == nil || baseNode == nil || baseNode.GetEdge() == nil {
+		return nil, false
+	}
+	scope := findFunction(impl.meta, impl.GetString(baseNode.GetEdge().Caller.Pkg), impl.GetString(baseNode.GetEdge().Caller.Name))
+	if scope == nil {
+		return nil, false
+	}
+
+	var calleeFunc, valPos string
+	switch base.GetKind() {
+	case metadata.KindCall:
+		if base.Fun == nil {
+			return nil, false
+		}
+		calleeFunc = base.Fun.GetName()
+		valPos = impl.GetString(base.Position)
+	case metadata.KindIdent:
+		assignMap := callerAssignmentMap(impl, baseNode.GetEdge(), base.GetName())
+		if assignMap == nil {
+			return nil, false
+		}
+		as := assignMap[base.GetName()]
+		if len(as) == 0 || as[len(as)-1].Value.GetKind() != metadata.KindCall {
+			return nil, false
+		}
+		calleeFunc = as[len(as)-1].CalleeFunc
+		valPos = impl.GetString(as[len(as)-1].Value.Position)
+	default:
+		return nil, false
+	}
+	if calleeFunc == "" {
+		return nil, false
+	}
+
+	// The constructor call edge, its return field's parameter, and the argument
+	// bound to that parameter — the branch variable (`statusCode`).
+	ctorEdge := findCallEdge(impl, baseNode.GetEdge().Caller.ID(), calleeFunc, valPos)
+	if ctorEdge == nil || ctorEdge.ParamArgMap == nil {
+		return nil, false
+	}
+	ctor := findFunctionByName(impl.meta, impl.GetString(ctorEdge.Callee.Pkg), calleeFunc)
+	if ctor == nil {
+		return nil, false
+	}
+	paramName := constructorFieldParam(ctor, fieldName)
+	if paramName == "" {
+		return nil, false
+	}
+	statusArg, ok := ctorEdge.ParamArgMap[paramName]
+	if !ok || statusArg.GetKind() != metadata.KindIdent {
+		return nil, false
+	}
+	return r.expandVarStatuses(statusArg.GetName(), scope, impl)
+}
+
+// findCallEdge returns the call-graph edge from callerID to a callee named
+// calleeFunc, preferring the one at valPos (disambiguating repeated calls to the
+// same function in one caller) and falling back to the first match.
+func findCallEdge(impl *ContextProviderImpl, callerID, calleeFunc, valPos string) *metadata.CallGraphEdge {
+	var first *metadata.CallGraphEdge
+	for i := range impl.meta.CallGraph {
+		e := &impl.meta.CallGraph[i]
+		if e.Caller.ID() != callerID || impl.GetString(e.Callee.Name) != calleeFunc {
+			continue
+		}
+		if valPos != "" && impl.GetString(e.Callee.Position) == valPos {
+			return e
+		}
+		if first == nil {
+			first = e
+		}
+	}
+	return first
+}
+
 // compositeLitOf peels an optional address-of (`&T{...}`) and returns the
 // composite literal, or nil when arg is not (a pointer to) one.
 func compositeLitOf(arg *metadata.CallArgument) *metadata.CallArgument {
@@ -2647,40 +2766,62 @@ func (r *ResponsePatternMatcherImpl) expandStatusesFromIdent(arg *metadata.CallA
 	if !ok || impl.meta == nil {
 		return nil
 	}
-	callerName := impl.GetString(edge.Caller.Name)
-	callerPkg := impl.GetString(edge.Caller.Pkg)
-	fn := findFunction(impl.meta, callerPkg, callerName)
+	fn := findFunction(impl.meta, impl.GetString(edge.Caller.Pkg), impl.GetString(edge.Caller.Name))
 	if fn == nil {
 		return nil
 	}
-	assigns, ok := fn.AssignmentMap[arg.GetName()]
+	codes, _ := r.expandVarStatuses(arg.GetName(), fn, impl)
+	return codes
+}
+
+// expandVarStatuses fans a variable's branch assignments in function fn out to
+// the set of HTTP status codes it can hold: `statusCode = http.StatusNotFound`
+// (a constant, in any branch of a switch/if) and `err = NewError(msg, 404)` (a
+// constructor call carrying a status literal) both count. residue is true when
+// at least one assignment is non-constant (its concrete code can't be pinned),
+// so the caller can keep an honest `default` for it. Returns nil codes when the
+// variable has fewer than two assignments — single-branch flows resolve through
+// the normal latest-wins path and must not be split. Issues #39 and #155.
+func (r *ResponsePatternMatcherImpl) expandVarStatuses(name string, fn *metadata.Function, impl *ContextProviderImpl) (codes []int, residue bool) {
+	assigns, ok := fn.AssignmentMap[name]
 	if !ok || len(assigns) < 2 {
-		return nil
+		return nil, false
 	}
 	seen := make(map[int]struct{}, len(assigns))
-	out := make([]int, 0, len(assigns))
-	for _, a := range assigns {
-		if a.Value.GetKind() != metadata.KindCall {
+	for i := range assigns {
+		if s, ok := r.statusCodeOfValue(&assigns[i].Value, impl); ok {
+			if _, dup := seen[s]; !dup {
+				seen[s] = struct{}{}
+				codes = append(codes, s)
+			}
 			continue
 		}
-		for _, callArg := range a.Value.Args {
-			if callArg == nil {
-				continue
-			}
-			argStr := impl.GetArgumentInfo(callArg)
-			status, ok := r.schemaMapper.MapStatusCode(argStr)
-			if !ok {
-				continue
-			}
-			if _, dup := seen[status]; dup {
-				break
-			}
-			seen[status] = struct{}{}
-			out = append(out, status)
-			break // first matching arg wins per assignment
-		}
+		residue = true
 	}
-	return out
+	return codes, residue
+}
+
+// statusCodeOfValue resolves a single assignment right-hand side to an HTTP
+// status code: a constant / const-selector (`http.StatusNotFound`, `404`)
+// directly, or a constructor call by taking the first argument that parses as a
+// status literal (`NewError(msg, 404)`). Returns false for a non-constant value
+// (a computed status that can't be pinned).
+func (r *ResponsePatternMatcherImpl) statusCodeOfValue(value *metadata.CallArgument, impl *ContextProviderImpl) (int, bool) {
+	if value == nil {
+		return 0, false
+	}
+	if value.GetKind() == metadata.KindCall {
+		for _, a := range value.Args {
+			if a == nil {
+				continue
+			}
+			if s, ok := r.schemaMapper.MapStatusCode(impl.GetArgumentInfo(a)); ok {
+				return s, true
+			}
+		}
+		return 0, false
+	}
+	return r.schemaMapper.MapStatusCode(impl.GetArgumentInfo(value))
 }
 
 // resolveTypeOrigin traces the origin of a type through assignments and type parameters

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -30,6 +30,12 @@ const (
 	// source of truth is internal/typemodel.
 	TypeSep    = typemodel.Sep
 	defaultSep = "."
+
+	// unresolvedStatus marks a ResponseInfo whose HTTP status could not be
+	// pinned to a concrete code; buildResponses maps any StatusCode < 0 to the
+	// OpenAPI "default" response. Used for the residue of a branched status set
+	// with a non-constant branch (issue #155).
+	unresolvedStatus = -1
 )
 
 // RouteInfo represents extracted route information
@@ -2351,15 +2357,14 @@ func (r *ResponsePatternMatcherImpl) ExtractResponse(node TrackerNodeInterface, 
 	// err)) still produce responses when the branches encode the codes.
 	if r.pattern.StatusFromArg && len(edge.Args) > r.pattern.StatusArgIndex {
 		statusArg := edge.Args[r.pattern.StatusArgIndex]
-		expanded := r.expandStatusesFromIdent(statusArg, edge)
-		residue := false
-		if len(expanded) == 0 {
+		expanded, residue := r.expandStatusesFromIdent(statusArg, edge)
+		if len(expanded) == 0 && !residue {
 			// The status arg wasn't a directly branch-assigned local. It may be
 			// a constructor field (err.Code) whose value was set across branches
 			// then handed to the error constructor — issue #155.
 			expanded, residue = r.statusesFromConstructorField(statusArg, node)
 		}
-		if len(expanded) > 1 || (len(expanded) == 1 && residue) {
+		if len(expanded) > 1 || (len(expanded) >= 1 && residue) {
 			out := make([]*ResponseInfo, 0, len(expanded)+1)
 			for _, st := range expanded {
 				out = append(out, &ResponseInfo{
@@ -2369,10 +2374,12 @@ func (r *ResponsePatternMatcherImpl) ExtractResponse(node TrackerNodeInterface, 
 					Schema:      respInfo.Schema,
 				})
 			}
-			// A non-constant branch keeps an honest `default` for the residue.
+			// A non-constant branch keeps an honest `default`: a fresh
+			// unresolved status (below every real code), never a copy of an
+			// already-resolved concrete status.
 			if residue {
 				out = append(out, &ResponseInfo{
-					StatusCode:  respInfo.StatusCode,
+					StatusCode:  unresolvedStatus,
 					ContentType: respInfo.ContentType,
 					BodyType:    respInfo.BodyType,
 					Schema:      respInfo.Schema,
@@ -2689,7 +2696,7 @@ func findCallEdge(impl *ContextProviderImpl, callerID, calleeFunc, valPos string
 		if e.Caller.ID() != callerID || impl.GetString(e.Callee.Name) != calleeFunc {
 			continue
 		}
-		if valPos != "" && impl.GetString(e.Callee.Position) == valPos {
+		if valPos != "" && impl.GetString(e.Position) == valPos {
 			return e
 		}
 		if first == nil {
@@ -2730,7 +2737,7 @@ func constructorArgForParam(impl *ContextProviderImpl, caller metadata.Call, ass
 			impl.GetString(e.Callee.Pkg) != assign.CalleePkg {
 			continue
 		}
-		if valPos != "" && impl.GetString(e.Callee.Position) == valPos {
+		if valPos != "" && impl.GetString(e.Position) == valPos {
 			chosen = e
 			break
 		}
@@ -2758,20 +2765,19 @@ func constructorArgForParam(impl *ContextProviderImpl, caller metadata.Call, ass
 //   - the caller function or its AssignmentMap can't be located, or
 //   - fewer than two assignments exist (single-branch flows are left
 //     untouched so existing latest-wins behaviour is preserved).
-func (r *ResponsePatternMatcherImpl) expandStatusesFromIdent(arg *metadata.CallArgument, edge *metadata.CallGraphEdge) []int {
+func (r *ResponsePatternMatcherImpl) expandStatusesFromIdent(arg *metadata.CallArgument, edge *metadata.CallGraphEdge) ([]int, bool) {
 	if arg == nil || arg.GetKind() != metadata.KindIdent || edge == nil {
-		return nil
+		return nil, false
 	}
 	impl, ok := r.contextProvider.(*ContextProviderImpl)
 	if !ok || impl.meta == nil {
-		return nil
+		return nil, false
 	}
 	fn := findFunction(impl.meta, impl.GetString(edge.Caller.Pkg), impl.GetString(edge.Caller.Name))
 	if fn == nil {
-		return nil
+		return nil, false
 	}
-	codes, _ := r.expandVarStatuses(arg.GetName(), fn, impl)
-	return codes
+	return r.expandVarStatuses(arg.GetName(), fn, impl)
 }
 
 // expandVarStatuses fans a variable's branch assignments in function fn out to
@@ -2811,13 +2817,23 @@ func (r *ResponsePatternMatcherImpl) statusCodeOfValue(value *metadata.CallArgum
 		return 0, false
 	}
 	if value.GetKind() == metadata.KindCall {
+		// Accept a constructor's status only when EXACTLY ONE argument parses as
+		// a status — otherwise which numeric field is the HTTP status is a guess
+		// (e.g. NewErr(retryAfter, code)), so keep it as an unresolved residue
+		// rather than pick the first. Precise field→parameter resolution for the
+		// multi-status case is handled by statusesFromConstructorField.
+		found, count := 0, 0
 		for _, a := range value.Args {
 			if a == nil {
 				continue
 			}
 			if s, ok := r.schemaMapper.MapStatusCode(impl.GetArgumentInfo(a)); ok {
-				return s, true
+				found = s
+				count++
 			}
+		}
+		if count == 1 {
+			return found, true
 		}
 		return 0, false
 	}

--- a/internal/spec/extractor_sweep_test.go
+++ b/internal/spec/extractor_sweep_test.go
@@ -1110,7 +1110,7 @@ func TestSweepExpandStatusesFromIdent(t *testing.T) {
 		m := NewResponsePatternMatcher(ResponsePattern{}, cfg, NewContextProvider(nil), nil)
 		meta := exSweepMeta()
 		edge := sweepEdge(meta, "h", "app", "JSON", "gin", "", "")
-		if got := m.expandStatusesFromIdent(sweepIdent(meta, "code"), edge); got != nil {
+		if got, _ := m.expandStatusesFromIdent(sweepIdent(meta, "code"), edge); got != nil {
 			t.Errorf("got %v, want nil", got)
 		}
 	})
@@ -1119,7 +1119,7 @@ func TestSweepExpandStatusesFromIdent(t *testing.T) {
 		meta := exSweepMeta()
 		m := NewResponsePatternMatcher(ResponsePattern{}, cfg, NewContextProvider(meta), nil)
 		edge := sweepEdge(meta, "h", "app", "JSON", "gin", "", "")
-		if got := m.expandStatusesFromIdent(sweepIdent(meta, "code"), edge); got != nil {
+		if got, _ := m.expandStatusesFromIdent(sweepIdent(meta, "code"), edge); got != nil {
 			t.Errorf("got %v, want nil", got)
 		}
 	})
@@ -1150,9 +1150,12 @@ func TestSweepExpandStatusesFromIdent(t *testing.T) {
 		}
 		m := NewResponsePatternMatcher(ResponsePattern{}, cfg, NewContextProvider(meta), nil)
 		edge := sweepEdge(meta, "h", "app", "JSON", "gin", "", "")
-		got := m.expandStatusesFromIdent(sweepIdent(meta, "code"), edge)
+		got, residue := m.expandStatusesFromIdent(sweepIdent(meta, "code"), edge)
 		if len(got) != 2 || got[0] != 400 || got[1] != 500 {
 			t.Errorf("got %v, want [400 500]", got)
+		}
+		if !residue {
+			t.Error("a non-constant branch must report a residue")
 		}
 	})
 }

--- a/testdata/branched_status_constructor/go.mod
+++ b/testdata/branched_status_constructor/go.mod
@@ -1,0 +1,3 @@
+module github.com/ehabterra/apispec/testdata/branched_status_constructor
+
+go 1.24.3

--- a/testdata/branched_status_constructor/main.go
+++ b/testdata/branched_status_constructor/main.go
@@ -1,0 +1,80 @@
+// Fixture: a status set across switch/if branches, handed to an error
+// constructor, then written by a shared error helper (issue #155). Previously
+// the status resolved to the branch variable — an ident, not a literal — so the
+// operation got a single `default`. Fanning the variable's branch assignments
+// out recovers the concrete {400, 404, 500}. Covers the inline constructor form,
+// the variable form (e := NewAPIError(...)), and an if-based branch set.
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+)
+
+var (
+	ErrNotFound   = errors.New("not found")
+	ErrValidation = errors.New("validation")
+)
+
+type APIError struct {
+	Message string `json:"message"`
+	Code    int    `json:"-"`
+}
+
+func NewAPIError(msg string, code int) *APIError { return &APIError{Message: msg, Code: code} }
+
+// RespondWithError writes the constructor's Code as the status.
+func RespondWithError(w http.ResponseWriter, e *APIError) {
+	w.WriteHeader(e.Code)
+	_ = json.NewEncoder(w).Encode(e)
+}
+
+// writeError sets the status across switch branches, then hands it to the
+// constructor inline — the shape from issue #155.
+func writeError(w http.ResponseWriter, err error) {
+	var statusCode int
+	switch {
+	case errors.Is(err, ErrNotFound):
+		statusCode = http.StatusNotFound
+	case errors.Is(err, ErrValidation):
+		statusCode = http.StatusBadRequest
+	default:
+		statusCode = http.StatusInternalServerError
+	}
+	RespondWithError(w, NewAPIError(err.Error(), statusCode))
+}
+
+// writeErrorVar is the variable form: e := NewAPIError(...); Respond(w, e).
+func writeErrorVar(w http.ResponseWriter, err error) {
+	var statusCode int
+	if errors.Is(err, ErrNotFound) {
+		statusCode = http.StatusNotFound
+	} else {
+		statusCode = http.StatusInternalServerError
+	}
+	e := NewAPIError(err.Error(), statusCode)
+	RespondWithError(w, e)
+}
+
+// getThing reports every error through writeError, so its concrete error
+// statuses come only from the branch set.
+func getThing(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Query().Get("id") == "" {
+		writeError(w, ErrValidation)
+		return
+	}
+	writeError(w, ErrNotFound)
+}
+
+// getOther reports errors through the variable-form helper.
+func getOther(w http.ResponseWriter, r *http.Request) {
+	writeErrorVar(w, ErrNotFound)
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /thing", getThing)
+	mux.HandleFunc("GET /other", getOther)
+	_ = http.ListenAndServe(":8080", mux)
+}

--- a/testdata/branched_status_constructor/main.go
+++ b/testdata/branched_status_constructor/main.go
@@ -57,6 +57,28 @@ func writeErrorVar(w http.ResponseWriter, err error) {
 	RespondWithError(w, e)
 }
 
+// mapStatus is a non-constant (computed) status — the residue branch.
+func mapStatus(err error) int { return http.StatusServiceUnavailable }
+
+// writeErrorMixed has a constant branch (404) and a computed branch (residue):
+// the concrete 404 must survive, and the residue's honest `default` is emitted
+// then pruned by buildResponses as redundant with 404's body (a shared error
+// helper writes the same body across branches).
+func writeErrorMixed(w http.ResponseWriter, err error) {
+	var statusCode int
+	if errors.Is(err, ErrNotFound) {
+		statusCode = http.StatusNotFound
+	} else {
+		statusCode = mapStatus(err)
+	}
+	RespondWithError(w, NewAPIError(err.Error(), statusCode))
+}
+
+// getMixed reports errors through the mixed (constant + computed) helper.
+func getMixed(w http.ResponseWriter, r *http.Request) {
+	writeErrorMixed(w, ErrNotFound)
+}
+
 // getThing reports every error through writeError, so its concrete error
 // statuses come only from the branch set.
 func getThing(w http.ResponseWriter, r *http.Request) {
@@ -76,5 +98,6 @@ func main() {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /thing", getThing)
 	mux.HandleFunc("GET /other", getOther)
+	mux.HandleFunc("GET /mixed", getMixed)
 	_ = http.ListenAndServe(":8080", mux)
 }


### PR DESCRIPTION
## Summary

Fixes #155. A status set across switch/if branches, handed to an error constructor, then written by a shared error helper, resolved to a single `default` — losing the concrete codes the branches clearly set.

```go
func writeError(w http.ResponseWriter, err error) {
    var statusCode int
    switch {
    case errors.Is(err, ErrNotFound):   statusCode = http.StatusNotFound          // 404
    case errors.Is(err, ErrValidation): statusCode = http.StatusBadRequest        // 400
    default:                            statusCode = http.StatusInternalServerError // 500
    }
    RespondWithError(w, NewAPIError(err.Error(), statusCode)) // w.WriteHeader(err.Code)
}
// before: responses = { default }
// after:  responses = { 400, 404, 500 }
```

## How

- **`expandVarStatuses`** fans a variable's branch assignments out to the set of status codes, now handling **direct constants** (`statusCode = http.StatusNotFound`) in addition to the existing constructor-call form (`err = NewError(msg, 404)`). A non-constant branch (a computed status) marks a **residue** so an honest `default` is kept alongside the concrete codes.
- **`statusesFromConstructorField`** resolves the `WriteHeader` status argument (`err.Code`) *through the error constructor* — both **inline** (`Respond(w, NewErr(...))`) and **variable** (`e := NewErr(...); Respond(w, e)`) forms — to the branch variable, then expands it.
- Wired into `ExtractResponse`'s existing one→many response loop (from #39).

## Scope (honest boundary)

This handles the issue's shape: the **switch and the constructor live in the same function**. A status that is a struct **field** branch-assigned *inside a different returning function* — `api := MapError(err); http.Error(w, api.Message, api.Status)`, where `MapError` holds the switch — is a **distinct, harder pattern** (cross-function field-branch resolution) and is **left for a follow-up**. Verified it's correctly unchanged.

## Tests

- `testdata/branched_status_constructor/` — inline + variable forms; asserts `/thing` = {400,404,500} with no `default`, `/other` = {404,500}.
- Unit tests for `expandVarStatuses` (constants, residue, single-assignment no-fan-out) and `statusCodeOfValue` (constant / constructor-call / non-constant).

## Verification

Full `go test ./...` passes with **zero output drift** (the #39 `conditional_status` fixture still passes — the shared `expandStatusesFromIdent` change only adds constant handling); `gofmt`, `go vet`, `golangci-lint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved response-spec generation when error status codes vary by branch, including correct fan-out to concrete HTTP statuses.
  * Ensured a truthful `default` slot is preserved when some branches can’t be determined statically.
  * Enhanced extraction to expand selector/constructor-based status fields and track residue for non-constant assignments.
* **Tests**
  * Added unit coverage for constant, dynamic, and constructor-field status-code resolution, including edge-selection and guard behavior.
  * Updated sweep tests for new residue-aware expansion behavior.
  * Added fixture-based generator validation to confirm no unresolved placeholders remain and that branches resolve as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->