### PR TITLE
refactor(spec): consolidate call-site assignment lookups (#182)

### DIFF
--- a/internal/spec/branched_status_constructor_test.go
+++ b/internal/spec/branched_status_constructor_test.go
@@ -274,3 +274,44 @@ func TestConstructorFieldParam(t *testing.T) {
 		t.Errorf(`non-composite return should yield "", got %q`, got)
 	}
 }
+
+// TestAssignmentLookups covers the two canonical assignment entry points and the
+// scope difference between them (issue #182): assignmentsAt / latestAssignment
+// consult the call edge first then the enclosing function; latestCallerAssignment
+// resolves the enclosing-function scope only and ignores the edge's own map.
+func TestAssignmentLookups(t *testing.T) {
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	impl := NewContextProvider(meta)
+
+	rhs := httpStatusSelector(meta, "StatusOK")
+	edge := &metadata.CallGraphEdge{
+		Caller:        metadata.Call{Name: meta.StringPool.Get("h"), Pkg: meta.StringPool.Get("app")},
+		AssignmentMap: map[string][]metadata.Assignment{"x": {{Value: rhs}}},
+	}
+
+	// Edge-map hit: no enclosing-function fallback needed.
+	if got := assignmentsAt(impl, edge, "x"); len(got) != 1 {
+		t.Fatalf("edge-map hit: got %d assignments, want 1", len(got))
+	}
+	// Guards.
+	if assignmentsAt(impl, nil, "x") != nil {
+		t.Error("nil edge must yield nil")
+	}
+	if assignmentsAt(impl, edge, "") != nil {
+		t.Error("empty name must yield nil")
+	}
+	// Unknown var with no enclosing function registered -> nil.
+	if assignmentsAt(impl, edge, "missing") != nil {
+		t.Error("unknown var with no function scope must yield nil")
+	}
+	// latestAssignment returns the latest RHS of the edge assignment.
+	if la := latestAssignment(impl, edge, "x"); la == nil || la.GetKind() != metadata.KindSelector {
+		t.Errorf("latestAssignment should return the selector RHS, got %v", la)
+	}
+	// latestCallerAssignment is function-scope only: it ignores the edge's own
+	// map, so with no enclosing function it reports ok=false even though the edge
+	// records `x`.
+	if _, ok := latestCallerAssignment(impl, edge, "x"); ok {
+		t.Error("function-scope lookup must ignore the edge map (ok=false)")
+	}
+}

