### PR TITLE
fix(spec): resolve constructor-field status via edge-first lookup (#189)

### DIFF
--- a/internal/spec/branched_status_constructor_test.go
+++ b/internal/spec/branched_status_constructor_test.go
@@ -312,14 +312,109 @@ func TestAssignmentLookups(t *testing.T) {
 	if assignmentsAt(impl, edge, "missing") != nil {
 		t.Error("unknown var with no function scope must yield nil")
 	}
-	// latestAssignment returns the latest RHS of the edge assignment.
+	// latestAssignment returns the latest RHS of the edge assignment. The
+	// edge-first lookup recovers an assignment recorded only on the call edge —
+	// the case #189 relies on to resolve constructor-field statuses for error
+	// variables assigned inside returned handler closures.
 	if la := latestAssignment(impl, edge, "x"); la == nil || la.GetKind() != metadata.KindSelector {
 		t.Errorf("latestAssignment should return the selector RHS, got %v", la)
 	}
-	// latestCallerAssignment is function-scope only: it ignores the edge's own
-	// map, so with no enclosing function it reports ok=false even though the edge
-	// records `x`.
-	if _, ok := latestCallerAssignment(impl, edge, "x"); ok {
-		t.Error("function-scope lookup must ignore the edge map (ok=false)")
+}
+
+// TestStatusesFromConstructorField_EdgeOnlyAssignment proves the #189 behavior at
+// the layer it changed: when the error variable's `e := NewAPIError(...)`
+// assignment is recorded only on the call edge — as it is for a variable
+// assigned inside a returned handler closure, where function-scope lookup
+// (findFunctionByName / ParentFunction) cannot reach it — the edge-first
+// assignmentsAt lookup still resolves the constructor-field status through to the
+// branch set. The pre-#189 function-scope-only path missed it (the operation lost
+// its concrete error statuses); this is the minimal isolation of the real-project
+// gain, which a synthetic full-pipeline fixture cannot reproduce because clean
+// code keeps the closure's locals on the enclosing method's scope.
+func TestStatusesFromConstructorField_EdgeOnlyAssignment(t *testing.T) {
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+
+	// Scope function app.handler records the branch variable `statusCode` (set
+	// across three branches) but NOT the error variable `e` — `e` lives only on
+	// the call edge below, so function-scope resolution alone would miss it.
+	asg := func(v metadata.CallArgument) metadata.Assignment {
+		return metadata.Assignment{Value: v, VariableName: -1, Pkg: -1, ConcreteType: -1, Position: -1, Scope: -1, Func: -1}
+	}
+	handlerFn := &metadata.Function{AssignmentMap: map[string][]metadata.Assignment{
+		"statusCode": {
+			asg(httpStatusSelector(meta, "StatusNotFound")),
+			asg(httpStatusSelector(meta, "StatusBadRequest")),
+			asg(httpStatusSelector(meta, "StatusInternalServerError")),
+		},
+	}}
+
+	// Constructor app.NewAPIError returning &APIError{Message: message, Code: code}.
+	kv := func(field, param string) *metadata.CallArgument {
+		e := metadata.NewCallArgument(meta)
+		e.SetKind(metadata.KindKeyValue)
+		key := mkIdent(meta, field, "")
+		val := mkIdent(meta, param, "")
+		e.X, e.Fun = key, val
+		return e
+	}
+	lit := metadata.NewCallArgument(meta)
+	lit.SetKind(metadata.KindCompositeLit)
+	lit.Args = []*metadata.CallArgument{kv("Message", "message"), kv("Code", "code")}
+	addr := metadata.NewCallArgument(meta)
+	addr.SetKind(metadata.KindUnary)
+	addr.X = lit
+	ctorFn := &metadata.Function{ReturnVars: []metadata.CallArgument{*addr}}
+
+	meta.Packages = map[string]*metadata.Package{
+		"app": {Files: map[string]*metadata.File{
+			"f": {Functions: map[string]*metadata.Function{"handler": handlerFn, "NewAPIError": ctorFn}},
+		}},
+	}
+
+	caller := metadata.Call{
+		Name: meta.StringPool.Get("handler"), Pkg: meta.StringPool.Get("app"),
+		Position: -1, RecvType: -1, Scope: -1, SignatureStr: -1,
+	}
+
+	// The NewAPIError call, recorded as `e`'s edge-only assignment RHS.
+	ctorCall := metadata.NewCallArgument(meta)
+	ctorCall.SetKind(metadata.KindCall)
+	ctorCall.Fun = mkIdent(meta, "NewAPIError", "")
+	ctorCall.Position = meta.StringPool.Get("callpos")
+
+	baseEdge := &metadata.CallGraphEdge{
+		Caller: caller,
+		AssignmentMap: map[string][]metadata.Assignment{
+			"e": {{Value: *ctorCall, CalleeFunc: "NewAPIError", CalleePkg: "app",
+				VariableName: -1, Pkg: -1, ConcreteType: -1, Position: -1, Scope: -1, Func: -1}},
+		},
+	}
+	node := &fakeNode{edge: baseEdge}
+
+	// The constructor call edge binds parameter `code` to the branch variable.
+	meta.CallGraph = []metadata.CallGraphEdge{{
+		Caller: caller,
+		Callee: metadata.Call{
+			Name: meta.StringPool.Get("NewAPIError"), Pkg: meta.StringPool.Get("app"),
+			Position: -1, RecvType: -1, Scope: -1, SignatureStr: -1,
+		},
+		Position:    meta.StringPool.Get("callpos"),
+		ParamArgMap: map[string]metadata.CallArgument{"code": *mkIdent(meta, "statusCode", "")},
+	}}
+
+	// arg = e.Code
+	arg := metadata.NewCallArgument(meta)
+	arg.SetKind(metadata.KindSelector)
+	arg.X = mkIdent(meta, "e", "")
+	arg.Sel = mkIdent(meta, "Code", "")
+
+	m := branchStatusMatcher(meta)
+	codes, residue := m.statusesFromConstructorField(arg, node)
+	sort.Ints(codes)
+	if want := []int{400, 404, 500}; len(codes) != 3 || codes[0] != want[0] || codes[1] != want[1] || codes[2] != want[2] {
+		t.Errorf("edge-only assignment must still resolve the branch set: codes = %v, want %v", codes, want)
+	}
+	if residue {
+		t.Error("all-constant branches must not report a residue")
 	}
 }

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -1845,25 +1845,6 @@ func callerAssignmentMap(impl *ContextProviderImpl, edge *metadata.CallGraphEdge
 	return methodAssignmentMap(impl.meta, impl.GetString(pf.Pkg), impl.GetString(pf.RecvType), impl.GetString(pf.Name), varName)
 }
 
-// latestCallerAssignment returns the most recent assignment to `name` in the
-// enclosing function's scope at the given edge (via callerAssignmentMap), and
-// whether one exists. It is the function-scope counterpart of latestAssignment:
-// the constructor-field status resolvers deliberately resolve the error variable
-// in the handler-body scope only and never consult the edge's own AssignmentMap.
-// Widening them to the edge-first assignmentsAt resolves additional real-project
-// statuses but is a behavior change, tracked separately (issue #182 follow-up).
-func latestCallerAssignment(impl *ContextProviderImpl, edge *metadata.CallGraphEdge, name string) (metadata.Assignment, bool) {
-	am := callerAssignmentMap(impl, edge, name)
-	if am == nil {
-		return metadata.Assignment{}, false
-	}
-	as := am[name]
-	if len(as) == 0 {
-		return metadata.Assignment{}, false
-	}
-	return as[len(as)-1], true
-}
-
 // assignmentsAt returns the assignments to the variable `name` visible at the
 // given call site: the call edge's own AssignmentMap first, then the enclosing
 // function's scope (via callerAssignmentMap) for a variable assigned in the
@@ -2575,8 +2556,15 @@ func (r *ResponsePatternMatcherImpl) statusFromConstructorField(arg *metadata.Ca
 	}
 
 	// 2. That local's latest assignment, which must come from a constructor call.
-	assign, ok := latestCallerAssignment(impl, callerEdge, baseVar.GetName())
-	if !ok || assign.Value.GetKind() != metadata.KindCall || assign.CalleeFunc == "" {
+	//    Edge-first (assignmentsAt): the error variable may be assigned inside a
+	//    returned handler closure, where its assignment is recorded on the call
+	//    edge rather than a name-resolvable declared function's scope (#189).
+	assigns := assignmentsAt(impl, callerEdge, baseVar.GetName())
+	if len(assigns) == 0 {
+		return 0, false
+	}
+	assign := assigns[len(assigns)-1]
+	if assign.Value.GetKind() != metadata.KindCall || assign.CalleeFunc == "" {
 		return 0, false
 	}
 
@@ -2670,12 +2658,15 @@ func (r *ResponsePatternMatcherImpl) statusesFromConstructorField(arg *metadata.
 		calleeFunc = base.Fun.GetName()
 		valPos = impl.GetString(base.Position)
 	case metadata.KindIdent:
-		assign, ok := latestCallerAssignment(impl, baseNode.GetEdge(), base.GetName())
-		if !ok || assign.Value.GetKind() != metadata.KindCall {
+		// Edge-first (assignmentsAt): the error variable may be assigned inside a
+		// returned handler closure, where the assignment is recorded on the call
+		// edge rather than a name-resolvable declared function's scope (#189).
+		as := assignmentsAt(impl, baseNode.GetEdge(), base.GetName())
+		if len(as) == 0 || as[len(as)-1].Value.GetKind() != metadata.KindCall {
 			return nil, false
 		}
-		calleeFunc = assign.CalleeFunc
-		valPos = impl.GetString(assign.Value.Position)
+		calleeFunc = as[len(as)-1].CalleeFunc
+		valPos = impl.GetString(as[len(as)-1].Value.Position)
 	default:
 		return nil, false
 	}


### PR DESCRIPTION
Closes #189. Builds on the `assignmentsAt` primitive from #188 (merged).

## Problem

The constructor-field status resolvers resolved the error variable through **function scope only**. When the error variable is assigned inside a **returned handler closure** — the chi handler-factory shape —

```go
func (h *handler) Login(...) func(w http.ResponseWriter, r *http.Request) {
    return func(w http.ResponseWriter, r *http.Request) {
        lmdError := common.NewLmdError("...", http.StatusBadRequest)
        common.RespondWithError(w, lmdError) // w.WriteHeader(err.Code)
        return
    }
}
```

the `lmdError := NewLmdError(...)` assignment is recorded on the **call edge**, not on any name-resolvable declared function's scope, so function-scope lookup missed it and the operation **lost its concrete error status**.

## Fix

Switch both `statusFromConstructorField` / `statusesFromConstructorField` to the edge-first `assignmentsAt` lookup (edge map → then enclosing function) from #188, and remove the now-unused function-only helper `latestCallerAssignment`.

## Purely additive — verified

A/B byte-diff of generated specs across **all** configured real projects and **every** testdata fixture:

| | added | removed | changed |
|---|---|---|---|
| one real project | **+32** concrete 4xx | 0 | 0 |
| all other projects | 0 | 0 | 0 |
| all testdata fixtures | 0 | 0 | 0 |

It only ever *gains* correct error responses — never removes or changes one.

## Test coverage

Guarded by a **metadata-level unit test** (`TestStatusesFromConstructorField_EdgeOnlyAssignment`) that drives the resolver with an assignment recorded **only on the call edge** (function scope empty) — the exact case #189 fixes and the pre-#189 path could not resolve. The existing `branched_status_constructor` fixture already exercises the same `KindIdent` code path end-to-end.

**Why no new testdata fixture:** I built and tested ten structurally-faithful synthetic fixtures (chi, cross-package, handler-factory method, generics, multi-branch error vars). All resolve identically under both scopes — in clean synthetic code the enclosing method's scope keeps the closure's locals, so `methodAssignmentMap` succeeds and there is no gap to observe. The miss only manifests under real-project graph complexity, so the metadata unit test (which isolates the precise condition) is the reliable guard, backed by the additive-only real-project A/B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP status detection when error values are assigned within returned handler closures.
  * Correctly resolves status codes, including multiple branch-specific values such as 400, 404, and 500.
  * Preserves accurate handling when status assignments are ambiguous or unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->