### PR TITLE
docs: changelog + README for v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-07-20
+
 ### Added
 
+- Handler Go doc comments are mapped to the operation: the first line becomes
+  `summary` and the remaining lines become `description`.
+  ([#168](https://github.com/ehabterra/apispec/issues/168))
+- Validator `dive` tag support — post-`dive` rules now constrain slice/map
+  **elements** (`items.minimum`/`maximum`/…) while the rules before `dive`
+  constrain the container.
+  ([#165](https://github.com/ehabterra/apispec/issues/165))
+- Struct-level (cross-field) validation expressed on a blank marker field
+  (`_ struct{} \`validate:"gtefield=Min"\``) is surfaced as a note on the schema
+  `description` instead of being silently dropped (OpenAPI has no native
+  cross-field rule). ([#166](https://github.com/ehabterra/apispec/issues/166))
+- Response status resolved through an error mapper's struct field and through
+  cross-package error constructors/mappers.
+  ([#187](https://github.com/ehabterra/apispec/issues/187),
+  [#192](https://github.com/ehabterra/apispec/issues/192),
+  [#155](https://github.com/ehabterra/apispec/issues/155))
 - `.golangci.yml` pinning the linter set (the golangci-lint v2 `standard` set)
   so local `make lint` and CI agree and version bumps can't silently change the
   rules. ([#172](https://github.com/ehabterra/apispec/issues/172))
 - `docs/CONFIGURATION.md` — field-by-field configuration reference.
   ([#172](https://github.com/ehabterra/apispec/issues/172))
 - This `CHANGELOG.md`. ([#172](https://github.com/ehabterra/apispec/issues/172))
+
+### Fixed
+
+- Response over-detection: response detection is now anchored on the write to the
+  response writer (`w.Write`/encoder-bound-to-`w`) and traces the written bytes
+  back to their `json.Marshal` source. A `json.Marshal` whose result never
+  reaches the writer — e.g. a downstream HTTP client's outbound-request marshal —
+  is no longer emitted as a spurious `default` response.
+  ([#195](https://github.com/ehabterra/apispec/issues/195))
+- String `min`/`max` validator tags now map to `minLength`/`maxLength` (they
+  constrain length in go-playground/validator), and slice `min`/`max` to
+  `minItems`/`maxItems`, instead of being dropped or mis-applied as numeric
+  `minimum`/`maximum`. ([#167](https://github.com/ehabterra/apispec/issues/167))
+- A detected (decoded) JSON request body is now marked `required: true`.
+  ([#167](https://github.com/ehabterra/apispec/issues/167))
+- Response schema is gated by write-destination provenance, so a value encoded
+  to a non-writer sink (a `bytes.Buffer`, a hash) is not treated as the response.
+  ([#170](https://github.com/ehabterra/apispec/issues/170))
+- Response value types resolve through two or more helper hops.
+  ([#180](https://github.com/ehabterra/apispec/issues/180))
+- `r.FormValue`-style reads resolve to a valid OpenAPI parameter location
+  (query for GET/HEAD/DELETE, form body for POST/PUT/PATCH).
+  ([#171](https://github.com/ehabterra/apispec/issues/171))
 
 ## [0.5.1] - 2026-07-17
 

--- a/README.md
+++ b/README.md
@@ -295,7 +295,8 @@ APISpec aims for practical coverage of real-world Go services. A quick survey of
 - Wrapper/envelope response specialisation — when a handler's payload flows through a shared helper whose field is declared `interface{}`/`any` (e.g. `RespondWithSuccess(w, msg, data, code)` → `NewEnvelope{Data: data}`), APISpec recovers the concrete per-route payload type from the call site and emits an `allOf` of the base envelope `$ref` plus a `data` override, instead of a generic `object`.
 - Interface-typed response bodies — when a handler encodes an interface-typed variable (`var a Animal = Dog{}; json.NewEncoder(w).Encode(a)`, or `var a Animal; a = Dog{}`), the schema documents the **concrete** type statically assigned to it (`Dog`) rather than the empty interface. When the handler assigns more than one concrete type on different branches the result is ambiguous, so the interface is kept (honest over wrong). A concrete value returned through a function whose declared return type is the interface (`Encode(makeAnimal())` where `makeAnimal() Animal { return Dog{} }`) resolves via the callee's return value. A value passed into a helper through an interface parameter — named (`writeAnimal(w, v Animal)`) or `interface{}`/`any` — resolves to the concrete argument bound at the call site. Embedded-interface handler dispatch (the DI/clean-architecture `Handlers{ AuthorHandler }` pattern) also resolves to the concrete implementation. See `testdata/interface_response/`. In every case, when the concrete type is genuinely ambiguous (several concrete types on different branches) the interface is kept rather than guessed.
 - External package types automatically resolved to underlying primitives (with `externalTypes` for custom overrides).
-- `go-playground/validator` tags mapped to OpenAPI constraints.
+- `go-playground/validator` (`validate:`) tags mapped to OpenAPI constraints — `required`, formats (`email`, `uuid`, …), patterns, and length/value/item constraints that route by field type: `min`/`max` on a string → `minLength`/`maxLength`, on a number → `minimum`/`maximum`, on a slice → `minItems`/`maxItems`. The `dive` tag applies post-`dive` rules to slice/map **elements** (`items.*`). Struct-level (cross-field) rules on a blank marker field (`_ struct{} \`validate:"gtefield=Min"\``) surface as a schema `description` note. A decoded JSON request body is marked `required: true`.
+- Handler Go doc comments mapped to the operation `summary` (first line) and `description` (remaining lines).
 - CGO packages can be skipped to avoid build errors.
 - Dependency-injected route groups.
 - Go 1.22 `net/http.ServeMux` method-aware routing — patterns that carry the verb on the registration (`mux.HandleFunc("GET /users/{id}", getUser)`) are split into method + path, `{id}` wildcards become path parameters, and `r.PathValue("id")` is recognised as a path parameter. ServeMux-only syntax (`{path...}` trailing wildcards, the `{$}` end-of-path anchor) is normalised to OpenAPI templating. See `testdata/servemux/`.
@@ -309,7 +310,7 @@ APISpec aims for practical coverage of real-world Go services. A quick survey of
 
 - Same path + same status code with different schemas — not yet supported.
 - Receiver/parent type tracing is limited; `Decode` on non-body targets may be misclassified (see [Request body source disambiguation](#request-body-source-disambiguation)).
-- `dive` validator tag (array-element validation) — planned.
+- Only `go-playground/validator`-style `validate:` tags are read; Gin/Echo `binding:` tags and comparison validators (`gt`/`gte`/`lt`/`lte`) are not yet mapped.
 
 ### Selected capability highlights
 


### PR DESCRIPTION
Documentation catch-up for the already-tagged **v0.5.2** release.

## CHANGELOG.md
Adds the `[0.5.2] - 2026-07-20` section:
- **Added:** doc comment → `summary`/`description` (#168); validator `dive` (#165); struct-level validation note on a blank marker field (#166); status through error mappers/cross-package constructors (#187/#192/#155); .golangci.yml + CONFIGURATION.md + CHANGELOG (#172).
- **Fixed:** write-sink-anchored response detection kills the downstream-marshal over-detection (#195); string `min`/`max` → `minLength`/`maxLength`, slice → `minItems`/`maxItems`, `requestBody: required` (#167); writer-provenance gating (#170); multi-hop response types (#180); form-value param location (#171).

## README.md
- `dive` moved out of "not yet" (now supported); expanded the validator-tag bullet to describe by-type routing, `dive` elements, struct-level notes, and required bodies.
- Added the doc-comment → summary/description capability.
- New honest caveat: only `validate:` tags are read — Gin/Echo `binding:` tags and comparison validators (`gt`/`gte`/`lt`/`lte`) are **not** mapped (verified during this pass).

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)