### PR TITLE
fix(spec): validator-tag & doc-comment fidelity (#167, #165, #166, #168)

### DIFF
--- a/generator/testdata_validation_tags_test.go
+++ b/generator/testdata_validation_tags_test.go
@@ -74,4 +74,19 @@ func TestTestdata_ValidationTags(t *testing.T) {
 	} else if age.Minimum != 18 || age.Maximum != 120 {
 		t.Errorf("age: got minimum=%v maximum=%v, want 18/120", age.Minimum, age.Maximum)
 	}
+
+	// #165: on `validate:"min=1,max=10,dive,min=5,max=100"`, the pre-dive rules
+	// constrain the container (minItems/maxItems) and the post-dive rules
+	// constrain each element (items.minimum/items.maximum).
+	scores := req.Properties["scores"]
+	switch {
+	case scores == nil:
+		t.Error("scores property missing")
+	case scores.MinItems != 1 || scores.MaxItems != 10:
+		t.Errorf("scores: got minItems=%d maxItems=%d, want 1/10 (#165 container)", scores.MinItems, scores.MaxItems)
+	case scores.Items == nil:
+		t.Error("scores.items missing")
+	case scores.Items.Minimum != 5 || scores.Items.Maximum != 100:
+		t.Errorf("scores.items: got minimum=%v maximum=%v, want 5/100 (#165 post-dive elements)", scores.Items.Minimum, scores.Items.Maximum)
+	}
 }

--- a/generator/testdata_validation_tags_test.go
+++ b/generator/testdata_validation_tags_test.go
@@ -97,4 +97,14 @@ func TestTestdata_ValidationTags(t *testing.T) {
 	case scores.Items.Minimum != 5 || scores.Items.Maximum != 100:
 		t.Errorf("scores.items: got minimum=%v maximum=%v, want 5/100 (#165 post-dive elements)", scores.Items.Minimum, scores.Items.Maximum)
 	}
+
+	// #166: a struct-level constraint on a blank marker field surfaces as a note
+	// on the schema description (OpenAPI has no native cross-field rule).
+	rng := schemaBySuffix(out.Components.Schemas, "_Range")
+	if rng == nil {
+		t.Fatalf("Range schema missing; have %v", mapSchemaKeys(out.Components.Schemas))
+	}
+	if !strings.Contains(rng.Description, "gtefield=Min") {
+		t.Errorf("Range: struct-level constraint not surfaced in description; got %q (#166)", rng.Description)
+	}
 }

--- a/generator/testdata_validation_tags_test.go
+++ b/generator/testdata_validation_tags_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	intspec "github.com/ehabterra/apispec/internal/spec"
+	"github.com/ehabterra/apispec/spec"
+)
+
+// schemaBySuffix returns the first component schema whose key ends with the
+// given suffix (component keys are fully package-qualified).
+func schemaBySuffix(schemas map[string]*intspec.Schema, suffix string) *intspec.Schema {
+	for k, v := range schemas {
+		if strings.HasSuffix(k, suffix) {
+			return v
+		}
+	}
+	return nil
+}
+
+// TestTestdata_ValidationTags covers validator-tag fidelity:
+//   - #167: string min/max → minLength/maxLength; numeric min/max →
+//     minimum/maximum; a decoded JSON body is required.
+//   - #165: on a slice, the pre-`dive` min/max constrain item count
+//     (minItems/maxItems) and the post-`dive` min/max constrain each element
+//     (items.minimum/items.maximum).
+func TestTestdata_ValidationTags(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "validation_tags", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+
+	post := opFor(out.Paths["/accounts"], "POST")
+	if post == nil {
+		t.Fatalf("POST /accounts missing; have %v", mapPathKeys(out.Paths))
+	}
+
+	// #167 part 1: a decoded JSON body is required.
+	if post.RequestBody == nil {
+		t.Fatal("POST /accounts: requestBody missing")
+	}
+	if !post.RequestBody.Required {
+		t.Error("POST /accounts: requestBody should be required:true (#167)")
+	}
+
+	req := schemaBySuffix(out.Components.Schemas, "CreateAccountRequest")
+	if req == nil {
+		t.Fatalf("CreateAccountRequest schema missing; have %v", mapSchemaKeys(out.Components.Schemas))
+	}
+
+	// #167 part 2: string min/max → minLength/maxLength.
+	if name := req.Properties["name"]; name == nil {
+		t.Error("name property missing")
+	} else if name.MinLength != 3 || name.MaxLength != 50 {
+		t.Errorf("name: got minLength=%d maxLength=%d, want 3/50 (#167 string min/max)", name.MinLength, name.MaxLength)
+	}
+
+	// Numeric min/max → minimum/maximum (regression guard).
+	if age := req.Properties["age"]; age == nil {
+		t.Error("age property missing")
+	} else if age.Minimum != 18 || age.Maximum != 120 {
+		t.Errorf("age: got minimum=%v maximum=%v, want 18/120", age.Minimum, age.Maximum)
+	}
+}

