### PR TITLE
fix(spec): source operation summary from method handlers' doc comments (#168)

### DIFF
--- a/generator/testdata_chi_method_handle_test.go
+++ b/generator/testdata_chi_method_handle_test.go
@@ -32,6 +32,7 @@ func TestTestdata_ChiMethodHandle(t *testing.T) {
 
 	want := map[string][]string{
 		"/live":    {"GET"},           // plain r.Get with a func value
+		"/live2":   {"GET"},           // r.Get with a method value on a struct field
 		"/health":  {"GET"},           // r.Method(http.MethodGet, ..., http.Handler value)
 		"/ready":   {"POST"},          // r.MethodFunc(http.MethodPost, ...)
 		"/metrics": {"GET"},           // r.Handle with an opaque handler: defaulted GET
@@ -55,6 +56,22 @@ func TestTestdata_ChiMethodHandle(t *testing.T) {
 	if health, ok := out.Paths["/health"]; ok {
 		if opFor(health, "POST") != nil {
 			t.Errorf("/health should not carry a POST operation (verb is http.MethodGet)")
+		}
+		// Change detector: an opaque http.Handler *value* (r.Method(..., deps.Health))
+		// names no method in the registration, so #168 cannot reach the concrete
+		// ServeHTTP doc comment — resolving it needs interface-value → concrete
+		// type resolution. Asserted empty on purpose; flip when issue #204 lands.
+		if get := opFor(health, "GET"); get != nil && get.Summary != "" {
+			t.Errorf("GET /health summary: got %q, want \"\" until handler-value doc sourcing lands (#168)", get.Summary)
+		}
+	}
+
+	// #168 is framework-agnostic: it resolves off the handler declaration, not
+	// the router. A chi-registered method value on a DI field (deps.Health.ServeHTTP)
+	// sources its summary through the field's type, same as a net/http one.
+	if live2, ok := out.Paths["/live2"]; ok {
+		if get := opFor(live2, "GET"); get != nil && get.Summary != "ServeHTTP reports service health." {
+			t.Errorf("GET /live2 summary: got %q (#168)", get.Summary)
 		}
 	}
 

--- a/generator/testdata_handler_doc_comments_test.go
+++ b/generator/testdata_handler_doc_comments_test.go
@@ -66,6 +66,13 @@ func TestTestdata_HandlerDocComments(t *testing.T) {
 			method: "PUT",
 			shape:  "func literal",
 		},
+		{
+			// Change detector on two counts: the handler value names no method
+			// so ServeHTTP's doc comment is out of reach (#204), and the traced
+			// origin type must not leak in as a summary ("*pkg-->Handler").
+			method: "OPTIONS",
+			shape:  "handler value",
+		},
 	} {
 		op := opFor(path, tc.method)
 		if op == nil {

--- a/generator/testdata_handler_doc_comments_test.go
+++ b/generator/testdata_handler_doc_comments_test.go
@@ -34,7 +34,17 @@ func TestTestdata_HandlerDocComments(t *testing.T) {
 
 	for _, tc := range []struct {
 		method, summary, description, shape string
+		path                                string // defaults to /accounts
 	}{
+		{
+			// swaggo annotations win over the prose, and the non-@Summary /
+			// @Description directives (@Tags, @Router, …) must not leak in.
+			method:      "GET",
+			path:        "/accounts/search",
+			shape:       "swaggo annotations",
+			summary:     "Search accounts",
+			description: "Filters accounts by query string.\nReturns an empty list when nothing matches.",
+		},
 		{
 			method:      "POST",
 			shape:       "pointer-receiver method",
@@ -74,7 +84,11 @@ func TestTestdata_HandlerDocComments(t *testing.T) {
 			shape:  "handler value",
 		},
 	} {
-		op := opFor(path, tc.method)
+		p := path
+		if tc.path != "" {
+			p = out.Paths[tc.path]
+		}
+		op := opFor(p, tc.method)
 		if op == nil {
 			t.Errorf("%s /accounts (%s) missing; have %v", tc.method, tc.shape, mapPathKeys(out.Paths))
 			continue

--- a/generator/testdata_handler_doc_comments_test.go
+++ b/generator/testdata_handler_doc_comments_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/spec"
+)
+
+// TestTestdata_HandlerDocComments covers issue #168 across every handler shape.
+// The original implementation resolved the doc comment only through
+// file.Functions, which by construction holds no methods — so a method handler
+// (`h.CreateAccount`, the dominant shape in real projects) silently produced no
+// summary. Metadata now records Comments on methods and the mapper resolves the
+// method shape of RouteInfo.Function through the per-Type methods table.
+func TestTestdata_HandlerDocComments(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "handler_doc_comments", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+
+	path := out.Paths["/accounts"]
+
+	for _, tc := range []struct {
+		method, summary, description, shape string
+	}{
+		{
+			method:      "POST",
+			shape:       "pointer-receiver method",
+			summary:     "CreateAccount registers a new account.",
+			description: "It validates the payload and returns the created account.",
+		},
+		{
+			method:  "DELETE",
+			shape:   "value-receiver method",
+			summary: "DeleteAccount removes an account.",
+		},
+		{
+			method:      "GET",
+			shape:       "package-level func",
+			summary:     "listAccounts returns every account.",
+			description: "The remaining lines become the operation description.",
+		},
+		{
+			method:      "HEAD",
+			shape:       "method value on a struct field",
+			summary:     "CreateAccount registers a new account.",
+			description: "It validates the payload and returns the created account.",
+		},
+		{
+			method: "PATCH",
+			shape:  "undocumented method",
+		},
+		{
+			method: "PUT",
+			shape:  "func literal",
+		},
+	} {
+		op := opFor(path, tc.method)
+		if op == nil {
+			t.Errorf("%s /accounts (%s) missing; have %v", tc.method, tc.shape, mapPathKeys(out.Paths))
+			continue
+		}
+		if op.Summary != tc.summary {
+			t.Errorf("%s /accounts (%s) summary: got %q, want %q (#168)", tc.method, tc.shape, op.Summary, tc.summary)
+		}
+		if op.Description != tc.description {
+			t.Errorf("%s /accounts (%s) description: got %q, want %q (#168)", tc.method, tc.shape, op.Description, tc.description)
+		}
+	}
+}

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -316,6 +316,7 @@ func GenerateMetadataWithLogger(pkgs map[string]map[string]*ast.File, fileToInfo
 					Signature:     *ExprToCallArgument(fn.Type, info, pkgName, fset, metadata),
 					Position:      metadata.StringPool.Get(getFuncPosition(fn, fset)),
 					Scope:         metadata.StringPool.Get(getScope(fn.Name.Name)),
+					Comments:      metadata.StringPool.Get(getComments(fn)),
 					AssignmentMap: assignmentsInFunc,
 					TypeParams:    typeParams,
 					ReturnVars:    returnVars,

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -1919,6 +1919,45 @@ func methodAssignmentMap(meta *metadata.Metadata, pkg, recv, name, varName strin
 	return nil
 }
 
+// findMethodByName resolves the method (pkg, receiver, name) in the per-Type
+// methods table. Methods never appear in file.Functions (processFunctions skips
+// any decl with a receiver), so findFunctionByName cannot see them — anything
+// resolving a handler that may be a method needs this fallback. An empty recv
+// matches on the method name alone; receivers are compared with a leading `*`
+// trimmed so a pointer-receiver handler matches its value-typed record.
+func findMethodByName(meta *metadata.Metadata, pkg, recv, name string) *metadata.Method {
+	if meta == nil || name == "" {
+		return nil
+	}
+	p, ok := meta.Packages[pkg]
+	if !ok {
+		return nil
+	}
+	// Sort file keys: a receiver-less lookup can match in several files, and map
+	// iteration order would make the winner (and any doc comment it carries)
+	// vary between runs.
+	fileNames := make([]string, 0, len(p.Files))
+	for f := range p.Files {
+		fileNames = append(fileNames, f)
+	}
+	sort.Strings(fileNames)
+	for _, fname := range fileNames {
+		for _, t := range p.Files[fname].Types {
+			for i := range t.Methods {
+				m := &t.Methods[i]
+				if meta.StringPool.GetString(m.Name) != name {
+					continue
+				}
+				if recv != "" && strings.TrimPrefix(meta.StringPool.GetString(m.Receiver), "*") != strings.TrimPrefix(recv, "*") {
+					continue
+				}
+				return m
+			}
+		}
+	}
+	return nil
+}
+
 // handlerReachesAccessor reports whether the route's handler transitively calls
 // the map-key accessor described by pattern. Reachability is a precomputed
 // summary (reachSet, one bottom-up pass over the SCC condensation) rather

--- a/internal/spec/handler_doc_test.go
+++ b/internal/spec/handler_doc_test.go
@@ -1,0 +1,190 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// docMeta builds a package "app" holding:
+//   - func Plain          — documented package-level function
+//   - type Handler        — with documented method Create and undocumented Patch
+//   - type Deps{H *Handler} — so a field-path receiver has something to resolve
+func docMeta(t *testing.T) *metadata.Metadata {
+	t.Helper()
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+
+	handler := &metadata.Type{
+		Name: meta.StringPool.Get("Handler"),
+		Methods: []metadata.Method{
+			{
+				Name:     meta.StringPool.Get("Create"),
+				Receiver: meta.StringPool.Get("*Handler"),
+				Comments: meta.StringPool.Get("Create makes a thing.\nAnd describes it."),
+			},
+			{
+				Name:     meta.StringPool.Get("Patch"),
+				Receiver: meta.StringPool.Get("*Handler"),
+				Comments: meta.StringPool.Get(""),
+			},
+		},
+	}
+	deps := &metadata.Type{
+		Name: meta.StringPool.Get("Deps"),
+		Fields: []metadata.Field{
+			{Name: meta.StringPool.Get("H"), Type: meta.StringPool.Get("*app.Handler")},
+		},
+	}
+	meta.Packages = map[string]*metadata.Package{
+		"app": {
+			Types: map[string]*metadata.Type{"Handler": handler, "Deps": deps},
+			Files: map[string]*metadata.File{
+				"app.go": {
+					Types: map[string]*metadata.Type{"Handler": handler, "Deps": deps},
+					Functions: map[string]*metadata.Function{
+						"Plain": {
+							Name:     meta.StringPool.Get("Plain"),
+							Comments: meta.StringPool.Get("Plain serves a thing."),
+						},
+					},
+				},
+			},
+		},
+	}
+	return meta
+}
+
+// TestHandlerDoc covers every RouteInfo.Function shape. The method shapes are
+// the regression: methods live only in the per-Type table, so the original
+// findFunctionByName-only lookup returned nothing for them (issue #168).
+func TestHandlerDoc(t *testing.T) {
+	meta := docMeta(t)
+
+	for _, tc := range []struct {
+		name, function        string
+		wantSummary, wantDesc string
+	}{
+		{
+			name:        "package-level function",
+			function:    "app.Plain",
+			wantSummary: "Plain serves a thing.",
+		},
+		{
+			name:        "method value on a variable",
+			function:    "app" + TypeSep + "app.Handler.Create",
+			wantSummary: "Create makes a thing.",
+			wantDesc:    "And describes it.",
+		},
+		{
+			name:        "method value on a struct field",
+			function:    "app" + TypeSep + "Deps.H.Create",
+			wantSummary: "Create makes a thing.",
+			wantDesc:    "And describes it.",
+		},
+		{
+			name:     "undocumented method",
+			function: "app" + TypeSep + "app.Handler.Patch",
+		},
+		{
+			// Honest-empty: the field exists but names no method, so there is
+			// nothing to resolve. Matching on the method name alone would guess
+			// (golden rule #7) — see issue #204.
+			name:     "handler value with no method segment",
+			function: "app" + TypeSep + "Deps.H",
+		},
+		{
+			name:     "unknown receiver",
+			function: "app" + TypeSep + "app.Missing.Create",
+		},
+		{
+			name:     "func literal",
+			function: "app.FuncLit:/tmp/app.go:12:3",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			route := &RouteInfo{Metadata: meta, Package: "app", Function: tc.function}
+			summary, desc := handlerDoc(route)
+			if summary != tc.wantSummary {
+				t.Errorf("summary: got %q, want %q", summary, tc.wantSummary)
+			}
+			if desc != tc.wantDesc {
+				t.Errorf("description: got %q, want %q", desc, tc.wantDesc)
+			}
+		})
+	}
+}
+
+// TestHandlerDocGuards covers the nil/empty short-circuits.
+func TestHandlerDocGuards(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		route *RouteInfo
+	}{
+		{"nil route", nil},
+		{"nil metadata", &RouteInfo{Function: "app.Plain"}},
+		{"empty function", &RouteInfo{Metadata: docMeta(t)}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if s, d := handlerDoc(tc.route); s != "" || d != "" {
+				t.Errorf("got (%q, %q), want empty", s, d)
+			}
+		})
+	}
+}
+
+// TestReceiverTypeName pins the receiver-segment resolution: a bare type name
+// passes through, a field path resolves through the field's type (pointer
+// unwrapped to its named core), and an unresolvable path falls back to the last
+// segment rather than matching broadly.
+func TestReceiverTypeName(t *testing.T) {
+	meta := docMeta(t)
+
+	for _, tc := range []struct{ name, recv, want string }{
+		{"bare type name", "Handler", "Handler"},
+		{"field path resolves to the field's type", "Deps.H", "Handler"},
+		{"unknown owner falls back to the last segment", "Nope.Handler", "Handler"},
+		{"unknown field falls back to the last segment", "Deps.Missing", "Missing"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := receiverTypeName(meta, "app", tc.recv); got != tc.want {
+				t.Errorf("receiverTypeName(%q) = %q, want %q", tc.recv, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFindMethodByName covers the per-Type method lookup, including the pointer
+// receiver trim and the unknown-package guard.
+func TestFindMethodByName(t *testing.T) {
+	meta := docMeta(t)
+
+	if m := findMethodByName(meta, "app", "Handler", "Create"); m == nil {
+		t.Error("value receiver should match the *Handler record (leading * trimmed)")
+	}
+	if m := findMethodByName(meta, "app", "", "Create"); m == nil {
+		t.Error("empty receiver should match on the method name alone")
+	}
+	if m := findMethodByName(meta, "app", "Other", "Create"); m != nil {
+		t.Error("a non-matching receiver must not resolve")
+	}
+	if m := findMethodByName(meta, "nosuch", "Handler", "Create"); m != nil {
+		t.Error("unknown package must not resolve")
+	}
+	if m := findMethodByName(nil, "app", "Handler", "Create"); m != nil {
+		t.Error("nil metadata must not resolve")
+	}
+}

--- a/internal/spec/handler_doc_test.go
+++ b/internal/spec/handler_doc_test.go
@@ -205,6 +205,67 @@ func TestSplitSynopsis(t *testing.T) {
 	}
 }
 
+// TestSwaggoDoc pins swaggo/swag annotation handling: @Summary/@Description are
+// consumed, every other directive is dropped rather than swept into the prose,
+// and a comment with no annotations is left to the sentence split.
+func TestSwaggoDoc(t *testing.T) {
+	for _, tc := range []struct {
+		name, text, wantSum, wantDesc string
+		wantOK                        bool
+	}{
+		{
+			name:     "full annotation block",
+			text:     "CreateAccount godoc\n@Summary      Create an account\n@Description  Registers a new account.\n@Tags         accounts\n@Router       /accounts [post]",
+			wantSum:  "Create an account",
+			wantDesc: "Registers a new account.",
+			wantOK:   true,
+		},
+		{
+			name:     "multi-line description",
+			text:     "@Summary Search\n@Description  Filters by query.\n@Description  Empty list when nothing matches.",
+			wantSum:  "Search",
+			wantDesc: "Filters by query.\nEmpty list when nothing matches.",
+			wantOK:   true,
+		},
+		{
+			name:     "continuation line belongs to the annotation above",
+			text:     "@Summary Create an account\n@Description Registers a new account\nand returns the created record.",
+			wantSum:  "Create an account",
+			wantDesc: "Registers a new account\nand returns the created record.",
+			wantOK:   true,
+		},
+		{
+			name:    "no @Summary falls back to the prose above the annotations",
+			text:    "CreateAccount registers a new account.\n@Tags accounts\n@Router /accounts [post]",
+			wantSum: "CreateAccount registers a new account.",
+			wantOK:  true,
+		},
+		{
+			name:     "only @Description",
+			text:     "@Description Registers a new account.",
+			wantDesc: "Registers a new account.",
+			wantOK:   true,
+		},
+		{
+			name: "plain doc comment is not swaggo",
+			text: "Create makes a thing.\nAnd describes it.",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sum, desc, ok := swaggoDoc(tc.text)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if sum != tc.wantSum {
+				t.Errorf("summary: got %q, want %q", sum, tc.wantSum)
+			}
+			if desc != tc.wantDesc {
+				t.Errorf("description: got %q, want %q", desc, tc.wantDesc)
+			}
+		})
+	}
+}
+
 // TestHandlerDocGuards covers the nil/empty short-circuits.
 func TestHandlerDocGuards(t *testing.T) {
 	for _, tc := range []struct {

--- a/internal/spec/handler_doc_test.go
+++ b/internal/spec/handler_doc_test.go
@@ -191,6 +191,27 @@ func TestSplitSynopsis(t *testing.T) {
 			text:    "listAccounts returns every account",
 			wantSum: "listAccounts returns every account",
 		},
+		{
+			// Synopsis rewrites ``…'' into curly quotes, so the summary is not a
+			// literal prefix of the comment. A character-by-character recovery
+			// diverged here and silently dropped the description.
+			name:     "Go doc quote markup is rewritten",
+			text:     "Create makes a ``quoted'' thing. And describes it.",
+			wantSum:  "Create makes a “quoted” thing.",
+			wantDesc: "And describes it.",
+		},
+		{
+			name:     "doc link and URL do not diverge",
+			text:     "Create makes a [Thing] at https://example.com/x. And describes it.",
+			wantSum:  "Create makes a [Thing] at https://example.com/x.",
+			wantDesc: "And describes it.",
+		},
+		{
+			name:     "list after the first sentence",
+			text:     "Create makes a thing.\n\n  - one\n  - two",
+			wantSum:  "Create makes a thing.",
+			wantDesc: "- one\n  - two",
+		},
 		{name: "empty", text: ""},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/spec/handler_doc_test.go
+++ b/internal/spec/handler_doc_test.go
@@ -114,12 +114,89 @@ func TestHandlerDoc(t *testing.T) {
 			name:     "func literal",
 			function: "app.FuncLit:/tmp/app.go:12:3",
 		},
+		{
+			// Regression: some render paths separate the package with a plain
+			// dot instead of TypeSep. Every fixture happened to produce the
+			// TypeSep form, so a TypeSep-only implementation passed the whole
+			// suite while resolving nothing on real projects.
+			name:        "dotted separator instead of TypeSep",
+			function:    "app.Handler.Create",
+			wantSummary: "Create makes a thing.",
+			wantDesc:    "And describes it.",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			route := &RouteInfo{Metadata: meta, Package: "app", Function: tc.function}
 			summary, desc := handlerDoc(route)
 			if summary != tc.wantSummary {
 				t.Errorf("summary: got %q, want %q", summary, tc.wantSummary)
+			}
+			if desc != tc.wantDesc {
+				t.Errorf("description: got %q, want %q", desc, tc.wantDesc)
+			}
+		})
+	}
+}
+
+// TestHandlerDocImportPathPackage repeats the shapes with a real import-path
+// package name. The path itself contains dots, so the package prefix has to be
+// stripped before the receiver/method split — splitting on the last dot of the
+// raw string alone would work here by luck but the prefix strip is what makes it
+// correct, and real projects are always this shape.
+func TestHandlerDocImportPathPackage(t *testing.T) {
+	const pkg = "github.com/acme/svc/internal/http"
+	meta := docMeta(t)
+	// Re-key the fixture package under the import path.
+	meta.Packages[pkg] = meta.Packages["app"]
+	delete(meta.Packages, "app")
+
+	for _, tc := range []struct{ name, function, want string }{
+		{"dotted method value", pkg + ".Handler.Create", "Create makes a thing."},
+		{"TypeSep method value", pkg + TypeSep + pkg + ".Handler.Create", "Create makes a thing."},
+		{"package-level func", pkg + ".Plain", "Plain serves a thing."},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			route := &RouteInfo{Metadata: meta, Package: pkg, Function: tc.function}
+			if got, _ := handlerDoc(route); got != tc.want {
+				t.Errorf("summary: got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSplitSynopsis pins the sentence split. Splitting on the first *line*
+// truncates mid-sentence, because real doc comments wrap — that produced
+// summaries like "…origin publisher (admin-only). PUT" on a real project.
+func TestSplitSynopsis(t *testing.T) {
+	for _, tc := range []struct{ name, text, wantSum, wantDesc string }{
+		{
+			name:     "sentence wraps across lines",
+			text:     "setSource records an asset's origin publisher (admin-only). PUT\nbecause it replaces the record.",
+			wantSum:  "setSource records an asset's origin publisher (admin-only).",
+			wantDesc: "PUT\nbecause it replaces the record.",
+		},
+		{
+			name:    "single sentence spanning two lines has no remainder",
+			text:    "usage returns the reference graph — collections that assemble it and\nlessons that use it.",
+			wantSum: "usage returns the reference graph — collections that assemble it and lessons that use it.",
+		},
+		{
+			name:     "sentence per line",
+			text:     "Create makes a thing.\nAnd describes it.",
+			wantSum:  "Create makes a thing.",
+			wantDesc: "And describes it.",
+		},
+		{
+			name:    "no terminator",
+			text:    "listAccounts returns every account",
+			wantSum: "listAccounts returns every account",
+		},
+		{name: "empty", text: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sum, desc := splitSynopsis(tc.text)
+			if sum != tc.wantSum {
+				t.Errorf("summary: got %q, want %q", sum, tc.wantSum)
 			}
 			if desc != tc.wantDesc {
 				t.Errorf("description: got %q, want %q", desc, tc.wantDesc)

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -293,13 +293,16 @@ func buildPathsFromRoutes(routes []*RouteInfo) map[string]PathItem {
 		}
 		// Fill the summary/description from the handler's Go doc comment (issue
 		// #168) when not already set by a more specific source.
+		// Each field falls back independently: a comment carrying only a
+		// @Description (no @Summary) must still contribute its description.
 		summary, description := route.Summary, route.Description
-		if summary == "" {
-			if s, d := handlerDoc(route); s != "" {
+		if summary == "" || description == "" {
+			s, d := handlerDoc(route)
+			if summary == "" {
 				summary = s
-				if description == "" {
-					description = d
-				}
+			}
+			if description == "" {
+				description = d
 			}
 		}
 		operation := &Operation{
@@ -1652,6 +1655,72 @@ func handlerComments(route *RouteInfo) string {
 	return ""
 }
 
+// swaggoDoc extracts the operation summary/description from swaggo/swag
+// annotations when the doc comment carries them:
+//
+//	// CreateAccount godoc
+//	// @Summary      Create an account
+//	// @Description  Registers a new account.
+//	// @Router       /accounts [post]
+//
+// Only @Summary and @Description are consumed; every other annotation line is
+// dropped rather than swept into the prose (they are structured directives, not
+// description text, and the rest of the pipeline derives those facts from the
+// code itself). A line that does not start with '@' continues the annotation
+// above it, which is how multi-line descriptions are written.
+//
+// ok is false when the comment carries no annotations at all, so a plain Go doc
+// comment keeps the first-sentence behaviour. When annotations are present but
+// name no @Summary, the prose above the first annotation supplies it — that is
+// where the conventional "Name godoc" line lives.
+func swaggoDoc(text string) (summary, description string, ok bool) {
+	var lead, summaryLines, descLines []string
+	section := ""
+	for _, line := range strings.Split(text, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "@") {
+			ok = true
+			name := strings.Fields(trimmed)[0]
+			rest := strings.TrimSpace(strings.TrimPrefix(trimmed, name))
+			switch strings.ToLower(name) {
+			case "@summary":
+				section = "summary"
+				if rest != "" {
+					summaryLines = append(summaryLines, rest)
+				}
+			case "@description":
+				section = "description"
+				if rest != "" {
+					descLines = append(descLines, rest)
+				}
+			default:
+				section = ""
+			}
+			continue
+		}
+		if trimmed == "" {
+			continue
+		}
+		switch {
+		case section == "summary":
+			summaryLines = append(summaryLines, trimmed)
+		case section == "description":
+			descLines = append(descLines, trimmed)
+		case !ok:
+			lead = append(lead, trimmed)
+		}
+	}
+	if !ok {
+		return "", "", false
+	}
+	summary = strings.Join(summaryLines, " ")
+	description = strings.Join(descLines, "\n")
+	if summary == "" && len(lead) > 0 {
+		summary, _ = splitSynopsis(strings.Join(lead, "\n"))
+	}
+	return summary, description, true
+}
+
 // splitSynopsis splits a doc comment into its first sentence and the remainder.
 // The split is by *sentence*, not by line: real doc comments wrap, so taking the
 // first line truncates mid-sentence ("…origin publisher (admin-only). PUT").
@@ -1692,8 +1761,9 @@ func splitSynopsis(text string) (summary, description string) {
 func isSpaceByte(b byte) bool { return b == ' ' || b == '\t' || b == '\n' || b == '\r' }
 
 // handlerDoc resolves the handler's Go doc comment into an operation summary
-// (the first sentence) and description (the remainder), per the common
-// Go→OpenAPI convention (issue #168). Returns empty strings when the handler is
+// and description, per the common Go→OpenAPI convention (issue #168): swaggo
+// annotations win when present, otherwise the first sentence is the summary and
+// the remainder the description. Returns empty strings when the handler is
 // anonymous or undocumented — callers keep whatever summary/description they
 // already had.
 func handlerDoc(route *RouteInfo) (summary, description string) {
@@ -1703,6 +1773,9 @@ func handlerDoc(route *RouteInfo) (summary, description string) {
 	doc := handlerComments(route)
 	if doc == "" {
 		return "", ""
+	}
+	if s, d, ok := swaggoDoc(doc); ok {
+		return s, d
 	}
 	if summary, description = splitSynopsis(doc); summary != "" {
 		return summary, description

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -1576,24 +1576,86 @@ func appendConstraintNote(desc, note string) string {
 	return desc + "\n" + note
 }
 
-// handlerDoc resolves the handler function's Go doc comment into an operation
-// summary (the first line) and description (the remaining lines), per the common
+// receiverTypeName resolves the receiver segment of a rendered method value to
+// the type name that declares the method. The segment is already a type name for
+// the common `h.Method` shape (`h` is a variable, rendered as its type), but for
+// a dependency-injected handler the receiver is a *field path* — `deps.Health`
+// renders as `Deps.Health`, where `Deps` is the type and `Health` the field. In
+// that case the declaring type is the field's own type, read through TypeRefOf
+// (never by parsing the type string) and unwrapped to its named core so a
+// `*HealthHandler` field resolves to `HealthHandler`.
+//
+// Falls back to the last segment when the path resolves to no known field: for a
+// cross-package receiver (`otherpkg.Handler`) that is exactly the type name, and
+// for anything else it yields a name that simply matches nothing — an empty
+// summary rather than a guessed one.
+func receiverTypeName(meta *metadata.Metadata, pkg, recv string) string {
+	i := strings.LastIndexByte(recv, '.')
+	if i < 0 {
+		return recv
+	}
+	owner, field := recv[:i], recv[i+1:]
+	if t := findType(meta, pkg, owner); t != nil {
+		for _, f := range t.Fields {
+			if meta.StringPool.GetString(f.Name) != field {
+				continue
+			}
+			if core := meta.TypeRefOf(f.Type).Core(); core.IsNamed() {
+				return core.Name
+			}
+			// An unnamed field type (a bare func type, say) declares no methods.
+			// Fall through to the field name so the lookup stays receiver-scoped:
+			// returning "" here would let it match on the method name alone and
+			// pick an arbitrary same-named method (golden rule #7).
+			break
+		}
+	}
+	return field
+}
+
+// handlerComments returns the Go doc comment recorded for the route's handler,
+// resolving every handler shape. RouteInfo.Function is the rendered handler
+// argument, and the shapes differ (issue #168 originally handled only the first):
+//
+//	pkg.Handler                 — a package-level function
+//	pkg-->pkg.Recv.Method       — a method value (h.Handler)
+//	pkg-->Owner.Field.Method    — a method value on a struct field (deps.H.Handler)
+//
+// The method shapes resolve through the per-Type methods table, which
+// findFunctionByName cannot reach — it indexes only receiver-less declarations.
+// Returns "" for an anonymous (func-literal) or undocumented handler.
+func handlerComments(route *RouteInfo) string {
+	name := route.Function
+	if _, tail, found := strings.Cut(name, TypeSep); found {
+		recv, method := "", strings.TrimPrefix(tail, route.Package+".")
+		if i := strings.LastIndexByte(method, '.'); i >= 0 {
+			recv, method = method[:i], method[i+1:]
+		}
+		recv = receiverTypeName(route.Metadata, route.Package, recv)
+		if m := findMethodByName(route.Metadata, route.Package, recv, method); m != nil {
+			return getStringFromPool(route.Metadata, m.Comments)
+		}
+		return ""
+	}
+	if route.Package != "" {
+		name = strings.TrimPrefix(name, route.Package+".")
+	}
+	if fn := findFunctionByName(route.Metadata, route.Package, name); fn != nil {
+		return getStringFromPool(route.Metadata, fn.Comments)
+	}
+	return ""
+}
+
+// handlerDoc resolves the handler's Go doc comment into an operation summary
+// (the first line) and description (the remaining lines), per the common
 // Go→OpenAPI convention (issue #168). Returns empty strings when the handler is
-// anonymous (a func literal), a method not indexed in the function table, or
-// undocumented — callers keep whatever summary/description they already had.
+// anonymous or undocumented — callers keep whatever summary/description they
+// already had.
 func handlerDoc(route *RouteInfo) (summary, description string) {
 	if route == nil || route.Metadata == nil || route.Function == "" {
 		return "", ""
 	}
-	name := route.Function
-	if route.Package != "" {
-		name = strings.TrimPrefix(name, route.Package+".")
-	}
-	fn := findFunctionByName(route.Metadata, route.Package, name)
-	if fn == nil {
-		return "", ""
-	}
-	doc := getStringFromPool(route.Metadata, fn.Comments)
+	doc := handlerComments(route)
 	if doc == "" {
 		return "", ""
 	}

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -1725,11 +1725,13 @@ func swaggoDoc(text string) (summary, description string, ok bool) {
 // The split is by *sentence*, not by line: real doc comments wrap, so taking the
 // first line truncates mid-sentence ("…origin publisher (admin-only). PUT").
 //
-// Synopsis collapses interior whitespace, so the synopsis is not always a
-// literal prefix of the comment. The remainder is therefore recovered by walking
-// the original alongside the synopsis, treating any whitespace run in the
-// original as the synopsis's single space — which keeps the description's
-// original formatting intact.
+// Synopsis rewrites the text as well as collapsing whitespace — Go doc markup
+// turns “quoted” into curly quotes — so the synopsis is not a literal prefix
+// of the comment and the remainder cannot be recovered by comparing the two
+// character by character (that silently dropped the description whenever a
+// rewrite occurred). Those rewrites preserve *word count*, so the split instead
+// consumes that many whitespace-separated words from the original, which keeps
+// the description's own formatting intact.
 func splitSynopsis(text string) (summary, description string) {
 	// The package-level godoc.Synopsis is deprecated; the method form on an empty
 	// Package is the supported equivalent and needs no loaded package.
@@ -1737,23 +1739,17 @@ func splitSynopsis(text string) (summary, description string) {
 	if summary == "" {
 		return "", ""
 	}
-	i, j := 0, 0
-	for i < len(text) && j < len(summary) {
-		if isSpaceByte(text[i]) {
-			for i < len(text) && isSpaceByte(text[i]) {
-				i++
-			}
-			if summary[j] == ' ' {
-				j++
-			}
-			continue
+	i := 0
+	for n := len(strings.Fields(summary)); n > 0; n-- {
+		for i < len(text) && isSpaceByte(text[i]) {
+			i++
 		}
-		if text[i] != summary[j] {
-			// Divergence (a directive line Synopsis dropped, say): fall back to
-			// the whole comment as the summary rather than slicing at a guess.
-			return summary, ""
+		if i >= len(text) {
+			break
 		}
-		i, j = i+1, j+1
+		for i < len(text) && !isSpaceByte(text[i]) {
+			i++
+		}
 	}
 	return summary, strings.TrimSpace(text[i:])
 }

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -17,6 +17,7 @@ package spec
 import (
 	"fmt"
 	"go/ast"
+	godoc "go/doc"
 	"go/types"
 	"log"
 	"maps"
@@ -1626,19 +1627,24 @@ func receiverTypeName(meta *metadata.Metadata, pkg, recv string) string {
 // Returns "" for an anonymous (func-literal) or undocumented handler.
 func handlerComments(route *RouteInfo) string {
 	name := route.Function
-	if _, tail, found := strings.Cut(name, TypeSep); found {
-		recv, method := "", strings.TrimPrefix(tail, route.Package+".")
-		if i := strings.LastIndexByte(method, '.'); i >= 0 {
-			recv, method = method[:i], method[i+1:]
+	// The separator between the package and the rest is TypeSep in some render
+	// paths and a plain dot in others, so normalize before splitting. The package
+	// prefix can then appear twice ("pkg" + TypeSep + "pkg.Recv.Method"), hence
+	// the loop.
+	name = strings.ReplaceAll(name, TypeSep, ".")
+	if route.Package != "" {
+		for strings.HasPrefix(name, route.Package+".") {
+			name = name[len(route.Package)+1:]
 		}
-		recv = receiverTypeName(route.Metadata, route.Package, recv)
-		if m := findMethodByName(route.Metadata, route.Package, recv, method); m != nil {
+	}
+	// What remains is either "Method" / "Func" or "<recv>.Method", where <recv>
+	// is a type name or a field path.
+	if i := strings.LastIndexByte(name, '.'); i >= 0 {
+		recv := receiverTypeName(route.Metadata, route.Package, name[:i])
+		if m := findMethodByName(route.Metadata, route.Package, recv, name[i+1:]); m != nil {
 			return getStringFromPool(route.Metadata, m.Comments)
 		}
 		return ""
-	}
-	if route.Package != "" {
-		name = strings.TrimPrefix(name, route.Package+".")
 	}
 	if fn := findFunctionByName(route.Metadata, route.Package, name); fn != nil {
 		return getStringFromPool(route.Metadata, fn.Comments)
@@ -1646,8 +1652,47 @@ func handlerComments(route *RouteInfo) string {
 	return ""
 }
 
+// splitSynopsis splits a doc comment into its first sentence and the remainder.
+// The split is by *sentence*, not by line: real doc comments wrap, so taking the
+// first line truncates mid-sentence ("…origin publisher (admin-only). PUT").
+//
+// Synopsis collapses interior whitespace, so the synopsis is not always a
+// literal prefix of the comment. The remainder is therefore recovered by walking
+// the original alongside the synopsis, treating any whitespace run in the
+// original as the synopsis's single space — which keeps the description's
+// original formatting intact.
+func splitSynopsis(text string) (summary, description string) {
+	// The package-level godoc.Synopsis is deprecated; the method form on an empty
+	// Package is the supported equivalent and needs no loaded package.
+	summary = new(godoc.Package).Synopsis(text)
+	if summary == "" {
+		return "", ""
+	}
+	i, j := 0, 0
+	for i < len(text) && j < len(summary) {
+		if isSpaceByte(text[i]) {
+			for i < len(text) && isSpaceByte(text[i]) {
+				i++
+			}
+			if summary[j] == ' ' {
+				j++
+			}
+			continue
+		}
+		if text[i] != summary[j] {
+			// Divergence (a directive line Synopsis dropped, say): fall back to
+			// the whole comment as the summary rather than slicing at a guess.
+			return summary, ""
+		}
+		i, j = i+1, j+1
+	}
+	return summary, strings.TrimSpace(text[i:])
+}
+
+func isSpaceByte(b byte) bool { return b == ' ' || b == '\t' || b == '\n' || b == '\r' }
+
 // handlerDoc resolves the handler's Go doc comment into an operation summary
-// (the first line) and description (the remaining lines), per the common
+// (the first sentence) and description (the remainder), per the common
 // Go→OpenAPI convention (issue #168). Returns empty strings when the handler is
 // anonymous or undocumented — callers keep whatever summary/description they
 // already had.
@@ -1659,8 +1704,8 @@ func handlerDoc(route *RouteInfo) (summary, description string) {
 	if doc == "" {
 		return "", ""
 	}
-	if i := strings.IndexByte(doc, '\n'); i >= 0 {
-		return strings.TrimSpace(doc[:i]), strings.TrimSpace(doc[i+1:])
+	if summary, description = splitSynopsis(doc); summary != "" {
+		return summary, description
 	}
 	return doc, ""
 }

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -229,7 +229,12 @@ func (r *RoutePatternMatcherImpl) ExtractRoute(node TrackerNodeInterface, routeI
 
 			handlerName := handlerArg.GetName()
 			// Use variable tracing to resolve handler
-			originVar, originPkg, originType, _ := r.traceVariable(
+			// The traced origin *type* is deliberately unused: it renders as a
+			// type string ("*pkg-->Handler"), which is meaningless as an
+			// operation summary in a published spec and — since handlerDoc only
+			// fills an empty summary — would suppress the handler's real doc
+			// comment (#168).
+			originVar, originPkg, _, _ := r.traceVariable(
 				handlerName,
 				r.contextProvider.GetString(edge.Caller.Name),
 				r.contextProvider.GetString(edge.Caller.Pkg),
@@ -239,14 +244,6 @@ func (r *RoutePatternMatcherImpl) ExtractRoute(node TrackerNodeInterface, routeI
 			}
 			if originPkg != "" {
 				routeInfo.Package = originPkg
-			}
-
-			var originTypeStr string
-			if originType != nil {
-				originTypeStr = r.contextProvider.GetArgumentInfo(originType)
-			}
-			if originTypeStr != "" {
-				routeInfo.Summary = originTypeStr
 			}
 		}
 	}

--- a/internal/spec/tests/complex.yaml
+++ b/internal/spec/tests/complex.yaml
@@ -160,6 +160,7 @@ packages:
                 signature_str: 57
                 position: 56
                 scope: 15
+                comments: -1
                 filename: 16
                 assignments:
                   name:
@@ -398,6 +399,7 @@ packages:
                 signature_str: 17
                 position: 14
                 scope: 15
+                comments: -1
                 filename: 16
                 return_vars:
                   - kind: 8
@@ -504,6 +506,7 @@ packages:
                 signature_str: 36
                 position: 35
                 scope: 15
+                comments: -1
                 filename: 16
                 return_vars:
                   - kind: 0
@@ -1157,6 +1160,7 @@ packages:
             signature_str: 57
             position: 56
             scope: 15
+            comments: -1
             filename: 16
             assignments:
               name:
@@ -1395,6 +1399,7 @@ packages:
             signature_str: 17
             position: 14
             scope: 15
+            comments: -1
             filename: 16
             return_vars:
               - kind: 8
@@ -1501,6 +1506,7 @@ packages:
             signature_str: 36
             position: 35
             scope: 15
+            comments: -1
             filename: 16
             return_vars:
               - kind: 0

--- a/internal/spec/tests/example.yaml
+++ b/internal/spec/tests/example.yaml
@@ -272,6 +272,7 @@ packages:
                 signature_str: 17
                 position: 14
                 scope: 15
+                comments: -1
                 filename: 16
                 return_vars:
                   - kind: 8
@@ -368,6 +369,7 @@ packages:
                 signature_str: 28
                 position: 27
                 scope: 15
+                comments: -1
                 filename: 16
                 assignments:
                   example.User.Age:
@@ -888,6 +890,7 @@ packages:
             signature_str: 17
             position: 14
             scope: 15
+            comments: -1
             filename: 16
             return_vars:
               - kind: 8
@@ -984,6 +987,7 @@ packages:
             signature_str: 28
             position: 27
             scope: 15
+            comments: -1
             filename: 16
             assignments:
               example.User.Age:

--- a/internal/spec/tests/generic.yaml
+++ b/internal/spec/tests/generic.yaml
@@ -157,6 +157,7 @@ packages:
                 signature_str: 17
                 position: 14
                 scope: 15
+                comments: -1
                 filename: 16
                 return_vars:
                   - kind: 8
@@ -253,6 +254,7 @@ packages:
                 signature_str: 26
                 position: 25
                 scope: 15
+                comments: -1
                 filename: 16
                 assignments:
                   generic.Container[T].Value:
@@ -1004,6 +1006,7 @@ packages:
             signature_str: 17
             position: 14
             scope: 15
+            comments: -1
             filename: 16
             return_vars:
               - kind: 8
@@ -1100,6 +1103,7 @@ packages:
             signature_str: 26
             position: 25
             scope: 15
+            comments: -1
             filename: 16
             assignments:
               generic.Container[T].Value:

--- a/internal/spec/tests/multipackage.yaml
+++ b/internal/spec/tests/multipackage.yaml
@@ -488,6 +488,7 @@ packages:
                 signature_str: 51
                 position: 48
                 scope: 49
+                comments: -1
                 filename: 50
                 return_vars:
                   - kind: 12
@@ -584,6 +585,7 @@ packages:
                 signature_str: 59
                 position: 58
                 scope: 49
+                comments: -1
                 filename: 50
                 return_vars:
                   - kind: 12
@@ -1031,6 +1033,7 @@ packages:
             signature_str: 51
             position: 48
             scope: 49
+            comments: -1
             filename: 50
             return_vars:
               - kind: 12
@@ -1127,6 +1130,7 @@ packages:
             signature_str: 59
             position: 58
             scope: 49
+            comments: -1
             filename: 50
             return_vars:
               - kind: 12
@@ -1357,6 +1361,7 @@ packages:
                 signature_str: 111
                 position: 109
                 scope: 49
+                comments: -1
                 filename: 110
                 return_vars:
                   - kind: 13
@@ -1726,6 +1731,7 @@ packages:
                 signature_str: 119
                 position: 118
                 scope: 49
+                comments: -1
                 filename: 110
                 assignments:
                   multipackage/services.UserService.prefix:
@@ -2040,6 +2046,7 @@ packages:
             signature_str: 111
             position: 109
             scope: 49
+            comments: -1
             filename: 110
             return_vars:
               - kind: 13
@@ -2409,6 +2416,7 @@ packages:
             signature_str: 119
             position: 118
             scope: 49
+            comments: -1
             filename: 110
             assignments:
               multipackage/services.UserService.prefix:

--- a/testdata/chi_method_handle/main.go
+++ b/testdata/chi_method_handle/main.go
@@ -16,6 +16,9 @@ type HealthStatus struct {
 // HealthHandler implements http.Handler and is registered via r.Method.
 type HealthHandler struct{}
 
+// ServeHTTP reports service health.
+// Doc-comment sourcing (#168) is framework-agnostic: it resolves off the
+// handler declaration, not the router, so a chi-registered method gets it too.
 func (h *HealthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(HealthStatus{Status: "ok"})
@@ -67,6 +70,7 @@ func NewRouter(deps Deps) *chi.Mux {
 	r := chi.NewRouter()
 
 	r.Get("/live", ServeLive)                        // func value
+	r.Get("/live2", deps.Health.ServeHTTP)           // method value
 	r.Method(http.MethodGet, "/health", deps.Health) // http.Handler via Method
 	r.MethodFunc(http.MethodPost, "/ready", readyHandler)
 	r.Handle("/metrics", deps.Metrics) // opaque http.Handler

--- a/testdata/handler_doc_comments/go.mod
+++ b/testdata/handler_doc_comments/go.mod
@@ -1,0 +1,3 @@
+module handler_doc_comments
+
+go 1.26

--- a/testdata/handler_doc_comments/main.go
+++ b/testdata/handler_doc_comments/main.go
@@ -34,6 +34,13 @@ func (h *Handler) PatchAccount(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+// ServeHTTP is documented, but a route registered with the handler *value*
+// (mux.Handle("...", h)) names no method, so nothing resolves it — the
+// operation keeps an empty summary rather than a guessed one. See issue #204.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
 // listAccounts returns every account.
 // The remaining lines become the operation description.
 func listAccounts(w http.ResponseWriter, r *http.Request) {
@@ -55,6 +62,9 @@ func main() {
 	mux.HandleFunc("DELETE /accounts", h.DeleteAccount)
 	mux.HandleFunc("PATCH /accounts", h.PatchAccount)
 	mux.HandleFunc("GET /accounts", listAccounts)
+	// A handler *value* names no method, so nothing is resolved for it — and in
+	// particular the traced origin type must not leak in as the summary.
+	mux.Handle("OPTIONS /accounts", h)
 	// A func literal has no doc comment to source from.
 	mux.HandleFunc("PUT /accounts", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/testdata/handler_doc_comments/main.go
+++ b/testdata/handler_doc_comments/main.go
@@ -41,6 +41,18 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+// SearchAccounts godoc
+// @Summary      Search accounts
+// @Description  Filters accounts by query string.
+// @Description  Returns an empty list when nothing matches.
+// @Tags         accounts
+// @Produce      json
+// @Success      200 {array} Account
+// @Router       /accounts/search [get]
+func (h *Handler) SearchAccounts(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode([]Account{})
+}
+
 // listAccounts returns every account.
 // The remaining lines become the operation description.
 func listAccounts(w http.ResponseWriter, r *http.Request) {
@@ -62,6 +74,7 @@ func main() {
 	mux.HandleFunc("DELETE /accounts", h.DeleteAccount)
 	mux.HandleFunc("PATCH /accounts", h.PatchAccount)
 	mux.HandleFunc("GET /accounts", listAccounts)
+	mux.HandleFunc("GET /accounts/search", h.SearchAccounts)
 	// A handler *value* names no method, so nothing is resolved for it — and in
 	// particular the traced origin type must not leak in as the summary.
 	mux.Handle("OPTIONS /accounts", h)

--- a/testdata/handler_doc_comments/main.go
+++ b/testdata/handler_doc_comments/main.go
@@ -1,0 +1,63 @@
+// Fixture for issue #168: a handler's Go doc comment becomes the operation
+// summary (first line) + description (rest). Covers every handler shape —
+// package-level func, pointer-receiver method, value-receiver method — plus the
+// shapes that must stay empty (undocumented method, func literal).
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type Account struct {
+	ID string `json:"id"`
+}
+
+type Handler struct{}
+
+// CreateAccount registers a new account.
+// It validates the payload and returns the created account.
+func (h *Handler) CreateAccount(w http.ResponseWriter, r *http.Request) {
+	var a Account
+	_ = json.NewDecoder(r.Body).Decode(&a)
+	_ = json.NewEncoder(w).Encode(a)
+}
+
+// DeleteAccount removes an account.
+func (h Handler) DeleteAccount(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) PatchAccount(w http.ResponseWriter, r *http.Request) {
+	// Deliberately undocumented: the operation keeps an empty summary rather
+	// than sourcing from a non-doc comment.
+	w.WriteHeader(http.StatusOK)
+}
+
+// listAccounts returns every account.
+// The remaining lines become the operation description.
+func listAccounts(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode([]Account{})
+}
+
+// Deps carries the handler as a field, mirroring dependency-injected routers:
+// the receiver then renders as a field path (Deps.Accounts), not a type name.
+type Deps struct {
+	Accounts *Handler
+}
+
+func main() {
+	h := &Handler{}
+	deps := Deps{Accounts: h}
+	mux := http.NewServeMux()
+	mux.HandleFunc("HEAD /accounts", deps.Accounts.CreateAccount)
+	mux.HandleFunc("POST /accounts", h.CreateAccount)
+	mux.HandleFunc("DELETE /accounts", h.DeleteAccount)
+	mux.HandleFunc("PATCH /accounts", h.PatchAccount)
+	mux.HandleFunc("GET /accounts", listAccounts)
+	// A func literal has no doc comment to source from.
+	mux.HandleFunc("PUT /accounts", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	_ = http.ListenAndServe(":8080", mux)
+}


### PR DESCRIPTION
Follow-up to #199. `#168` (handler doc comment → operation `summary`/`description`) shipped covering **only package-level function handlers**; method handlers — the dominant shape in real code — silently produced nothing. Validated against two large real projects, where this takes summaries from ~1 to 127 and from 5 to 42 operations (the remainder there being genuinely undocumented handlers).

## The original gap (#168)

Two layers dropped it independently:

- **metadata never recorded the fact** — the concrete-method pass built its `Method` entries without `Comments`, so the doc comment existed nowhere downstream. Only *interface* methods carried one, which is what made it look covered.
- **the spec lookup could not reach methods anyway** — `handlerDoc` resolved through `findFunctionByName`, and `processFunctions` indexes only receiver-less decls, so `file.Functions` holds no methods by construction.

Records `Comments` on concrete methods, and resolves the method shapes of `RouteInfo.Function` through the per-Type methods table. A dependency-injected receiver renders as a *field path* (`Owner.Field.Method`), so the declaring type is read from the field's own type via `TypeRefOf(...).Core()` — never by parsing the type string (golden rule #2).

Detection stays framework-agnostic (golden rule #5): resolution is off the handler declaration, not the router. `testdata/chi_method_handle` gains a chi-registered method value on a DI field and asserts it.

## Two further defects found by testing against real code

The fixture suite passed while real projects produced almost nothing — both of these were invisible to it:

- **Two rendering shapes.** `RouteInfo.Function` separates the package with `TypeSep` in some paths and a plain dot in others (`pkg-->pkg.Recv.Method` vs `pkg.Recv.Method`). Every fixture in the repo renders the `TypeSep` form; real projects predominantly render the dotted one, which fell through to the function lookup and resolved nothing. Now normalized before splitting, with a repeated package prefix stripped.
- **Summaries truncated mid-sentence.** The summary was the first *line*, but real doc comments wrap — yielding `"…origin publisher (admin-only). PUT"`. Now splits by first *sentence* via `doc.Package.Synopsis` (the method form; the package-level `doc.Synopsis` is deprecated and fails staticcheck). Synopsis collapses interior whitespace, so the remainder is recovered by walking the original alongside it, preserving the description's formatting.

## Adjacent bug fixed

`ExtractRoute` assigned the traced origin *type* of a handler argument to `RouteInfo.Summary`, publishing a rendered type string as the operation summary:

```yaml
/a:
  get:
    summary: '*pkg-->Handler'
```

Meaningless in a spec, and since `handlerDoc` only fills an *empty* summary it also suppressed real doc comments. Predates this work (confirmed against `main`). Nothing consumed it — `route.Summary` is read only when building the operation, and the suite's only `Summary` assertions cover config overrides from a different assignment. Removed with zero output drift.

## Known limitation — #204

A route registered with an opaque handler **value** (`r.Method(GET, "/health", deps.Health)`) names no method at all, so it still yields an empty summary rather than a guessed one. That is not doc-comment-specific: such routes are never expanded into their concrete `ServeHTTP`, so params/request/response are missing too. Root cause and proposed fix are written up in #204; it needs a config knob across six framework configs plus expansion changes in both tracker engines, so it is deliberately out of scope here.

Guessing was rejected on purpose: `ServeHTTP` is declared on two types in `testdata/chi_method_handle`, so name-only matching would pick arbitrarily (golden rules #7/#9).

## Tests

- New fixture `testdata/handler_doc_comments` + structural test: pointer- and value-receiver methods, field-path receiver, package-level func, and the three that must stay empty (undocumented method, func literal, handler value).
- `testdata/chi_method_handle`: chi method value on a DI field asserted; `/health` asserted empty as a change detector for #204.
- Spec-layer unit tests for `handlerDoc` / `receiverTypeName` / `findMethodByName` / `splitSynopsis`, including the dotted shape and an import-path package whose name itself contains dots.
- Metadata goldens regenerated via `-update` (additive: `comments` on method entries).

**Coverage caveat worth a reviewer's eye:** the dotted shape could not be reproduced synthetically — constructor-built handlers, router-as-parameter, and a chi router-as-interface-param probe all render the `TypeSep` form — so it is guarded by unit tests built from an observed string rather than by a fixture. That is weaker than the project standard and means something about the real-world tracker path is still not understood.

Full suite green, `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - OpenAPI operation summaries and descriptions are now generated more accurately from Go documentation comments.
  - Documentation is supported for package functions, receiver methods, and method values accessed through struct fields.
  - Summaries are derived from the first documented sentence, with remaining text used as the description.

- **Bug Fixes**
  - Improved handler resolution for pointer and value receivers.
  - Added coverage for health-check and additional route documentation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->