### PR TITLE
fix(spec): anchor response detection on the write sink (#195)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,14 @@ make metrics-view         # interactive metrics viewer (scripts/view_metrics.sh)
 
 ## Testing conventions
 
+- **Probe every uncovered shape with a fixture.** When you hit a code shape no
+  existing fixture covers — a new wiring style, an edge case, a suspected gap —
+  reproduce it as a `testdata/` fixture first, then decide from what it shows:
+  if it exposes a real bug, file an issue (golden rule #9) and, when the fix is
+  deferred, keep the fixture as a change-detector (assert the current behavior
+  with a comment so the test flips when it's fixed); if it already works, the
+  fixture is regression coverage. Never assert a case is (un)covered from
+  reasoning alone — build the fixture and look.
 - **Fixture projects** live in `testdata/<name>/` (a `main.go` + `go.mod`).
   Every fixture is wired into `go test` via structural tests in `generator/`
   (`testdata_*_test.go`): expected routes/methods present, no dangling

--- a/generator/testdata_downstream_client_not_response_test.go
+++ b/generator/testdata_downstream_client_not_response_test.go
@@ -20,17 +20,12 @@ import (
 	"github.com/ehabterra/apispec/spec"
 )
 
-// TestTestdata_DownstreamClientNotResponse pins the KNOWN over-detection bug of
-// issue #195: json.Marshal is matched as a response with no write-sink check, so
-// a downstream HTTP client's OUTBOUND-request marshal (in a method with no
-// ResponseWriter) leaks as a spurious `default` response of the outer route.
-// The handler's real responses are the success 200 and the error 500.
-//
-// This is a CHANGE-DETECTOR for the unsolved bug: it asserts the spurious
-// `default` is still present. When #195's root-cause fix lands (anchor response
-// detection on the write to w and trace the written value's type back), the
-// spurious default disappears — this test then fails, prompting the update to
-// require exactly {200, 500}.
+// TestTestdata_DownstreamClientNotResponse covers the fix for issue #195:
+// response detection is anchored on the write to w, so a downstream HTTP
+// client's OUTBOUND-request marshal (json.Marshal in a method with no
+// ResponseWriter) is never reached from a sink and does NOT leak as a spurious
+// `default` response of the outer route. The handler's only responses are the
+// success 200 (its RespondWithSuccess encode) and the error 500 (http.Error).
 func TestTestdata_DownstreamClientNotResponse(t *testing.T) {
 	out := loadTestdataWithFixtureConfig(t, "downstream_client_not_response", spec.DefaultHTTPConfig())
 	noDanglingRefs(t, out)
@@ -44,7 +39,7 @@ func TestTestdata_DownstreamClientNotResponse(t *testing.T) {
 			t.Errorf("GET /pk missing status %s; have %v", want, keysOf(get.Responses))
 		}
 	}
-	if _, ok := get.Responses["default"]; !ok {
-		t.Errorf("issue #195 appears FIXED (no spurious `default` on GET /pk) — update this test to require exactly {200,500}")
+	if _, ok := get.Responses["default"]; ok {
+		t.Errorf("GET /pk: spurious `default` response present — the downstream client's outbound-request marshal leaked (issue #195 regressed); have %v", keysOf(get.Responses))
 	}
 }

--- a/generator/testdata_downstream_client_not_response_test.go
+++ b/generator/testdata_downstream_client_not_response_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/spec"
+)
+
+// TestTestdata_DownstreamClientNotResponse pins the KNOWN over-detection bug of
+// issue #195: json.Marshal is matched as a response with no write-sink check, so
+// a downstream HTTP client's OUTBOUND-request marshal (in a method with no
+// ResponseWriter) leaks as a spurious `default` response of the outer route.
+// The handler's real responses are the success 200 and the error 500.
+//
+// This is a CHANGE-DETECTOR for the unsolved bug: it asserts the spurious
+// `default` is still present. When #195's root-cause fix lands (anchor response
+// detection on the write to w and trace the written value's type back), the
+// spurious default disappears — this test then fails, prompting the update to
+// require exactly {200, 500}.
+func TestTestdata_DownstreamClientNotResponse(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "downstream_client_not_response", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+
+	get := opFor(out.Paths["/pk"], "GET")
+	if get == nil {
+		t.Fatalf("GET /pk missing; have %v", mapPathKeys(out.Paths))
+	}
+	for _, want := range []string{"200", "500"} {
+		if _, ok := get.Responses[want]; !ok {
+			t.Errorf("GET /pk missing status %s; have %v", want, keysOf(get.Responses))
+		}
+	}
+	if _, ok := get.Responses["default"]; !ok {
+		t.Errorf("issue #195 appears FIXED (no spurious `default` on GET /pk) — update this test to require exactly {200,500}")
+	}
+}

--- a/generator/testdata_write_sink_marshal_test.go
+++ b/generator/testdata_write_sink_marshal_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	intspec "github.com/ehabterra/apispec/internal/spec"
+	"github.com/ehabterra/apispec/spec"
+)
+
+// TestTestdata_WriteSinkMarshal covers the write-sink model of issue #195:
+// response detection anchored on the write to w, resolving the body by tracing
+// the written []byte back to the serialization transform that produced it.
+//
+//   - /marshal-write (FIXED, direct case): b, _ := json.Marshal(v); w.Write(b).
+//     The sink resolves the body to v's type (Payload) at the adjacent
+//     WriteHeader(200) status, and no spurious `default` remains.
+//   - /raw-write: w.Write([]byte("pong")) — a raw write with no transform behind
+//     it stays a plain (schema-less) 200, never a spurious $ref body.
+//   - /helper-write (CHANGE-DETECTOR, helper hop still pending): the marshal
+//     lives one function boundary away (encodeEnvelope returns json.Marshal(e)),
+//     so the sink can't yet trace through it — the Envelope body still lands on
+//     `default` instead of 200. When the helper-return hop lands, this flips.
+func TestTestdata_WriteSinkMarshal(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "write_sink_marshal", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+
+	// Direct case: the payload is on 200, and there is no spurious default.
+	mw := opFor(out.Paths["/marshal-write"], "GET")
+	if mw == nil {
+		t.Fatalf("GET /marshal-write missing; have %v", mapPathKeys(out.Paths))
+	}
+	if !responseRefsAt(mw.Responses, "200", "Payload") {
+		t.Errorf("GET /marshal-write: expected 200 to ref Payload (sink traced b->json.Marshal(v)), got %v", keysOf(mw.Responses))
+	}
+	if _, ok := mw.Responses["default"]; ok {
+		t.Errorf("GET /marshal-write: unexpected spurious `default` response — the write-sink model should have absorbed the marshal into 200")
+	}
+
+	// Raw write: 200 exists but carries no $ref body (it is raw bytes).
+	rw := opFor(out.Paths["/raw-write"], "GET")
+	if rw == nil {
+		t.Fatalf("GET /raw-write missing; have %v", mapPathKeys(out.Paths))
+	}
+	for status, resp := range rw.Responses {
+		for ct, media := range resp.Content {
+			if media.Schema != nil && media.Schema.Ref != "" {
+				t.Errorf("GET /raw-write [%s %s]: unexpected $ref %q — a raw w.Write([]byte) must not synthesize a body", status, ct, media.Schema.Ref)
+			}
+		}
+	}
+
+	// Helper hop still pending: Envelope lands on `default`, not 200. When the
+	// helper-return hop is implemented, the sink will resolve Envelope at 200 and
+	// this assertion flips — update it to require 200->Envelope with no default.
+	hw := opFor(out.Paths["/helper-write"], "GET")
+	if hw == nil {
+		t.Fatalf("GET /helper-write missing; have %v", mapPathKeys(out.Paths))
+	}
+	if !responseRefsAt(hw.Responses, "default", "Envelope") {
+		t.Errorf("helper-return hop appears IMPLEMENTED (Envelope no longer on `default`) — update this test to require 200->Envelope with no default")
+	}
+}
+
+// responseRefsAt reports whether the response at the given status has a content
+// schema whose $ref names the given type.
+func responseRefsAt(responses map[string]intspec.Response, status, name string) bool {
+	resp, ok := responses[status]
+	if !ok {
+		return false
+	}
+	for _, media := range resp.Content {
+		if media.Schema != nil && strings.Contains(media.Schema.Ref, name) {
+			return true
+		}
+	}
+	return false
+}

--- a/generator/testdata_write_sink_marshal_test.go
+++ b/generator/testdata_write_sink_marshal_test.go
@@ -87,6 +87,30 @@ func TestTestdata_WriteSinkMarshal(t *testing.T) {
 	if !responseRefsAt(mtw.Responses, "200", "Member") {
 		t.Errorf("GET /method-write: expected 200 to ref Member (method-scope sink unwrap), got %v", keysOf(mtw.Responses))
 	}
+
+	// Multi-param helper: the serialized payload is the helper's SECOND
+	// parameter, so the sink must bind to the correct positional call-site arg.
+	mpw := opFor(out.Paths["/multiparam-write"], "GET")
+	if mpw == nil {
+		t.Fatalf("GET /multiparam-write missing; have %v", mapPathKeys(out.Paths))
+	}
+	if !responseRefsAt(mpw.Responses, "200", "Boxed") {
+		t.Errorf("GET /multiparam-write: expected 200 to ref Boxed (positional param binding), got %v", keysOf(mpw.Responses))
+	}
+
+	// Raw helper: returns non-serialized bytes, so no body transform is found —
+	// the response carries no $ref schema.
+	rhw := opFor(out.Paths["/rawhelper-write"], "GET")
+	if rhw == nil {
+		t.Fatalf("GET /rawhelper-write missing; have %v", mapPathKeys(out.Paths))
+	}
+	for status, resp := range rhw.Responses {
+		for ct, media := range resp.Content {
+			if media.Schema != nil && media.Schema.Ref != "" {
+				t.Errorf("GET /rawhelper-write [%s %s]: unexpected $ref %q — a raw-bytes helper must not synthesize a body", status, ct, media.Schema.Ref)
+			}
+		}
+	}
 }
 
 // responseRefsAt reports whether the response at the given status has a content

--- a/generator/testdata_write_sink_marshal_test.go
+++ b/generator/testdata_write_sink_marshal_test.go
@@ -31,10 +31,10 @@ import (
 //     WriteHeader(200) status, and no spurious `default` remains.
 //   - /raw-write: w.Write([]byte("pong")) — a raw write with no transform behind
 //     it stays a plain (schema-less) 200, never a spurious $ref body.
-//   - /helper-write (CHANGE-DETECTOR, helper hop still pending): the marshal
-//     lives one function boundary away (encodeEnvelope returns json.Marshal(e)),
-//     so the sink can't yet trace through it — the Envelope body still lands on
-//     `default` instead of 200. When the helper-return hop lands, this flips.
+//   - /helper-write: the marshal lives one function boundary away
+//     (encodeEnvelope returns json.Marshal(e)); the sink traces through the
+//     helper's return to the serialized parameter and binds it to the call-site
+//     value, resolving Envelope at 200.
 func TestTestdata_WriteSinkMarshal(t *testing.T) {
 	out := loadTestdataWithFixtureConfig(t, "write_sink_marshal", spec.DefaultHTTPConfig())
 	noDanglingRefs(t, out)
@@ -64,15 +64,28 @@ func TestTestdata_WriteSinkMarshal(t *testing.T) {
 		}
 	}
 
-	// Helper hop still pending: Envelope lands on `default`, not 200. When the
-	// helper-return hop is implemented, the sink will resolve Envelope at 200 and
-	// this assertion flips — update it to require 200->Envelope with no default.
+	// Helper hop: Envelope resolves at 200 (traced through encodeEnvelope's
+	// returned marshal, bound to the call-site value), with no spurious default.
 	hw := opFor(out.Paths["/helper-write"], "GET")
 	if hw == nil {
 		t.Fatalf("GET /helper-write missing; have %v", mapPathKeys(out.Paths))
 	}
-	if !responseRefsAt(hw.Responses, "default", "Envelope") {
-		t.Errorf("helper-return hop appears IMPLEMENTED (Envelope no longer on `default`) — update this test to require 200->Envelope with no default")
+	if !responseRefsAt(hw.Responses, "200", "Envelope") {
+		t.Errorf("GET /helper-write: expected 200 to ref Envelope (sink traced through helper return), got %v", keysOf(hw.Responses))
+	}
+	if _, ok := hw.Responses["default"]; ok {
+		t.Errorf("GET /helper-write: unexpected spurious `default` — the helper-return hop should resolve Envelope at 200")
+	}
+
+	// Method handler: the sink resolves b := json.Marshal(m) from the method's
+	// own scope (via the method table, since a plain method has no
+	// ParentFunction), yielding Member at 200.
+	mtw := opFor(out.Paths["/method-write"], "GET")
+	if mtw == nil {
+		t.Fatalf("GET /method-write missing; have %v", mapPathKeys(out.Paths))
+	}
+	if !responseRefsAt(mtw.Responses, "200", "Member") {
+		t.Errorf("GET /method-write: expected 200 to ref Member (method-scope sink unwrap), got %v", keysOf(mtw.Responses))
 	}
 }
 

--- a/internal/spec/config.go
+++ b/internal/spec/config.go
@@ -803,6 +803,12 @@ func jsonMarshalPattern() ResponsePattern {
 		TypeArgIndex: 0,
 		TypeFromArg:  true,
 		Deref:        true,
+		// NOTE: json.Marshal(v) returns []byte with no writer argument, so it is
+		// not destination-gated. It therefore over-detects — a Marshal reachable
+		// anywhere (e.g. a downstream client marshaling its OUTBOUND request) is
+		// treated as a response. Root cause + fix (anchor detection on the write
+		// sink, trace the written value's type back) tracked in issue #195; a
+		// writer-in-scope filter was tried and reverted as a workaround (#197).
 	}
 }
 

--- a/internal/spec/config.go
+++ b/internal/spec/config.go
@@ -88,6 +88,31 @@ type ResponseContextConfig struct {
 	// because it could not be resolved to a concrete value — could be the
 	// writer, so the response is kept (honest over wrong).
 	WriterCompatibleTypeRegexes []string `yaml:"writerCompatibleTypeRegexes,omitempty" json:"writerCompatibleTypeRegexes,omitempty"`
+
+	// BodyTransforms describe serialization calls whose result is a response
+	// body. When a write sink writes their result — the decoupled shape
+	// `b, _ := json.Marshal(v); w.Write(b)`, or `w.Write(encode(v))` — the body
+	// type is resolved from the transform's payload argument (v), not from the
+	// []byte the sink literally receives. Anchoring response detection on the
+	// write sink and tracing back through these transforms is what removes the
+	// marshal-anywhere over-detection (issue #195): a json.Marshal whose result
+	// never reaches a sink (a downstream client's outbound request) is simply
+	// never a response.
+	BodyTransforms []BodyTransform `yaml:"bodyTransforms,omitempty" json:"bodyTransforms,omitempty"`
+}
+
+// BodyTransform matches a serialization call (by callee function name and
+// package) whose result is a serialized response body, and names the argument
+// that carries the payload whose type the schema should document. Used by the
+// write-sink resolver to trace a written []byte back to its source value.
+type BodyTransform struct {
+	// CallRegex matches the callee function name, e.g. "^Marshal(Indent)?$".
+	CallRegex string `yaml:"callRegex,omitempty" json:"callRegex,omitempty"`
+	// PkgRegex matches the callee package path, e.g. "^encoding/json$". Empty
+	// matches any package.
+	PkgRegex string `yaml:"pkgRegex,omitempty" json:"pkgRegex,omitempty"`
+	// ArgIndex is the position of the payload argument (json.Marshal(v) -> 0).
+	ArgIndex int `yaml:"argIndex,omitempty" json:"argIndex,omitempty"`
 }
 
 // RequestContextConfig describes the types and accessors that identify an

--- a/internal/spec/config.go
+++ b/internal/spec/config.go
@@ -820,22 +820,14 @@ func netHTTPResponsePatterns() []ResponsePattern {
 	}
 }
 