--- a/generator/testdata_validation_tags_test.go
+++ b/generator/testdata_validation_tags_test.go
@@ -56,6 +56,14 @@ func TestTestdata_ValidationTags(t *testing.T) {
 		t.Error("POST /accounts: requestBody should be required:true (#167)")
 	}
 
+	// #168: the handler's Go doc comment → summary (first line) + description.
+	if post.Summary != "createAccount registers a new account." {
+		t.Errorf("POST /accounts summary: got %q (#168)", post.Summary)
+	}
+	if post.Description != "It validates the payload and returns the created account." {
+		t.Errorf("POST /accounts description: got %q (#168)", post.Description)
+	}
+
 	req := schemaBySuffix(out.Components.Schemas, "CreateAccountRequest")
 	if req == nil {
 		t.Fatalf("CreateAccountRequest schema missing; have %v", mapSchemaKeys(out.Components.Schemas))

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -48,10 +48,13 @@ type RouteInfo struct {
 	File      string
 	Function  string
 	Summary   string
-	Tags      []string
-	Request   *RequestInfo
-	Response  map[string]*ResponseInfo
-	Params    []Parameter
+	// Description is the operation's long description, sourced from the handler's
+	// Go doc comment (issue #168) when not otherwise set.
+	Description string
+	Tags        []string
+	Request     *RequestInfo
+	Response    map[string]*ResponseInfo
+	Params      []Parameter
 
 	// OperationIDSuffix disambiguates the operationId when one handler yields
 	// several operations (e.g. an r.Method dispatch split into GET/POST). Empty

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -1978,8 +1978,13 @@ func applyValidationConstraints(schema *Schema, constraints *ValidationConstrain
 		} else if constraints.Max != nil {
 			schema.MaxItems = int(*constraints.Max)
 		}
-		// Post-`dive` constraints apply to each element (issue #165).
+		// Post-`dive` constraints apply to each element (issue #165). Clone the
+		// item schema before mutating it: even though promoted element types
+		// currently resolve to a fresh $ref (making this a no-op there), the
+		// codebase treats component schemas as shared/immutable — cloning keeps
+		// per-field dive rules from ever leaking into a shared component.
 		if constraints.Dive != nil && schema.Items != nil {
+			schema.Items = cloneSchema(schema.Items)
 			applyValidationConstraints(schema.Items, constraints.Dive)
 		}
 	}

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -290,9 +290,21 @@ func buildPathsFromRoutes(routes []*RouteInfo) map[string]PathItem {
 		if route.OperationIDSuffix != "" {
 			operationID += "_" + route.OperationIDSuffix
 		}
+		// Fill the summary/description from the handler's Go doc comment (issue
+		// #168) when not already set by a more specific source.
+		summary, description := route.Summary, route.Description
+		if summary == "" {
+			if s, d := handlerDoc(route); s != "" {
+				summary = s
+				if description == "" {
+					description = d
+				}
+			}
+		}
 		operation := &Operation{
 			OperationID: operationID,
-			Summary:     route.Summary,
+			Summary:     summary,
+			Description: description,
 			Tags:        route.Tags,
 		}
 
@@ -1520,6 +1532,33 @@ func extractJSONName(tag string) string {
 	}
 
 	return ""
+}
+
+// handlerDoc resolves the handler function's Go doc comment into an operation
+// summary (the first line) and description (the remaining lines), per the common
+// Go→OpenAPI convention (issue #168). Returns empty strings when the handler is
+// anonymous (a func literal), a method not indexed in the function table, or
+// undocumented — callers keep whatever summary/description they already had.
+func handlerDoc(route *RouteInfo) (summary, description string) {
+	if route == nil || route.Metadata == nil || route.Function == "" {
+		return "", ""
+	}
+	name := route.Function
+	if route.Package != "" {
+		name = strings.TrimPrefix(name, route.Package+".")
+	}
+	fn := findFunctionByName(route.Metadata, route.Package, name)
+	if fn == nil {
+		return "", ""
+	}
+	doc := getStringFromPool(route.Metadata, fn.Comments)
+	if doc == "" {
+		return "", ""
+	}
+	if i := strings.IndexByte(doc, '\n'); i >= 0 {
+		return strings.TrimSpace(doc[:i]), strings.TrimSpace(doc[i+1:])
+	}
+	return doc, ""
 }
 
 // ValidationConstraints represents validation constraints extracted from struct tags

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -296,9 +296,12 @@ func buildPathsFromRoutes(routes []*RouteInfo) map[string]PathItem {
 			Tags:        route.Tags,
 		}
 
-		// Add request body if present
+		// Add request body if present. A detected request body means the handler
+		// decodes it, so it is required (issue #167) — an OpenAPI requestBody
+		// defaults to optional otherwise.
 		if route.Request != nil {
 			operation.RequestBody = &RequestBody{
+				Required: true,
 				Content: map[string]MediaType{
 					route.Request.ContentType: {
 						Schema: route.Request.Schema,
@@ -1817,13 +1820,20 @@ func applyValidationConstraints(schema *Schema, constraints *ValidationConstrain
 		return
 	}
 
-	// Apply string length constraints (only for string types)
+	// Apply string length constraints (only for string types). In
+	// go-playground/validator, `min`/`max` on a string constrain its LENGTH, not
+	// a numeric value — so route Min/Max here to minLength/maxLength (issue
+	// #167). Explicit len/minlen/maxlen (MinLength/MaxLength) take precedence.
 	if schema.Type == "string" {
 		if constraints.MinLength != nil {
 			schema.MinLength = *constraints.MinLength
+		} else if constraints.Min != nil {
+			schema.MinLength = int(*constraints.Min)
 		}
 		if constraints.MaxLength != nil {
 			schema.MaxLength = *constraints.MaxLength
+		} else if constraints.Max != nil {
+			schema.MaxLength = int(*constraints.Max)
 		}
 	}
 
@@ -1841,6 +1851,22 @@ func applyValidationConstraints(schema *Schema, constraints *ValidationConstrain
 		}
 		if constraints.MaxLength != nil && schema.Type == "integer" {
 			schema.Maximum = float64(*constraints.MaxLength)
+		}
+	}
+
+	// Apply item-count constraints (for array types). `min`/`max` (and
+	// len/minlen/maxlen) on a slice constrain the number of ELEMENTS — map them
+	// to minItems/maxItems (issue #167). Explicit length rules win.
+	if schema.Type == "array" {
+		if constraints.MinLength != nil {
+			schema.MinItems = *constraints.MinLength
+		} else if constraints.Min != nil {
+			schema.MinItems = int(*constraints.Min)
+		}
+		if constraints.MaxLength != nil {
+			schema.MaxItems = *constraints.MaxLength
+		} else if constraints.Max != nil {
+			schema.MaxItems = int(*constraints.Max)
 		}
 	}
 

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -1532,6 +1532,23 @@ type ValidationConstraints struct {
 	Pattern   string
 	Required  bool
 	Enum      []interface{}
+	// Dive holds the constraints that follow a `dive` token in a validator tag;
+	// they apply to the ELEMENTS of a slice/map rather than the container
+	// (issue #165). Nil when the tag has no `dive`.
+	Dive *ValidationConstraints
+}
+
+// splitOnDive splits a go-playground/validator rule string on the first `dive`
+// token (comma-delimited). Rules before `dive` constrain the container; rules
+// after constrain each element. found is false when there is no `dive`.
+func splitOnDive(validateTag string) (before, after string, found bool) {
+	parts := strings.Split(validateTag, ",")
+	for i, p := range parts {
+		if strings.TrimSpace(p) == "dive" {
+			return strings.Join(parts[:i], ","), strings.Join(parts[i+1:], ","), true
+		}
+	}
+	return validateTag, "", false
 }
 
 // extractValidationConstraints extracts validation constraints from struct tags
@@ -1547,6 +1564,17 @@ func extractValidationConstraints(tag string) *ValidationConstraints {
 		parts := strings.Split(tag, "validate:")
 		if len(parts) > 1 {
 			validateTag := strings.Trim(parts[1], "\"")
+
+			// Peel off post-`dive` rules: they constrain slice/map elements, not
+			// the container, so parse them separately into constraints.Dive
+			// (issue #165). The container rules (before `dive`) fall through to
+			// the loop below.
+			if before, after, found := splitOnDive(validateTag); found {
+				validateTag = before
+				if trimmed := strings.Trim(after, ", "); trimmed != "" {
+					constraints.Dive = extractValidationConstraints(`validate:"` + trimmed + `"`)
+				}
+			}
 
 			// Parse common validation rules - improved regex to handle various formats
 			// Matches: required, email, min=5, max=10, len=8, regexp=^[a-z]{2,3}$, oneof=val1 val2, etc.
@@ -1807,7 +1835,8 @@ func extractValidationConstraints(tag string) *ValidationConstraints {
 	if constraints.MinLength == nil && constraints.MaxLength == nil &&
 		constraints.Min == nil && constraints.Max == nil &&
 		constraints.Pattern == "" && constraints.Format == "" &&
-		!constraints.Required && len(constraints.Enum) == 0 {
+		!constraints.Required && len(constraints.Enum) == 0 &&
+		constraints.Dive == nil {
 		return nil
 	}
 
@@ -1867,6 +1896,10 @@ func applyValidationConstraints(schema *Schema, constraints *ValidationConstrain
 			schema.MaxItems = *constraints.MaxLength
 		} else if constraints.Max != nil {
 			schema.MaxItems = int(*constraints.Max)
+		}
+		// Post-`dive` constraints apply to each element (issue #165).
+		if constraints.Dive != nil && schema.Items != nil {
+			applyValidationConstraints(schema.Items, constraints.Dive)
 		}
 	}
 

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -1251,6 +1251,15 @@ func generateStructSchema(usedTypes map[string]*Schema, key string, typ *metadat
 		// or an unexported field. Mirrors the anonymous-struct path so both
 		// stay consistent.
 		if jsonFieldOmitted(getStringFromPool(meta, field.Tag)) || !ast.IsExported(fieldName) {
+			// A blank marker field (`_ struct{} `validate:"gtefield=Min"`)
+			// carries struct-level, cross-field validation that OpenAPI cannot
+			// express natively. Surface it as a note on the schema description so
+			// it is not silently dropped (issue #166).
+			if fieldName == "_" {
+				if note := structLevelValidationNote(getStringFromPool(meta, field.Tag)); note != "" {
+					schema.Description = appendConstraintNote(schema.Description, note)
+				}
+			}
 			continue
 		}
 
@@ -1532,6 +1541,39 @@ func extractJSONName(tag string) string {
 	}
 
 	return ""
+}
+
+// validateTagValue returns the value of the `validate:"..."` struct tag, or ""
+// when absent. Robust to other tags sharing the struct-tag string.
+func validateTagValue(tag string) string {
+	const key = `validate:"`
+	idx := strings.Index(tag, key)
+	if idx == -1 {
+		return ""
+	}
+	rest := tag[idx+len(key):]
+	if end := strings.IndexByte(rest, '"'); end != -1 {
+		return rest[:end]
+	}
+	return ""
+}
+
+// structLevelValidationNote turns a blank marker field's validate rules into a
+// human-readable schema note, or "" when there are none (issue #166).
+func structLevelValidationNote(tag string) string {
+	rules := strings.TrimSpace(validateTagValue(tag))
+	if rules == "" || rules == "-" {
+		return ""
+	}
+	return "Struct-level validation: " + rules
+}
+
+// appendConstraintNote appends a note to a description on its own line.
+func appendConstraintNote(desc, note string) string {
+	if desc == "" {
+		return note
+	}
+	return desc + "\n" + note
 }
 
 // handlerDoc resolves the handler function's Go doc comment into an operation

--- a/internal/spec/validation_helpers_test.go
+++ b/internal/spec/validation_helpers_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import "testing"
+
+// TestValidateTagValue covers the struct-tag extractor: present, absent, and a
+// malformed (unterminated) validate tag.
+func TestValidateTagValue(t *testing.T) {
+	cases := map[string]string{
+		`json:"x" validate:"required,min=3"`: "required,min=3",
+		`json:"x"`:                           "",
+		`validate:"gtefield=Min" json:"y"`:   "gtefield=Min",
+		`validate:"unterminated`:             "",
+	}
+	for tag, want := range cases {
+		if got := validateTagValue(tag); got != want {
+			t.Errorf("validateTagValue(%q) = %q, want %q", tag, got, want)
+		}
+	}
+}
+
+// TestStructLevelValidationNote covers #166's note builder, including the
+// empty/"-"/absent residues.
+func TestStructLevelValidationNote(t *testing.T) {
+	cases := map[string]string{
+		`validate:"gtefield=Min"`: "Struct-level validation: gtefield=Min",
+		`validate:"-"`:            "",
+		`validate:""`:             "",
+		`json:"x"`:                "",
+	}
+	for tag, want := range cases {
+		if got := structLevelValidationNote(tag); got != want {
+			t.Errorf("structLevelValidationNote(%q) = %q, want %q", tag, got, want)
+		}
+	}
+}
+
+// TestAppendConstraintNote covers both the empty-description and
+// existing-description branches.
+func TestAppendConstraintNote(t *testing.T) {
+	if got := appendConstraintNote("", "note"); got != "note" {
+		t.Errorf("append to empty: got %q", got)
+	}
+	if got := appendConstraintNote("desc", "note"); got != "desc\nnote" {
+		t.Errorf("append to existing: got %q", got)
+	}
+}
+
+// TestApplyValidationConstraints_ByType pins that min/max route by schema type:
+// length for strings, item-count for arrays (with post-dive on items), and
+// value for numbers.
+func TestApplyValidationConstraints_ByType(t *testing.T) {
+	f := func(v float64) *float64 { return &v }
+
+	str := &Schema{Type: "string"}
+	applyValidationConstraints(str, &ValidationConstraints{Min: f(3), Max: f(50)})
+	if str.MinLength != 3 || str.MaxLength != 50 {
+		t.Errorf("string: got minLength=%d maxLength=%d, want 3/50", str.MinLength, str.MaxLength)
+	}
+
+	num := &Schema{Type: "integer"}
+	applyValidationConstraints(num, &ValidationConstraints{Min: f(18), Max: f(120)})
+	if num.Minimum != 18 || num.Maximum != 120 {
+		t.Errorf("integer: got minimum=%v maximum=%v, want 18/120", num.Minimum, num.Maximum)
+	}
+
+	arr := &Schema{Type: "array", Items: &Schema{Type: "integer"}}
+	applyValidationConstraints(arr, &ValidationConstraints{
+		Min: f(1), Max: f(10),
+		Dive: &ValidationConstraints{Min: f(5), Max: f(100)},
+	})
+	if arr.MinItems != 1 || arr.MaxItems != 10 {
+		t.Errorf("array: got minItems=%d maxItems=%d, want 1/10", arr.MinItems, arr.MaxItems)
+	}
+	if arr.Items.Minimum != 5 || arr.Items.Maximum != 100 {
+		t.Errorf("array items: got minimum=%v maximum=%v, want 5/100", arr.Items.Minimum, arr.Items.Maximum)
+	}
+}

--- a/testdata/validation_tags/go.mod
+++ b/testdata/validation_tags/go.mod
@@ -1,0 +1,3 @@
+module validation_tags
+
+go 1.26

--- a/testdata/validation_tags/main.go
+++ b/testdata/validation_tags/main.go
@@ -14,6 +14,18 @@ type CreateAccountRequest struct {
 	// Slice min/max constrain ITEM COUNT → minItems / maxItems; the post-`dive`
 	// rules constrain each element → items.minimum / items.maximum (#165).
 	Scores []int `json:"scores" validate:"required,min=1,max=10,dive,min=5,max=100"`
+	// Bounds carries a struct-level (cross-field) constraint on a blank marker
+	// field (#166).
+	Bounds Range `json:"bounds"`
+}
+
+// Range has a whole-struct constraint expressed on a blank marker field: Max
+// must be >= Min. OpenAPI has no native cross-field rule, so it surfaces as a
+// schema description note (#166).
+type Range struct {
+	Min int      `json:"min" validate:"required"`
+	Max int      `json:"max" validate:"required"`
+	_   struct{} `validate:"gtefield=Min"`
 }
 
 // createAccount registers a new account.

--- a/testdata/validation_tags/main.go
+++ b/testdata/validation_tags/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// CreateAccountRequest exercises validator-tag fidelity (issues #165, #166, #167).
+type CreateAccountRequest struct {
+	// String min/max constrain LENGTH → minLength / maxLength (#167).
+	Name string `json:"name" validate:"required,min=3,max=50"`
+	// Numeric min/max constrain VALUE → minimum / maximum.
+	Age int `json:"age" validate:"min=18,max=120"`
+	// Slice min/max constrain ITEM COUNT → minItems / maxItems; the post-`dive`
+	// rules constrain each element → items.minimum / items.maximum (#165).
+	Scores []int `json:"scores" validate:"required,min=1,max=10,dive,min=5,max=100"`
+}
+
+func createAccount(w http.ResponseWriter, r *http.Request) {
+	var req CreateAccountRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(req)
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /accounts", createAccount)
+	_ = http.ListenAndServe(":8080", mux)
+}

--- a/testdata/validation_tags/main.go
+++ b/testdata/validation_tags/main.go
@@ -16,6 +16,8 @@ type CreateAccountRequest struct {
 	Scores []int `json:"scores" validate:"required,min=1,max=10,dive,min=5,max=100"`
 }
 
+// createAccount registers a new account.
+// It validates the payload and returns the created account.
 func createAccount(w http.ResponseWriter, r *http.Request) {
 	var req CreateAccountRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {


### PR DESCRIPTION
Closes #167, #165, #166, #168. Four DTO/operation-fidelity gaps, one theme (validator-tag + doc-comment fidelity), one fixture (`testdata/validation_tags`).

## #167 — requestBody.required + string min/max
- A detected (decoded) JSON request body is now marked `required: true` (OpenAPI defaults it to optional otherwise).
- String `min`/`max` validator tags map to `minLength`/`maxLength` (they constrain length in go-playground/validator), and slice `min`/`max` to `minItems`/`maxItems`, instead of being dropped or mis-applied as numeric `minimum`/`maximum`. Explicit `len`/`minlen`/`maxlen` still take precedence.

## #165 — `dive`
`min=1,max=10,dive,min=5,max=100` on a slice: the pre-`dive` rules now constrain the container (`minItems`/`maxItems`) and the post-`dive` rules constrain each element (`items.minimum`/`maximum`) — previously the element rules bled into the container or were dropped. Parsed into `ValidationConstraints.Dive`, applied to the items schema.

## #166 — struct-level validate on a blank marker field
`_ struct{} `validate:"gtefield=Min"`` was silently dropped (unexported field, skipped). OpenAPI has no native cross-field rule, so it now surfaces as a note on the struct schema's `description` ("Struct-level validation: …") rather than being lost.

## #168 — doc comment → summary/description
A handler's Go doc comment now populates the operation: first line → `summary`, remainder → `description` (the common Go→OpenAPI convention). Only fills when a more specific source hasn't set them; anonymous/undocumented handlers are unaffected.

## Verification
- Full suite green; coverage **96.0%** (floor met); lint/vet/gofmt clean.
- New fixture `testdata/validation_tags` + structural test assert all four; validator-helper unit tests cover the by-type routing and residues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenAPI documentation now automatically includes operation summaries and descriptions from handler documentation.
  * Request bodies are marked as required by default when an endpoint expects one.
  * Validation rules now generate more complete schema metadata, including string lengths, numeric ranges, array sizes, and item constraints.
  * Struct-level validation rules are surfaced in schema descriptions.
* **Tests**
  * Added coverage for validation metadata and generated OpenAPI documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->