### PR TITLE
docs+test: document the json.Marshal response over-detection (#195); no gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,14 @@ make metrics-view         # interactive metrics viewer (scripts/view_metrics.sh)
 
 ## Testing conventions
 
+- **Probe every uncovered shape with a fixture.** When you hit a code shape no
+  existing fixture covers — a new wiring style, an edge case, a suspected gap —
+  reproduce it as a `testdata/` fixture first, then decide from what it shows:
+  if it exposes a real bug, file an issue (golden rule #9) and, when the fix is
+  deferred, keep the fixture as a change-detector (assert the current behavior
+  with a comment so the test flips when it's fixed); if it already works, the
+  fixture is regression coverage. Never assert a case is (un)covered from
+  reasoning alone — build the fixture and look.
 - **Fixture projects** live in `testdata/<name>/` (a `main.go` + `go.mod`).
   Every fixture is wired into `go test` via structural tests in `generator/`
   (`testdata_*_test.go`): expected routes/methods present, no dangling

--- a/generator/testdata_downstream_client_not_response_test.go
+++ b/generator/testdata_downstream_client_not_response_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/spec"
+)
+
+// TestTestdata_DownstreamClientNotResponse pins the KNOWN over-detection bug of
+// issue #195: json.Marshal is matched as a response with no write-sink check, so
+// a downstream HTTP client's OUTBOUND-request marshal (in a method with no
+// ResponseWriter) leaks as a spurious `default` response of the outer route.
+// The handler's real responses are the success 200 and the error 500.
+//
+// This is a CHANGE-DETECTOR for the unsolved bug: it asserts the spurious
+// `default` is still present. When #195's root-cause fix lands (anchor response
+// detection on the write to w and trace the written value's type back), the
+// spurious default disappears — this test then fails, prompting the update to
+// require exactly {200, 500}.
+func TestTestdata_DownstreamClientNotResponse(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "downstream_client_not_response", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+
+	get := opFor(out.Paths["/pk"], "GET")
+	if get == nil {
+		t.Fatalf("GET /pk missing; have %v", mapPathKeys(out.Paths))
+	}
+	for _, want := range []string{"200", "500"} {
+		if _, ok := get.Responses[want]; !ok {
+			t.Errorf("GET /pk missing status %s; have %v", want, keysOf(get.Responses))
+		}
+	}
+	if _, ok := get.Responses["default"]; !ok {
+		t.Errorf("issue #195 appears FIXED (no spurious `default` on GET /pk) — update this test to require exactly {200,500}")
+	}
+}

--- a/internal/spec/config.go
+++ b/internal/spec/config.go
@@ -803,6 +803,12 @@ func jsonMarshalPattern() ResponsePattern {
 		TypeArgIndex: 0,
 		TypeFromArg:  true,
 		Deref:        true,
+		// NOTE: json.Marshal(v) returns []byte with no writer argument, so it is
+		// not destination-gated. It therefore over-detects — a Marshal reachable
+		// anywhere (e.g. a downstream client marshaling its OUTBOUND request) is
+		// treated as a response. Root cause + fix (anchor detection on the write
+		// sink, trace the written value's type back) tracked in issue #195; a
+		// writer-in-scope filter was tried and reverted as a workaround (#197).
 	}
 }
 

--- a/testdata/downstream_client_not_response/client/client.go
+++ b/testdata/downstream_client_not_response/client/client.go
@@ -1,0 +1,32 @@
+// Package client is a downstream HTTP client. Its json.Marshal serializes the
+// OUTBOUND request — the client method has no ResponseWriter, so the request
+// type must NOT surface as the outer route's response (issue #195).
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type FetchRequest struct {
+	Amount   int               `json:"amount"`
+	Metadata map[string]string `json:"metadata"`
+}
+
+type FetchResponse struct {
+	Key string `json:"key"`
+}
+
+type Client struct{}
+
+func (c *Client) Fetch(params *FetchRequest) (*FetchResponse, error) {
+	payload, err := json.Marshal(params) // outbound request marshal — goes to the wire, not w
+	if err != nil {
+		return nil, err
+	}
+	_, _ = http.Post("http://svc/fetch", "application/json", nil)
+	_ = payload
+	var resp FetchResponse
+	_ = json.Unmarshal([]byte(`{}`), &resp)
+	return &resp, nil
+}

--- a/testdata/downstream_client_not_response/common/common.go
+++ b/testdata/downstream_client_not_response/common/common.go
@@ -1,0 +1,17 @@
+package common
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type Response struct {
+	Message string      `json:"message"`
+	Data    interface{} `json:"data"`
+}
+
+func RespondWithSuccess(w http.ResponseWriter, msg string, data interface{}, code int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(Response{Message: msg, Data: data})
+}

--- a/testdata/downstream_client_not_response/go.mod
+++ b/testdata/downstream_client_not_response/go.mod
@@ -1,0 +1,3 @@
+module downstream_client_not_response
+
+go 1.26

--- a/testdata/downstream_client_not_response/main.go
+++ b/testdata/downstream_client_not_response/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"net/http"
+
+	"downstream_client_not_response/common"
+	"downstream_client_not_response/usecase"
+)
+
+type dto struct {
+	Key string `json:"key"`
+}
+
+func handler(uc usecase.UseCase) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		key, err := uc.Get(r.Context())
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		common.RespondWithSuccess(w, "ok", dto{Key: key}, http.StatusOK)
+	}
+}
+
+func main() {
+	uc := usecase.New()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /pk", handler(uc))
+	_ = http.ListenAndServe(":8080", mux)
+}