-// jsonMarshalPattern returns the encoding/json.Marshal-style response
-// pattern. Identical across every framework default.
-func jsonMarshalPattern() ResponsePattern {
-	return ResponsePattern{
-		CallRegex:    `^Marshal$`,
-		TypeArgIndex: 0,
-		TypeFromArg:  true,
-		Deref:        true,
-		// NOTE: json.Marshal(v) returns []byte with no writer argument, so it is
-		// not destination-gated. It therefore over-detects — a Marshal reachable
-		// anywhere (e.g. a downstream client marshaling its OUTBOUND request) is
-		// treated as a response. Root cause + fix (anchor detection on the write
-		// sink, trace the written value's type back) tracked in issue #195; a
-		// writer-in-scope filter was tried and reverted as a workaround (#197).
-	}
-}
+// Response detection for json.Marshal is intentionally NOT a standalone
+// pattern. json.Marshal(v) returns []byte with no writer argument, so matching
+// it in isolation over-detects: a Marshal reachable anywhere (e.g. a downstream
+// client marshaling its OUTBOUND request) would be treated as a response.
+// Instead, detection is anchored on the write sink — the ^Write$ pattern —
+// which traces the written []byte back through ResponseContext.BodyTransforms to
+// the marshaled value's type (see unwrapWriteSink, issue #195). A marshal whose
+// result never reaches a sink is therefore never a response, structurally.
 
 // jsonEncodePattern returns the json.Encoder.Encode response pattern.
 // recvTypeRegex varies between frameworks: pass "" to match any receiver,

