### PR TITLE
fix(spec): resolve status through a cross-package error constructor/mapper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,20 @@ make metrics-view         # interactive metrics viewer (scripts/view_metrics.sh)
    blocked the #170 write-destination gate; the denylist attempt was reverted
    and the metadata gap was filed instead.)
 
+10. **A call's callee name is package-shaped — never read it from `Fun.GetName()`
+    alone.** For a same-package call the `CallArgument.Fun` is an ident and
+    `Fun.GetName()` is the function name; for a **cross-package** call
+    (`pkg.NewErr(...)`) the `Fun` is a *selector* and the name lives in
+    `Fun.Sel` — `Fun.GetName()` returns `""`. Any code resolving a callee from a
+    call node must use `calleeNameOf(fun)` (ident name, else selector `.Sel`),
+    or the whole resolution silently collapses for every cross-package call.
+    This is invisible in single-package fixtures — the same-package shape works,
+    so a bug here only surfaces on real multi-package projects. (Origin: PR #194
+    — the inline constructor/mapper status resolvers bailed on a cross-package
+    error constructor `common.NewError(...)`, collapsing every cross-package
+    error status to `default`; `testdata/cross_package_constructor_status`
+    guards it.)
+
 ## Testing conventions
 
 - **Fixture projects** live in `testdata/<name>/` (a `main.go` + `go.mod`).

--- a/generator/testdata_cross_package_constructor_status_test.go
+++ b/generator/testdata_cross_package_constructor_status_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/ehabterra/apispec/spec"
+)
+
+// TestTestdata_CrossPackageConstructorStatus covers the cross-package error
+// constructor: a branch-assigned status handed to `common.NewAPIError(...)` (a
+// selector call, whose callee name lives in .Sel, not the selector itself). This
+// previously collapsed to a bare `default`; the resolver must resolve the callee
+// name from the selector and fan the branch statuses to {400, 404, 500}.
+func TestTestdata_CrossPackageConstructorStatus(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "cross_package_constructor_status", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+	noUnresolvedPlaceholders(t, out)
+
+	post := opFor(out.Paths["/reserve"], "POST")
+	if post == nil {
+		t.Fatalf("POST /reserve missing; have %v", mapPathKeys(out.Paths))
+	}
+	got := keysOf(post.Responses)
+	sort.Strings(got)
+	for _, want := range []string{"400", "404", "500"} {
+		if _, ok := post.Responses[want]; !ok {
+			t.Errorf("POST /reserve missing status %s; have %v", want, got)
+		}
+	}
+	if _, ok := post.Responses["default"]; ok {
+		t.Errorf("POST /reserve still has an unresolved default; cross-package constructor statuses should be concrete; have %v", got)
+	}
+}

--- a/internal/spec/branched_status_constructor_test.go
+++ b/internal/spec/branched_status_constructor_test.go
@@ -426,3 +426,28 @@ func TestStatusesFromConstructorField_EdgeOnlyAssignment(t *testing.T) {
 		t.Error("all-constant branches must not report a residue")
 	}
 }
