### PR TITLE
feat: resolve response status through an error mapper's struct field (#187, #192)

### DIFF
--- a/generator/testdata_mapper_field_status_test.go
+++ b/generator/testdata_mapper_field_status_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/ehabterra/apispec/spec"
+)
+
+// TestTestdata_MapperFieldStatus covers issue #187: the status handed to
+// http.Error is a struct field (api.Status) whose value is set across the return
+// branches of an error mapper (api := MapError(err)). It must resolve to the
+// concrete branch statuses {400, 404, 500} — recursing through the per-status
+// helper mappers and reading positional struct literals — not a bare default.
+func TestTestdata_MapperFieldStatus(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "mapper_field_status", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+	noUnresolvedPlaceholders(t, out)
+
+	get := opFor(out.Paths["/thing"], "GET")
+	if get == nil {
+		t.Fatalf("GET /thing missing; have %v", mapPathKeys(out.Paths))
+	}
+	got := keysOf(get.Responses)
+	sort.Strings(got)
+	for _, want := range []string{"400", "404", "500"} {
+		if _, ok := get.Responses[want]; !ok {
+			t.Errorf("GET /thing missing status %s; have %v", want, got)
+		}
+	}
+	if _, ok := get.Responses["default"]; ok {
+		t.Errorf("GET /thing still has an unresolved default; the mapper statuses should be concrete; have %v", got)
+	}
+}

--- a/generator/testdata_mapper_field_status_test.go
+++ b/generator/testdata_mapper_field_status_test.go
@@ -37,6 +37,11 @@ func TestTestdata_MapperFieldStatus(t *testing.T) {
 	}
 	got := keysOf(get.Responses)
 	sort.Strings(got)