--- a/internal/spec/config_chi.go
+++ b/internal/spec/config_chi.go
@@ -35,7 +35,6 @@ func DefaultChiConfig() *APISpecConfig {
 			StatusFromArg:  true,
 			RecvTypeRegex:  "^github\\.com/go-chi/render$",
 		},
-		jsonMarshalPattern(),
 		jsonEncodePattern(".*json(iter)?\\.\\*?Encoder"),
 	)
 

--- a/internal/spec/config_echo.go
+++ b/internal/spec/config_echo.go
@@ -49,7 +49,6 @@ func DefaultEchoConfig() *APISpecConfig {
 			TypeArgIndex:   -1,
 			RecvTypeRegex:  "github\\.com/labstack/echo/v\\d\\.Context",
 		},
-		jsonMarshalPattern(),
 		jsonEncodePattern(".*json(iter)?\\.\\*?Encoder"),
 	)
 

--- a/internal/spec/config_fiber.go
+++ b/internal/spec/config_fiber.go
@@ -59,7 +59,6 @@ func DefaultFiberConfig() *APISpecConfig {
 			TypeArgIndex:   -1,
 			RecvTypeRegex:  `^github\.com/gofiber/fiber(/v\d)?\.\*Ctx$`,
 		},
-		jsonMarshalPattern(),
 		jsonEncodePattern(".*json(iter)?\\.\\*?Encoder"),
 	)
 

--- a/internal/spec/config_gin.go
+++ b/internal/spec/config_gin.go
@@ -40,7 +40,6 @@ func DefaultGinConfig() *APISpecConfig {
 			TypeFromArg:    true,
 			StatusFromArg:  true,
 		},
-		jsonMarshalPattern(),
 		jsonEncodePattern(""),
 	)
 

--- a/internal/spec/config_http.go
+++ b/internal/spec/config_http.go
@@ -44,6 +44,13 @@ var netHTTPResponseContext = ResponseContextConfig{
 		`^io\.WriteCloser$`,
 		`^io\.ReadWriter$`,
 	},
+	// Serializers whose result, when written to the response writer, carries the
+	// response body's type on their payload argument (issue #195). Serializer-
+	// level, not framework-level, so every net/http-family framework shares it.
+	BodyTransforms: []BodyTransform{
+		{CallRegex: `^Marshal$`, PkgRegex: `^encoding/json$`, ArgIndex: 0},
+		{CallRegex: `^MarshalIndent$`, PkgRegex: `^encoding/json$`, ArgIndex: 0},
+	},
 }
 
 // DefaultHTTPConfig returns a default configuration for net/http.

--- a/internal/spec/config_http.go
+++ b/internal/spec/config_http.go
@@ -67,7 +67,6 @@ func DefaultHTTPConfig() *APISpecConfig {
 			TypeFromArg:    true,
 			Deref:          true,
 		},
-		jsonMarshalPattern(),
 		jsonEncodePattern(""),
 	)
 