+
+// TestCalleeNameOf covers same-package idents, cross-package selectors, and the
+// empty cases.
+func TestCalleeNameOf(t *testing.T) {
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	if got := calleeNameOf(mkIdent(meta, "NewErr", "")); got != "NewErr" {
+		t.Errorf("ident: got %q, want NewErr", got)
+	}
+	// pkg.NewErr — a selector whose name lives in .Sel.
+	sel := metadata.NewCallArgument(meta)
+	sel.SetKind(metadata.KindSelector)
+	sel.X, sel.Sel = mkIdent(meta, "pkg", ""), mkIdent(meta, "NewErr", "")
+	if got := calleeNameOf(sel); got != "NewErr" {
+		t.Errorf("selector: got %q, want NewErr", got)
+	}
+	if got := calleeNameOf(nil); got != "" {
+		t.Errorf("nil: got %q, want empty", got)
+	}
+	// A selector with no Sel yields empty.
+	bare := metadata.NewCallArgument(meta)
+	bare.SetKind(metadata.KindSelector)
+	if got := calleeNameOf(bare); got != "" {
+		t.Errorf("selector without Sel: got %q, want empty", got)
+	}
+}

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -2648,10 +2648,7 @@ func (r *ResponsePatternMatcherImpl) statusesFromConstructorField(arg *metadata.
 	var calleeFunc, valPos string
 	switch base.GetKind() {
 	case metadata.KindCall:
-		if base.Fun == nil {
-			return nil, false
-		}
-		calleeFunc = base.Fun.GetName()
+		calleeFunc = calleeNameOf(base.Fun)
 		valPos = impl.GetString(base.Position)
 	case metadata.KindIdent:
 		// Edge-first (assignmentsAt): the error variable may be assigned inside a
@@ -2678,6 +2675,23 @@ func (r *ResponsePatternMatcherImpl) statusesFromConstructorField(arg *metadata.
 		return nil, false
 	}
 	return r.expandVarStatuses(statusArg.GetName(), scope, impl)
+}
+
+// calleeNameOf returns the bare name of the function a call invokes, from the
+// call's Fun. A same-package call (`NewErr(...)`) has a plain ident Fun whose
+// name is the function; a cross-package call (`pkg.NewErr(...)`) has a selector
+// Fun whose name lives in .Sel. Returns "" when neither yields a name.
+func calleeNameOf(fun *metadata.CallArgument) string {
+	if fun == nil {
+		return ""
+	}
+	if name := fun.GetName(); name != "" {
+		return name
+	}
+	if fun.GetKind() == metadata.KindSelector && fun.Sel != nil {
+		return fun.Sel.GetName()
+	}
+	return ""
 }
 
 // findCallEdge returns the call-graph edge from callerID to a callee named

--- a/internal/spec/mapper_field_status.go
+++ b/internal/spec/mapper_field_status.go
@@ -71,10 +71,9 @@ func (r *ResponsePatternMatcherImpl) statusesFromMapperField(arg *metadata.CallA
 	var mapperFunc, mapperPkg string
 	switch base.GetKind() {
 	case metadata.KindCall:
-		if base.Fun == nil {
-			return nil, false
-		}
-		mapperFunc = base.Fun.GetName()
+		// Same-package `MapError(...)` (ident Fun) or cross-package
+		// `pkg.MapError(...)` (selector Fun — name lives in .Sel).
+		mapperFunc = calleeNameOf(base.Fun)
 	case metadata.KindIdent:
 		as := assignmentsAt(impl, baseNode.GetEdge(), base.GetName())
 		if len(as) == 0 || as[len(as)-1].Value.GetKind() != metadata.KindCall {
@@ -171,12 +170,14 @@ func (r *ResponsePatternMatcherImpl) fieldStatusOfValue(impl *ContextProviderImp
 		}
 		return residue
 	case metadata.KindCall:
-		// A returned helper call directly (`return mapAsXxx(err)`). The callee
-		// package is usually the mapper's own; fall back to a name search.
-		if val.Fun == nil {
+		// A returned helper call directly (`return mapAsXxx(err)` or
+		// `return pkg.mapAsXxx(err)`). The callee package is usually the mapper's
+		// own; findFunctionByName falls back to an all-packages name search.
+		name := calleeNameOf(val.Fun)
+		if name == "" {
 			return false
 		}
-		helper := findFunctionByName(impl.meta, impl.GetString(scope.Pkg), val.Fun.GetName())
+		helper := findFunctionByName(impl.meta, impl.GetString(scope.Pkg), name)
 		return r.returnFieldStatuses(impl, helper, fieldName, set, seen, depth+1)
 	}
 	return false

--- a/testdata/cross_package_constructor_status/common/common.go
+++ b/testdata/cross_package_constructor_status/common/common.go
@@ -1,0 +1,24 @@
+// Package common holds the shared error constructor and responder — in a
+// DIFFERENT package from the handler that sets the branched status. This is the
+// cross-package shape that previously collapsed the status to `default`: the
+// call `common.NewAPIError(...)` has a selector Fun (`common.NewAPIError`), whose
+// name lives in .Sel, so the resolver must read the selector field, not the
+// selector itself.
+package common
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type APIError struct {
+	Message string `json:"message"`
+	Code    int    `json:"-"`
+}
+
+func NewAPIError(message string, code int) *APIError { return &APIError{Message: message, Code: code} }
+
+func RespondWithError(w http.ResponseWriter, err *APIError) {
+	w.WriteHeader(err.Code)
+	_ = json.NewEncoder(w).Encode(err)
+}

--- a/testdata/cross_package_constructor_status/go.mod
+++ b/testdata/cross_package_constructor_status/go.mod
@@ -1,0 +1,3 @@
+module cross_package_constructor_status
+
+go 1.26

--- a/testdata/cross_package_constructor_status/main.go
+++ b/testdata/cross_package_constructor_status/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"errors"
+	"net/http"
+
+	"cross_package_constructor_status/common"
+)
+
+var (
+	ErrNotFound   = errors.New("not found")
+	ErrValidation = errors.New("validation")
+)
+
+// paymentError sets the status across branches, then hands it to the
+// cross-package error constructor + responder.
+func paymentError(w http.ResponseWriter, err error) {
+	var statusCode int
+	switch {
+	case errors.Is(err, ErrNotFound):
+		statusCode = http.StatusNotFound
+	case errors.Is(err, ErrValidation):
+		statusCode = http.StatusBadRequest
+	default:
+		statusCode = http.StatusInternalServerError
+	}
+	common.RespondWithError(w, common.NewAPIError("error", statusCode))
+}
+
+func doReserve(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Query().Get("id") == "" {
+		paymentError(w, ErrValidation)
+		return
+	}
+	paymentError(w, ErrNotFound)
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /reserve", doReserve)
+	_ = http.ListenAndServe(":8080", mux)
+}


### PR DESCRIPTION
Found while investigating the `default` responses.

## Root cause

The status resolvers read the called function's name from a call's `Fun` via `Fun.GetName()`. For a **same-package** call that Fun is an ident (`NewErr(...)`) and `GetName()` returns the name. For a **cross-package** call it's a **selector** (`common.NewErr(...)`), whose name lives in `.Sel` — so `GetName()` returns `""` and the inline-constructor branch of `statusesFromConstructorField` (and the mapper base of `statusesFromMapperField`) bailed, collapsing the operation to a bare `default`.

## Fix

Add `calleeNameOf`, which reads the name from an ident Fun or a selector's `.Sel`, and route the three inline-call sites through it (constructor-field resolution, mapper-field base, mapper helper-return recursion).

## How it was found

Narrowed with four variants — the culprit was cross-package, independent of the chi handler-factory:

| package | handler | before |
|---|---|---|
| same | plain / chi factory | ✅ resolves |
| **cross** | plain / chi factory | ❌ only `default` |

Minimal repro: `testdata/cross_package_constructor_status` (a `common` package with the constructor + responder, a handler that sets the branched status).

## Purely additive — verified

A/B byte-diff (this branch vs `main`) across all testdata and real projects:

- fixture: `default` → `{400,404,500}` (default replaced by concrete codes)
- one real project: **+17 concrete error statuses**, 0 removed (the branch codes — e.g. the `404`s — that were collapsing now resolve)
- every other project: unchanged
- **zero concrete statuses removed anywhere**

Fixture + structural test + `calleeNameOf` unit test; full suite, `-race`, lint, determinism pass; coverage at the 96% floor.

## Note

This resolves the *error-mapper* statuses. The remaining `default`s on those same real-project operations are a **separate** issue — a secondary success-response body whose status isn't pinned — not the error path. Tracking that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of constructor and mapper references across packages.
  * Correctly resolves status codes from selector-style calls, including concrete responses such as 400, 404, and 500.
  * Prevented unresolved placeholders and unintended default responses in generated API specifications.

* **Tests**
  * Added coverage for cross-package constructor status resolution and varied call-expression forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