+	// The mapper resolves to exactly {400, 404, 500}; any extra status (or a
+	// spurious success code) is a regression.
+	if len(got) != 3 {
+		t.Fatalf("GET /thing responses = %v, want exactly [400 404 500]", got)
+	}
 	for _, want := range []string{"400", "404", "500"} {
 		if _, ok := get.Responses[want]; !ok {
 			t.Errorf("GET /thing missing status %s; have %v", want, got)

--- a/internal/metadata/extract_returns_test.go
+++ b/internal/metadata/extract_returns_test.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"go/ast"
+	"testing"
+)
+
+// TestExtractReturns_SkipsNestedClosures guards against a nested func literal's
+// return statements leaking into the enclosing function's Returns (which would
+// then pollute status extraction over that function). The handler-factory shape
+// — a function returning a closure that has its own internal returns — is the
+// canonical case.
+func TestExtractReturns_SkipsNestedClosures(t *testing.T) {
+	src := `package p
+type E struct{ Code int }
+func Factory() func() E {
+	return func() E {
+		if false {
+			return E{Code: 400}
+		}
+		return E{Code: 404}
+	}
+}`
+	file, info, fset := sweepTypeCheck(t, src)
+	meta := &Metadata{StringPool: NewStringPool()}
+
+	var body *ast.BlockStmt
+	for _, d := range file.Decls {
+		if fn, ok := d.(*ast.FuncDecl); ok && fn.Name.Name == "Factory" {
+			body = fn.Body
+		}
+	}
+	if body == nil {
+		t.Fatal("Factory declaration not found")
+	}
+
+	_, allReturns := extractReturns(body, info, "p", fset, meta)
+
+	// Factory has exactly one return of its own — `return func() E {…}`. The two
+	// returns inside the closure must NOT be recorded here.
+	if len(allReturns) != 1 {
+		t.Fatalf("Factory.Returns = %d entries, want 1; the nested closure's returns leaked", len(allReturns))
+	}
+	// And that single return is the func literal, never the closure's `E{…}`.
+	if len(allReturns[0]) != 1 || allReturns[0][0].GetKind() == KindCompositeLit {
+		t.Errorf("Factory's return should be the func literal, not a struct composite from the closure body")
+	}
+}

--- a/internal/metadata/io.go
+++ b/internal/metadata/io.go
@@ -179,6 +179,11 @@ func setupMetadataReferences(metadata *Metadata) {
 				for j := range fn.ReturnVars {
 					setCallArgumentMeta(&fn.ReturnVars[j], metadata)
 				}
+				for k := range fn.Returns {
+					for j := range fn.Returns[k] {
+						setCallArgumentMeta(&fn.Returns[k][j], metadata)
+					}
+				}
 
 				file.Functions[funcName] = fn
 			}
@@ -192,6 +197,11 @@ func setupMetadataReferences(metadata *Metadata) {
 
 					for j := range method.ReturnVars {
 						setCallArgumentMeta(&method.ReturnVars[j], metadata)
+					}
+					for k := range method.Returns {
+						for j := range method.Returns[k] {
+							setCallArgumentMeta(&method.Returns[k][j], metadata)
+						}
 					}
 					for varName, assignments := range method.AssignmentMap {
 						for j := range assignments {

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -1464,6 +1464,12 @@ func extractReturns(body *ast.BlockStmt, info *types.Info, pkgName string, fset 
 	}
 	maxReturnCount := 0
 	ast.Inspect(body, func(n ast.Node) bool {
+		// Don't descend into nested closures: a func literal's return statements
+		// belong to that closure, not the enclosing function, and would otherwise
+		// pollute this function's Returns (and status extraction over them).
+		if _, ok := n.(*ast.FuncLit); ok {
+			return false
+		}
 		ret, ok := n.(*ast.ReturnStmt)
 		if !ok || len(ret.Results) == 0 {
 			return true

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -291,29 +291,8 @@ func GenerateMetadataWithLogger(pkgs map[string]map[string]*ast.File, fileToInfo
 					}
 				}
 
-				// Extract return value origins
-				var returnVars []CallArgument
-				var maxReturnCount int
-
-				if fn.Body != nil {
-					ast.Inspect(fn.Body, func(n ast.Node) bool {
-						ret, ok := n.(*ast.ReturnStmt)
-						if !ok {
-							return true
-						}
-
-						// Track the maximum number of return values seen
-						if len(ret.Results) > maxReturnCount {
-							maxReturnCount = len(ret.Results)
-							returnVars = nil // Clear and rebuild with the most complete return
-							for _, expr := range ret.Results {
-								returnVars = append(returnVars, *ExprToCallArgument(expr, info, pkgName, fset, metadata))
-							}
-						}
-
-						return true // Continue traversal to see all returns
-					})
-				}
+				// Extract return value origins (#192: all returns + max-arity)
+				returnVars, allReturns := extractReturns(fn.Body, info, pkgName, fset, metadata)
 
 				// Use funcMap to get callee function declaration
 				var assignmentsInFunc = make(map[string][]Assignment)
@@ -340,6 +319,7 @@ func GenerateMetadataWithLogger(pkgs map[string]map[string]*ast.File, fileToInfo
 					AssignmentMap: assignmentsInFunc,
 					TypeParams:    typeParams,
 					ReturnVars:    returnVars,
+					Returns:       allReturns,
 					Filename:      metadata.StringPool.Get(fileName),
 				}
 				m.SignatureStr = metadata.StringPool.Get(CallArgToString(&m.Signature))
@@ -1168,29 +1148,8 @@ func processFunctions(file *ast.File, info *types.Info, pkgName string, fset *to
 			}
 		}
 
-		// Extract return value origins
-		var returnVars []CallArgument
-		var maxReturnCount int
-
-		if fn.Body != nil {
-			ast.Inspect(fn.Body, func(n ast.Node) bool {
-				ret, ok := n.(*ast.ReturnStmt)
-				if !ok {
-					return true
-				}
-
-				// Track the maximum number of return values seen
-				if len(ret.Results) > maxReturnCount {
-					maxReturnCount = len(ret.Results)
-					returnVars = nil // Clear and rebuild with the most complete return
-					for _, expr := range ret.Results {
-						returnVars = append(returnVars, *ExprToCallArgument(expr, info, pkgName, fset, metadata))
-					}
-				}
-
-				return true // Continue traversal to see all returns
-			})
-		}
+		// Extract return value origins (#192: all returns + max-arity)
+		returnVars, allReturns := extractReturns(fn.Body, info, pkgName, fset, metadata)
 
 		// Use funcMap to get callee function declaration
 		var assignmentsInFunc = make(map[string][]Assignment)
@@ -1246,6 +1205,7 @@ func processFunctions(file *ast.File, info *types.Info, pkgName string, fset *to
 			Comments:       metadata.StringPool.Get(comments),
 			TypeParams:     typeParams,
 			ReturnVars:     returnVars,
+			Returns:        allReturns,
 			AssignmentMap:  assignmentsInFunc,
 			MethodDispatch: detectMethodDispatch(fn.Body, info, fset),
 		}
@@ -1490,6 +1450,40 @@ func processImports(file *ast.File, metadata *Metadata, f *File) {
 }
 
 // buildCallGraph builds the call graph for all files in a package
+// extractReturns walks a function or method body and returns both:
+//   - returnVars: the values of the greatest-arity return statement (kept for
+//     callers that resolve a returned value by index), and
+//   - allReturns: every explicit return statement's values in source order, so a
+//     function with several returns (e.g. an error mapper whose branches each
+//     return a differently-statused struct) can have each return's fields
+//     enumerated (#192, unblocks #187). Naked returns (no explicit results) are
+//     skipped — they carry no expression to resolve.
+func extractReturns(body *ast.BlockStmt, info *types.Info, pkgName string, fset *token.FileSet, metadata *Metadata) (returnVars []CallArgument, allReturns [][]CallArgument) {
+	if body == nil {
+		return nil, nil
+	}
+	maxReturnCount := 0
+	ast.Inspect(body, func(n ast.Node) bool {
+		ret, ok := n.(*ast.ReturnStmt)
+		if !ok || len(ret.Results) == 0 {
+			return true
+		}
+		vals := make([]CallArgument, len(ret.Results))
+		for i, expr := range ret.Results {
+			vals[i] = *ExprToCallArgument(expr, info, pkgName, fset, metadata)
+		}
+		allReturns = append(allReturns, vals)
+		// The first return of the greatest arity wins ReturnVars, matching the
+		// prior behavior (strictly-greater comparison, no override on ties).
+		if len(ret.Results) > maxReturnCount {
+			maxReturnCount = len(ret.Results)
+			returnVars = append([]CallArgument(nil), vals...)
+		}
+		return true
+	})
+	return returnVars, allReturns
+}
+
 func buildCallGraph(files map[string]*ast.File, pkgs map[string]map[string]*ast.File, pkgName string, fileToInfo map[*ast.File]*types.Info, fset *token.FileSet, funcMap map[string]*ast.FuncDecl, metadata *Metadata) {
 	// Stable file order within the package (files is a map) so call-graph edge
 	// order is deterministic across runs.

--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -442,8 +442,14 @@ type Method struct {
 	// Type parameter names for generics
 	TypeParams []string `yaml:"type_params,omitempty"`
 
-	// Return value origins for tracing through return values
-	ReturnVars []CallArgument `yaml:"return_vars,omitempty"`
+	// Return value origins for tracing through return values. ReturnVars holds
+	// only the greatest-arity return statement (for resolving a returned value by
+	// index); Returns holds EVERY explicit return statement's values in source
+	// order, so a function with several returns (e.g. an error mapper whose
+	// branches each return a differently-statused struct) can have each return's
+	// fields enumerated. See #192.
+	ReturnVars []CallArgument   `yaml:"return_vars,omitempty"`
+	Returns    [][]CallArgument `yaml:"returns,omitempty"`
 
 	// map of variable name to all assignments (for alias/reassignment tracking)
 	AssignmentMap map[string][]Assignment `yaml:"assignments,omitempty"`
@@ -463,8 +469,14 @@ type Function struct {
 	// Type parameter names for generics
 	TypeParams []string `yaml:"type_params,omitempty"`
 
-	// Return value origins for tracing through return values
-	ReturnVars []CallArgument `yaml:"return_vars,omitempty"`
+	// Return value origins for tracing through return values. ReturnVars holds
+	// only the greatest-arity return statement (for resolving a returned value by
+	// index); Returns holds EVERY explicit return statement's values in source
+	// order, so a function with several returns (e.g. an error mapper whose
+	// branches each return a differently-statused struct) can have each return's
+	// fields enumerated. See #192.
+	ReturnVars []CallArgument   `yaml:"return_vars,omitempty"`
+	Returns    [][]CallArgument `yaml:"returns,omitempty"`
 
 	// map of variable name to all assignments (for alias/reassignment tracking)
 	AssignmentMap map[string][]Assignment `yaml:"assignments,omitempty"`

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -2375,6 +2375,11 @@ func (r *ResponsePatternMatcherImpl) ExtractResponse(node TrackerNodeInterface, 
 			// then handed to the error constructor — issue #155.
 			expanded, residue = r.statusesFromConstructorField(statusArg, node)
 		}
+		if len(expanded) == 0 && !residue {
+			// Or a mapper field (api.Status) whose value is set across the return
+			// branches of an error mapper (api := MapError(err)) — issue #187.
+			expanded, residue = r.statusesFromMapperField(statusArg, node)
+		}
 		if len(expanded) > 1 || (len(expanded) >= 1 && residue) {
 			out := make([]*ResponseInfo, 0, len(expanded)+1)
 			for _, st := range expanded {

--- a/internal/spec/mapper_field_status.go
+++ b/internal/spec/mapper_field_status.go
@@ -1,0 +1,257 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"sort"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// maxMapperDepth bounds recursion through nested error mappers (mapper calling
+// a per-status helper mapper, …). Deep enough for the real MapError→mapAsXxx
+// shape, small enough to stay cheap.
+const maxMapperDepth = 8
+
+// statusesFromMapperField resolves `x.Field` where x is produced by a *mapper*
+// function whose return statements set that struct field across branches — the
+// write-side status-mapper pattern (issue #187):
+//
+//	api := MapError(err)                     // api produced by a mapper
+//	http.Error(w, api.Message, api.Status)   // status = api.Status
+//
+//	func MapError(err error) APIError {
+//	    if api, ok := mapAs404(err); ok { return api }   // -> 404 (via helper)
+//	    ...
+//	    return APIError{http.StatusInternalServerError, "internal error"} // -> 500
+//	}
+//
+// It enumerates the concrete statuses the field takes across every return of the
+// mapper — recursing through helper mappers (`return api` where `api` came from
+// `mapAsXxx(err)`) and reading struct-literal fields (keyed or positional) — and
+// unions them. residue is true when a branch sets the field to a non-constant
+// value, so the caller keeps an honest `default`. Returns nil when the base is
+// not a mapper-produced struct field or nothing resolves.
+//
+// Depends on #192: enumeration needs every return statement (Function.Returns),
+// not just the greatest-arity one.
+func (r *ResponsePatternMatcherImpl) statusesFromMapperField(arg *metadata.CallArgument, node TrackerNodeInterface) (codes []int, residue bool) {
+	if arg == nil || arg.GetKind() != metadata.KindSelector || arg.X == nil || arg.Sel == nil {
+		return nil, false
+	}
+	fieldName := arg.Sel.GetName()
+	if fieldName == "" {
+		return nil, false
+	}
+	impl, ok := r.contextProvider.(*ContextProviderImpl)
+	if !ok || impl.meta == nil {
+		return nil, false
+	}
+
+	// The selector base up to its producer: either the mapper call itself
+	// (inline `MapError(err).Status`) or a local assigned from it
+	// (`api := MapError(err); … api.Status`).
+	base, baseNode := resolveArgThroughParams(arg.X, node)
+	if base == nil || baseNode == nil || baseNode.GetEdge() == nil {
+		return nil, false
+	}
+
+	var mapperFunc, mapperPkg string
+	switch base.GetKind() {
+	case metadata.KindCall:
+		if base.Fun == nil {
+			return nil, false
+		}
+		mapperFunc = base.Fun.GetName()
+	case metadata.KindIdent:
+		as := assignmentsAt(impl, baseNode.GetEdge(), base.GetName())
+		if len(as) == 0 || as[len(as)-1].Value.GetKind() != metadata.KindCall {
+			return nil, false
+		}
+		mapperFunc = as[len(as)-1].CalleeFunc
+		mapperPkg = as[len(as)-1].CalleePkg
+	default:
+		return nil, false
+	}
+	if mapperFunc == "" {
+		return nil, false
+	}
+
+	mapper := findFunctionByName(impl.meta, mapperPkg, mapperFunc)
+	if mapper == nil {
+		return nil, false
+	}
+
+	set := map[int]bool{}
+	residue = r.returnFieldStatuses(impl, mapper, fieldName, set, map[string]bool{}, 0)
+	if len(set) == 0 {
+		return nil, residue
+	}
+	codes = make([]int, 0, len(set))
+	for c := range set {
+		codes = append(codes, c)
+	}
+	sort.Ints(codes)
+	return codes, residue
+}
+
+// returnFieldStatuses adds, to set, the concrete statuses fieldName takes across
+// every return of fn, recursing through helper mappers. residue is true when a
+// branch sets the field to a non-constant value. seen guards against recursive
+// mappers; depth bounds the chain length.
+func (r *ResponsePatternMatcherImpl) returnFieldStatuses(impl *ContextProviderImpl, fn *metadata.Function, fieldName string, set map[int]bool, seen map[string]bool, depth int) (residue bool) {
+	if fn == nil {
+		return false
+	}
+	if depth > maxMapperDepth {
+		return true // gave up before resolving — honest residue
+	}
+	fnID := impl.GetString(fn.Pkg) + "." + impl.GetString(fn.Name)
+	if seen[fnID] {
+		return false // already accounted for on the first visit
+	}
+	seen[fnID] = true
+
+	for i := range fn.Returns {
+		for j := range fn.Returns[i] {
+			residue = r.fieldStatusOfValue(impl, &fn.Returns[i][j], fieldName, fn, set, seen, depth) || residue
+		}
+	}
+	return residue
+}
+
+// fieldStatusOfValue resolves fieldName on a single returned value: a struct
+// composite (read the field directly), a returned local (resolve its assignment,
+// recursing into a helper mapper), or a direct helper call. A value that has no
+// such field (a bool/string tuple element, an empty struct) contributes nothing
+// and is *not* residue.
+func (r *ResponsePatternMatcherImpl) fieldStatusOfValue(impl *ContextProviderImpl, val *metadata.CallArgument, fieldName string, scope *metadata.Function, set map[int]bool, seen map[string]bool, depth int) (residue bool) {
+	if val == nil {
+		return false
+	}
+
+	// A struct composite literal (possibly behind `&`): read the field.
+	if lit := compositeLitOf(val); lit != nil {
+		fv := structFieldValue(impl, lit, fieldName, scope)
+		if fv == nil {
+			return false // field not set here (e.g. APIError{}) — no status, not residue
+		}
+		if s, ok := r.statusCodeOfValue(fv, impl); ok {
+			set[s] = true
+			return false
+		}
+		return true // field set to a non-constant — honest residue
+	}
+
+	switch val.GetKind() {
+	case metadata.KindIdent:
+		// A returned local (`return api`): union over every assignment to it in
+		// this scope — each a helper-mapper call or a struct composite.
+		for i := range scope.AssignmentMap[val.GetName()] {
+			a := &scope.AssignmentMap[val.GetName()][i]
+			switch a.Value.GetKind() {
+			case metadata.KindCall:
+				helper := findFunctionByName(impl.meta, a.CalleePkg, a.CalleeFunc)
+				residue = r.returnFieldStatuses(impl, helper, fieldName, set, seen, depth+1) || residue
+			default:
+				residue = r.fieldStatusOfValue(impl, &a.Value, fieldName, scope, set, seen, depth+1) || residue
+			}
+		}
+		return residue
+	case metadata.KindCall:
+		// A returned helper call directly (`return mapAsXxx(err)`). The callee
+		// package is usually the mapper's own; fall back to a name search.
+		if val.Fun == nil {
+			return false
+		}
+		helper := findFunctionByName(impl.meta, impl.GetString(scope.Pkg), val.Fun.GetName())
+		return r.returnFieldStatuses(impl, helper, fieldName, set, seen, depth+1)
+	}
+	return false
+}
+
+// structFieldValue returns the value a struct composite literal assigns to
+// fieldName, handling both keyed (`T{Field: v}`) and positional (`T{v, …}`)
+// forms. For the positional form it indexes the field via the type's declared
+// field order. Returns nil when the field is absent (including an empty `T{}`).
+func structFieldValue(impl *ContextProviderImpl, lit *metadata.CallArgument, fieldName string, scope *metadata.Function) *metadata.CallArgument {
+	// Keyed form: any KeyValue element means the whole literal is keyed.
+	for _, elt := range lit.Args {
+		if elt != nil && elt.GetKind() == metadata.KindKeyValue {
+			return keyedFieldValue(lit, fieldName)
+		}
+	}
+
+	// Positional form: index fieldName through the type definition.
+	if lit.X == nil {
+		return nil
+	}
+	pkg := impl.GetString(scope.Pkg)
+	typeName := lit.X.GetName()
+	if lit.X.GetKind() == metadata.KindSelector && lit.X.X != nil && lit.X.Sel != nil {
+		pkg = lit.X.X.GetName() // pkg-qualified type: use the selector's package
+		typeName = lit.X.Sel.GetName()
+	}
+	typ := findType(impl.meta, pkg, typeName)
+	if typ == nil {
+		typ = findTypeAnywhere(impl.meta, typeName)
+	}
+	if typ == nil {
+		return nil
+	}
+	idx := -1
+	for i := range typ.Fields {
+		if impl.GetString(typ.Fields[i].Name) == fieldName {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 || idx >= len(lit.Args) {
+		return nil
+	}
+	return lit.Args[idx]
+}
+
+// keyedFieldValue returns the value for fieldName in a keyed composite literal,
+// or nil when absent.
+func keyedFieldValue(lit *metadata.CallArgument, fieldName string) *metadata.CallArgument {
+	for _, elt := range lit.Args {
+		if elt != nil && elt.GetKind() == metadata.KindKeyValue &&
+			elt.X != nil && elt.X.GetName() == fieldName {
+			return elt.Fun
+		}
+	}
+	return nil
+}
+
+// findTypeAnywhere locates a type by bare name across all packages, sorted for
+// determinism. Used when a positional composite's package can't be pinned to the
+// scope's package (a cross-package struct).
+func findTypeAnywhere(meta *metadata.Metadata, typeName string) *metadata.Type {
+	if meta == nil || typeName == "" {
+		return nil
+	}
+	pkgs := make([]string, 0, len(meta.Packages))
+	for p := range meta.Packages {
+		pkgs = append(pkgs, p)
+	}
+	sort.Strings(pkgs)
+	for _, p := range pkgs {
+		if t := findType(meta, p, typeName); t != nil {
+			return t
+		}
+	}
+	return nil
+}

--- a/internal/spec/mapper_field_status_test.go
+++ b/internal/spec/mapper_field_status_test.go
@@ -1,0 +1,386 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// compositeLit builds `TypeName{args...}` as a KindCompositeLit CallArgument.
+func compositeLit(meta *metadata.Metadata, typeName string, args ...*metadata.CallArgument) *metadata.CallArgument {
+	lit := metadata.NewCallArgument(meta)
+	lit.SetKind(metadata.KindCompositeLit)
+	lit.X = mkIdent(meta, typeName, "")
+	lit.Args = args
+	return lit
+}
+
+// kvArg builds `field: val` as a KindKeyValue CallArgument.
+func kvArg(meta *metadata.Metadata, field string, val *metadata.CallArgument) *metadata.CallArgument {
+	kv := metadata.NewCallArgument(meta)
+	kv.SetKind(metadata.KindKeyValue)
+	kv.X = mkIdent(meta, field, "")
+	kv.Fun = val
+	return kv
+}
+
+// regType registers a struct type with the given field order (for positional
+// composite resolution).
+func regType(meta *metadata.Metadata, pkg, name string, fields ...string) {
+	t := &metadata.Type{Name: meta.StringPool.Get(name)}
+	for _, f := range fields {
+		t.Fields = append(t.Fields, metadata.Field{Name: meta.StringPool.Get(f)})
+	}
+	if meta.Packages == nil {
+		meta.Packages = map[string]*metadata.Package{}
+	}
+	if meta.Packages[pkg] == nil {
+		meta.Packages[pkg] = &metadata.Package{Files: map[string]*metadata.File{}}
+	}
+	if meta.Packages[pkg].Files["f"] == nil {
+		meta.Packages[pkg].Files["f"] = &metadata.File{Types: map[string]*metadata.Type{}, Functions: map[string]*metadata.Function{}}
+	}
+	meta.Packages[pkg].Files["f"].Types[name] = t
+}
+
+func TestStructFieldValue(t *testing.T) {
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	impl := NewContextProvider(meta)
+	regType(meta, "app", "APIError", "Status", "Message")
+	scope := &metadata.Function{Pkg: meta.StringPool.Get("app")}
+	st := httpStatusSelector(meta, "StatusNotFound")
+
+	t.Run("keyed hit", func(t *testing.T) {
+		lit := compositeLit(meta, "APIError", kvArg(meta, "Message", mkIdent(meta, "m", "")), kvArg(meta, "Status", &st))
+		if got := structFieldValue(impl, lit, "Status", scope); got == nil || got.GetKind() != metadata.KindSelector {
+			t.Errorf("keyed Status should resolve to the selector, got %v", got)
+		}
+	})
+	t.Run("keyed miss", func(t *testing.T) {
+		lit := compositeLit(meta, "APIError", kvArg(meta, "Message", mkIdent(meta, "m", "")))
+		if got := structFieldValue(impl, lit, "Status", scope); got != nil {
+			t.Errorf("absent keyed field must be nil, got %v", got)
+		}
+	})
+	t.Run("positional", func(t *testing.T) {
+		lit := compositeLit(meta, "APIError", &st, mkIdent(meta, "m", ""))
+		got := structFieldValue(impl, lit, "Status", scope)
+		if got == nil || got.GetKind() != metadata.KindSelector {
+			t.Errorf("positional Status (field 0) should resolve, got %v", got)
+		}
+	})
+	t.Run("positional empty -> nil", func(t *testing.T) {
+		lit := compositeLit(meta, "APIError")
+		if got := structFieldValue(impl, lit, "Status", scope); got != nil {
+			t.Errorf("empty composite must yield nil, got %v", got)
+		}
+	})
+	t.Run("field absent from type -> nil", func(t *testing.T) {
+		lit := compositeLit(meta, "APIError", &st, mkIdent(meta, "m", ""))
+		if got := structFieldValue(impl, lit, "Nonexistent", scope); got != nil {
+			t.Errorf("field not in the type must yield nil, got %v", got)
+		}
+	})
+	t.Run("nil type expr -> nil", func(t *testing.T) {
+		lit := metadata.NewCallArgument(meta)
+		lit.SetKind(metadata.KindCompositeLit)
+		lit.Args = []*metadata.CallArgument{&st}
+		if got := structFieldValue(impl, lit, "Status", scope); got != nil {
+			t.Errorf("composite without a type expr must yield nil, got %v", got)
+		}
+	})
+	t.Run("cross-package via findTypeAnywhere", func(t *testing.T) {
+		// scope in pkg "other" (no APIError there) — the type is only in "app".
+		otherScope := &metadata.Function{Pkg: meta.StringPool.Get("other")}
+		lit := compositeLit(meta, "APIError", &st, mkIdent(meta, "m", ""))
+		if got := structFieldValue(impl, lit, "Status", otherScope); got == nil {
+			t.Error("positional field should resolve via the all-packages type fallback")
+		}
+	})
+	t.Run("package-qualified positional type", func(t *testing.T) {
+		regType(meta, "errs", "HTTPError", "Status", "Message")
+		// lit type is `errs.HTTPError{...}` — a selector, not a bare ident.
+		lit := metadata.NewCallArgument(meta)
+		lit.SetKind(metadata.KindCompositeLit)
+		qual := metadata.NewCallArgument(meta)
+		qual.SetKind(metadata.KindSelector)
+		qual.X, qual.Sel = mkIdent(meta, "errs", ""), mkIdent(meta, "HTTPError", "")
+		lit.X = qual
+		lit.Args = []*metadata.CallArgument{&st, mkIdent(meta, "m", "")}
+		if got := structFieldValue(impl, lit, "Status", scope); got == nil {
+			t.Error("pkg-qualified positional type should resolve the field")
+		}
+	})
+}
+
+func TestFindTypeAnywhere(t *testing.T) {
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	regType(meta, "app", "APIError", "Status", "Message")
+	if findTypeAnywhere(meta, "APIError") == nil {
+		t.Error("APIError should be found across packages")
+	}
+	if findTypeAnywhere(meta, "Missing") != nil {
+		t.Error("unknown type must be nil")
+	}
+	if findTypeAnywhere(nil, "APIError") != nil {
+		t.Error("nil meta must be nil")
+	}
+}
+
+func TestReturnFieldStatuses(t *testing.T) {
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	m := branchStatusMatcher(meta)
+	impl := m.contextProvider.(*ContextProviderImpl)
+	regType(meta, "app", "APIError", "Status", "Message")
+
+	st404 := httpStatusSelector(meta, "StatusNotFound")
+	st500 := httpStatusSelector(meta, "StatusInternalServerError")
+	// A mapper whose returns are two positional composites: 404 and 500.
+	mapper := &metadata.Function{
+		Pkg: meta.StringPool.Get("app"), Name: meta.StringPool.Get("MapError"),
+		Returns: [][]metadata.CallArgument{
+			{*compositeLit(meta, "APIError", &st404, mkIdent(meta, "m", ""))},
+			{*compositeLit(meta, "APIError", &st500, mkIdent(meta, "m", ""))},
+		},
+	}
+	set := map[int]bool{}
+	residue := m.returnFieldStatuses(impl, mapper, "Status", set, map[string]bool{}, 0)
+	if residue {
+		t.Error("all-constant returns must not report residue")
+	}
+	got := keysOfIntSet(set)
+	if len(got) != 2 || got[0] != 404 || got[1] != 500 {
+		t.Errorf("got %v, want [404 500]", got)
+	}
+
+	t.Run("depth cap -> residue", func(t *testing.T) {
+		s := map[int]bool{}
+		if !m.returnFieldStatuses(impl, mapper, "Status", s, map[string]bool{}, maxMapperDepth+1) {
+			t.Error("exceeding depth must report residue")
+		}
+	})
+	t.Run("nil fn", func(t *testing.T) {
+		if m.returnFieldStatuses(impl, nil, "Status", map[int]bool{}, map[string]bool{}, 0) {
+			t.Error("nil fn must not be residue")
+		}
+	})
+	t.Run("cycle guard", func(t *testing.T) {
+		seen := map[string]bool{"app.MapError": true}
+		if m.returnFieldStatuses(impl, mapper, "Status", map[int]bool{}, seen, 0) {
+			t.Error("already-seen fn must short-circuit without residue")
+		}
+	})
+}
+
+func TestFieldStatusOfValue(t *testing.T) {
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	m := branchStatusMatcher(meta)
+	impl := m.contextProvider.(*ContextProviderImpl)
+	regType(meta, "app", "APIError", "Status", "Message")
+	scope := &metadata.Function{Pkg: meta.StringPool.Get("app")}
+
+	t.Run("empty composite -> nothing, no residue", func(t *testing.T) {
+		set := map[int]bool{}
+		if m.fieldStatusOfValue(impl, compositeLit(meta, "APIError"), "Status", scope, set, map[string]bool{}, 0) {
+			t.Error("empty composite must not be residue")
+		}
+		if len(set) != 0 {
+			t.Errorf("empty composite must add nothing, got %v", set)
+		}
+	})
+	t.Run("non-constant field -> residue", func(t *testing.T) {
+		dyn := metadata.NewCallArgument(meta)
+		dyn.SetKind(metadata.KindCall)
+		dyn.Fun = mkIdent(meta, "computeStatus", "")
+		lit := compositeLit(meta, "APIError", dyn, mkIdent(meta, "m", ""))
+		if !m.fieldStatusOfValue(impl, lit, "Status", scope, map[int]bool{}, map[string]bool{}, 0) {
+			t.Error("non-constant field value must be residue")
+		}
+	})
+	t.Run("nil value", func(t *testing.T) {
+		if m.fieldStatusOfValue(impl, nil, "Status", scope, map[int]bool{}, map[string]bool{}, 0) {
+			t.Error("nil value must not be residue")
+		}
+	})
+	t.Run("ident resolving through a helper call", func(t *testing.T) {
+		st := httpStatusSelector(meta, "StatusBadRequest")
+		regType(meta, "app", "APIError", "Status", "Message")
+		meta.Packages["app"].Files["f"].Functions["mapAs400"] = &metadata.Function{
+			Pkg: meta.StringPool.Get("app"), Name: meta.StringPool.Get("mapAs400"),
+			Returns: [][]metadata.CallArgument{{*compositeLit(meta, "APIError", &st, mkIdent(meta, "m", ""))}},
+		}
+		call := metadata.NewCallArgument(meta)
+		call.SetKind(metadata.KindCall)
+		call.Fun = mkIdent(meta, "mapAs400", "")
+		fnScope := &metadata.Function{
+			Pkg: meta.StringPool.Get("app"), Name: meta.StringPool.Get("MapError"),
+			AssignmentMap: map[string][]metadata.Assignment{
+				"api": {{Value: *call, CalleeFunc: "mapAs400", CalleePkg: "app"}},
+			},
+		}
+		set := map[int]bool{}
+		m.fieldStatusOfValue(impl, mkIdent(meta, "api", ""), "Status", fnScope, set, map[string]bool{}, 0)
+		if !set[400] {
+			t.Errorf("returned ident should resolve through the helper to 400, got %v", set)
+		}
+	})
+}
+
+func TestStatusesFromMapperField_Guards(t *testing.T) {
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	m := branchStatusMatcher(meta)
+	node := &fakeNode{edge: &metadata.CallGraphEdge{Caller: metadata.Call{Name: meta.StringPool.Get("h"), Pkg: meta.StringPool.Get("app")}}}
+
+	sel := func(base, field string) *metadata.CallArgument {
+		a := metadata.NewCallArgument(meta)
+		a.SetKind(metadata.KindSelector)
+		a.X, a.Sel = mkIdent(meta, base, ""), mkIdent(meta, field, "")
+		return a
+	}
+	cases := []struct {
+		name string
+		arg  *metadata.CallArgument
+	}{
+		{"nil arg", nil},
+		{"non-selector", mkIdent(meta, "x", "")},
+		{"selector, no producing assignment", sel("api", "Status")},
+	}
+	// A base assigned from a call to an unknown function: the mapper can't be
+	// located, so nothing resolves.
+	node.edge.AssignmentMap = map[string][]metadata.Assignment{}
+	{
+		call := metadata.NewCallArgument(meta)
+		call.SetKind(metadata.KindCall)
+		call.Fun = mkIdent(meta, "NoSuchMapper", "")
+		node.edge.AssignmentMap["api"] = []metadata.Assignment{{Value: *call, CalleeFunc: "NoSuchMapper", CalleePkg: "app"}}
+	}
+	if codes, residue := m.statusesFromMapperField(sel("api", "Status"), node); codes != nil || residue {
+		t.Errorf("unknown mapper must yield (nil,false); got (%v,%v)", codes, nil)
+	}
+	node.edge.AssignmentMap = nil
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if codes, residue := m.statusesFromMapperField(tc.arg, node); codes != nil || residue {
+				t.Errorf("guard %q must yield (nil,false); got (%v,%v)", tc.name, codes, residue)
+			}
+		})
+	}
+}
+
+// TestStatusesFromMapperField_Resolves drives the full resolver: a selector
+// api.Status whose base is assigned from a mapper call on the edge, through to
+// the mapper's composite returns.
+func TestStatusesFromMapperField_Resolves(t *testing.T) {
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	m := branchStatusMatcher(meta)
+	regType(meta, "app", "APIError", "Status", "Message")
+	st404 := httpStatusSelector(meta, "StatusNotFound")
+	st500 := httpStatusSelector(meta, "StatusInternalServerError")
+	meta.Packages["app"].Files["f"].Functions["MapError"] = &metadata.Function{
+		Pkg: meta.StringPool.Get("app"), Name: meta.StringPool.Get("MapError"),
+		Returns: [][]metadata.CallArgument{
+			{*compositeLit(meta, "APIError", &st404, mkIdent(meta, "m", ""))},
+			{*compositeLit(meta, "APIError", &st500, mkIdent(meta, "m", ""))},
+		},
+	}
+	call := metadata.NewCallArgument(meta)
+	call.SetKind(metadata.KindCall)
+	call.Fun = mkIdent(meta, "MapError", "")
+	edge := &metadata.CallGraphEdge{
+		Caller: metadata.Call{Name: meta.StringPool.Get("writeError"), Pkg: meta.StringPool.Get("app")},
+		AssignmentMap: map[string][]metadata.Assignment{
+			"api": {{Value: *call, CalleeFunc: "MapError", CalleePkg: "app"}},
+		},
+	}
+	node := &fakeNode{edge: edge}
+	arg := metadata.NewCallArgument(meta)
+	arg.SetKind(metadata.KindSelector)
+	arg.X, arg.Sel = mkIdent(meta, "api", ""), mkIdent(meta, "Status", "")
+
+	codes, residue := m.statusesFromMapperField(arg, node)
+	if residue {
+		t.Error("all-constant mapper returns must not report residue")
+	}
+	if len(codes) != 2 || codes[0] != 404 || codes[1] != 500 {
+		t.Errorf("codes = %v, want [404 500]", codes)
+	}
+
+	// Inline base: MapError(err).Status (no intermediate variable).
+	t.Run("inline mapper call base", func(t *testing.T) {
+		inlineCall := metadata.NewCallArgument(meta)
+		inlineCall.SetKind(metadata.KindCall)
+		inlineCall.Fun = mkIdent(meta, "MapError", "")
+		sel := metadata.NewCallArgument(meta)
+		sel.SetKind(metadata.KindSelector)
+		sel.X, sel.Sel = inlineCall, mkIdent(meta, "Status", "")
+		got, res := m.statusesFromMapperField(sel, node)
+		if res || len(got) != 2 || got[0] != 404 || got[1] != 500 {
+			t.Errorf("inline base: got (%v,%v), want ([404 500],false)", got, res)
+		}
+	})
+}
+
+// TestFieldStatusOfValue_MoreShapes covers the direct-helper-call return and a
+// returned ident bound to a composite (not a call).
+func TestFieldStatusOfValue_MoreShapes(t *testing.T) {
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	m := branchStatusMatcher(meta)
+	impl := m.contextProvider.(*ContextProviderImpl)
+	regType(meta, "app", "APIError", "Status", "Message")
+	scope := &metadata.Function{Pkg: meta.StringPool.Get("app")}
+
+	t.Run("direct return of a helper call", func(t *testing.T) {
+		st := httpStatusSelector(meta, "StatusBadRequest")
+		meta.Packages["app"].Files["f"].Functions["mapAsX"] = &metadata.Function{
+			Pkg: meta.StringPool.Get("app"), Name: meta.StringPool.Get("mapAsX"),
+			Returns: [][]metadata.CallArgument{{*compositeLit(meta, "APIError", &st, mkIdent(meta, "m", ""))}},
+		}
+		call := metadata.NewCallArgument(meta)
+		call.SetKind(metadata.KindCall)
+		call.Fun = mkIdent(meta, "mapAsX", "")
+		set := map[int]bool{}
+		m.fieldStatusOfValue(impl, call, "Status", scope, set, map[string]bool{}, 0)
+		if !set[400] {
+			t.Errorf("direct helper-call return should resolve to 400, got %v", set)
+		}
+	})
+
+	t.Run("returned ident bound to a composite", func(t *testing.T) {
+		st := httpStatusSelector(meta, "StatusNotFound")
+		fnScope := &metadata.Function{
+			Pkg: meta.StringPool.Get("app"),
+			AssignmentMap: map[string][]metadata.Assignment{
+				"e": {{Value: *compositeLit(meta, "APIError", &st, mkIdent(meta, "m", ""))}},
+			},
+		}
+		set := map[int]bool{}
+		m.fieldStatusOfValue(impl, mkIdent(meta, "e", ""), "Status", fnScope, set, map[string]bool{}, 0)
+		if !set[404] {
+			t.Errorf("ident bound to a composite should resolve to 404, got %v", set)
+		}
+	})
+}
+
+func keysOfIntSet(s map[int]bool) []int {
+	out := make([]int, 0, len(s))
+	for k := range s {
+		out = append(out, k)
+	}
+	sort.Ints(out)
+	return out
+}

--- a/internal/spec/tests/complex.yaml
+++ b/internal/spec/tests/complex.yaml
@@ -429,6 +429,36 @@ packages:
                     position: 4
                     resolved_type: -1
                     generic_type_name: -1
+                returns:
+                  - - kind: 8
+                      name: -1
+                      value: -1
+                      x:
+                        kind: 0
+                        name: 1
+                        value: -1
+                        raw: -1
+                        pkg: 2
+                        type: 3
+                        position: 4
+                        resolved_type: -1
+                        generic_type_name: -1
+                      sel:
+                        kind: 0
+                        name: 5
+                        value: -1
+                        raw: -1
+                        pkg: 2
+                        type: 6
+                        position: 7
+                        resolved_type: -1
+                        generic_type_name: -1
+                      raw: -1
+                      pkg: 2
+                      type: 6
+                      position: 4
+                      resolved_type: -1
+                      generic_type_name: -1
               - name: 34
                 receiver: 10
                 signature:
@@ -485,6 +515,16 @@ packages:
                     position: 19
                     resolved_type: -1
                     generic_type_name: -1
+                returns:
+                  - - kind: 0
+                      name: 18
+                      value: -1
+                      raw: -1
+                      pkg: 2
+                      type: 6
+                      position: 19
+                      resolved_type: -1
+                      generic_type_name: -1
                 assignments:
                   result:
                     - variable_name: 18
@@ -693,6 +733,66 @@ packages:
                 position: 80
                 resolved_type: -1
                 generic_type_name: -1
+            returns:
+              - - kind: 66
+                  name: -1
+                  value: 67
+                  x:
+                    kind: 65
+                    name: -1
+                    value: -1
+                    x:
+                      kind: 0
+                      name: 60
+                      value: -1
+                      raw: -1
+                      pkg: 2
+                      type: 60
+                      position: 76
+                      resolved_type: -1
+                      generic_type_name: -1
+                    args:
+                      - kind: 64
+                        name: -1
+                        value: -1
+                        x:
+                          kind: 0
+                          name: 42
+                          value: -1
+                          raw: -1
+                          pkg: 2
+                          type: 3
+                          position: 77
+                          resolved_type: -1
+                          generic_type_name: -1
+                        fun:
+                          kind: 0
+                          name: 78
+                          value: -1
+                          raw: -1
+                          pkg: 2
+                          type: 3
+                          position: 79
+                          resolved_type: -1
+                          generic_type_name: -1
+                        raw: -1
+                        pkg: -1
+                        type: -1
+                        position: 77
+                        resolved_type: -1
+                        generic_type_name: -1
+                    raw: -1
+                    pkg: -1
+                    type: -1
+                    position: 76
+                    resolved_type: -1
+                    generic_type_name: -1
+                  raw: -1
+                  pkg: -1
+                  type: -1
+                  position: 80
+                  resolved_type: -1
+                  generic_type_name: -1
           NewService:
             name: 69
             pkg: 2
@@ -810,6 +910,66 @@ packages:
                 position: 68
                 resolved_type: -1
                 generic_type_name: -1
+            returns:
+              - - kind: 66
+                  name: -1
+                  value: 67
+                  x:
+                    kind: 65
+                    name: -1
+                    value: -1
+                    x:
+                      kind: 0
+                      name: 45
+                      value: -1
+                      raw: -1
+                      pkg: 2
+                      type: 45
+                      position: 61
+                      resolved_type: -1
+                      generic_type_name: -1
+                    args:
+                      - kind: 64
+                        name: -1
+                        value: -1
+                        x:
+                          kind: 0
+                          name: 5
+                          value: -1
+                          raw: -1
+                          pkg: 2
+                          type: 6
+                          position: 62
+                          resolved_type: -1
+                          generic_type_name: -1
+                        fun:
+                          kind: 0
+                          name: 5
+                          value: -1
+                          raw: -1
+                          pkg: 2
+                          type: 6
+                          position: 63
+                          resolved_type: -1
+                          generic_type_name: -1
+                        raw: -1
+                        pkg: -1
+                        type: -1
+                        position: 62
+                        resolved_type: -1
+                        generic_type_name: -1
+                    raw: -1
+                    pkg: -1
+                    type: -1
+                    position: 61
+                    resolved_type: -1
+                    generic_type_name: -1
+                  raw: -1
+                  pkg: -1
+                  type: -1
+                  position: 68
+                  resolved_type: -1
+                  generic_type_name: -1
           main:
             name: 92
             pkg: 2
@@ -1266,6 +1426,36 @@ packages:
                 position: 4
                 resolved_type: -1
                 generic_type_name: -1
+            returns:
+              - - kind: 8
+                  name: -1
+                  value: -1
+                  x:
+                    kind: 0
+                    name: 1
+                    value: -1
+                    raw: -1
+                    pkg: 2
+                    type: 3
+                    position: 4
+                    resolved_type: -1
+                    generic_type_name: -1
+                  sel:
+                    kind: 0
+                    name: 5
+                    value: -1
+                    raw: -1
+                    pkg: 2
+                    type: 6
+                    position: 7
+                    resolved_type: -1
+                    generic_type_name: -1
+                  raw: -1
+                  pkg: 2
+                  type: 6
+                  position: 4
+                  resolved_type: -1
+                  generic_type_name: -1
           - name: 34
             receiver: 10
             signature:
@@ -1322,6 +1512,16 @@ packages:
                 position: 19
                 resolved_type: -1
                 generic_type_name: -1
+            returns:
+              - - kind: 0
+                  name: 18
+                  value: -1
+                  raw: -1
+                  pkg: 2
+                  type: 6
+                  position: 19
+                  resolved_type: -1
+                  generic_type_name: -1
             assignments:
               result:
                 - variable_name: 18

--- a/internal/spec/tests/example.yaml
+++ b/internal/spec/tests/example.yaml
@@ -303,6 +303,36 @@ packages:
                     position: 4
                     resolved_type: -1
                     generic_type_name: -1
+                returns:
+                  - - kind: 8
+                      name: -1
+                      value: -1
+                      x:
+                        kind: 0
+                        name: 1
+                        value: -1
+                        raw: -1
+                        pkg: 2
+                        type: 3
+                        position: 4
+                        resolved_type: -1
+                        generic_type_name: -1
+                      sel:
+                        kind: 0
+                        name: 5
+                        value: -1
+                        raw: -1
+                        pkg: 2
+                        type: 6
+                        position: 7
+                        resolved_type: -1
+                        generic_type_name: -1
+                      raw: -1
+                      pkg: 2
+                      type: 6
+                      position: 4
+                      resolved_type: -1
+                      generic_type_name: -1
               - name: 26
                 receiver: 10
                 signature:
@@ -464,6 +494,16 @@ packages:
                 position: 43
                 resolved_type: -1
                 generic_type_name: -1
+            returns:
+              - - kind: 0
+                  name: 1
+                  value: -1
+                  raw: -1
+                  pkg: 2
+                  type: 3
+                  position: 43
+                  resolved_type: -1
+                  generic_type_name: -1
             assignments:
               u:
                 - variable_name: 1
@@ -879,6 +919,36 @@ packages:
                 position: 4
                 resolved_type: -1
                 generic_type_name: -1
+            returns:
+              - - kind: 8
+                  name: -1
+                  value: -1
+                  x:
+                    kind: 0
+                    name: 1
+                    value: -1
+                    raw: -1
+                    pkg: 2
+                    type: 3
+                    position: 4
+                    resolved_type: -1
+                    generic_type_name: -1
+                  sel:
+                    kind: 0
+                    name: 5
+                    value: -1
+                    raw: -1
+                    pkg: 2
+                    type: 6
+                    position: 7
+                    resolved_type: -1
+                    generic_type_name: -1
+                  raw: -1
+                  pkg: 2
+                  type: 6
+                  position: 4
+                  resolved_type: -1
+                  generic_type_name: -1
           - name: 26
             receiver: 10
             signature:

--- a/internal/spec/tests/generic.yaml
+++ b/internal/spec/tests/generic.yaml
@@ -52,17 +52,20 @@ string_pool:
   - func[T any](T) *Container[T any][T]
   - zero
   - generic/generic.go:22:10
+  - items
+  - '[]T'
+  - generic/generic.go:24:9
+  - literal
+  - "0"
   - Process
   - generic/generic.go:19:36
   - array_type
   - generic/generic.go:19:34
-  - items
   - comparable
   - generic/generic.go:19:16
   - generic/generic.go:19:39
   - generic/generic.go:19:1
   - func[T comparable]([]T) T
-  - literal
   - "42"
   - func[T any](value T) *generic.Container[T]
   - generic/generic.go:28:7
@@ -93,7 +96,6 @@ string_pool:
   - 'func() '
   - Container[T]
   - '[]string'
-  - '[]T'
   - generic/generic.go:21:9
   - generic/generic.go:21:5
   - len
@@ -186,6 +188,36 @@ packages:
                     position: 4
                     resolved_type: -1
                     generic_type_name: -1
+                returns:
+                  - - kind: 8
+                      name: -1
+                      value: -1
+                      x:
+                        kind: 0
+                        name: 1
+                        value: -1
+                        raw: -1
+                        pkg: 2
+                        type: 3
+                        position: 4
+                        resolved_type: -1
+                        generic_type_name: -1
+                      sel:
+                        kind: 0
+                        name: 5
+                        value: -1
+                        raw: -1
+                        pkg: 2
+                        type: 6
+                        position: 7
+                        resolved_type: -1
+                        generic_type_name: -1
+                      raw: -1
+                      pkg: 2
+                      type: 6
+                      position: 4
+                      resolved_type: -1
+                      generic_type_name: -1
               - name: 24
                 receiver: 10
                 signature:
@@ -354,7 +386,7 @@ packages:
               pkg: -1
               type: -1
               position: -1
-              resolved_type: 103
+              resolved_type: 105
               generic_type_name: -1
             signature_str: 50
             position: 49
@@ -442,8 +474,88 @@ packages:
                 position: 40
                 resolved_type: -1
                 generic_type_name: -1
+            returns:
+              - - kind: 38
+                  name: -1
+                  value: 39
+                  x:
+                    kind: 37
+                    name: -1
+                    value: -1
+                    x:
+                      kind: 33
+                      name: -1
+                      value: -1
+                      x:
+                        kind: 0
+                        name: 27
+                        value: -1
+                        raw: -1
+                        pkg: 2
+                        type: 30
+                        position: 31
+                        resolved_type: -1
+                        generic_type_name: -1
+                      fun:
+                        kind: 0
+                        name: 6
+                        value: -1
+                        raw: -1
+                        pkg: 2
+                        type: 6
+                        position: 32
+                        resolved_type: -1
+                        generic_type_name: -1
+                      raw: -1
+                      pkg: -1
+                      type: -1
+                      position: 31
+                      resolved_type: -1
+                      generic_type_name: -1
+                    args:
+                      - kind: 36
+                        name: -1
+                        value: -1
+                        x:
+                          kind: 0
+                          name: 5
+                          value: -1
+                          raw: -1
+                          pkg: 2
+                          type: 6
+                          position: 34
+                          resolved_type: -1
+                          generic_type_name: -1
+                        fun:
+                          kind: 0
+                          name: 19
+                          value: -1
+                          raw: -1
+                          pkg: 2
+                          type: 6
+                          position: 35
+                          resolved_type: -1
+                          generic_type_name: -1
+                        raw: -1
+                        pkg: -1
+                        type: -1
+                        position: 34
+                        resolved_type: -1
+                        generic_type_name: -1
+                    raw: -1
+                    pkg: -1
+                    type: -1
+                    position: 31
+                    resolved_type: -1
+                    generic_type_name: -1
+                  raw: -1
+                  pkg: -1
+                  type: -1
+                  position: 40
+                  resolved_type: -1
+                  generic_type_name: -1
           Process:
-            name: 53
+            name: 58
             pkg: 2
             signature:
               kind: 12
@@ -460,7 +572,7 @@ packages:
                     raw: -1
                     pkg: 2
                     type: 6
-                    position: 60
+                    position: 64
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -470,8 +582,8 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 55
-                  name: 57
+                - kind: 60
+                  name: 53
                   value: -1
                   x:
                     kind: 0
@@ -480,13 +592,13 @@ packages:
                     raw: -1
                     pkg: 2
                     type: 6
-                    position: 54
+                    position: 59
                     resolved_type: -1
                     generic_type_name: -1
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 56
+                  position: 61
                   resolved_type: -1
                   generic_type_name: -1
               tparams:
@@ -495,8 +607,8 @@ packages:
                   value: -1
                   raw: -1
                   pkg: -1
-                  type: 58
-                  position: 59
+                  type: 62
+                  position: 63
                   resolved_type: -1
                   generic_type_name: -1
               raw: -1
@@ -505,8 +617,8 @@ packages:
               position: -1
               resolved_type: 6
               generic_type_name: -1
-            signature_str: 62
-            position: 61
+            signature_str: 66
+            position: 65
             scope: 15
             comments: -1
             type_params:
@@ -521,8 +633,47 @@ packages:
                 position: 52
                 resolved_type: -1
                 generic_type_name: -1
+            returns:
+              - - kind: 0
+                  name: 51
+                  value: -1
+                  raw: -1
+                  pkg: 2
+                  type: 6
+                  position: 52
+                  resolved_type: -1
+                  generic_type_name: -1
+              - - kind: 33
+                  name: -1
+                  value: -1
+                  x:
+                    kind: 0
+                    name: 53
+                    value: -1
+                    raw: -1
+                    pkg: 2
+                    type: 54
+                    position: 55
+                    resolved_type: -1
+                    generic_type_name: -1
+                  fun:
+                    kind: 56
+                    name: -1
+                    value: 57
+                    raw: -1
+                    pkg: -1
+                    type: -1
+                    position: -1
+                    resolved_type: -1
+                    generic_type_name: -1
+                  raw: -1
+                  pkg: -1
+                  type: -1
+                  position: 55
+                  resolved_type: -1
+                  generic_type_name: -1
           main:
-            name: 73
+            name: 76
             pkg: 2
             signature:
               kind: 12
@@ -544,19 +695,19 @@ packages:
               position: -1
               resolved_type: -1
               generic_type_name: -1
-            signature_str: 91
-            position: 90
-            scope: 72
+            signature_str: 94
+            position: 93
+            scope: 75
             comments: -1
             assignments:
               c:
                 - variable_name: 1
                   pkg: 2
-                  concrete_type: 70
-                  position: 71
-                  scope: 72
+                  concrete_type: 73
+                  position: 74
+                  scope: 75
                   value:
-                    kind: 69
+                    kind: 72
                     name: -1
                     value: -1
                     fun:
@@ -569,30 +720,30 @@ packages:
                         value: -1
                         raw: -1
                         pkg: 2
-                        type: 65
-                        position: 66
+                        type: 68
+                        position: 69
                         resolved_type: -1
                         generic_type_name: -1
                       fun:
                         kind: 0
-                        name: 67
+                        name: 70
                         value: -1
                         raw: -1
                         pkg: -1
-                        type: 67
-                        position: 68
+                        type: 70
+                        position: 71
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
                       pkg: -1
                       type: -1
-                      position: 66
+                      position: 69
                       resolved_type: -1
                       generic_type_name: -1
                     args:
-                      - kind: 63
+                      - kind: 56
                         name: -1
-                        value: 64
+                        value: 67
                         raw: -1
                         pkg: -1
                         type: -1
@@ -601,8 +752,8 @@ packages:
                         generic_type_name: -1
                     raw: -1
                     pkg: -1
-                    type: 70
-                    position: 66
+                    type: 73
+                    position: 69
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
@@ -611,21 +762,21 @@ packages:
                     value: -1
                     raw: -1
                     pkg: 2
-                    type: 70
-                    position: 71
+                    type: 73
+                    position: 74
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 73
+                  func: 76
                   callee_func: NewContainer
                   callee_pkg: generic
               result:
-                - variable_name: 88
+                - variable_name: 91
                   pkg: 2
-                  concrete_type: 80
-                  position: 89
-                  scope: 72
+                  concrete_type: 83
+                  position: 92
+                  scope: 75
                   value:
-                    kind: 69
+                    kind: 72
                     name: -1
                     value: -1
                     fun:
@@ -634,28 +785,28 @@ packages:
                       value: -1
                       x:
                         kind: 0
-                        name: 53
+                        name: 58
                         value: -1
                         raw: -1
                         pkg: 2
-                        type: 85
-                        position: 86
+                        type: 88
+                        position: 89
                         resolved_type: -1
                         generic_type_name: -1
                       fun:
                         kind: 0
-                        name: 80
+                        name: 83
                         value: -1
                         raw: -1
                         pkg: -1
-                        type: 80
-                        position: 87
+                        type: 83
+                        position: 90
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
                       pkg: -1
                       type: -1
-                      position: 86
+                      position: 89
                       resolved_type: -1
                       generic_type_name: -1
                     args:
@@ -663,38 +814,38 @@ packages:
                         name: -1
                         value: -1
                         x:
-                          kind: 55
+                          kind: 60
                           name: -1
                           value: -1
                           x:
                             kind: 0
-                            name: 80
+                            name: 83
                             value: -1
                             raw: -1
                             pkg: -1
-                            type: 80
-                            position: 81
+                            type: 83
+                            position: 84
                             resolved_type: -1
                             generic_type_name: -1
                           raw: -1
                           pkg: -1
                           type: -1
-                          position: 82
+                          position: 85
                           resolved_type: -1
                           generic_type_name: -1
                         args:
-                          - kind: 63
+                          - kind: 56
                             name: -1
-                            value: 83
+                            value: 86
                             raw: -1
                             pkg: -1
                             type: -1
                             position: -1
                             resolved_type: -1
                             generic_type_name: -1
-                          - kind: 63
+                          - kind: 56
                             name: -1
-                            value: 84
+                            value: 87
                             raw: -1
                             pkg: -1
                             type: -1
@@ -704,36 +855,36 @@ packages:
                         raw: -1
                         pkg: -1
                         type: -1
-                        position: 82
+                        position: 85
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
                     pkg: -1
-                    type: 80
-                    position: 86
+                    type: 83
+                    position: 89
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
                     kind: 0
-                    name: 88
+                    name: 91
                     value: -1
                     raw: -1
                     pkg: 2
-                    type: 80
-                    position: 89
+                    type: 83
+                    position: 92
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 73
+                  func: 76
                   callee_func: Process
                   callee_pkg: generic
               val:
-                - variable_name: 78
+                - variable_name: 81
                   pkg: 2
-                  concrete_type: 67
-                  position: 79
-                  scope: 72
+                  concrete_type: 70
+                  position: 82
+                  scope: 75
                   value:
-                    kind: 69
+                    kind: 72
                     name: -1
                     value: -1
                     fun:
@@ -746,8 +897,8 @@ packages:
                         value: -1
                         raw: -1
                         pkg: 2
-                        type: 70
-                        position: 74
+                        type: 73
+                        position: 77
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
@@ -756,54 +907,54 @@ packages:
                         value: -1
                         raw: -1
                         pkg: 2
-                        type: 75
-                        position: 76
+                        type: 78
+                        position: 79
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
                       pkg: 2
-                      type: 75
-                      position: 74
+                      type: 78
+                      position: 77
                       resolved_type: -1
                       generic_type_name: -1
                       receiver_type:
                         kind: 0
-                        name: 77
+                        name: 80
                         value: -1
                         raw: -1
                         pkg: 2
-                        type: 77
+                        type: 80
                         position: -1
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
                     pkg: -1
-                    type: 67
-                    position: 74
+                    type: 70
+                    position: 77
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
                     kind: 0
-                    name: 78
+                    name: 81
                     value: -1
                     raw: -1
                     pkg: 2
-                    type: 67
-                    position: 79
+                    type: 70
+                    position: 82
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 73
+                  func: 76
                   callee_func: Get
                   callee_pkg: generic
         struct_instances:
-          - type: 92
+          - type: 95
             pkg: 2
             position: 31
             fields:
               5: 19
-          - type: 93
+          - type: 96
             pkg: 2
-            position: 82
+            position: 85
         imports: {}
     types:
       Container:
@@ -884,6 +1035,36 @@ packages:
                 position: 4
                 resolved_type: -1
                 generic_type_name: -1
+            returns:
+              - - kind: 8
+                  name: -1
+                  value: -1
+                  x:
+                    kind: 0
+                    name: 1
+                    value: -1
+                    raw: -1
+                    pkg: 2
+                    type: 3
+                    position: 4
+                    resolved_type: -1
+                    generic_type_name: -1
+                  sel:
+                    kind: 0
+                    name: 5
+                    value: -1
+                    raw: -1
+                    pkg: 2
+                    type: 6
+                    position: 7
+                    resolved_type: -1
+                    generic_type_name: -1
+                  raw: -1
+                  pkg: 2
+                  type: 6
+                  position: 4
+                  resolved_type: -1
+                  generic_type_name: -1
           - name: 24
             receiver: 10
             signature:
@@ -972,50 +1153,50 @@ packages:
           - T
 call_graph:
   - caller:
-      name: 53
+      name: 58
       pkg: 2
       position: -1
       recv_type: -1
       scope: 15
-      signature_str: 62
+      signature_str: 66
     callee:
-      name: 97
+      name: 99
       pkg: 2
-      position: 96
+      position: 98
       recv_type: -1
-      scope: 72
-      signature_str: 98
-    position: 96
+      scope: 75
+      signature_str: 100
+    position: 98
     args:
       - kind: 0
-        name: 57
+        name: 53
         value: -1
         raw: -1
         pkg: 2
-        type: 94
-        position: 95
+        type: 54
+        position: 97
         resolved_type: -1
         generic_type_name: -1
     callee_recv_var_name: generic.Container[T].Value
   - caller:
-      name: 73
+      name: 76
       pkg: 2
       position: -1
       recv_type: -1
-      scope: 72
-      signature_str: 91
+      scope: 75
+      signature_str: 94
     callee:
       name: 41
       pkg: 2
-      position: 66
+      position: 69
       recv_type: -1
       scope: 15
-      signature_str: 65
-    position: 66
+      signature_str: 68
+    position: 69
     args:
-      - kind: 63
+      - kind: 56
         name: -1
-        value: 64
+        value: 67
         raw: -1
         pkg: -1
         type: -1
@@ -1026,11 +1207,11 @@ call_graph:
       c:
         - variable_name: 1
           pkg: 2
-          concrete_type: 70
-          position: 71
-          scope: 72
+          concrete_type: 73
+          position: 74
+          scope: 75
           value:
-            kind: 69
+            kind: 72
             name: -1
             value: -1
             fun:
@@ -1043,30 +1224,30 @@ call_graph:
                 value: -1
                 raw: -1
                 pkg: 2
-                type: 65
-                position: 66
+                type: 68
+                position: 69
                 resolved_type: -1
                 generic_type_name: -1
               fun:
                 kind: 0
-                name: 67
+                name: 70
                 value: -1
                 raw: -1
                 pkg: -1
-                type: 67
-                position: 68
+                type: 70
+                position: 71
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
               pkg: -1
               type: -1
-              position: 66
+              position: 69
               resolved_type: -1
               generic_type_name: -1
             args:
-              - kind: 63
+              - kind: 56
                 name: -1
-                value: 64
+                value: 67
                 raw: -1
                 pkg: -1
                 type: -1
@@ -1075,8 +1256,8 @@ call_graph:
                 generic_type_name: -1
             raw: -1
             pkg: -1
-            type: 70
-            position: 66
+            type: 73
+            position: 69
             resolved_type: -1
             generic_type_name: -1
           lhs:
@@ -1085,18 +1266,18 @@ call_graph:
             value: -1
             raw: -1
             pkg: 2
-            type: 70
-            position: 71
+            type: 73
+            position: 74
             resolved_type: -1
             generic_type_name: -1
-          func: 73
+          func: 76
           callee_func: NewContainer
           callee_pkg: generic
     param_arg_map:
       value:
-        kind: 63
+        kind: 56
         name: -1
-        value: 64
+        value: 67
         raw: -1
         pkg: -1
         type: -1
@@ -1107,29 +1288,29 @@ call_graph:
       T: int
     callee_recv_var_name: c
   - caller:
-      name: 73
+      name: 76
       pkg: 2
       position: -1
       recv_type: -1
-      scope: 72
-      signature_str: 91
+      scope: 75
+      signature_str: 94
     callee:
       name: 9
       pkg: 2
-      position: 74
-      recv_type: 99
+      position: 77
+      recv_type: 101
       scope: 15
-      signature_str: 75
-    position: 74
+      signature_str: 78
+    position: 77
     assignments:
       val:
-        - variable_name: 78
+        - variable_name: 81
           pkg: 2
-          concrete_type: 67
-          position: 79
-          scope: 72
+          concrete_type: 70
+          position: 82
+          scope: 75
           value:
-            kind: 69
+            kind: 72
             name: -1
             value: -1
             fun:
@@ -1142,8 +1323,8 @@ call_graph:
                 value: -1
                 raw: -1
                 pkg: 2
-                type: 70
-                position: 74
+                type: 73
+                position: 77
                 resolved_type: -1
                 generic_type_name: -1
               sel:
@@ -1152,67 +1333,67 @@ call_graph:
                 value: -1
                 raw: -1
                 pkg: 2
-                type: 75
-                position: 76
+                type: 78
+                position: 79
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
               pkg: 2
-              type: 75
-              position: 74
+              type: 78
+              position: 77
               resolved_type: -1
               generic_type_name: -1
               receiver_type:
                 kind: 0
-                name: 77
+                name: 80
                 value: -1
                 raw: -1
                 pkg: 2
-                type: 77
+                type: 80
                 position: -1
                 resolved_type: -1
                 generic_type_name: -1
             raw: -1
             pkg: -1
-            type: 67
-            position: 74
+            type: 70
+            position: 77
             resolved_type: -1
             generic_type_name: -1
           lhs:
             kind: 0
-            name: 78
+            name: 81
             value: -1
             raw: -1
             pkg: 2
-            type: 67
-            position: 79
+            type: 70
+            position: 82
             resolved_type: -1
             generic_type_name: -1
-          func: 73
+          func: 76
           callee_func: Get
           callee_pkg: generic
     callee_var_name: c
     callee_recv_var_name: val
     chain_root: c
   - caller:
-      name: 73
+      name: 76
       pkg: 2
       position: -1
       recv_type: -1
-      scope: 72
-      signature_str: 91
+      scope: 75
+      signature_str: 94
     callee:
       name: 24
       pkg: 2
-      position: 101
-      recv_type: 99
+      position: 103
+      recv_type: 101
       scope: 15
-      signature_str: 102
-    position: 101
+      signature_str: 104
+    position: 103
     args:
-      - kind: 63
+      - kind: 56
         name: -1
-        value: 100
+        value: 102
         raw: -1
         pkg: -1
         type: -1
@@ -1221,9 +1402,9 @@ call_graph:
         generic_type_name: -1
     param_arg_map:
       value:
-        kind: 63
+        kind: 56
         name: -1
-        value: 100
+        value: 102
         raw: -1
         pkg: -1
         type: -1
@@ -1233,57 +1414,57 @@ call_graph:
     callee_var_name: c
     chain_root: c
   - caller:
-      name: 73
+      name: 76
       pkg: 2
       position: -1
       recv_type: -1
-      scope: 72
-      signature_str: 91
+      scope: 75
+      signature_str: 94
     callee:
-      name: 53
+      name: 58
       pkg: 2
-      position: 86
+      position: 89
       recv_type: -1
       scope: 15
-      signature_str: 85
-    position: 86
+      signature_str: 88
+    position: 89
     args:
       - kind: 37
         name: -1
         value: -1
         x:
-          kind: 55
+          kind: 60
           name: -1
           value: -1
           x:
             kind: 0
-            name: 80
+            name: 83
             value: -1
             raw: -1
             pkg: -1
-            type: 80
-            position: 81
+            type: 83
+            position: 84
             resolved_type: -1
             generic_type_name: -1
           raw: -1
           pkg: -1
           type: -1
-          position: 82
+          position: 85
           resolved_type: -1
           generic_type_name: -1
         args:
-          - kind: 63
+          - kind: 56
             name: -1
-            value: 83
+            value: 86
             raw: -1
             pkg: -1
             type: -1
             position: -1
             resolved_type: -1
             generic_type_name: -1
-          - kind: 63
+          - kind: 56
             name: -1
-            value: 84
+            value: 87
             raw: -1
             pkg: -1
             type: -1
@@ -1293,18 +1474,18 @@ call_graph:
         raw: -1
         pkg: -1
         type: -1
-        position: 82
+        position: 85
         resolved_type: -1
         generic_type_name: -1
     assignments:
       result:
-        - variable_name: 88
+        - variable_name: 91
           pkg: 2
-          concrete_type: 80
-          position: 89
-          scope: 72
+          concrete_type: 83
+          position: 92
+          scope: 75
           value:
-            kind: 69
+            kind: 72
             name: -1
             value: -1
             fun:
@@ -1313,28 +1494,28 @@ call_graph:
               value: -1
               x:
                 kind: 0
-                name: 53
+                name: 58
                 value: -1
                 raw: -1
                 pkg: 2
-                type: 85
-                position: 86
+                type: 88
+                position: 89
                 resolved_type: -1
                 generic_type_name: -1
               fun:
                 kind: 0
-                name: 80
+                name: 83
                 value: -1
                 raw: -1
                 pkg: -1
-                type: 80
-                position: 87
+                type: 83
+                position: 90
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
               pkg: -1
               type: -1
-              position: 86
+              position: 89
               resolved_type: -1
               generic_type_name: -1
             args:
@@ -1342,38 +1523,38 @@ call_graph:
                 name: -1
                 value: -1
                 x:
-                  kind: 55
+                  kind: 60
                   name: -1
                   value: -1
                   x:
                     kind: 0
-                    name: 80
+                    name: 83
                     value: -1
                     raw: -1
                     pkg: -1
-                    type: 80
-                    position: 81
+                    type: 83
+                    position: 84
                     resolved_type: -1
                     generic_type_name: -1
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 82
+                  position: 85
                   resolved_type: -1
                   generic_type_name: -1
                 args:
-                  - kind: 63
+                  - kind: 56
                     name: -1
-                    value: 83
+                    value: 86
                     raw: -1
                     pkg: -1
                     type: -1
                     position: -1
                     resolved_type: -1
                     generic_type_name: -1
-                  - kind: 63
+                  - kind: 56
                     name: -1
-                    value: 84
+                    value: 87
                     raw: -1
                     pkg: -1
                     type: -1
@@ -1383,26 +1564,26 @@ call_graph:
                 raw: -1
                 pkg: -1
                 type: -1
-                position: 82
+                position: 85
                 resolved_type: -1
                 generic_type_name: -1
             raw: -1
             pkg: -1
-            type: 80
-            position: 86
+            type: 83
+            position: 89
             resolved_type: -1
             generic_type_name: -1
           lhs:
             kind: 0
-            name: 88
+            name: 91
             value: -1
             raw: -1
             pkg: 2
-            type: 80
-            position: 89
+            type: 83
+            position: 92
             resolved_type: -1
             generic_type_name: -1
-          func: 73
+          func: 76
           callee_func: Process
           callee_pkg: generic
     param_arg_map:
@@ -1411,38 +1592,38 @@ call_graph:
         name: -1
         value: -1
         x:
-          kind: 55
+          kind: 60
           name: -1
           value: -1
           x:
             kind: 0
-            name: 80
+            name: 83
             value: -1
             raw: -1
             pkg: -1
-            type: 80
-            position: 81
+            type: 83
+            position: 84
             resolved_type: -1
             generic_type_name: -1
           raw: -1
           pkg: -1
           type: -1
-          position: 82
+          position: 85
           resolved_type: -1
           generic_type_name: -1
         args:
-          - kind: 63
+          - kind: 56
             name: -1
-            value: 83
+            value: 86
             raw: -1
             pkg: -1
             type: -1
             position: -1
             resolved_type: -1
             generic_type_name: -1
-          - kind: 63
+          - kind: 56
             name: -1
-            value: 84
+            value: 87
             raw: -1
             pkg: -1
             type: -1
@@ -1452,7 +1633,7 @@ call_graph:
         raw: -1
         pkg: -1
         type: -1
-        position: 82
+        position: 85
         resolved_type: -1
         generic_type_name: -1
     type_param_map:

--- a/internal/spec/tests/multipackage.yaml
+++ b/internal/spec/tests/multipackage.yaml
@@ -519,6 +519,36 @@ packages:
                     position: 42
                     resolved_type: -1
                     generic_type_name: -1
+                returns:
+                  - - kind: 12
+                      name: -1
+                      value: -1
+                      x:
+                        kind: 5
+                        name: 41
+                        value: -1
+                        raw: -1
+                        pkg: 7
+                        type: 14
+                        position: 42
+                        resolved_type: -1
+                        generic_type_name: -1
+                      sel:
+                        kind: 5
+                        name: 43
+                        value: -1
+                        raw: -1
+                        pkg: 7
+                        type: 35
+                        position: 44
+                        resolved_type: -1
+                        generic_type_name: -1
+                      raw: -1
+                      pkg: 7
+                      type: 35
+                      position: 42
+                      resolved_type: -1
+                      generic_type_name: -1
               - name: 56
                 receiver: 46
                 signature:
@@ -585,6 +615,36 @@ packages:
                     position: 52
                     resolved_type: -1
                     generic_type_name: -1
+                returns:
+                  - - kind: 12
+                      name: -1
+                      value: -1
+                      x:
+                        kind: 5
+                        name: 41
+                        value: -1
+                        raw: -1
+                        pkg: 7
+                        type: 14
+                        position: 52
+                        resolved_type: -1
+                        generic_type_name: -1
+                      sel:
+                        kind: 5
+                        name: 53
+                        value: -1
+                        raw: -1
+                        pkg: 7
+                        type: 54
+                        position: 55
+                        resolved_type: -1
+                        generic_type_name: -1
+                      raw: -1
+                      pkg: 7
+                      type: 54
+                      position: 52
+                      resolved_type: -1
+                      generic_type_name: -1
             comments: -1
           UserInterface:
             name: 65
@@ -819,6 +879,95 @@ packages:
                 position: 79
                 resolved_type: -1
                 generic_type_name: -1
+            returns:
+              - - kind: 77
+                  name: -1
+                  value: 78
+                  x:
+                    kind: 76
+                    name: -1
+                    value: -1
+                    x:
+                      kind: 5
+                      name: 60
+                      value: -1
+                      raw: -1
+                      pkg: 7
+                      type: 60
+                      position: 68
+                      resolved_type: -1
+                      generic_type_name: -1
+                    args:
+                      - kind: 72
+                        name: -1
+                        value: -1
+                        x:
+                          kind: 5
+                          name: 43
+                          value: -1
+                          raw: -1
+                          pkg: 7
+                          type: 35
+                          position: 69
+                          resolved_type: -1
+                          generic_type_name: -1
+                        fun:
+                          kind: 5
+                          name: 70
+                          value: -1
+                          raw: -1
+                          pkg: 7
+                          type: 35
+                          position: 71
+                          resolved_type: -1
+                          generic_type_name: -1
+                        raw: -1
+                        pkg: -1
+                        type: -1
+                        position: 69
+                        resolved_type: -1
+                        generic_type_name: -1
+                      - kind: 72
+                        name: -1
+                        value: -1
+                        x:
+                          kind: 5
+                          name: 53
+                          value: -1
+                          raw: -1
+                          pkg: 7
+                          type: 54
+                          position: 73
+                          resolved_type: -1
+                          generic_type_name: -1
+                        fun:
+                          kind: 5
+                          name: 74
+                          value: -1
+                          raw: -1
+                          pkg: 7
+                          type: 54
+                          position: 75
+                          resolved_type: -1
+                          generic_type_name: -1
+                        raw: -1
+                        pkg: -1
+                        type: -1
+                        position: 73
+                        resolved_type: -1
+                        generic_type_name: -1
+                    raw: -1
+                    pkg: -1
+                    type: -1
+                    position: 68
+                    resolved_type: -1
+                    generic_type_name: -1
+                  raw: -1
+                  pkg: -1
+                  type: -1
+                  position: 79
+                  resolved_type: -1
+                  generic_type_name: -1
         struct_instances:
           - type: 60
             pkg: 7
@@ -913,6 +1062,36 @@ packages:
                 position: 42
                 resolved_type: -1
                 generic_type_name: -1
+            returns:
+              - - kind: 12
+                  name: -1
+                  value: -1
+                  x:
+                    kind: 5
+                    name: 41
+                    value: -1
+                    raw: -1
+                    pkg: 7
+                    type: 14
+                    position: 42
+                    resolved_type: -1
+                    generic_type_name: -1
+                  sel:
+                    kind: 5
+                    name: 43
+                    value: -1
+                    raw: -1
+                    pkg: 7
+                    type: 35
+                    position: 44
+                    resolved_type: -1
+                    generic_type_name: -1
+                  raw: -1
+                  pkg: 7
+                  type: 35
+                  position: 42
+                  resolved_type: -1
+                  generic_type_name: -1
           - name: 56
             receiver: 46
             signature:
@@ -979,6 +1158,36 @@ packages:
                 position: 52
                 resolved_type: -1
                 generic_type_name: -1
+            returns:
+              - - kind: 12
+                  name: -1
+                  value: -1
+                  x:
+                    kind: 5
+                    name: 41
+                    value: -1
+                    raw: -1
+                    pkg: 7
+                    type: 14
+                    position: 52
+                    resolved_type: -1
+                    generic_type_name: -1
+                  sel:
+                    kind: 5
+                    name: 53
+                    value: -1
+                    raw: -1
+                    pkg: 7
+                    type: 54
+                    position: 55
+                    resolved_type: -1
+                    generic_type_name: -1
+                  raw: -1
+                  pkg: 7
+                  type: 54
+                  position: 52
+                  resolved_type: -1
+                  generic_type_name: -1
         comments: -1
       UserInterface:
         name: 65
@@ -1246,6 +1455,103 @@ packages:
                     position: 94
                     resolved_type: -1
                     generic_type_name: -1
+                returns:
+                  - - kind: 13
+                      name: -1
+                      value: -1
+                      fun:
+                        kind: 12
+                        name: -1
+                        value: -1
+                        x:
+                          kind: 5
+                          name: 40
+                          value: -1
+                          raw: -1
+                          pkg: 40
+                          type: -1
+                          position: 94
+                          resolved_type: -1
+                          generic_type_name: -1
+                        sel:
+                          kind: 5
+                          name: 95
+                          value: -1
+                          raw: -1
+                          pkg: 40
+                          type: 96
+                          position: 97
+                          resolved_type: -1
+                          generic_type_name: -1
+                        raw: -1
+                        pkg: 40
+                        type: 96
+                        position: 94
+                        resolved_type: -1
+                        generic_type_name: -1
+                      args:
+                        - kind: 2
+                          name: -1
+                          value: 87
+                          raw: -1
+                          pkg: -1
+                          type: -1
+                          position: -1
+                          resolved_type: -1
+                          generic_type_name: -1
+                        - kind: 12
+                          name: -1
+                          value: -1
+                          x:
+                            kind: 5
+                            name: 88
+                            value: -1
+                            raw: -1
+                            pkg: 21
+                            type: 26
+                            position: 89
+                            resolved_type: -1
+                            generic_type_name: -1
+                          sel:
+                            kind: 5
+                            name: 90
+                            value: -1
+                            raw: -1
+                            pkg: 21
+                            type: 35
+                            position: 91
+                            resolved_type: -1
+                            generic_type_name: -1
+                          raw: -1
+                          pkg: 21
+                          type: 35
+                          position: 89
+                          resolved_type: -1
+                          generic_type_name: -1
+                        - kind: 5
+                          name: 70
+                          value: -1
+                          raw: -1
+                          pkg: 21
+                          type: 35
+                          position: 92
+                          resolved_type: -1
+                          generic_type_name: -1
+                        - kind: 5
+                          name: 74
+                          value: -1
+                          raw: -1
+                          pkg: 21
+                          type: 54
+                          position: 93
+                          resolved_type: -1
+                          generic_type_name: -1
+                      raw: -1
+                      pkg: -1
+                      type: 35
+                      position: 94
+                      resolved_type: -1
+                      generic_type_name: -1
                 assignments:
                   age:
                     - variable_name: 74
@@ -1577,6 +1883,66 @@ packages:
                 position: 123
                 resolved_type: -1
                 generic_type_name: -1
+            returns:
+              - - kind: 77
+                  name: -1
+                  value: 78
+                  x:
+                    kind: 76
+                    name: -1
+                    value: -1
+                    x:
+                      kind: 5
+                      name: 34
+                      value: -1
+                      raw: -1
+                      pkg: 21
+                      type: 34
+                      position: 120
+                      resolved_type: -1
+                      generic_type_name: -1
+                    args:
+                      - kind: 72
+                        name: -1
+                        value: -1
+                        x:
+                          kind: 5
+                          name: 90
+                          value: -1
+                          raw: -1
+                          pkg: 21
+                          type: 35
+                          position: 121
+                          resolved_type: -1
+                          generic_type_name: -1
+                        fun:
+                          kind: 2
+                          name: -1
+                          value: 122
+                          raw: -1
+                          pkg: -1
+                          type: -1
+                          position: -1
+                          resolved_type: -1
+                          generic_type_name: -1
+                        raw: -1
+                        pkg: -1
+                        type: -1
+                        position: 121
+                        resolved_type: -1
+                        generic_type_name: -1
+                    raw: -1
+                    pkg: -1
+                    type: -1
+                    position: 120
+                    resolved_type: -1
+                    generic_type_name: -1
+                  raw: -1
+                  pkg: -1
+                  type: -1
+                  position: 123
+                  resolved_type: -1
+                  generic_type_name: -1
         struct_instances:
           - type: 34
             pkg: 21
@@ -1772,6 +2138,103 @@ packages:
                 position: 94
                 resolved_type: -1
                 generic_type_name: -1
+            returns:
+              - - kind: 13
+                  name: -1
+                  value: -1
+                  fun:
+                    kind: 12
+                    name: -1
+                    value: -1
+                    x:
+                      kind: 5
+                      name: 40
+                      value: -1
+                      raw: -1
+                      pkg: 40
+                      type: -1
+                      position: 94
+                      resolved_type: -1
+                      generic_type_name: -1
+                    sel:
+                      kind: 5
+                      name: 95
+                      value: -1
+                      raw: -1
+                      pkg: 40
+                      type: 96
+                      position: 97
+                      resolved_type: -1
+                      generic_type_name: -1
+                    raw: -1
+                    pkg: 40
+                    type: 96
+                    position: 94
+                    resolved_type: -1
+                    generic_type_name: -1
+                  args:
+                    - kind: 2
+                      name: -1
+                      value: 87
+                      raw: -1
+                      pkg: -1
+                      type: -1
+                      position: -1
+                      resolved_type: -1
+                      generic_type_name: -1
+                    - kind: 12
+                      name: -1
+                      value: -1
+                      x:
+                        kind: 5
+                        name: 88
+                        value: -1
+                        raw: -1
+                        pkg: 21
+                        type: 26
+                        position: 89
+                        resolved_type: -1
+                        generic_type_name: -1
+                      sel:
+                        kind: 5
+                        name: 90
+                        value: -1
+                        raw: -1
+                        pkg: 21
+                        type: 35
+                        position: 91
+                        resolved_type: -1
+                        generic_type_name: -1
+                      raw: -1
+                      pkg: 21
+                      type: 35
+                      position: 89
+                      resolved_type: -1
+                      generic_type_name: -1
+                    - kind: 5
+                      name: 70
+                      value: -1
+                      raw: -1
+                      pkg: 21
+                      type: 35
+                      position: 92
+                      resolved_type: -1
+                      generic_type_name: -1
+                    - kind: 5
+                      name: 74
+                      value: -1
+                      raw: -1
+                      pkg: 21
+                      type: 54
+                      position: 93
+                      resolved_type: -1
+                      generic_type_name: -1
+                  raw: -1
+                  pkg: -1
+                  type: 35
+                  position: 94
+                  resolved_type: -1
+                  generic_type_name: -1
             assignments:
               age:
                 - variable_name: 74
@@ -2136,6 +2599,96 @@ packages:
                 position: 139
                 resolved_type: -1
                 generic_type_name: -1
+            returns:
+              - - kind: 13
+                  name: -1
+                  value: -1
+                  fun:
+                    kind: 12
+                    name: -1
+                    value: -1
+                    x:
+                      kind: 5
+                      name: 134
+                      value: -1
+                      raw: -1
+                      pkg: 134
+                      type: -1
+                      position: 139
+                      resolved_type: -1
+                      generic_type_name: -1
+                    sel:
+                      kind: 5
+                      name: 140
+                      value: -1
+                      raw: -1
+                      pkg: 134
+                      type: 137
+                      position: 141
+                      resolved_type: -1
+                      generic_type_name: -1
+                    raw: -1
+                    pkg: 134
+                    type: 137
+                    position: 139
+                    resolved_type: -1
+                    generic_type_name: -1
+                  args:
+                    - kind: 13
+                      name: -1
+                      value: -1
+                      fun:
+                        kind: 12
+                        name: -1
+                        value: -1
+                        x:
+                          kind: 5
+                          name: 134
+                          value: -1
+                          raw: -1
+                          pkg: 134
+                          type: -1
+                          position: 135
+                          resolved_type: -1
+                          generic_type_name: -1
+                        sel:
+                          kind: 5
+                          name: 136
+                          value: -1
+                          raw: -1
+                          pkg: 134
+                          type: 137
+                          position: 138
+                          resolved_type: -1
+                          generic_type_name: -1
+                        raw: -1
+                        pkg: 134
+                        type: 137
+                        position: 135
+                        resolved_type: -1
+                        generic_type_name: -1
+                      args:
+                        - kind: 5
+                          name: 131
+                          value: -1
+                          raw: -1
+                          pkg: 132
+                          type: 35
+                          position: 133
+                          resolved_type: -1
+                          generic_type_name: -1
+                      raw: -1
+                      pkg: -1
+                      type: 35
+                      position: 135
+                      resolved_type: -1
+                      generic_type_name: -1
+                  raw: -1
+                  pkg: -1
+                  type: 35
+                  position: 139
+                  resolved_type: -1
+                  generic_type_name: -1
           ValidateAge:
             name: 155
             pkg: 132
@@ -2253,6 +2806,76 @@ packages:
                 position: 147
                 resolved_type: -1
                 generic_type_name: -1
+            returns:
+              - - kind: 149
+                  name: -1
+                  value: 154
+                  x:
+                    kind: 149
+                    name: -1
+                    value: 150
+                    x:
+                      kind: 5
+                      name: 74
+                      value: -1
+                      raw: -1
+                      pkg: 132
+                      type: 54
+                      position: 147
+                      resolved_type: -1
+                      generic_type_name: -1
+                    fun:
+                      kind: 2
+                      name: -1
+                      value: 148
+                      raw: -1
+                      pkg: -1
+                      type: -1
+                      position: -1
+                      resolved_type: -1
+                      generic_type_name: -1
+                    raw: -1
+                    pkg: -1
+                    type: -1
+                    position: 147
+                    resolved_type: -1
+                    generic_type_name: -1
+                  fun:
+                    kind: 149
+                    name: -1
+                    value: 153
+                    x:
+                      kind: 5
+                      name: 74
+                      value: -1
+                      raw: -1
+                      pkg: 132
+                      type: 54
+                      position: 151
+                      resolved_type: -1
+                      generic_type_name: -1
+                    fun:
+                      kind: 2
+                      name: -1
+                      value: 152
+                      raw: -1
+                      pkg: -1
+                      type: -1
+                      position: -1
+                      resolved_type: -1
+                      generic_type_name: -1
+                    raw: -1
+                    pkg: -1
+                    type: -1
+                    position: 151
+                    resolved_type: -1
+                    generic_type_name: -1
+                  raw: -1
+                  pkg: -1
+                  type: -1
+                  position: 147
+                  resolved_type: -1
+                  generic_type_name: -1
         variables:
           DefaultFormat:
             name: 167

--- a/testdata/mapper_field_status/go.mod
+++ b/testdata/mapper_field_status/go.mod
@@ -1,0 +1,3 @@
+module mapper_field_status
+
+go 1.26

--- a/testdata/mapper_field_status/main.go
+++ b/testdata/mapper_field_status/main.go
@@ -1,0 +1,67 @@
+// Fixture: the write-side status mapper pattern (issue #187). The status handed
+// to http.Error is a struct FIELD (api.Status) whose value is set across the
+// return branches of a mapper function (MapError) — one level deep through
+// per-status helpers (mapAs404/mapAs400) that return (APIError, bool) positional
+// composites, plus a direct APIError{500,...} literal. The operation must resolve
+// to {400, 404, 500}, not a bare default.
+package main
+
+import (
+	"errors"
+	"net/http"
+)
+
+var (
+	ErrNotFound   = errors.New("not found")
+	ErrBadRequest = errors.New("bad request")
+)
+
+type APIError struct {
+	Status  int
+	Message string
+}
+
+func mapAs404(err error) (APIError, bool) {
+	if errors.Is(err, ErrNotFound) {
+		return APIError{http.StatusNotFound, "not found"}, true
+	}
+	return APIError{}, false
+}
+
+func mapAs400(err error) (APIError, bool) {
+	if errors.Is(err, ErrBadRequest) {
+		return APIError{http.StatusBadRequest, "bad request"}, true
+	}
+	return APIError{}, false
+}
+
+// MapError's returns set the Status field across branches: two come from helper
+// calls (var assigned from mapAsXXX), one is a direct literal.
+func MapError(err error) APIError {
+	if api, ok := mapAs404(err); ok {
+		return api
+	}
+	if api, ok := mapAs400(err); ok {
+		return api
+	}
+	return APIError{http.StatusInternalServerError, "internal error"}
+}
+
+func writeError(w http.ResponseWriter, err error) {
+	api := MapError(err)
+	http.Error(w, api.Message, api.Status)
+}
+
+func getThing(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Query().Get("id") == "" {
+		writeError(w, ErrBadRequest)
+		return
+	}
+	writeError(w, ErrNotFound)
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /thing", getThing)
+	_ = http.ListenAndServe(":8080", mux)
+}


### PR DESCRIPTION
Closes #187 and #192. Foundation + feature, shipped together (the metadata change has no consumer on its own).

## The pattern (real-project, ~250 handlers)

```go
api := MapError(err)
http.Error(w, api.Message, api.Status)   // status = a struct FIELD

func MapError(err error) APIError {
    if api, ok := mapAs404(err); ok { return api }   // -> 404 (via helper)
    if api, ok := mapAs400(err); ok { return api }   // -> 400
    return APIError{http.StatusInternalServerError, "internal error"} // -> 500
}
```

`api.Status` resolved to a bare `default`.

## Commit 1 — #192 (metadata foundation)

`Function.ReturnVars` recorded only the **max-arity** return statement, dropping all others. Since `MapError`'s returns are all single-valued, only the first `return api` survived — the concrete `500` literal and the other branches were gone.

Add `Returns [][]CallArgument` (every explicit return, source order) beside `ReturnVars` (kept for the return-by-index callers). Shared `extractReturns` helper; io.go wires meta; goldens regenerated via `-update`. **Pure fact addition — zero spec-output drift** across all testdata + real projects (verified by byte-diff; only the metadata goldens gain `returns:`).

## Commit 2 — #187 (the resolver)

`statusesFromMapperField`: resolves the selector base to the mapper call, then enumerates the concrete statuses the field takes across **every** return of the mapper — recursing through per-status helper mappers (`return api` where `api := mapAsXxx(err)`) and reading struct literals both **keyed** (`APIError{Status: 404}`) and **positional** (`APIError{404, "..."}`, indexed via the type's field order). A non-constant branch keeps an honest `default`; nothing is guessed. Wired as a third resolver after the #155 constructor-field path.

## Additive & honest — verified

A/B byte-diff (this branch vs the metadata-only baseline) across every testdata fixture and all configured real projects:

| | concrete removed | effect |
|---|---|---|
| every testdata fixture | 0 | only the new fixture differs |
| every other real project | 0 | unchanged |
| one real project | **0** | **`default` 66 → 9** (57 resolved), +concrete error-code sets |

**Zero concrete statuses removed anywhere** — the only removals are `default`s that became concrete. The 9 remaining defaults are genuinely non-constant branches (honest residue).

Note: this fans the mapper's full error-code set (e.g. `{400,401,403,404,409,422,500}`) onto every handler that reports through the mapper — the sound over-approximation, since any domain error can map to any of them. If that reads as too broad, a "collapse large shared-body error sets" policy is a separate follow-up, not a correctness issue here.

## Tests

`testdata/mapper_field_status` + structural test; unit tests for every resolver branch (keyed/positional/cross-package/pkg-qualified fields, helper recursion, cycle + depth guards, honest residue). Full suite, `-race`, lint, determinism pass; coverage at the 96% floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved detection of concrete HTTP response statuses returned through status-mapping patterns.
  - Added detailed metadata for every explicit function and method return statement.

- **Bug Fixes**
  - Resolved previously unresolved or default response statuses in generated specifications.
  - Improved metadata handling for nested return values.

- **Tests**
  - Added coverage for mapper-based status resolution, return metadata, and updated specification fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->