--- a/testdata/downstream_client_not_response/usecase/usecase.go
+++ b/testdata/downstream_client_not_response/usecase/usecase.go
@@ -1,0 +1,23 @@
+package usecase
+
+import (
+	"context"
+
+	"downstream_client_not_response/client"
+)
+
+type UseCase interface {
+	Get(ctx context.Context) (string, error)
+}
+
+type impl struct{ c *client.Client }
+
+func New() UseCase { return &impl{c: &client.Client{}} }
+
+func (u *impl) Get(ctx context.Context) (string, error) {
+	resp, err := u.c.Fetch(&client.FetchRequest{Amount: 1})
+	if err != nil {
+		return "", err
+	}
+	return resp.Key, nil
+}


### PR DESCRIPTION
Does **not** close #195 — it documents the over-detection and deliberately does **not** ship a fix.

## What happened

`json.Marshal(v)` returns `[]byte` with no writer argument, so it can't be destination-gated like `json.NewEncoder(w).Encode(v)`. Result: every reachable `json.Marshal` is treated as a response, and a downstream client's **outbound-request** marshal leaks as a spurious `default`.

I first tried a `RequireWriterInScope` gate (drop the marshal when the enclosing function has no response writer). On review that's a **workaround**, for two reasons:

1. It gates on a **proxy** ("is a writer nearby") rather than the real signal ("do the marshaled bytes reach `w`?"). It's a *necessary*, not *sufficient*, condition.
2. Exposing that proxy as a **config knob** institutionalizes a heuristic we already know is incomplete — it introduced its own false negative (a helper marshal whose bytes a different helper writes was dropped). That's trading one wrong answer for another (golden rule #9).

So the gate is **reverted**. The honest state is the tracked bug, not a config-flagged heuristic.

## What this PR keeps

- `json.Marshal` stays ungated; a `NOTE` on `jsonMarshalPattern` points at #195.
- `testdata/downstream_client_not_response` — a **change-detector**: asserts the spurious `default` is still present, and fails when #195's root-cause fix lands.
- CLAUDE.md — the general rule (probe every uncovered shape with a fixture; file an issue if real; keep it as a change-detector when deferred).

No behavior change vs `main` (the gate never merged). The root-cause fix — anchor response detection on the **write sink** (`w.Write(x)` / encoder bound to `w`) and trace the written value's type back — is tracked in **#195**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)