--- a/internal/spec/branched_status_constructor_test.go
+++ b/internal/spec/branched_status_constructor_test.go
@@ -284,9 +284,17 @@ func TestAssignmentLookups(t *testing.T) {
 	impl := NewContextProvider(meta)
 
 	rhs := httpStatusSelector(meta, "StatusOK")
+	// Unused pooled int fields must be -1, not the zero value: index 0 is a valid
+	// interned string ("http" here), so a zero Position/Scope would resolve to it.
 	edge := &metadata.CallGraphEdge{
-		Caller:        metadata.Call{Name: meta.StringPool.Get("h"), Pkg: meta.StringPool.Get("app")},
-		AssignmentMap: map[string][]metadata.Assignment{"x": {{Value: rhs}}},
+		Caller: metadata.Call{
+			Name: meta.StringPool.Get("h"), Pkg: meta.StringPool.Get("app"),
+			Position: -1, RecvType: -1, Scope: -1, SignatureStr: -1,
+		},
+		AssignmentMap: map[string][]metadata.Assignment{"x": {{
+			Value:        rhs,
+			VariableName: -1, Pkg: -1, ConcreteType: -1, Position: -1, Scope: -1, Func: -1,
+		}}},
 	}
 
 	// Edge-map hit: no enclosing-function fallback needed.

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -1845,28 +1845,58 @@ func callerAssignmentMap(impl *ContextProviderImpl, edge *metadata.CallGraphEdge
 	return methodAssignmentMap(impl.meta, impl.GetString(pf.Pkg), impl.GetString(pf.RecvType), impl.GetString(pf.Name), varName)
 }
 
-// latestAssignment returns the right-hand side of the most recent assignment to
-// the variable `name` visible at the given call site — the Decode/Encode call
-// edge's own AssignmentMap first, then the enclosing handler function's scope
-// (via callerAssignmentMap) for a variable assigned in the handler body rather
-// than at the call edge. Returns nil when there is no such assignment.
+// latestCallerAssignment returns the most recent assignment to `name` in the
+// enclosing function's scope at the given edge (via callerAssignmentMap), and
+// whether one exists. It is the function-scope counterpart of latestAssignment:
+// the constructor-field status resolvers deliberately resolve the error variable
+// in the handler-body scope only and never consult the edge's own AssignmentMap.
+// Widening them to the edge-first assignmentsAt resolves additional real-project
+// statuses but is a behavior change, tracked separately (issue #182 follow-up).
+func latestCallerAssignment(impl *ContextProviderImpl, edge *metadata.CallGraphEdge, name string) (metadata.Assignment, bool) {
+	am := callerAssignmentMap(impl, edge, name)
+	if am == nil {
+		return metadata.Assignment{}, false
+	}
+	as := am[name]
+	if len(as) == 0 {
+		return metadata.Assignment{}, false
+	}
+	return as[len(as)-1], true
+}
+
+// assignmentsAt returns the assignments to the variable `name` visible at the
+// given call site: the call edge's own AssignmentMap first, then the enclosing
+// function's scope (via callerAssignmentMap) for a variable assigned in the
+// handler body rather than at the edge. The edge map and the function scope
+// record the same assignment for a given variable, so consulting the edge first
+// is a fast path, not a different answer.
 //
-// This is the shared variable-assignment lookup used by both the request-body
-// source resolver (src := r.Body) and the response-destination resolver
-// (dst := w, lw := &loggingWriter{w}); see issue #182 for consolidating it with
-// the other variable-resolution mechanisms.
-func latestAssignment(cp ContextProvider, edge *metadata.CallGraphEdge, name string) *metadata.CallArgument {
+// This is the one canonical call-site assignment lookup (issue #182): the
+// request-body / response-destination resolvers reach it via latestAssignment
+// (latest RHS), and the constructor-field status resolvers consume the full
+// Assignment (CalleeFunc / position) directly. Returns nil when there is none.
+func assignmentsAt(cp ContextProvider, edge *metadata.CallGraphEdge, name string) []metadata.Assignment {
 	if name == "" || edge == nil {
 		return nil
 	}
-	assigns := edge.AssignmentMap[name]
-	if len(assigns) == 0 {
-		if impl, ok := cp.(*ContextProviderImpl); ok {
-			if am := callerAssignmentMap(impl, edge, name); am != nil {
-				assigns = am[name]
-			}
+	if assigns := edge.AssignmentMap[name]; len(assigns) > 0 {
+		return assigns
+	}
+	if impl, ok := cp.(*ContextProviderImpl); ok {
+		if am := callerAssignmentMap(impl, edge, name); am != nil {
+			return am[name]
 		}
 	}
+	return nil
+}
+
+// latestAssignment returns the right-hand side of the most recent assignment to
+// the variable `name` visible at the given call site (see assignmentsAt for the
+// scope). Returns nil when there is no such assignment. Used by the request-body
+// source resolver (src := r.Body) and the response-destination resolver
+// (dst := w, lw := &loggingWriter{w}).
+func latestAssignment(cp ContextProvider, edge *metadata.CallGraphEdge, name string) *metadata.CallArgument {
+	assigns := assignmentsAt(cp, edge, name)
 	if len(assigns) == 0 {
 		return nil
 	}
@@ -2545,16 +2575,8 @@ func (r *ResponsePatternMatcherImpl) statusFromConstructorField(arg *metadata.Ca
 	}
 
 	// 2. That local's latest assignment, which must come from a constructor call.
-	assignMap := callerAssignmentMap(impl, callerEdge, baseVar.GetName())
-	if assignMap == nil {
-		return 0, false
-	}
-	assigns, ok := assignMap[baseVar.GetName()]
-	if !ok || len(assigns) == 0 {
-		return 0, false
-	}
-	assign := assigns[len(assigns)-1]
-	if assign.Value.GetKind() != metadata.KindCall || assign.CalleeFunc == "" {
+	assign, ok := latestCallerAssignment(impl, callerEdge, baseVar.GetName())
+	if !ok || assign.Value.GetKind() != metadata.KindCall || assign.CalleeFunc == "" {
 		return 0, false
 	}
 
@@ -2648,16 +2670,12 @@ func (r *ResponsePatternMatcherImpl) statusesFromConstructorField(arg *metadata.
 		calleeFunc = base.Fun.GetName()
 		valPos = impl.GetString(base.Position)
 	case metadata.KindIdent:
-		assignMap := callerAssignmentMap(impl, baseNode.GetEdge(), base.GetName())
-		if assignMap == nil {
+		assign, ok := latestCallerAssignment(impl, baseNode.GetEdge(), base.GetName())
+		if !ok || assign.Value.GetKind() != metadata.KindCall {
 			return nil, false
 		}
-		as := assignMap[base.GetName()]
-		if len(as) == 0 || as[len(as)-1].Value.GetKind() != metadata.KindCall {
-			return nil, false
-		}
-		calleeFunc = as[len(as)-1].CalleeFunc
-		valPos = impl.GetString(as[len(as)-1].Value.Position)
+		calleeFunc = assign.CalleeFunc
+		valPos = impl.GetString(assign.Value.Position)
 	default:
 		return nil, false
 	}


### PR DESCRIPTION
Closes the first, zero-drift half of #182.

## What

The spec layer resolved "where was this variable assigned at this call site?" through hand-rolled combinations of `edge.AssignmentMap[name]`, `callerAssignmentMap`, and inline latest-element picks. This consolidates them into **two clearly-layered canonical entry points**, one per scope:

| Scope | Map primitive | Latest-wins convenience | Callers |
|---|---|---|---|
| Call-site (edge map → enclosing function) | `assignmentsAt` | `latestAssignment` (latest RHS) | request-body source, response-destination resolvers |
| Function scope only | `callerAssignmentMap` | `latestCallerAssignment` (latest `Assignment`) | constructor-field status resolvers |

`statusFromConstructorField` / `statusesFromConstructorField` no longer hand-roll `callerAssignmentMap(...)[name]` + last-element — both call `latestCallerAssignment`.

## Zero drift

This is a **pure refactor**. The constructor resolvers keep their exact function-only scope. Verified by A/B **byte-diff of generated specs** across every `testdata/` fixture **and** all configured real projects — identical output. Full suite + determinism + metadata goldens + `-race` pass unchanged. Coverage stays at the 96% floor (added `TestAssignmentLookups` + the earlier `TestFindCallEdge` / guard tests).

## Deliberately deferred

Widening the constructor resolvers from function-only to the edge-first `assignmentsAt` **is** a behavior change: it resolves additional real error responses (concrete `4xx` where they were previously missed) on real projects. Per the zero-drift-refactor rule that lands separately, with fixture coverage — tracked as #189.

## Scope note

#182 also names a fourth resolver family (return/field/constructor-arg: `constructorFieldParam`, `constructorArgForParam`, `findCallEdge`). Those are already layered on these assignment primitives via #155; this PR consolidates the assignment layer they sit on. Deeper unification of that family can follow once the edge-first widening lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request and response type inference for variables assigned at call sites.
  * Improved response status detection for constructor and field assignments, including local variables.
  * Assignment lookups now consistently recognize the most recent applicable value and safely handle missing or unknown variables.

* **Tests**
  * Added coverage for assignment lookup behavior, fallback handling, and constructor-related status inference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