--- a/internal/spec/config_mux.go
+++ b/internal/spec/config_mux.go
@@ -97,7 +97,6 @@ func DefaultMuxConfig() *APISpecConfig {
 				jsonUnmarshalRequestPattern("json"),
 			},
 			ResponsePatterns: append(netHTTPResponsePatterns(),
-				jsonMarshalPattern(),
 				jsonEncodePattern(".*json(iter)?\\.\\*?Encoder"),
 			),
 			ParamPatterns: []ParamPattern{

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -2256,6 +2256,15 @@ func (r *ResponsePatternMatcherImpl) ExtractResponse(node TrackerNodeInterface, 
 
 		arg := edge.Args[r.pattern.TypeArgIndex]
 
+		// Write-sink transform unwrap (issue #195): when the written value is the
+		// result of a serialization transform (b := json.Marshal(v); w.Write(b)),
+		// resolve the body from the transform's payload (v) rather than the []byte
+		// the sink literally receives. No-op when the arg isn't a transform result
+		// (a raw w.Write([]byte("ok"))), so raw writes are kept as-is.
+		if payload := r.unwrapWriteSink(arg, edge); payload != nil {
+			arg = payload
+		}
+
 		// Parameter tracing: if the body arg is a parameter of the
 		// enclosing function (e.g. Encode(v) inside writeJSON(w, status,
 		// v)), follow it to the caller's actual argument so we get the

--- a/internal/spec/write_sink.go
+++ b/internal/spec/write_sink.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import "github.com/ehabterra/apispec/internal/metadata"
+
+// unwrapWriteSink resolves a write-sink byte argument back to the payload of the
+// serialization transform that produced it. The write sink w.Write(b) sees only
+// b's []byte type; when b came from `b, _ := json.Marshal(v)` the response body
+// is v's type, one transform hop back. Returns the payload argument (v) when the
+// sink's argument traces to a configured BodyTransform, or nil when it does not —
+// a raw write (w.Write([]byte("ok"))) has no transform behind it and is kept
+// as-is (honest over wrong).
+//
+// This is the mechanism that lets response detection be anchored on the write
+// sink rather than on the marshal call in isolation (issue #195): a json.Marshal
+// whose result is never written to a response writer (a downstream client's
+// outbound request) is simply never reached from a sink, so it never becomes a
+// response.
+func (r *ResponsePatternMatcherImpl) unwrapWriteSink(arg *metadata.CallArgument, edge *metadata.CallGraphEdge) *metadata.CallArgument {
+	if arg == nil || edge == nil || len(r.cfg.Framework.ResponseContext.BodyTransforms) == 0 {
+		return nil
+	}
+	// Strip address-of/deref/paren so &b and *b trace the same as b.
+	for arg != nil && (arg.GetKind() == metadata.KindUnary || arg.GetKind() == metadata.KindStar || arg.GetKind() == metadata.KindParen) {
+		arg = arg.X
+	}
+	if arg == nil {
+		return nil
+	}
+
+	// Direct local assignment: b, _ := json.Marshal(v); w.Write(b). The
+	// assignment records the transform's callee (func + pkg) and its RHS call,
+	// whose payload argument is the response value.
+	if arg.GetKind() == metadata.KindIdent {
+		assigns := assignmentsAt(r.contextProvider, edge, arg.GetName())
+		if len(assigns) > 0 {
+			a := assigns[len(assigns)-1]
+			if idx, ok := r.matchBodyTransform(a.CalleeFunc, a.CalleePkg); ok {
+				if a.Value.GetKind() == metadata.KindCall && len(a.Value.Args) > idx {
+					return a.Value.Args[idx]
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// matchBodyTransform reports whether a call to (calleeFunc, calleePkg) is a
+// configured serialization transform, returning the index of its payload
+// argument. An empty PkgRegex matches any package.
+func (r *ResponsePatternMatcherImpl) matchBodyTransform(calleeFunc, calleePkg string) (int, bool) {
+	if calleeFunc == "" {
+		return 0, false
+	}
+	for _, t := range r.cfg.Framework.ResponseContext.BodyTransforms {
+		if t.CallRegex != "" {
+			re, err := cachedRegex(t.CallRegex)
+			if err != nil || !re.MatchString(calleeFunc) {
+				continue
+			}
+		}
+		if t.PkgRegex != "" {
+			re, err := cachedRegex(t.PkgRegex)
+			if err != nil || !re.MatchString(calleePkg) {
+				continue
+			}
+		}
+		return t.ArgIndex, true
+	}
+	return 0, false
+}

--- a/internal/spec/write_sink.go
+++ b/internal/spec/write_sink.go
@@ -61,7 +61,7 @@ func (r *ResponsePatternMatcherImpl) unwrapWriteSink(arg *metadata.CallArgument,
 	// parameter bound to THIS call's argument, so the type resolves in the
 	// caller's scope from the actual call-site value.
 	if arg.GetKind() == metadata.KindCall {
-		return r.unwrapHelperReturn(arg, edge, 0)
+		return r.unwrapHelperReturn(arg, edge)
 	}
 
 	return nil
@@ -73,11 +73,12 @@ func (r *ResponsePatternMatcherImpl) unwrapWriteSink(arg *metadata.CallArgument,
 // `b := json.Marshal(param)`), and — when the transform's payload is one of the
 // helper's parameters — binds that parameter back to the matching call-site
 // argument (per-call-site correct, unlike a call-graph origin trace that fixes
-// on one arbitrary caller). depth bounds recursion through helper-returning
-// helpers. Returns nil when the helper doesn't serialize a parameter (honest
-// over wrong: a raw-bytes helper produces no body).
-func (r *ResponsePatternMatcherImpl) unwrapHelperReturn(call *metadata.CallArgument, edge *metadata.CallGraphEdge, depth int) *metadata.CallArgument {
-	if call == nil || call.Fun == nil || depth > 3 {
+// on one arbitrary caller). Single-hop by design: a helper that returns another
+// helper's result is not followed (no fixture covers that shape yet). Returns
+// nil when the helper doesn't serialize a parameter (honest over wrong: a
+// raw-bytes helper produces no body).
+func (r *ResponsePatternMatcherImpl) unwrapHelperReturn(call *metadata.CallArgument, edge *metadata.CallGraphEdge) *metadata.CallArgument {
+	if call == nil || call.Fun == nil {
 		return nil
 	}
 	name := calleeNameOf(call.Fun)

--- a/internal/spec/write_sink.go
+++ b/internal/spec/write_sink.go
@@ -45,7 +45,7 @@ func (r *ResponsePatternMatcherImpl) unwrapWriteSink(arg *metadata.CallArgument,
 	// assignment records the transform's callee (func + pkg) and its RHS call,
 	// whose payload argument is the response value.
 	if arg.GetKind() == metadata.KindIdent {
-		assigns := assignmentsAt(r.contextProvider, edge, arg.GetName())
+		assigns := r.sinkAssignments(edge, arg.GetName())
 		if len(assigns) > 0 {
 			a := assigns[len(assigns)-1]
 			if idx, ok := r.matchBodyTransform(a.CalleeFunc, a.CalleePkg); ok {
@@ -56,7 +56,142 @@ func (r *ResponsePatternMatcherImpl) unwrapWriteSink(arg *metadata.CallArgument,
 		}
 	}
 
+	// Helper-return hop: w.Write(encode(v)) where encode returns a transform
+	// result (`b, _ := json.Marshal(e); return b`). The payload is the helper's
+	// parameter bound to THIS call's argument, so the type resolves in the
+	// caller's scope from the actual call-site value.
+	if arg.GetKind() == metadata.KindCall {
+		return r.unwrapHelperReturn(arg, edge, 0)
+	}
+
 	return nil
+}
+
+// unwrapHelperReturn resolves w.Write(helper(a0, a1, …)) to the call-site
+// argument that the helper serializes and returns. It finds the helper's return
+// value, follows it to a body transform (a returned marshal call, or a local
+// `b := json.Marshal(param)`), and — when the transform's payload is one of the
+// helper's parameters — binds that parameter back to the matching call-site
+// argument (per-call-site correct, unlike a call-graph origin trace that fixes
+// on one arbitrary caller). depth bounds recursion through helper-returning
+// helpers. Returns nil when the helper doesn't serialize a parameter (honest
+// over wrong: a raw-bytes helper produces no body).
+func (r *ResponsePatternMatcherImpl) unwrapHelperReturn(call *metadata.CallArgument, edge *metadata.CallGraphEdge, depth int) *metadata.CallArgument {
+	if call == nil || call.Fun == nil || depth > 3 {
+		return nil
+	}
+	name := calleeNameOf(call.Fun)
+	if name == "" {
+		return nil
+	}
+	impl, ok := r.contextProvider.(*ContextProviderImpl)
+	if !ok || impl.meta == nil {
+		return nil
+	}
+	pkg := call.Fun.GetPkg()
+	if pkg == "" {
+		pkg = r.contextProvider.GetString(edge.Caller.Pkg)
+	}
+	fn := findFunctionByName(impl.meta, pkg, name)
+	if fn == nil {
+		return nil
+	}
+
+	// Find the parameter name the helper serializes and returns.
+	paramName := r.helperSerializedParam(fn)
+	if paramName == "" {
+		return nil
+	}
+	// Bind the parameter to this call's positional argument.
+	if i := paramIndexOf(fn, paramName); i >= 0 && i < len(call.Args) {
+		return call.Args[i]
+	}
+	return nil
+}
+
+// helperSerializedParam returns the name of the parameter that fn serializes via
+// a body transform and returns, or "" when fn does not return a serialized
+// parameter. It inspects each returned value: a returned transform call
+// (`return json.Marshal(p)`), or a returned local whose assignment is a
+// transform (`b, _ := json.Marshal(p); return b`).
+func (r *ResponsePatternMatcherImpl) helperSerializedParam(fn *metadata.Function) string {
+	consider := func(rv *metadata.CallArgument) string {
+		if rv == nil {
+			return ""
+		}
+		// return json.Marshal(p)
+		if rv.GetKind() == metadata.KindCall && rv.Fun != nil {
+			if idx, ok := r.matchBodyTransform(calleeNameOf(rv.Fun), rv.Fun.GetPkg()); ok && len(rv.Args) > idx {
+				if p := rv.Args[idx]; p.GetKind() == metadata.KindIdent {
+					return p.GetName()
+				}
+			}
+			return ""
+		}
+		// return b, where b, _ := json.Marshal(p)
+		if rv.GetKind() == metadata.KindIdent {
+			for _, a := range fn.AssignmentMap[rv.GetName()] {
+				if idx, ok := r.matchBodyTransform(a.CalleeFunc, a.CalleePkg); ok {
+					if a.Value.GetKind() == metadata.KindCall && len(a.Value.Args) > idx {
+						if p := a.Value.Args[idx]; p.GetKind() == metadata.KindIdent {
+							return p.GetName()
+						}
+					}
+				}
+			}
+		}
+		return ""
+	}
+	for i := range fn.Returns {
+		for j := range fn.Returns[i] {
+			if p := consider(&fn.Returns[i][j]); p != "" {
+				return p
+			}
+		}
+	}
+	for i := range fn.ReturnVars {
+		if p := consider(&fn.ReturnVars[i]); p != "" {
+			return p
+		}
+	}
+	return ""
+}
+
+// paramIndexOf returns the positional index of the named parameter in fn's
+// signature, or -1. The signature's Args are the parameters in declared order,
+// each carrying its declared name (handleFuncType).
+func paramIndexOf(fn *metadata.Function, paramName string) int {
+	for i, p := range fn.Signature.Args {
+		if p != nil && p.GetName() == paramName {
+			return i
+		}
+	}
+	return -1
+}
+
+// sinkAssignments returns the assignments to `name` visible at the write sink.
+// It extends the canonical assignmentsAt with a method-handler case: a plain
+// method (not a closure) is absent from file.Functions and has no
+// ParentFunction — that field is populated only for function literals — so
+// assignmentsAt cannot reach its body. The write sink resolves it via the
+// method table keyed by the caller's own receiver type. Scoped to the sink path
+// so other resolvers keep their exact behaviour.
+func (r *ResponsePatternMatcherImpl) sinkAssignments(edge *metadata.CallGraphEdge, name string) []metadata.Assignment {
+	if a := assignmentsAt(r.contextProvider, edge, name); len(a) > 0 {
+		return a
+	}
+	impl, ok := r.contextProvider.(*ContextProviderImpl)
+	if !ok || impl.meta == nil {
+		return nil
+	}
+	recv := r.contextProvider.GetString(edge.Caller.RecvType)
+	if recv == "" {
+		return nil
+	}
+	am := methodAssignmentMap(impl.meta,
+		r.contextProvider.GetString(edge.Caller.Pkg), recv,
+		r.contextProvider.GetString(edge.Caller.Name), name)
+	return am[name]
 }
 
 // matchBodyTransform reports whether a call to (calleeFunc, calleePkg) is a

--- a/internal/spec/write_sink_test.go
+++ b/internal/spec/write_sink_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/ehabterra/apispec/internal/metadata"
 )
 
+// writeSinkMatcher builds a matcher whose ResponseContext configures the JSON
+// body transforms the write-sink resolver traces through.
 func writeSinkMatcher(meta *metadata.Metadata) *ResponsePatternMatcherImpl {
 	cfg := &APISpecConfig{Defaults: Defaults{ResponseContentType: "application/json"}}
 	cfg.Framework.ResponseContext.BodyTransforms = []BodyTransform{
@@ -35,6 +37,8 @@ func writeSinkMatcher(meta *metadata.Metadata) *ResponsePatternMatcherImpl {
 	}
 }
 
+// TestMatchBodyTransform pins the transform matcher: callee+package matching,
+// empty-PkgRegex-matches-any, and non-transform/empty rejection.
 func TestMatchBodyTransform(t *testing.T) {
 	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
 	m := writeSinkMatcher(meta)
@@ -61,7 +65,8 @@ func TestMatchBodyTransform(t *testing.T) {
 }
 
 // marshalHelper builds `func h(<params>) []byte { b, _ := json.Marshal(payload); return b }`
-// as a Function, where payload is the parameter named payloadParam.
+// as a Function, where payload is the parameter named payloadParam. Used to
+// exercise helperSerializedParam / paramIndexOf without a full metadata graph.
 func marshalHelper(meta *metadata.Metadata, params []string, payloadParam string) *metadata.Function {
 	sig := metadata.NewCallArgument(meta)
 	sig.SetKind(metadata.KindFuncType)
@@ -80,6 +85,9 @@ func marshalHelper(meta *metadata.Metadata, params []string, payloadParam string
 	}
 }
 
+// TestHelperSerializedParam pins the returned-local transform case: which
+// parameter a helper serializes and returns, its positional index (including a
+// non-zero index), an unknown-name lookup, and the raw-bytes (no-transform) residue.
 func TestHelperSerializedParam(t *testing.T) {
 	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
 	m := writeSinkMatcher(meta)
@@ -117,6 +125,9 @@ func TestHelperSerializedParam(t *testing.T) {
 	}
 }
 
+// TestHelperSerializedParam_InlineReturn pins the `return json.Marshal(p)`
+// branch (the returned value is itself the transform call) and the
+// literal-payload residue.
 func TestHelperSerializedParam_InlineReturn(t *testing.T) {
 	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
 	m := writeSinkMatcher(meta)
@@ -153,6 +164,8 @@ func TestHelperSerializedParam_InlineReturn(t *testing.T) {
 	}
 }
 
+// TestUnwrapWriteSink_ParenStrip pins the address-of/deref/paren strip loop and
+// the fully-stripped-to-nil path.
 func TestUnwrapWriteSink_ParenStrip(t *testing.T) {
 	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
 	m := writeSinkMatcher(meta)
@@ -179,6 +192,8 @@ func TestUnwrapWriteSink_ParenStrip(t *testing.T) {
 	}
 }
 
+// TestUnwrapWriteSink_Guards pins the early returns: nil arg, nil edge, and no
+// configured BodyTransforms.
 func TestUnwrapWriteSink_Guards(t *testing.T) {
 	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
 	m := writeSinkMatcher(meta)
@@ -200,22 +215,24 @@ func TestUnwrapWriteSink_Guards(t *testing.T) {
 	}
 }
 
+// TestUnwrapHelperReturn_Guards pins the guards: an unknown helper (not in
+// metadata) and a nil callee function.
 func TestUnwrapHelperReturn_Guards(t *testing.T) {
 	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
 	m := writeSinkMatcher(meta)
 	edge := &metadata.CallGraphEdge{}
 
-	// depth over the recursion bound → nil.
+	// A call to a helper that isn't in metadata (findFunctionByName → nil) → nil.
 	call := metadata.NewCallArgument(meta)
 	call.SetKind(metadata.KindCall)
 	call.Fun = identArg(meta, "helper")
-	if got := m.unwrapHelperReturn(call, edge, 4); got != nil {
-		t.Error("depth over bound should return nil")
+	if got := m.unwrapHelperReturn(call, edge); got != nil {
+		t.Error("unknown helper should return nil")
 	}
 	// nil Fun → nil.
 	bad := metadata.NewCallArgument(meta)
 	bad.SetKind(metadata.KindCall)
-	if got := m.unwrapHelperReturn(bad, edge, 0); got != nil {
+	if got := m.unwrapHelperReturn(bad, edge); got != nil {
 		t.Error("nil Fun should return nil")
 	}
 }

--- a/internal/spec/write_sink_test.go
+++ b/internal/spec/write_sink_test.go
@@ -169,7 +169,7 @@ func TestHelperSerializedParam_InlineReturn(t *testing.T) {
 func TestUnwrapWriteSink_ParenStrip(t *testing.T) {
 	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
 	m := writeSinkMatcher(meta)
-	edge := &metadata.CallGraphEdge{}
+	edge := &metadata.CallGraphEdge{Caller: metadata.Call{Name: -1, Pkg: -1, RecvType: -1}}
 
 	// *(b) — parenthesized deref wrapping an ident exercises the strip loop.
 	inner := identArg(meta, "b")
@@ -197,7 +197,7 @@ func TestUnwrapWriteSink_ParenStrip(t *testing.T) {
 func TestUnwrapWriteSink_Guards(t *testing.T) {
 	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
 	m := writeSinkMatcher(meta)
-	edge := &metadata.CallGraphEdge{}
+	edge := &metadata.CallGraphEdge{Caller: metadata.Call{Name: -1, Pkg: -1, RecvType: -1}}
 
 	if got := m.unwrapWriteSink(nil, edge); got != nil {
 		t.Error("nil arg should return nil")
@@ -220,7 +220,7 @@ func TestUnwrapWriteSink_Guards(t *testing.T) {
 func TestUnwrapHelperReturn_Guards(t *testing.T) {
 	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
 	m := writeSinkMatcher(meta)
-	edge := &metadata.CallGraphEdge{}
+	edge := &metadata.CallGraphEdge{Caller: metadata.Call{Name: -1, Pkg: -1, RecvType: -1}}
 
 	// A call to a helper that isn't in metadata (findFunctionByName → nil) → nil.
 	call := metadata.NewCallArgument(meta)

--- a/internal/spec/write_sink_test.go
+++ b/internal/spec/write_sink_test.go
@@ -1,0 +1,221 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+func writeSinkMatcher(meta *metadata.Metadata) *ResponsePatternMatcherImpl {
+	cfg := &APISpecConfig{Defaults: Defaults{ResponseContentType: "application/json"}}
+	cfg.Framework.ResponseContext.BodyTransforms = []BodyTransform{
+		{CallRegex: `^Marshal$`, PkgRegex: `^encoding/json$`, ArgIndex: 0},
+		{CallRegex: `^Encode$`, ArgIndex: 0}, // empty PkgRegex → any package
+	}
+	return &ResponsePatternMatcherImpl{
+		BasePatternMatcher: &BasePatternMatcher{
+			cfg:             cfg,
+			contextProvider: NewContextProvider(meta),
+			schemaMapper:    NewSchemaMapper(cfg),
+		},
+	}
+}
+
+func TestMatchBodyTransform(t *testing.T) {
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	m := writeSinkMatcher(meta)
+
+	if idx, ok := m.matchBodyTransform("Marshal", "encoding/json"); !ok || idx != 0 {
+		t.Errorf("Marshal/encoding/json: got (%d,%v), want (0,true)", idx, ok)
+	}
+	// Empty PkgRegex matches any package.
+	if _, ok := m.matchBodyTransform("Encode", "some/other/pkg"); !ok {
+		t.Error("Encode with any pkg should match (empty PkgRegex)")
+	}
+	// Wrong package for Marshal → no match.
+	if _, ok := m.matchBodyTransform("Marshal", "gopkg.in/yaml.v3"); ok {
+		t.Error("Marshal in a non-json package should not match")
+	}
+	// Non-transform callee → no match.
+	if _, ok := m.matchBodyTransform("Sprintf", "fmt"); ok {
+		t.Error("Sprintf should not match")
+	}
+	// Empty callee → no match.
+	if _, ok := m.matchBodyTransform("", "encoding/json"); ok {
+		t.Error("empty callee should not match")
+	}
+}
+
+// marshalHelper builds `func h(<params>) []byte { b, _ := json.Marshal(payload); return b }`
+// as a Function, where payload is the parameter named payloadParam.
+func marshalHelper(meta *metadata.Metadata, params []string, payloadParam string) *metadata.Function {
+	sig := metadata.NewCallArgument(meta)
+	sig.SetKind(metadata.KindFuncType)
+	for _, p := range params {
+		sig.Args = append(sig.Args, identArg(meta, p))
+	}
+	marshalCall := metadata.NewCallArgument(meta)
+	marshalCall.SetKind(metadata.KindCall)
+	marshalCall.Args = []*metadata.CallArgument{identArg(meta, payloadParam)}
+	return &metadata.Function{
+		Signature: *sig,
+		Returns:   [][]metadata.CallArgument{{*identArg(meta, "b")}},
+		AssignmentMap: map[string][]metadata.Assignment{
+			"b": {{CalleeFunc: "Marshal", CalleePkg: "encoding/json", Value: *marshalCall}},
+		},
+	}
+}
+
+func TestHelperSerializedParam(t *testing.T) {
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	m := writeSinkMatcher(meta)
+
+	// Single param: `b, _ := json.Marshal(v); return b` → serialized param "v".
+	fn := marshalHelper(meta, []string{"v"}, "v")
+	if got := m.helperSerializedParam(fn); got != "v" {
+		t.Errorf("helperSerializedParam single: got %q, want v", got)
+	}
+	if i := paramIndexOf(fn, "v"); i != 0 {
+		t.Errorf("paramIndexOf v: got %d, want 0", i)
+	}
+
+	// Multi-param, payload is the second: index 1.
+	fn2 := marshalHelper(meta, []string{"prefix", "v"}, "v")
+	if got := m.helperSerializedParam(fn2); got != "v" {
+		t.Errorf("helperSerializedParam multi: got %q, want v", got)
+	}
+	if i := paramIndexOf(fn2, "v"); i != 1 {
+		t.Errorf("paramIndexOf v (multi): got %d, want 1", i)
+	}
+
+	// Unknown param name → -1.
+	if i := paramIndexOf(fn2, "missing"); i != -1 {
+		t.Errorf("paramIndexOf missing: got %d, want -1", i)
+	}
+
+	// Helper that returns raw bytes (no transform) → no serialized param.
+	raw := &metadata.Function{
+		Returns: [][]metadata.CallArgument{{*identArg(meta, "b")}},
+		// b has no transform assignment recorded.
+	}
+	if got := m.helperSerializedParam(raw); got != "" {
+		t.Errorf("helperSerializedParam raw: got %q, want empty", got)
+	}
+}
+
+func TestHelperSerializedParam_InlineReturn(t *testing.T) {
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	m := writeSinkMatcher(meta)
+
+	// func h(p T) []byte { return json.Marshal(p) } — the return value is itself
+	// the transform call (KindCall branch).
+	marshalFun := identArg(meta, "Marshal")
+	marshalFun.SetPkg("encoding/json")
+	marshalCall := metadata.NewCallArgument(meta)
+	marshalCall.SetKind(metadata.KindCall)
+	marshalCall.Fun = marshalFun
+	marshalCall.Args = []*metadata.CallArgument{identArg(meta, "p")}
+	fn := &metadata.Function{
+		Signature: metadata.CallArgument{},
+		Returns:   [][]metadata.CallArgument{{*marshalCall}},
+	}
+	if got := m.helperSerializedParam(fn); got != "p" {
+		t.Errorf("inline-return: got %q, want p", got)
+	}
+
+	// A returned transform call whose payload is a literal (not an ident) yields
+	// no serialized parameter.
+	litCall := metadata.NewCallArgument(meta)
+	litCall.SetKind(metadata.KindCall)
+	lf := identArg(meta, "Marshal")
+	lf.SetPkg("encoding/json")
+	litCall.Fun = lf
+	lit := metadata.NewCallArgument(meta)
+	lit.SetKind(metadata.KindLiteral)
+	litCall.Args = []*metadata.CallArgument{lit}
+	fnLit := &metadata.Function{ReturnVars: []metadata.CallArgument{*litCall}}
+	if got := m.helperSerializedParam(fnLit); got != "" {
+		t.Errorf("literal payload: got %q, want empty", got)
+	}
+}
+
+func TestUnwrapWriteSink_ParenStrip(t *testing.T) {
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	m := writeSinkMatcher(meta)
+	edge := &metadata.CallGraphEdge{}
+
+	// *(b) — parenthesized deref wrapping an ident exercises the strip loop.
+	inner := identArg(meta, "b")
+	paren := metadata.NewCallArgument(meta)
+	paren.SetKind(metadata.KindParen)
+	paren.X = inner
+	star := metadata.NewCallArgument(meta)
+	star.SetKind(metadata.KindStar)
+	star.X = paren
+	// No assignment for b at this edge → resolves to nil, but the strip runs.
+	if got := m.unwrapWriteSink(star, edge); got != nil {
+		t.Errorf("paren/star strip with no assignment: got %v, want nil", got)
+	}
+
+	// A fully-stripped nil (unary wrapping nothing) → nil.
+	unary := metadata.NewCallArgument(meta)
+	unary.SetKind(metadata.KindUnary)
+	if got := m.unwrapWriteSink(unary, edge); got != nil {
+		t.Errorf("unary wrapping nil: got %v, want nil", got)
+	}
+}
+
+func TestUnwrapWriteSink_Guards(t *testing.T) {
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	m := writeSinkMatcher(meta)
+	edge := &metadata.CallGraphEdge{}
+
+	if got := m.unwrapWriteSink(nil, edge); got != nil {
+		t.Error("nil arg should return nil")
+	}
+	if got := m.unwrapWriteSink(identArg(meta, "b"), nil); got != nil {
+		t.Error("nil edge should return nil")
+	}
+
+	// No configured transforms → nil regardless of arg.
+	empty := &ResponsePatternMatcherImpl{BasePatternMatcher: &BasePatternMatcher{
+		cfg: &APISpecConfig{}, contextProvider: NewContextProvider(meta), schemaMapper: NewSchemaMapper(&APISpecConfig{}),
+	}}
+	if got := empty.unwrapWriteSink(identArg(meta, "b"), edge); got != nil {
+		t.Error("no BodyTransforms should return nil")
+	}
+}
+
+func TestUnwrapHelperReturn_Guards(t *testing.T) {
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	m := writeSinkMatcher(meta)
+	edge := &metadata.CallGraphEdge{}
+
+	// depth over the recursion bound → nil.
+	call := metadata.NewCallArgument(meta)
+	call.SetKind(metadata.KindCall)
+	call.Fun = identArg(meta, "helper")
+	if got := m.unwrapHelperReturn(call, edge, 4); got != nil {
+		t.Error("depth over bound should return nil")
+	}
+	// nil Fun → nil.
+	bad := metadata.NewCallArgument(meta)
+	bad.SetKind(metadata.KindCall)
+	if got := m.unwrapHelperReturn(bad, edge, 0); got != nil {
+		t.Error("nil Fun should return nil")
+	}
+}

--- a/testdata/downstream_client_not_response/client/client.go
+++ b/testdata/downstream_client_not_response/client/client.go
@@ -1,0 +1,32 @@
+// Package client is a downstream HTTP client. Its json.Marshal serializes the
+// OUTBOUND request — the client method has no ResponseWriter, so the request
+// type must NOT surface as the outer route's response (issue #195).
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type FetchRequest struct {
+	Amount   int               `json:"amount"`
+	Metadata map[string]string `json:"metadata"`
+}
+
+type FetchResponse struct {
+	Key string `json:"key"`
+}
+
+type Client struct{}
+
+func (c *Client) Fetch(params *FetchRequest) (*FetchResponse, error) {
+	payload, err := json.Marshal(params) // outbound request marshal — goes to the wire, not w
+	if err != nil {
+		return nil, err
+	}
+	_, _ = http.Post("http://svc/fetch", "application/json", nil)
+	_ = payload
+	var resp FetchResponse
+	_ = json.Unmarshal([]byte(`{}`), &resp)
+	return &resp, nil
+}

--- a/testdata/downstream_client_not_response/common/common.go
+++ b/testdata/downstream_client_not_response/common/common.go
@@ -1,0 +1,17 @@
+package common
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type Response struct {
+	Message string      `json:"message"`
+	Data    interface{} `json:"data"`
+}
+
+func RespondWithSuccess(w http.ResponseWriter, msg string, data interface{}, code int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(Response{Message: msg, Data: data})
+}

--- a/testdata/downstream_client_not_response/go.mod
+++ b/testdata/downstream_client_not_response/go.mod
@@ -1,0 +1,3 @@
+module downstream_client_not_response
+
+go 1.26

--- a/testdata/downstream_client_not_response/main.go
+++ b/testdata/downstream_client_not_response/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"net/http"
+
+	"downstream_client_not_response/common"
+	"downstream_client_not_response/usecase"
+)
+
+type dto struct {
+	Key string `json:"key"`
+}
+
+func handler(uc usecase.UseCase) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		key, err := uc.Get(r.Context())
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		common.RespondWithSuccess(w, "ok", dto{Key: key}, http.StatusOK)
+	}
+}
+
+func main() {
+	uc := usecase.New()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /pk", handler(uc))
+	_ = http.ListenAndServe(":8080", mux)
+}

--- a/testdata/downstream_client_not_response/usecase/usecase.go
+++ b/testdata/downstream_client_not_response/usecase/usecase.go
@@ -1,0 +1,23 @@
+package usecase
+
+import (
+	"context"
+
+	"downstream_client_not_response/client"
+)
+
+type UseCase interface {
+	Get(ctx context.Context) (string, error)
+}
+
+type impl struct{ c *client.Client }
+
+func New() UseCase { return &impl{c: &client.Client{}} }
+
+func (u *impl) Get(ctx context.Context) (string, error) {
+	resp, err := u.c.Fetch(&client.FetchRequest{Amount: 1})
+	if err != nil {
+		return "", err
+	}
+	return resp.Key, nil
+}

--- a/testdata/schema/main.go
+++ b/testdata/schema/main.go
@@ -67,16 +67,18 @@ type Handler struct{}
 // GetUserHandler handles GET /user requests
 func (h *Handler) GetUserHandler(w http.ResponseWriter, r *http.Request) {
 	user := GetUser()
-	// This will trigger schema generation for User type
+	// Marshal the User and write it to the response: the write sink traces the
+	// []byte back to json.Marshal(user), resolving the User schema.
 	w.Header().Set("Content-Type", "application/json")
-	// Use json.Marshal to trigger response pattern matching
-	json.Marshal(user)
+	b, _ := json.Marshal(user)
+	w.Write(b)
 }
 
 func (h *Handler) GetProductHandler(w http.ResponseWriter, r *http.Request) {
 	product := GetProduct()
 	w.Header().Set("Content-Type", "application/json")
-	json.Marshal(product)
+	b, _ := json.Marshal(product)
+	w.Write(b)
 }
 
 func main() {

--- a/testdata/write_sink_marshal/go.mod
+++ b/testdata/write_sink_marshal/go.mod
@@ -1,0 +1,3 @@
+module write_sink_marshal
+
+go 1.26

--- a/testdata/write_sink_marshal/main.go
+++ b/testdata/write_sink_marshal/main.go
@@ -54,10 +54,29 @@ func helperWriteHandler(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write(encodeEnvelope(Envelope{Data: "d"}))
 }
 
+// Handler exercises the method-handler shape: a plain method (not a closure)
+// is absent from the file's functions and has no ParentFunction, so the write
+// sink must resolve its local `b := json.Marshal(m)` via the method table.
+type Handler struct{}
+
+// Member is the real response body of GET /method-write.
+type Member struct {
+	Name string `json:"name"`
+}
+
+func (h *Handler) MethodWrite(w http.ResponseWriter, r *http.Request) {
+	m := Member{Name: "n"}
+	b, _ := json.Marshal(m)
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(b)
+}
+
 func main() {
+	h := &Handler{}
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /marshal-write", marshalWriteHandler)
 	mux.HandleFunc("GET /raw-write", rawWriteHandler)
 	mux.HandleFunc("GET /helper-write", helperWriteHandler)
+	mux.HandleFunc("GET /method-write", h.MethodWrite)
 	_ = http.ListenAndServe(":8080", mux)
 }

--- a/testdata/write_sink_marshal/main.go
+++ b/testdata/write_sink_marshal/main.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// Payload is the real response body of GET /marshal-write. It reaches the wire
+// through the decoupled shape `b, _ := json.Marshal(v); w.Write(b)` — the sink
+// is w.Write, the body type lives one transform hop back on json.Marshal's arg.
+type Payload struct {
+	Key   string `json:"key"`
+	Count int    `json:"count"`
+}
+
+// marshalWriteHandler is the shape issue #195's write-sink model must resolve:
+// the marshal result is stored in a local, then written. Today w.Write(b) only
+// sees b's []byte type; the fix traces b's assignment back to json.Marshal(v)
+// and recovers v's type (Payload).
+func marshalWriteHandler(w http.ResponseWriter, r *http.Request) {
+	v := Payload{Key: "k", Count: 1}
+	b, err := json.Marshal(v)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(b)
+}
+
+// rawWriteHandler writes raw bytes with no marshal transform behind them. The
+// write-sink trace must find NO json payload here and produce a response with
+// no JSON schema — not a spurious body.
+func rawWriteHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("pong"))
+}
+
+// Envelope is the real response body of GET /helper-write, produced by a helper
+// that returns the marshal result. Exercises the param/return hop of the
+// backward trace (challenge #2): the transform is one function-boundary away
+// from the sink.
+type Envelope struct {
+	Data string `json:"data"`
+}
+
+func encodeEnvelope(e Envelope) []byte {
+	b, _ := json.Marshal(e)
+	return b
+}
+
+func helperWriteHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(encodeEnvelope(Envelope{Data: "d"}))
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /marshal-write", marshalWriteHandler)
+	mux.HandleFunc("GET /raw-write", rawWriteHandler)
+	mux.HandleFunc("GET /helper-write", helperWriteHandler)
+	_ = http.ListenAndServe(":8080", mux)
+}

--- a/testdata/write_sink_marshal/main.go
+++ b/testdata/write_sink_marshal/main.go
@@ -54,6 +54,34 @@ func helperWriteHandler(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write(encodeEnvelope(Envelope{Data: "d"}))
 }
 
+// Boxed is the real response body of GET /multiparam-write, serialized by a
+// helper whose payload is its SECOND parameter — the sink must bind the returned
+// marshal's parameter to the correct positional call-site argument, not arg 0.
+type Boxed struct {
+	V int `json:"v"`
+}
+
+func encodeWithPrefix(prefix string, v Boxed) []byte {
+	b, _ := json.Marshal(v)
+	return b
+}
+
+func multiparamWriteHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(encodeWithPrefix("meta", Boxed{V: 7}))
+}
+
+// rawHelper returns bytes that are not a serialized parameter, so the sink must
+// find no body transform and produce a schema-less response (honest over wrong).
+func rawHelper() []byte {
+	return []byte("static")
+}
+
+func rawHelperWriteHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(rawHelper())
+}
+
 // Handler exercises the method-handler shape: a plain method (not a closure)
 // is absent from the file's functions and has no ParentFunction, so the write
 // sink must resolve its local `b := json.Marshal(m)` via the method table.
@@ -77,6 +105,8 @@ func main() {
 	mux.HandleFunc("GET /marshal-write", marshalWriteHandler)
 	mux.HandleFunc("GET /raw-write", rawWriteHandler)
 	mux.HandleFunc("GET /helper-write", helperWriteHandler)
+	mux.HandleFunc("GET /multiparam-write", multiparamWriteHandler)
+	mux.HandleFunc("GET /rawhelper-write", rawHelperWriteHandler)
 	mux.HandleFunc("GET /method-write", h.MethodWrite)
 	_ = http.ListenAndServe(":8080", mux)
 }


### PR DESCRIPTION
Closes #195. Supersedes #196 (the docs-only "no gate" PR).

## Problem
`json.Marshal` was matched as a response in isolation, with no write-destination check — so **every** reachable `json.Marshal(v)` became a response, including a downstream HTTP client's outbound-request marshal, which leaked as a spurious `default` on the outer route. On real projects this was the majority of remaining `default`s.

A `RequireWriterInScope` gate (#196) was tried and **reverted** as a config-flagged proxy heuristic (golden rule #9).

## Fix: invert detection onto the write sink
Anchor on the write to `w`, then resolve the body by tracing the written `[]byte` back to the serialization transform that produced it — and **retire the marshal-anywhere pattern entirely**. A marshal whose result never reaches a sink is then never a response, structurally, with no marshal-side heuristic.

- **`ResponseContext.BodyTransforms`** — config-driven serializer set (`json.Marshal`/`MarshalIndent`), framework-agnostic (golden rule #5).
- **`unwrapWriteSink` (direct)** — `b, _ := json.Marshal(v); w.Write(b)` resolves `v`'s type at the sink's status.
- **helper hop** — `w.Write(encode(v))` traces the helper's returned marshal and binds its parameter to the call-site value (per-call-site correct via `Signature.Args`, not a first-caller origin trace).
- **`sinkAssignments` (method fix)** — a plain method has no `ParentFunction` (set only for closures), so `assignmentsAt` couldn't reach its body; fall back to the method table by `edge.Caller.RecvType`. Scoped to the sink path (no drift to other resolvers).
- **retired `jsonMarshalPattern`** from all 6 framework configs.

## Verification
- **A/B on 10 real projects** (marshal-ON baseline vs. this branch): **zero concrete-status responses removed, zero new dangling refs**, routes unchanged; spurious `default`s dropped substantially.
- **Full suite green** — the false-negative net. `testdata/schema`'s handlers marshaled-and-discarded (an old over-detection shortcut) and were rewritten to write the response for real.
- **Coverage 96.0%** (floor met). Lint/vet/gofmt clean.

## Fixtures
- `testdata/write_sink_marshal` — direct, raw, helper, method, multi-param, raw-helper cases.
- `downstream_client_not_response` change-detector flipped to require exactly `{200, 500}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved response schema detection by tracing response-writer byte writes back to configured serialization calls (including helpers and indirect flows).
  - Removed standalone JSON `Marshal` response matching to prevent spurious `default` responses; behavior remains correct for raw byte writes and encoder-based responses across supported web frameworks.
- **Tests**
  - Added new fixture-based regression tests for downstream client responses and write-sink marshaling, plus unit tests for transform matching and write-sink unwrapping.
- **Documentation**
  - Updated testing conventions to encourage using `testdata/` fixtures first and treating them appropriately based on whether behavior already works.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->