### PR TITLE
fix: trace handler-value routes into their concrete method (#204, #178)

### DIFF
--- a/generator/handler_value_parity_test.go
+++ b/generator/handler_value_parity_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/engine"
+	"github.com/ehabterra/apispec/spec"
+)
+
+// TestHandlerValueEngineParity runs the handler-value fixtures through BOTH
+// tracker engines and requires identical results.
+//
+// The eager tree materializes nodes up front while the lazy tree expands by key,
+// so a capability added to one is silently absent from the other — which is
+// exactly what happened when handler-value expansion (#204) first landed in
+// LazyTree alone: summaries resolved (shared mapper code) while bodies did not.
+// Both engines ship, so both must resolve the same routes.
+func TestHandlerValueEngineParity(t *testing.T) {
+	for _, tc := range []struct {
+		name, fixture, path, method string
+		cfg                         *spec.APISpecConfig
+	}{
+		{"chi handler value", "chi_method_handle", "/health", "GET", spec.DefaultChiConfig()},
+		{"mux handler value", "mux", "/status", "GET", spec.DefaultMuxConfig()},
+		{"net/http handler value", "handler_doc_comments", "/accounts", "OPTIONS", spec.DefaultHTTPConfig()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lazy := generateWithTracker(t, tc.fixture, tc.cfg, true)
+			eager := generateWithTracker(t, tc.fixture, tc.cfg, false)
+
+			lazyItem, ok := lazy.Paths[tc.path]
+			if !ok {
+				t.Fatalf("lazy: %s missing; have %v", tc.path, mapPathKeys(lazy.Paths))
+			}
+			eagerItem, ok := eager.Paths[tc.path]
+			if !ok {
+				t.Fatalf("eager: %s missing; have %v", tc.path, mapPathKeys(eager.Paths))
+			}
+			lazyOp, eagerOp := opFor(lazyItem, tc.method), opFor(eagerItem, tc.method)
+			if lazyOp == nil || eagerOp == nil {
+				t.Fatalf("%s %s: lazy=%v eager=%v", tc.method, tc.path, lazyOp != nil, eagerOp != nil)
+			}
+
+			if lazyOp.Summary != eagerOp.Summary {
+				t.Errorf("summary differs between engines:\n lazy:  %q\n eager: %q", lazyOp.Summary, eagerOp.Summary)
+			}
+			if lazyOp.Summary == "" {
+				t.Errorf("%s %s: expected a handler-value summary in both engines (#204)", tc.method, tc.path)
+			}
+			// Response *status sets* must match. Bodies are compared by presence
+			// rather than by schema identity: the point is that the handler was
+			// expanded at all, which is what diverged.
+			if len(lazyOp.Responses) != len(eagerOp.Responses) {
+				t.Errorf("response count differs: lazy=%d eager=%d", len(lazyOp.Responses), len(eagerOp.Responses))
+			}
+			for status := range lazyOp.Responses {
+				if _, ok := eagerOp.Responses[status]; !ok {
+					t.Errorf("status %q present in lazy but not eager", status)
+				}
+			}
+		})
+	}
+}
+
+// generateWithTracker builds the spec for a fixture with the chosen tracker
+// engine. The public Generator always uses the lazy tree, so the engine is
+// driven directly here.
+func generateWithTracker(t *testing.T, fixture string, cfg *spec.APISpecConfig, lazy bool) *spec.OpenAPISpec {
+	t.Helper()
+	ec := engine.DefaultEngineConfig()
+	ec.InputDir = filepath.Join("..", "testdata", fixture)
+	ec.APISpecConfig = cfg
+	ec.UseLazyTracker = lazy
+
+	out, err := engine.NewEngine(ec).GenerateOpenAPI()
+	if err != nil {
+		t.Fatalf("GenerateOpenAPI(%s, lazy=%v): %v", fixture, lazy, err)
+	}
+	if out == nil || out.Paths == nil {
+		t.Fatalf("nil spec for %s (lazy=%v)", fixture, lazy)
+	}
+	return out
+}

--- a/generator/testdata_chi_method_handle_test.go
+++ b/generator/testdata_chi_method_handle_test.go
@@ -57,12 +57,16 @@ func TestTestdata_ChiMethodHandle(t *testing.T) {
 		if opFor(health, "POST") != nil {
 			t.Errorf("/health should not carry a POST operation (verb is http.MethodGet)")
 		}
-		// Change detector: an opaque http.Handler *value* (r.Method(..., deps.Health))
-		// names no method in the registration, so #168 cannot reach the concrete
-		// ServeHTTP doc comment — resolving it needs interface-value → concrete
-		// type resolution. Asserted empty on purpose; flip when issue #204 lands.
-		if get := opFor(health, "GET"); get != nil && get.Summary != "" {
-			t.Errorf("GET /health summary: got %q, want \"\" until handler-value doc sourcing lands (#168)", get.Summary)
+		// #204: an opaque http.Handler *value* (r.Method(..., deps.Health)) names
+		// no method in the registration, so the framework's handler interface
+		// supplies it — the route resolves both its doc comment and its body.
+		if get := opFor(health, "GET"); get != nil {
+			if get.Summary != "ServeHTTP reports service health." {
+				t.Errorf("GET /health summary: got %q (#204)", get.Summary)
+			}
+			if _, ok := get.Responses["200"]; !ok {
+				t.Errorf("GET /health: expected the 200 response from ServeHTTP's body (#204)")
+			}
 		}
 	}
 

--- a/generator/testdata_frameworks_test.go
+++ b/generator/testdata_frameworks_test.go
@@ -107,6 +107,7 @@ func TestTestdata_Frameworks(t *testing.T) {
 			fallback: spec.DefaultMuxConfig(),
 			routes: []route{
 				{"/api/v1/health", []string{"GET"}},
+				{"/status", []string{"GET"}}, // r.Handle with an http.Handler value (#204)
 				{"/users", []string{"GET", "POST"}},
 				{"/users/{id}", []string{"GET", "PUT", "DELETE"}},
 			},

--- a/generator/testdata_handler_doc_comments_test.go
+++ b/generator/testdata_handler_doc_comments_test.go
@@ -77,11 +77,13 @@ func TestTestdata_HandlerDocComments(t *testing.T) {
 			shape:  "func literal",
 		},
 		{
-			// Change detector on two counts: the handler value names no method
-			// so ServeHTTP's doc comment is out of reach (#204), and the traced
-			// origin type must not leak in as a summary ("*pkg-->Handler").
-			method: "OPTIONS",
-			shape:  "handler value",
+			// #204: the handler value names no method, so the framework's
+			// handler interface (ServeHTTP) supplies it. Also guards that the
+			// traced origin type never leaks in as a summary ("*pkg-->Handler").
+			method:      "OPTIONS",
+			shape:       "handler value",
+			summary:     "ServeHTTP serves the account resource directly.",
+			description: "A route registered with the handler *value* (mux.Handle(\"...\", h)) names no\nmethod, so the framework's handler interface supplies it (issue #204).",
 		},
 	} {
 		p := path

--- a/generator/testdata_handler_doc_comments_test.go
+++ b/generator/testdata_handler_doc_comments_test.go
@@ -77,6 +77,16 @@ func TestTestdata_HandlerDocComments(t *testing.T) {
 			shape:  "func literal",
 		},
 		{
+			// #178 + #204: an interface-typed value resolves through the
+			// concrete implementers recorded for the stdlib interface. Unique
+			// implementer here, so the summary is unambiguous.
+			method:      "GET",
+			path:        "/accounts/direct",
+			shape:       "interface-typed handler value",
+			summary:     "ServeHTTP serves the account resource directly.",
+			description: "A route registered with the handler *value* (mux.Handle(\"...\", h)) names no\nmethod, so the framework's handler interface supplies it (issue #204).",
+		},
+		{
 			// #204: the handler value names no method, so the framework's
 			// handler interface (ServeHTTP) supplies it. Also guards that the
 			// traced origin type never leaks in as a summary ("*pkg-->Handler").

--- a/generator/testdata_handler_value_test.go
+++ b/generator/testdata_handler_value_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"testing"
+
+	intspec "github.com/ehabterra/apispec/internal/spec"
+	"github.com/ehabterra/apispec/spec"
+)
+
+// TestTestdata_HandlerValueRoutes covers issue #204 across frameworks: a route
+// registered with a handler *value* rather than a func names no method anywhere
+// in the registration, so nothing resolved it and the operation had no params,
+// request body, response, or summary. The method now comes from the framework
+// config (FrameworkConfig.HandlerInterfaceMethods), so the handler's body is
+// reachable — this must hold for every http.Handler-based framework, not just
+// the one that prompted the fix (golden rule #5).
+func TestTestdata_HandlerValueRoutes(t *testing.T) {
+	for _, tc := range []struct {
+		name, fixture, path, summary string
+		cfg                          *spec.APISpecConfig
+		schemaSuffix                 string
+	}{
+		{
+			name:         "net/http mux.Handle",
+			fixture:      "handler_doc_comments",
+			path:         "/accounts",
+			cfg:          spec.DefaultHTTPConfig(),
+			summary:      "ServeHTTP serves the account resource directly.",
+			schemaSuffix: "",
+		},
+		{
+			name:         "chi r.Method with an http.Handler field",
+			fixture:      "chi_method_handle",
+			path:         "/health",
+			cfg:          spec.DefaultChiConfig(),
+			summary:      "ServeHTTP reports service health.",
+			schemaSuffix: "HealthStatus",
+		},
+		{
+			name:         "gorilla/mux r.Handle with a value",
+			fixture:      "mux",
+			path:         "/status",
+			cfg:          spec.DefaultMuxConfig(),
+			summary:      "ServeHTTP reports the service status.",
+			schemaSuffix: "Status",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := loadTestdataWithFixtureConfig(t, tc.fixture, tc.cfg)
+			noDanglingRefs(t, out)
+
+			item, ok := out.Paths[tc.path]
+			if !ok {
+				t.Fatalf("%s missing; have %v", tc.path, mapPathKeys(out.Paths))
+			}
+			var op *intspec.Operation
+			for _, m := range []string{"GET", "OPTIONS"} {
+				if o := opFor(item, m); o != nil && o.Summary == tc.summary {
+					op = o
+					break
+				}
+			}
+			if op == nil {
+				t.Fatalf("%s: no operation carrying the handler-value summary %q (#204)", tc.path, tc.summary)
+			}
+			// The body must resolve too — the summary alone would mean the doc
+			// comment was found by name while the handler stayed unexpanded.
+			if tc.schemaSuffix != "" && len(op.Responses) == 0 {
+				t.Errorf("%s: handler body did not resolve — no responses (#204)", tc.path)
+			}
+		})
+	}
+}

--- a/generator/testdata_handler_value_test.go
+++ b/generator/testdata_handler_value_test.go
@@ -62,6 +62,7 @@ func TestTestdata_HandlerValueRoutes(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			out := loadTestdataWithFixtureConfig(t, tc.fixture, tc.cfg)
 			noDanglingRefs(t, out)
+			noUnresolvedPlaceholders(t, out)
 
 			item, ok := out.Paths[tc.path]
 			if !ok {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -672,7 +672,8 @@ func (e *Engine) GenerateOpenAPI() (*spec.OpenAPISpec, error) {
 			intspec.WithHandlerInterfaceMethods(apispecConfig.Framework.HandlerInterfaceMethods))
 		e.reportPhase("tracker tree ready (lazy)", time.Since(tTree))
 	} else {
-		tree = intspec.NewTrackerTree(meta, limits, NewVerboseLogger(e.config.Verbose))
+		tree = intspec.NewTrackerTree(meta, limits, NewVerboseLogger(e.config.Verbose),
+			intspec.WithEagerHandlerInterfaceMethods(apispecConfig.Framework.HandlerInterfaceMethods))
 		e.reportPhase("tracker tree built", time.Since(tTree))
 	}
 	if err := e.ctx().Err(); err != nil {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -668,7 +668,8 @@ func (e *Engine) GenerateOpenAPI() (*spec.OpenAPISpec, error) {
 	tTree := time.Now()
 	var tree intspec.TrackerTreeInterface
 	if e.config.UseLazyTracker {
-		tree = intspec.NewLazyTree(meta, limits)
+		tree = intspec.NewLazyTree(meta, limits,
+			intspec.WithHandlerInterfaceMethods(apispecConfig.Framework.HandlerInterfaceMethods))
 		e.reportPhase("tracker tree ready (lazy)", time.Since(tTree))
 	} else {
 		tree = intspec.NewTrackerTree(meta, limits, NewVerboseLogger(e.config.Verbose))

--- a/internal/metadata/external_interfaces_test.go
+++ b/internal/metadata/external_interfaces_test.go
@@ -1,0 +1,236 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata_test
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"slices"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+	"golang.org/x/tools/go/packages"
+)
+
+// TestExternalInterfaceImplementations covers issue #178: a user type that
+// implements a standard-library interface must record it in Implements.
+//
+// The in-package analysis can only pair types it has recorded, and an imported
+// package's interface declarations never become Type entries, so stdlib
+// interfaces were absent entirely — blocking every "does T implement I?"
+// question, including expanding a handler passed as an http.Handler value (#204).
+func TestExternalInterfaceImplementations(t *testing.T) {
+	fset := token.NewFileSet()
+	src := []testModule{{
+		Name: "extiface",
+		Files: map[string]interface{}{"main.go": `package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// Greeter is a LOCAL interface: the in-package analysis already covered it.
+type Greeter interface{ Greet() string }
+
+// H implements the local Greeter, the stdlib http.Handler, and fmt.Stringer.
+type H struct{}
+
+func (h *H) Greet() string  { return "hi" }
+func (h *H) String() string { return "H" }
+func (h *H) ServeHTTP(w http.ResponseWriter, r *http.Request) {}
+
+// Unreferenced implements io.Writer, but io.Writer is never named in this
+// source and never appears in a called signature — see the scope assertion.
+type Unreferenced struct{}
+
+func (u *Unreferenced) Write(p []byte) (int, error) { return 0, nil }
+
+// Plain implements nothing.
+type Plain struct{ N int }
+
+// Generic exists to prove that constraint interfaces (comparable, type sets)
+// are NOT recorded — nearly everything satisfies them, which is noise.
+type Generic[T comparable] struct{ V T }
+
+func main() {
+	h := &H{}
+	// http.Handler is never named here: it appears only as Handle's parameter
+	// type, which is the dominant real-world shape.
+	http.NewServeMux().Handle("/x", h)
+	// fmt.Stringer IS named here, so it is in scope for recording.
+	var _ fmt.Stringer = h
+	_ = Generic[int]{}
+	_ = Plain{}
+	_ = &Unreferenced{}
+}
+`}}}
+
+	cfg := exportModules(t, src)
+	cfg.Mode = packages.NeedName | packages.NeedFiles | packages.NeedSyntax | packages.NeedTypes | packages.NeedTypesInfo | packages.NeedImports
+	cfg.Fset = fset
+	cfg.Tests = false
+
+	pkgs, err := packages.Load(cfg, "./...")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkgsMetadata := map[string]map[string]*ast.File{}
+	fileToInfo := map[*ast.File]*types.Info{}
+	importPaths := map[string]string{}
+	for _, pkg := range pkgs {
+		if pkg.PkgPath == "" {
+			continue
+		}
+		pkgsMetadata[pkg.PkgPath] = make(map[string]*ast.File)
+		for i, f := range pkg.Syntax {
+			if i < len(pkg.GoFiles) {
+				pkgsMetadata[pkg.PkgPath][pkg.GoFiles[i]] = f
+				fileToInfo[f] = pkg.TypesInfo
+				importPaths[pkg.GoFiles[i]] = pkg.PkgPath
+			}
+		}
+	}
+
+	meta := metadata.GenerateMetadata(pkgsMetadata, fileToInfo, importPaths, fset)
+
+	implementsOf := func(name string) []string {
+		for _, pkg := range meta.Packages {
+			for _, file := range pkg.Files {
+				if typ, ok := file.Types[name]; ok {
+					out := make([]string, 0, len(typ.Implements))
+					for _, idx := range typ.Implements {
+						out = append(out, meta.StringPool.GetString(idx))
+					}
+					slices.Sort(out)
+					return out
+				}
+			}
+		}
+		t.Fatalf("type %q not recorded", name)
+		return nil
+	}
+
+	h := implementsOf("H")
+	for _, want := range []string{"net/http.Handler", "fmt.Stringer", "extiface.Greeter"} {
+		if !slices.Contains(h, want) {
+			t.Errorf("H.Implements missing %q (#178); got %v", want, h)
+		}
+	}
+
+	// Scope, asserted rather than left implicit: only interfaces the analyzed
+	// code actually references are candidates — named in source, or present in
+	// the signature of something it calls. Unreferenced implements io.Writer,
+	// but nothing here mentions io.Writer, so the fact is not recorded. This is
+	// deliberate (scanning every interface in every imported package would be
+	// costly and mostly noise) and it covers the motivating cases, where the
+	// interface is always in the registration's signature: http.Handler (#204),
+	// http.ResponseWriter (#170), io.Reader (#153).
+	if got := implementsOf("Unreferenced"); slices.Contains(got, "io.Writer") {
+		t.Errorf("scope changed: io.Writer is now recorded without being referenced; got %v", got)
+	}
+
+	if got := implementsOf("Plain"); len(got) != 0 {
+		t.Errorf("Plain implements nothing, got %v", got)
+	}
+
+	// Constraint interfaces must not be recorded: `comparable` is satisfied by
+	// nearly every type, so recording it is noise rather than a behavioral fact.
+	for _, name := range []string{"H", "Plain", "Generic"} {
+		if slices.Contains(implementsOf(name), "comparable") {
+			t.Errorf("%s.Implements records the `comparable` constraint", name)
+		}
+	}
+}
+
+// TestExternalInterfaceImplementationsDeterministic guards the ordering
+// invariant (golden rule #1): Implements feeds tree expansion and the spec, so
+// its order must not vary between runs.
+func TestExternalInterfaceImplementationsDeterministic(t *testing.T) {
+	var first []string
+	for i := 0; i < 3; i++ {
+		fset := token.NewFileSet()
+		src := []testModule{{
+			Name: "detiface",
+			Files: map[string]interface{}{"main.go": `package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+type Multi struct{}
+
+func (m *Multi) Write(p []byte) (int, error)                  { return 0, nil }
+func (m *Multi) String() string                               { return "" }
+func (m *Multi) ServeHTTP(w http.ResponseWriter, r *http.Request) {}
+
+func main() {
+	m := &Multi{}
+	var _ io.Writer = m
+	var _ fmt.Stringer = m
+	http.NewServeMux().Handle("/x", m)
+}
+`}}}
+		cfg := exportModules(t, src)
+		cfg.Mode = packages.NeedName | packages.NeedFiles | packages.NeedSyntax | packages.NeedTypes | packages.NeedTypesInfo | packages.NeedImports
+		cfg.Fset = fset
+		cfg.Tests = false
+		pkgs, err := packages.Load(cfg, "./...")
+		if err != nil {
+			t.Fatal(err)
+		}
+		pkgsMetadata := map[string]map[string]*ast.File{}
+		fileToInfo := map[*ast.File]*types.Info{}
+		importPaths := map[string]string{}
+		for _, pkg := range pkgs {
+			if pkg.PkgPath == "" {
+				continue
+			}
+			pkgsMetadata[pkg.PkgPath] = make(map[string]*ast.File)
+			for j, f := range pkg.Syntax {
+				if j < len(pkg.GoFiles) {
+					pkgsMetadata[pkg.PkgPath][pkg.GoFiles[j]] = f
+					fileToInfo[f] = pkg.TypesInfo
+					importPaths[pkg.GoFiles[j]] = pkg.PkgPath
+				}
+			}
+		}
+		meta := metadata.GenerateMetadata(pkgsMetadata, fileToInfo, importPaths, fset)
+
+		var got []string
+		for _, pkg := range meta.Packages {
+			for _, file := range pkg.Files {
+				if typ, ok := file.Types["Multi"]; ok {
+					for _, idx := range typ.Implements {
+						got = append(got, meta.StringPool.GetString(idx))
+					}
+				}
+			}
+		}
+		if len(got) == 0 {
+			t.Fatal("Multi recorded no Implements")
+		}
+		if i == 0 {
+			first = got
+			continue
+		}
+		if !slices.Equal(first, got) {
+			t.Fatalf("Implements order varies between runs:\n run 0: %v\n run %d: %v", first, i, got)
+		}
+	}
+}

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -377,6 +377,9 @@ func GenerateMetadataWithLogger(pkgs map[string]map[string]*ast.File, fileToInfo
 
 	// Analyze interface implementations
 	analyzeInterfaceImplementations(metadata.Packages, metadata.StringPool)
+	// …then the ones declared outside the analyzed set (stdlib), which the pass
+	// above structurally cannot see — issue #178.
+	analyzeExternalInterfaceImplementations(pkgs, fileToInfo, metadata)
 
 	if logger != nil {
 		logger.Println("Building call graph...")
@@ -2039,6 +2042,160 @@ func analyzeInterfaceImplementations(pkgs map[string]*Package, pool *StringPool)
 					if implementsInterface(structMethods, intrf, pool, sigMemo) {
 						stct.Implements = append(stct.Implements, pool.Get(interfacePkgName+"."+interfaceName))
 						intrf.ImplementedBy = append(intrf.ImplementedBy, pool.Get(pkgName+"."+structName))
+					}
+				}
+			}
+		}
+	}
+}
+
+// analyzeExternalInterfaceImplementations records user types that implement
+// interfaces declared OUTSIDE the analyzed package set — standard-library ones
+// above all (net/http.Handler, io.Writer, error, …). Issue #178.
+//
+// analyzeInterfaceImplementations can only pair types it has recorded, and an
+// imported package's interface declarations are never materialised as Type
+// entries, so a user type implementing http.Handler had an empty Implements
+// list. That blocks every question of the form "does T implement stdlib
+// interface I?" — the write-destination gate (#170), the request-body source
+// gate (#153), and expanding a handler passed as an http.Handler value (#204).
+//
+// Rather than synthesising Type entries for imported interfaces, this answers
+// the question with go/types directly: the loaded type information is already
+// available, and types.Implements is exact where a re-derived signature
+// comparison is approximate.
+//
+// Scope: the candidates are the interfaces the analyzed code actually
+// *references* — named in its own source, or appearing in the signature of
+// something it calls. A type implementing io.Writer in a program that never
+// mentions io.Writer is therefore not recorded. That is deliberate: scanning
+// every interface in every imported package would be costly and mostly noise,
+// and the motivating cases all have the interface in the registration's
+// signature — http.Handler (#204), http.ResponseWriter (#170), io.Reader (#153).
+//
+// The pointer method set is used because Go's method sets put pointer-receiver
+// methods only on *T, and a handler is virtually always registered as &T{}.
+func analyzeExternalInterfaceImplementations(
+	pkgs map[string]map[string]*ast.File,
+	fileToInfo map[*ast.File]*types.Info,
+	meta *Metadata,
+) {
+	// Candidate interfaces: every named interface referenced anywhere in the
+	// analyzed code whose declaring package is NOT itself analyzed. Keyed by
+	// "importpath.Name" so the recorded form matches the in-package analysis.
+	external := make(map[string]*types.Interface)
+	seen := make(map[types.Type]bool)
+	var consider func(t types.Type, depth int)
+	consider = func(t types.Type, depth int) {
+		// The walk must reach interfaces named only in a *signature*: the
+		// dominant shape is `mux.Handle("/x", h)`, where http.Handler appears
+		// solely as Handle's parameter type and never in the user's own source.
+		// Depth is bounded and types are visited once — info.Types is large on
+		// real projects, and named types can be mutually recursive.
+		if t == nil || depth > 4 || seen[t] {
+			return
+		}
+		seen[t] = true
+		switch t := t.(type) {
+		case *types.Named:
+			if t.Obj() == nil {
+				return
+			}
+			iface, ok := t.Underlying().(*types.Interface)
+			// Method count, not Empty(): `comparable` and type-set constraints
+			// (~int|~string) are non-empty interfaces that almost everything
+			// "implements", which is noise rather than a behavioral fact.
+			if !ok || iface.NumMethods() == 0 {
+				return
+			}
+			pkg := t.Obj().Pkg()
+			if pkg == nil {
+				// Universe scope: `error`. Recorded unqualified, as written.
+				external[t.Obj().Name()] = iface
+				return
+			}
+			if _, analyzed := pkgs[pkg.Path()]; analyzed {
+				return // already covered by the in-package analysis
+			}
+			external[pkg.Path()+"."+t.Obj().Name()] = iface
+		case *types.Signature:
+			for _, tup := range []*types.Tuple{t.Params(), t.Results()} {
+				for i := 0; i < tup.Len(); i++ {
+					consider(tup.At(i).Type(), depth+1)
+				}
+			}
+		case *types.Pointer:
+			consider(t.Elem(), depth+1)
+		case *types.Slice:
+			consider(t.Elem(), depth+1)
+		case *types.Array:
+			consider(t.Elem(), depth+1)
+		case *types.Map:
+			consider(t.Key(), depth+1)
+			consider(t.Elem(), depth+1)
+		case *types.Chan:
+			consider(t.Elem(), depth+1)
+		}
+	}
+	for _, info := range fileToInfo {
+		for _, obj := range info.Uses {
+			if obj != nil {
+				consider(obj.Type(), 0)
+			}
+		}
+		for _, tv := range info.Types {
+			consider(tv.Type, 0)
+		}
+	}
+	if len(external) == 0 {
+		return
+	}
+	ifaceNames := slices.Sorted(maps.Keys(external))
+
+	// Walk the analyzed declarations in sorted order so appends stay
+	// deterministic (the Implements/ImplementedBy ordering invariant).
+	for _, pkgName := range slices.Sorted(maps.Keys(pkgs)) {
+		metaPkg, ok := meta.Packages[pkgName]
+		if !ok {
+			continue
+		}
+		files := pkgs[pkgName]
+		for _, fileName := range slices.Sorted(maps.Keys(files)) {
+			info, ok := fileToInfo[files[fileName]]
+			if !ok || info == nil {
+				continue
+			}
+			for _, decl := range files[fileName].Decls {
+				gd, ok := decl.(*ast.GenDecl)
+				if !ok || gd.Tok != token.TYPE {
+					continue
+				}
+				for _, spec := range gd.Specs {
+					ts, ok := spec.(*ast.TypeSpec)
+					if !ok {
+						continue
+					}
+					recorded, ok := metaPkg.Types[ts.Name.Name]
+					if !ok || recorded == nil {
+						continue
+					}
+					obj, ok := info.Defs[ts.Name].(*types.TypeName)
+					if !ok || obj == nil || obj.Type() == nil {
+						continue
+					}
+					named, ok := obj.Type().(*types.Named)
+					if !ok {
+						continue
+					}
+					ptr := types.NewPointer(named)
+					for _, ifaceName := range ifaceNames {
+						if !types.Implements(ptr, external[ifaceName]) {
+							continue
+						}
+						idx := meta.StringPool.Get(ifaceName)
+						if !slices.Contains(recorded.Implements, idx) {
+							recorded.Implements = append(recorded.Implements, idx)
+						}
 					}
 				}
 			}

--- a/internal/spec/config.go
+++ b/internal/spec/config.go
@@ -34,6 +34,18 @@ type FrameworkConfig struct {
 	// Route extraction patterns
 	RoutePatterns []RoutePattern `yaml:"routePatterns" json:"routePatterns,omitempty"`
 
+	// HandlerInterfaceMethods names the method(s) through which this framework
+	// invokes a handler passed as a *value* rather than as a function — net/http
+	// and the routers built on it take an `http.Handler` and call `ServeHTTP`.
+	// A registration like `r.Method(GET, "/health", deps.Health)` names no method
+	// at all, so without this the handler's body is unreachable and the route
+	// yields no params, request body, response, or summary (issue #204).
+	// Frameworks whose handlers are plain func types (gin, echo, fiber) leave
+	// this empty. Expansion only follows a method the concrete type actually
+	// declares, so an unrelated value in a handler position resolves to nothing
+	// rather than to a guess.
+	HandlerInterfaceMethods []string `yaml:"handlerInterfaceMethods,omitempty" json:"handlerInterfaceMethods,omitempty"`
+
 	// Request body extraction patterns
 	RequestBodyPatterns []RequestBodyPattern `yaml:"requestBodyPatterns" json:"requestBodyPatterns,omitempty"`
 

--- a/internal/spec/config_chi.go
+++ b/internal/spec/config_chi.go
@@ -40,6 +40,9 @@ func DefaultChiConfig() *APISpecConfig {
 
 	return &APISpecConfig{
 		Framework: FrameworkConfig{
+			// A handler passed as a value (r.Handle("/x", h)) is invoked through
+			// http.Handler; without this its body is unreachable (issue #204).
+			HandlerInterfaceMethods: []string{"ServeHTTP"},
 			RoutePatterns: []RoutePattern{
 				{
 					CallRegex:       `(?i)(GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD)$`,

--- a/internal/spec/config_http.go
+++ b/internal/spec/config_http.go
@@ -72,6 +72,9 @@ func DefaultHTTPConfig() *APISpecConfig {
 
 	return &APISpecConfig{
 		Framework: FrameworkConfig{
+			// A handler passed as a value (r.Handle("/x", h)) is invoked through
+			// http.Handler; without this its body is unreachable (issue #204).
+			HandlerInterfaceMethods: []string{"ServeHTTP"},
 			RoutePatterns: []RoutePattern{
 				{
 					CallRegex:       `^HandleFunc$`,

--- a/internal/spec/config_mux.go
+++ b/internal/spec/config_mux.go
@@ -42,6 +42,9 @@ func DefaultMethodExtractionConfig() *MethodExtractionConfig {
 func DefaultMuxConfig() *APISpecConfig {
 	return &APISpecConfig{
 		Framework: FrameworkConfig{
+			// A handler passed as a value (r.Handle("/x", h)) is invoked through
+			// http.Handler; without this its body is unreachable (issue #204).
+			HandlerInterfaceMethods: []string{"ServeHTTP"},
 			RoutePatterns: []RoutePattern{
 				{
 					CallRegex:        `^HandleFunc$`,

--- a/internal/spec/handler_doc_test.go
+++ b/internal/spec/handler_doc_test.go
@@ -15,6 +15,7 @@
 package spec
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/ehabterra/apispec/internal/metadata"
@@ -213,6 +214,7 @@ func TestSplitSynopsis(t *testing.T) {
 			wantDesc: "- one\n  - two",
 		},
 		{name: "empty", text: ""},
+		{name: "whitespace only", text: "   \n\t\n"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			sum, desc := splitSynopsis(tc.text)
@@ -270,6 +272,21 @@ func TestSwaggoDoc(t *testing.T) {
 		{
 			name: "plain doc comment is not swaggo",
 			text: "Create makes a thing.\nAnd describes it.",
+		},
+		{
+			// A continuation line under a directive that is neither @Summary nor
+			// @Description belongs to that directive, so it is dropped with it
+			// rather than falling back into the prose.
+			name:     "continuation of an unrecognised directive is dropped",
+			text:     "@Summary Create\n@Param body body Acc true \"account\"\ncontinued param text\n@Description Registers it.",
+			wantSum:  "Create",
+			wantDesc: "Registers it.",
+			wantOK:   true,
+		},
+		{
+			name:   "annotations only, nothing to source",
+			text:   "@Router /accounts [post]",
+			wantOK: true,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -350,6 +367,154 @@ func TestHandlerValueComments(t *testing.T) {
 				t.Errorf("summary: got %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestHandlerValueCommentsExternalInterface covers the interface-typed half of
+// #204: the value's type is declared outside the analyzed set (net/http.Handler),
+// so it has no Type entry to carry ImplementedBy and the relation is read from
+// the concrete side's Implements facts (#178).
+//
+// The summary requires a UNIQUE implementer. Expansion may fan out to every
+// implementer of an interface, but a doc comment cannot: with two implementers
+// there are two different comments and no basis to choose (golden rule #7).
+func TestHandlerValueCommentsExternalInterface(t *testing.T) {
+	const ifaceKey = "net/http.Handler"
+
+	// newMeta builds a package holding `impls` types, each implementing the
+	// external interface and declaring a documented ServeHTTP, plus a Deps
+	// struct with an interface-typed field pointing at that interface.
+	newMeta := func(impls ...string) *metadata.Metadata {
+		meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+		types := map[string]*metadata.Type{}
+		for _, name := range impls {
+			types[name] = &metadata.Type{
+				Name:       meta.StringPool.Get(name),
+				Implements: []int{meta.StringPool.Get(ifaceKey)},
+				Methods: []metadata.Method{{
+					Name:     meta.StringPool.Get("ServeHTTP"),
+					Receiver: meta.StringPool.Get("*" + name),
+					Comments: meta.StringPool.Get(name + " serves it."),
+				}},
+			}
+		}
+		types["Deps"] = &metadata.Type{
+			Name: meta.StringPool.Get("Deps"),
+			Fields: []metadata.Field{
+				{Name: meta.StringPool.Get("Iface"), Type: meta.StringPool.Get(ifaceKey)},
+			},
+		}
+		meta.Packages = map[string]*metadata.Package{
+			"app": {Types: types, Files: map[string]*metadata.File{"app.go": {Types: types}}},
+		}
+		return meta
+	}
+
+	for _, tc := range []struct {
+		name, function string
+		impls          []string
+		want           string
+	}{
+		{
+			// A struct field declared http.Handler: the field's type is looked up.
+			name:     "unique implementer via a field path",
+			function: "app" + TypeSep + "Deps.Iface",
+			impls:    []string{"H"},
+			want:     "H serves it.",
+		},
+		{
+			// A plain var of interface type renders as the interface itself, so
+			// the rendered name IS the lookup key.
+			name:     "unique implementer via a bare interface name",
+			function: "app." + ifaceKey,
+			impls:    []string{"H"},
+			want:     "H serves it.",
+		},
+		{
+			name:     "ambiguous: two implementers yield no summary",
+			function: "app" + TypeSep + "Deps.Iface",
+			impls:    []string{"H", "Other"},
+			want:     "",
+		},
+		{
+			name:     "no implementers",
+			function: "app" + TypeSep + "Deps.Iface",
+			impls:    nil,
+			want:     "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			meta := newMeta(tc.impls...)
+			route := &RouteInfo{Metadata: meta, Package: "app", Function: tc.function}
+			if got, _ := handlerDoc(route, "ServeHTTP"); got != tc.want {
+				t.Errorf("summary: got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestValueTypeKey pins the field-path → external type resolution that feeds the
+// implementer lookup, including the shapes that must not resolve.
+func TestValueTypeKey(t *testing.T) {
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	deps := &metadata.Type{
+		Name: meta.StringPool.Get("Deps"),
+		Fields: []metadata.Field{
+			{Name: meta.StringPool.Get("Iface"), Type: meta.StringPool.Get("net/http.Handler")},
+			{Name: meta.StringPool.Get("Local"), Type: meta.StringPool.Get("Handler")},
+		},
+	}
+	meta.Packages = map[string]*metadata.Package{
+		"app": {
+			Types: map[string]*metadata.Type{"Deps": deps},
+			Files: map[string]*metadata.File{"app.go": {Types: map[string]*metadata.Type{"Deps": deps}}},
+		},
+	}
+	route := &RouteInfo{Metadata: meta, Package: "app"}
+
+	for _, tc := range []struct{ name, in, want string }{
+		{"external field type", "Deps.Iface", "net/http.Handler"},
+		{"unqualified field type has no package", "Deps.Local", ""},
+		{"no dot is not a field path", "Handler", ""},
+		{"unknown owner", "Nope.Iface", ""},
+		{"unknown field", "Deps.Missing", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := valueTypeKey(route, tc.in); got != tc.want {
+				t.Errorf("valueTypeKey(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestImplementersOfExternal covers the reverse lookup, including the sorted
+// order that tree expansion depends on (golden rule #1).
+func TestImplementersOfExternal(t *testing.T) {
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	iface := meta.StringPool.Get("net/http.Handler")
+	mk := func(name string, implements bool) *metadata.Type {
+		t := &metadata.Type{Name: meta.StringPool.Get(name)}
+		if implements {
+			t.Implements = []int{iface}
+		}
+		return t
+	}
+	// Deliberately inserted out of order: map iteration must not reach the result.
+	zeta, alpha, plain := mk("Zeta", true), mk("Alpha", true), mk("Plain", false)
+	meta.Packages = map[string]*metadata.Package{
+		"app": {Types: map[string]*metadata.Type{"Zeta": zeta, "Alpha": alpha, "Plain": plain}},
+	}
+
+	got := implementersOfExternal(meta, "net/http.Handler")
+	want := []string{"app.Alpha", "app.Zeta"}
+	if !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v (sorted, implementers only)", got, want)
+	}
+	if got := implementersOfExternal(meta, ""); got != nil {
+		t.Errorf("empty key: got %v, want nil", got)
+	}
+	if got := implementersOfExternal(nil, "net/http.Handler"); got != nil {
+		t.Errorf("nil metadata: got %v, want nil", got)
 	}
 }
 

--- a/internal/spec/handler_doc_test.go
+++ b/internal/spec/handler_doc_test.go
@@ -287,6 +287,72 @@ func TestSwaggoDoc(t *testing.T) {
 	}
 }
 
+// TestHandlerValueComments covers issue #204's mapper half: a handler passed as
+// a value names no method, so the framework's handler-interface method supplies
+// it. Resolution must stay scoped to the value's own type — a framework that
+// declares no handler method, or a type that does not implement it, resolves to
+// nothing rather than to a same-named method found elsewhere.
+func TestHandlerValueComments(t *testing.T) {
+	meta := docMeta(t)
+	// Give Handler a ServeHTTP, and a second type that also declares one, so a
+	// name-only match would be ambiguous.
+	handler := meta.Packages["app"].Types["Handler"]
+	handler.Methods = append(handler.Methods, metadata.Method{
+		Name:     meta.StringPool.Get("ServeHTTP"),
+		Receiver: meta.StringPool.Get("*Handler"),
+		Comments: meta.StringPool.Get("ServeHTTP serves it directly."),
+	})
+	other := &metadata.Type{
+		Name: meta.StringPool.Get("Other"),
+		Methods: []metadata.Method{{
+			Name:     meta.StringPool.Get("ServeHTTP"),
+			Receiver: meta.StringPool.Get("*Other"),
+			Comments: meta.StringPool.Get("Other serves something else."),
+		}},
+	}
+	meta.Packages["app"].Types["Other"] = other
+	meta.Packages["app"].Files["app.go"].Types["Other"] = other
+
+	for _, tc := range []struct {
+		name, function string
+		methods        []string
+		want           string
+	}{
+		{
+			name:     "value of a concrete type",
+			function: "app.Handler",
+			methods:  []string{"ServeHTTP"},
+			want:     "ServeHTTP serves it directly.",
+		},
+		{
+			name:     "value held in a struct field",
+			function: "app" + TypeSep + "Deps.H",
+			methods:  []string{"ServeHTTP"},
+			want:     "ServeHTTP serves it directly.",
+		},
+		{
+			// A func-handler framework declares none, so the same route resolves
+			// to nothing rather than picking one of the two ServeHTTPs.
+			name:     "framework declares no handler method",
+			function: "app.Handler",
+			want:     "",
+		},
+		{
+			name:     "type does not declare the handler method",
+			function: "app.Deps",
+			methods:  []string{"ServeHTTP"},
+			want:     "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			route := &RouteInfo{Metadata: meta, Package: "app", Function: tc.function}
+			if got, _ := handlerDoc(route, tc.methods...); got != tc.want {
+				t.Errorf("summary: got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestHandlerDocGuards covers the nil/empty short-circuits.
 func TestHandlerDocGuards(t *testing.T) {
 	for _, tc := range []struct {

--- a/internal/spec/handler_value.go
+++ b/internal/spec/handler_value.go
@@ -86,6 +86,15 @@ func handlerValueTypeOf(arg *metadata.CallArgument) (pkg, name string) {
 	if arg == nil {
 		return "", ""
 	}
+	// A func signature has to be rejected up front: the type model has no
+	// function kind (a signature is "otherwise opaque" KindNamed), so TypeRef
+	// splits "func(w http.ResponseWriter, r *http.Request)" at its last dot and
+	// yields a plausible-looking but meaningless pkg/name pair. findType would
+	// then simply miss, but resolving a garbage type is not something to rely on.
+	// The prefix check is how classifyArgument already distinguishes the two.
+	if strings.HasPrefix(arg.GetType(), "func(") || strings.HasPrefix(arg.GetType(), "func[") {
+		return "", ""
+	}
 	core := arg.TypeRef().Core()
 	if !core.IsNamed() || core.Pkg == "" || core.Name == "" {
 		return "", ""

--- a/internal/spec/handler_value.go
+++ b/internal/spec/handler_value.go
@@ -1,0 +1,180 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// Handler-value resolution (issue #204), shared by both tracker engines so they
+// cannot drift: a route registered with a handler *value* rather than a func
+// names no method anywhere in the registration, so the framework's handler
+// interface supplies it.
+
+// handlerMethodKeys returns the base IDs ("pkg.Type.Method") of the configured
+// handler methods declared by the type (pkg, name), fanning an interface out to
+// its implementers.
+//
+// Resolution is honest in both directions: a concrete type contributes a key
+// only for a method it actually declares, and an interface contributes only its
+// recorded implementers — never a same-named method picked from elsewhere
+// (golden rules #7/#9). Frameworks whose handlers are plain func types pass no
+// methods and get no keys.
+func handlerMethodKeys(meta *metadata.Metadata, handlerMethods []string, pkg, name string) []string {
+	if meta == nil || len(handlerMethods) == 0 || pkg == "" || name == "" {
+		return nil
+	}
+	typ := findType(meta, pkg, name)
+	if typ == nil {
+		// An interface declared outside the analyzed set (net/http.Handler) has
+		// no Type entry to carry ImplementedBy, so the relation is read from the
+		// concrete side — the Implements facts recorded by
+		// analyzeExternalInterfaceImplementations (issue #178).
+		var out []string
+		for _, impl := range implementersOfExternal(meta, pkg+"."+name) {
+			implPkg, implName, ok := splitTypeKey(impl)
+			if !ok {
+				continue
+			}
+			out = append(out, handlerMethodKeys(meta, handlerMethods, implPkg, implName)...)
+		}
+		return out
+	}
+	if getStringFromPool(meta, typ.Kind) == "interface" {
+		var out []string
+		for _, implIdx := range typ.ImplementedBy {
+			implPkg, implName, ok := splitTypeKey(getStringFromPool(meta, implIdx))
+			if !ok {
+				continue
+			}
+			out = append(out, handlerMethodKeys(meta, handlerMethods, implPkg, implName)...)
+		}
+		return out
+	}
+	var out []string
+	for _, method := range handlerMethods {
+		for i := range typ.Methods {
+			if getStringFromPool(meta, typ.Methods[i].Name) == method {
+				out = append(out, pkg+"."+name+"."+method)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// handlerValueTypeOf returns the named type of an argument that is a handler
+// *value*, or ("", "") when the argument is a func/method value (whose type is a
+// signature, resolved by the method-value paths instead) or is untyped.
+func handlerValueTypeOf(arg *metadata.CallArgument) (pkg, name string) {
+	if arg == nil {
+		return "", ""
+	}
+	core := arg.TypeRef().Core()
+	if !core.IsNamed() || core.Pkg == "" || core.Name == "" {
+		return "", ""
+	}
+	return core.Pkg, core.Name
+}
+
+// splitTypeKey splits an "import/path.Type" key. Package paths contain dots
+// (github.com/...), so the split is on the LAST dot, which is the type boundary.
+func splitTypeKey(key string) (pkg, name string, ok bool) {
+	i := strings.LastIndexByte(key, '.')
+	if i < 0 {
+		return "", "", false
+	}
+	return key[:i], key[i+1:], true
+}
+
+// attachHandlerValueChildren is the eager tree's counterpart to LazyTree's
+// handlerValueKeys expansion: it hangs the handler method's body under the
+// argument node so the route's responses, params and request body are reachable.
+//
+// The lazy tree expands by *key* and lets edgesFor find the bodies; the eager
+// tree materializes nodes up front, so the matching edges are looked up here —
+// every edge whose CALLER is the resolved handler method, which is exactly what
+// the existing method-value branch does for a selector argument.
+func attachHandlerValueChildren(
+	tree *TrackerTree,
+	meta *metadata.Metadata,
+	argNode *TrackerNode,
+	arg *metadata.CallArgument,
+	visited map[string]int,
+	assignmentIndex *assigmentIndexMap,
+	limits metadata.TrackerLimits,
+) {
+	if tree == nil || argNode == nil || len(tree.handlerMethods) == 0 {
+		return
+	}
+	pkg, name := handlerValueTypeOf(arg)
+	keys := handlerMethodKeys(meta, tree.handlerMethods, pkg, name)
+	if len(keys) == 0 {
+		return
+	}
+	for _, key := range keys {
+		methodPkgType, methodName, ok := splitTypeKey(key)
+		if !ok {
+			continue
+		}
+		keyPkg, recvType, ok := splitTypeKey(methodPkgType)
+		if !ok {
+			continue
+		}
+		nameIdx := meta.StringPool.Get(methodName)
+		pkgIdx := meta.StringPool.Get(keyPkg)
+		recvIdx := meta.StringPool.Get(recvType)
+		starRecvIdx := meta.StringPool.Get("*" + recvType)
+		for i := range meta.CallGraph {
+			e := &meta.CallGraph[i]
+			if e.Caller.Name != nameIdx || e.Caller.Pkg != pkgIdx ||
+				(e.Caller.RecvType != recvIdx && e.Caller.RecvType != starRecvIdx) {
+				continue
+			}
+			if child := NewTrackerNode(tree, meta, argNode.Key(), e.Callee.ID(), e, nil, visited, assignmentIndex, limits); child != nil {
+				argNode.AddChild(child)
+			}
+		}
+	}
+}
+
+// implementersOfExternal returns the "pkg.Type" keys of every recorded type
+// implementing the given interface key ("net/http.Handler"), read from the
+// concrete side's Implements facts (issue #178).
+//
+// Interfaces declared outside the analyzed set never become Type entries, so
+// they carry no ImplementedBy list to read the relation from — the concrete
+// types are the only place the fact is recorded. Results are sorted: they feed
+// tree expansion, whose order must not vary between runs (golden rule #1).
+func implementersOfExternal(meta *metadata.Metadata, ifaceKey string) []string {
+	if meta == nil || ifaceKey == "" {
+		return nil
+	}
+	want := meta.StringPool.Get(ifaceKey)
+	var out []string
+	for _, pkgName := range slices.Sorted(maps.Keys(meta.Packages)) {
+		p := meta.Packages[pkgName]
+		for _, typeName := range slices.Sorted(maps.Keys(p.Types)) {
+			if slices.Contains(p.Types[typeName].Implements, want) {
+				out = append(out, pkgName+"."+typeName)
+			}
+		}
+	}
+	return out
+}

--- a/internal/spec/handler_value_test.go
+++ b/internal/spec/handler_value_test.go
@@ -1,0 +1,136 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+func TestSplitTypeKey(t *testing.T) {
+	for _, tc := range []struct {
+		in, pkg, name string
+		ok            bool
+	}{
+		// Package paths contain dots, so the split is on the LAST dot.
+		{"net/http.Handler", "net/http", "Handler", true},
+		{"github.com/acme/svc/internal/api.Handler", "github.com/acme/svc/internal/api", "Handler", true},
+		{"app.H", "app", "H", true},
+		{"Handler", "", "", false},
+		{"", "", "", false},
+	} {
+		t.Run(tc.in, func(t *testing.T) {
+			pkg, name, ok := splitTypeKey(tc.in)
+			if pkg != tc.pkg || name != tc.name || ok != tc.ok {
+				t.Errorf("splitTypeKey(%q) = (%q, %q, %v), want (%q, %q, %v)",
+					tc.in, pkg, name, ok, tc.pkg, tc.name, tc.ok)
+			}
+		})
+	}
+}
+
+func TestHandlerValueTypeOf(t *testing.T) {
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+
+	named := metadata.NewCallArgument(meta)
+	named.SetKind(metadata.KindIdent)
+	named.SetName("h")
+	named.SetType("*app.H")
+
+	// A method value's type is a signature, not a named type: those resolve via
+	// the method-value paths, so this must decline them.
+	fn := metadata.NewCallArgument(meta)
+	fn.SetKind(metadata.KindSelector)
+	fn.SetType("func(w net/http.ResponseWriter, r *net/http.Request)")
+
+	untyped := metadata.NewCallArgument(meta)
+	untyped.SetKind(metadata.KindIdent)
+	untyped.SetName("x")
+
+	for _, tc := range []struct {
+		name       string
+		arg        *metadata.CallArgument
+		pkg, tname string
+	}{
+		{"named pointer type", named, "app", "H"},
+		{"func signature declines", fn, "", ""},
+		{"untyped declines", untyped, "", ""},
+		{"nil declines", nil, "", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pkg, name := handlerValueTypeOf(tc.arg)
+			if pkg != tc.pkg || name != tc.tname {
+				t.Errorf("got (%q, %q), want (%q, %q)", pkg, name, tc.pkg, tc.tname)
+			}
+		})
+	}
+}
+
+// TestHandlerMethodKeys covers the shared resolution both tracker engines use,
+// including the guards that keep it honest: a type contributes a key only for a
+// handler method it actually declares (golden rules #7/#9).
+func TestHandlerMethodKeys(t *testing.T) {
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	h := &metadata.Type{
+		Name: meta.StringPool.Get("H"),
+		Methods: []metadata.Method{
+			{Name: meta.StringPool.Get("ServeHTTP"), Receiver: meta.StringPool.Get("*H")},
+			{Name: meta.StringPool.Get("Other"), Receiver: meta.StringPool.Get("*H")},
+		},
+	}
+	// Declares no handler method at all.
+	plain := &metadata.Type{
+		Name:    meta.StringPool.Get("Plain"),
+		Methods: []metadata.Method{{Name: meta.StringPool.Get("Nope")}},
+	}
+	// A LOCAL interface, which carries ImplementedBy directly.
+	local := &metadata.Type{
+		Name:          meta.StringPool.Get("Local"),
+		Kind:          meta.StringPool.Get("interface"),
+		ImplementedBy: []int{meta.StringPool.Get("app.H")},
+	}
+	types := map[string]*metadata.Type{"H": h, "Plain": plain, "Local": local}
+	meta.Packages = map[string]*metadata.Package{
+		"app": {Types: types, Files: map[string]*metadata.File{"app.go": {Types: types}}},
+	}
+
+	methods := []string{"ServeHTTP"}
+	for _, tc := range []struct {
+		name, pkg, tname string
+		methods          []string
+		want             []string
+	}{
+		{"concrete type declaring the method", "app", "H", methods, []string{"app.H.ServeHTTP"}},
+		{"type declaring no handler method", "app", "Plain", methods, nil},
+		{"local interface fans out to implementers", "app", "Local", methods, []string{"app.H.ServeHTTP"}},
+		{"no configured methods", "app", "H", nil, nil},
+		{"unknown type", "app", "Missing", methods, nil},
+		{"empty package", "", "H", methods, nil},
+		{"empty name", "app", "", methods, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := handlerMethodKeys(meta, tc.methods, tc.pkg, tc.tname)
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	if got := handlerMethodKeys(nil, methods, "app", "H"); got != nil {
+		t.Errorf("nil metadata: got %v, want nil", got)
+	}
+}

--- a/internal/spec/lazytree.go
+++ b/internal/spec/lazytree.go
@@ -53,6 +53,11 @@ type LazyTree struct {
 	limits metadata.TrackerLimits
 	roots  []TrackerNodeInterface
 
+	// handlerMethods are the framework's handler-interface methods (net/http's
+	// "ServeHTTP"), used to expand a handler passed as a value — see
+	// handlerValueKeys and issue #204. Empty for func-handler frameworks.
+	handlerMethods []string
+
 	// calleeEdges memoizes, per function base key, the filtered+ordered call
 	// edges used to expand any node of that function. Computed once.
 	calleeEdges map[string][]*metadata.CallGraphEdge
@@ -358,11 +363,25 @@ func (t *LazyTree) buildRelations() {
 
 // NewLazyTree builds the root layer (main functions, like the eager tree)
 // and nothing else.
-func NewLazyTree(meta *metadata.Metadata, limits metadata.TrackerLimits) *LazyTree {
+// LazyTreeOption configures an optional tree capability. Options keep the
+// constructor's existing two-argument form working for every caller that does
+// not need them (notably the test suite).
+type LazyTreeOption func(*LazyTree)
+
+// WithHandlerInterfaceMethods supplies the framework's handler-interface methods
+// so a handler passed as a value expands into its body (issue #204).
+func WithHandlerInterfaceMethods(methods []string) LazyTreeOption {
+	return func(t *LazyTree) { t.handlerMethods = methods }
+}
+
+func NewLazyTree(meta *metadata.Metadata, limits metadata.TrackerLimits, opts ...LazyTreeOption) *LazyTree {
 	t := &LazyTree{
 		meta:        meta,
 		limits:      limits,
 		calleeEdges: make(map[string][]*metadata.CallGraphEdge),
+	}
+	for _, opt := range opts {
+		opt(t)
 	}
 	seen := map[string]bool{}
 	for _, edge := range meta.CallGraphRoots() {
@@ -730,6 +749,12 @@ func (t *LazyTree) buildPlan(n *LazyNode) []childSpec {
 	for _, methodKey := range n.methodBaseKeys() {
 		expandKey(methodKey)
 	}
+	// Handler *value* (r.Method(GET, "/health", deps.Health) / mux.Handle("/x", h)):
+	// the argument names no method at all, so the framework's handler-interface
+	// method supplies it — otherwise the handler body is unreachable (issue #204).
+	for _, methodKey := range n.handlerValueKeys() {
+		expandKey(methodKey)
+	}
 	// Variable/field argument (router.Mount("/cart", r.cartRouter) or
 	// Mount("/x", subRouter)): the producer subtree — the registrations
 	// claimed under the router that was stored into the variable/field —
@@ -794,6 +819,72 @@ func (n *LazyNode) methodBaseKeys() []string {
 	// the eager build's ImplementedBy attachment.
 	keys = append(keys, n.tree.implementerKeys(pkg, recv, selName)...)
 	return keys
+}
+
+// handlerValueKeys resolves an argument that is a handler *value* — a variable
+// or struct field holding something the framework invokes through an interface
+// method — to the base ID(s) of that method's body (issue #204).
+//
+// This is the shape methodBaseKeys cannot serve: `r.Method(GET, "/health",
+// deps.Health)` and `mux.Handle("/x", h)` name no method anywhere in the
+// registration, so there is no selector to resolve. The method name comes from
+// the framework config (FrameworkConfig.HandlerInterfaceMethods), never from a
+// hardcoded "ServeHTTP" — frameworks whose handlers are func types declare none
+// and get no keys.
+//
+// Resolution is honest in both directions: a concrete type contributes a key
+// only for a handler method it actually declares, and an interface-typed value
+// fans out to its recorded implementers (the same ImplementedBy index the
+// method-call paths use) rather than guessing one. A value whose type declares
+// no configured handler method yields nothing.
+func (n *LazyNode) handlerValueKeys() []string {
+	if !n.isArgument || n.arg == nil || len(n.tree.handlerMethods) == 0 {
+		return nil
+	}
+	// A method value (h.ServeHTTP) or func value already resolves via
+	// methodBaseKeys; its type is a signature, not a named type.
+	ref := n.arg.TypeRef()
+	core := ref.Core()
+	if !core.IsNamed() || core.Pkg == "" || core.Name == "" {
+		return nil
+	}
+	return n.tree.handlerImplKeys(core.Pkg, core.Name)
+}
+
+// handlerImplKeys returns the base IDs of the configured handler methods
+// declared by (pkg, name), fanning an interface out to its implementers. Kept
+// separate from handlerValueKeys so the interface and concrete cases share one
+// declaration check.
+func (t *LazyTree) handlerImplKeys(pkg, name string) []string {
+	typ := findType(t.meta, pkg, name)
+	if typ == nil {
+		return nil
+	}
+	if getString(t.meta, typ.Kind) == "interface" {
+		var out []string
+		for _, implIdx := range typ.ImplementedBy {
+			impl := getString(t.meta, implIdx) // "import/path.Type"
+			if impl == "" {
+				continue
+			}
+			i := strings.LastIndexByte(impl, '.')
+			if i < 0 {
+				continue
+			}
+			out = append(out, t.handlerImplKeys(impl[:i], impl[i+1:])...)
+		}
+		return out
+	}
+	var out []string
+	for _, method := range t.handlerMethods {
+		for i := range typ.Methods {
+			if getString(t.meta, typ.Methods[i].Name) == method {
+				out = append(out, pkg+"."+name+"."+method)
+				break
+			}
+		}
+	}
+	return out
 }
 
 // argProducerIDs resolves a variable or struct-field argument to the callee

--- a/internal/spec/lazytree.go
+++ b/internal/spec/lazytree.go
@@ -841,50 +841,8 @@ func (n *LazyNode) handlerValueKeys() []string {
 	if !n.isArgument || n.arg == nil || len(n.tree.handlerMethods) == 0 {
 		return nil
 	}
-	// A method value (h.ServeHTTP) or func value already resolves via
-	// methodBaseKeys; its type is a signature, not a named type.
-	ref := n.arg.TypeRef()
-	core := ref.Core()
-	if !core.IsNamed() || core.Pkg == "" || core.Name == "" {
-		return nil
-	}
-	return n.tree.handlerImplKeys(core.Pkg, core.Name)
-}
-
-// handlerImplKeys returns the base IDs of the configured handler methods
-// declared by (pkg, name), fanning an interface out to its implementers. Kept
-// separate from handlerValueKeys so the interface and concrete cases share one
-// declaration check.
-func (t *LazyTree) handlerImplKeys(pkg, name string) []string {
-	typ := findType(t.meta, pkg, name)
-	if typ == nil {
-		return nil
-	}
-	if getString(t.meta, typ.Kind) == "interface" {
-		var out []string
-		for _, implIdx := range typ.ImplementedBy {
-			impl := getString(t.meta, implIdx) // "import/path.Type"
-			if impl == "" {
-				continue
-			}
-			i := strings.LastIndexByte(impl, '.')
-			if i < 0 {
-				continue
-			}
-			out = append(out, t.handlerImplKeys(impl[:i], impl[i+1:])...)
-		}
-		return out
-	}
-	var out []string
-	for _, method := range t.handlerMethods {
-		for i := range typ.Methods {
-			if getString(t.meta, typ.Methods[i].Name) == method {
-				out = append(out, pkg+"."+name+"."+method)
-				break
-			}
-		}
-	}
-	return out
+	pkg, name := handlerValueTypeOf(n.arg)
+	return handlerMethodKeys(n.tree.meta, n.tree.handlerMethods, pkg, name)
 }
 
 // argProducerIDs resolves a variable or struct-field argument to the callee

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -167,7 +167,13 @@ func MapMetadataToOpenAPIWithDiagnostics(tree TrackerTreeInterface, cfg *APISpec
 	}
 
 	// Build paths
-	paths := buildPathsFromRoutes(routes)
+	// cfg is optional here (the nil case is handled below for Info), so read the
+	// handler methods defensively rather than dereferencing it unconditionally.
+	var handlerMethods []string
+	if cfg != nil {
+		handlerMethods = cfg.Framework.HandlerInterfaceMethods
+	}
+	paths := buildPathsFromRoutes(routes, handlerMethods...)
 
 	// Generate component schemas
 	components := generateComponentSchemas(tree.GetMetadata(), cfg, routes)
@@ -266,7 +272,7 @@ func reconcileSecuritySchemes(cfg *APISpecConfig, routes []*RouteInfo) map[strin
 }
 
 // buildPathsFromRoutes builds OpenAPI paths from extracted routes
-func buildPathsFromRoutes(routes []*RouteInfo) map[string]PathItem {
+func buildPathsFromRoutes(routes []*RouteInfo, handlerMethods ...string) map[string]PathItem {
 	paths := make(map[string]PathItem)
 
 	for _, route := range routes {
@@ -297,7 +303,7 @@ func buildPathsFromRoutes(routes []*RouteInfo) map[string]PathItem {
 		// @Description (no @Summary) must still contribute its description.
 		summary, description := route.Summary, route.Description
 		if summary == "" || description == "" {
-			s, d := handlerDoc(route)
+			s, d := handlerDoc(route, handlerMethods...)
 			if summary == "" {
 				summary = s
 			}
@@ -1628,7 +1634,7 @@ func receiverTypeName(meta *metadata.Metadata, pkg, recv string) string {
 // The method shapes resolve through the per-Type methods table, which
 // findFunctionByName cannot reach — it indexes only receiver-less declarations.
 // Returns "" for an anonymous (func-literal) or undocumented handler.
-func handlerComments(route *RouteInfo) string {
+func handlerComments(route *RouteInfo, handlerMethods ...string) string {
 	name := route.Function
 	// The separator between the package and the rest is TypeSep in some render
 	// paths and a plain dot in others, so normalize before splitting. The package
@@ -1647,10 +1653,34 @@ func handlerComments(route *RouteInfo) string {
 		if m := findMethodByName(route.Metadata, route.Package, recv, name[i+1:]); m != nil {
 			return getStringFromPool(route.Metadata, m.Comments)
 		}
-		return ""
+		return handlerValueComments(route, name, handlerMethods...)
 	}
 	if fn := findFunctionByName(route.Metadata, route.Package, name); fn != nil {
 		return getStringFromPool(route.Metadata, fn.Comments)
+	}
+	return handlerValueComments(route, name, handlerMethods...)
+}
+
+// handlerValueComments resolves the doc comment of a handler passed as a *value*
+// (issue #204): the registration names no method, so the framework's handler
+// interface supplies it. `name` is the rendered handler argument with the package
+// prefix already stripped — either a type name ("H", from `mux.Handle("/x", h)`)
+// or a field path ("Deps.Health", from `r.Method(GET, "/health", deps.Health)`),
+// both of which receiverTypeName resolves to the declaring type.
+//
+// This mirrors LazyTree.handlerValueKeys so the summary and the expanded body
+// agree on which method serves the route: whenever one resolves, so does the
+// other. A value whose type declares no configured handler method yields "",
+// never a same-named method picked from elsewhere.
+func handlerValueComments(route *RouteInfo, name string, handlerMethods ...string) string {
+	if len(handlerMethods) == 0 || name == "" {
+		return ""
+	}
+	recv := receiverTypeName(route.Metadata, route.Package, name)
+	for _, hm := range handlerMethods {
+		if m := findMethodByName(route.Metadata, route.Package, recv, hm); m != nil {
+			return getStringFromPool(route.Metadata, m.Comments)
+		}
 	}
 	return ""
 }
@@ -1762,11 +1792,11 @@ func isSpaceByte(b byte) bool { return b == ' ' || b == '\t' || b == '\n' || b =
 // the remainder the description. Returns empty strings when the handler is
 // anonymous or undocumented — callers keep whatever summary/description they
 // already had.
-func handlerDoc(route *RouteInfo) (summary, description string) {
+func handlerDoc(route *RouteInfo, handlerMethods ...string) (summary, description string) {
 	if route == nil || route.Metadata == nil || route.Function == "" {
 		return "", ""
 	}
-	doc := handlerComments(route)
+	doc := handlerComments(route, handlerMethods...)
 	if doc == "" {
 		return "", ""
 	}

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -1682,6 +1682,56 @@ func handlerValueComments(route *RouteInfo, name string, handlerMethods ...strin
 			return getStringFromPool(route.Metadata, m.Comments)
 		}
 	}
+	// The value may be interface-typed (a field declared `http.Handler`), whose
+	// declaring package is outside the analyzed set. The body expansion fans out
+	// to every implementer, but a summary cannot: with two implementers there are
+	// two different doc comments and no basis to choose, so one is sourced only
+	// when the implementer is unique (golden rule #7).
+	// A variable of interface type renders as the interface itself
+	// ("net/http.Handler"), so the name IS the key; a struct field renders as the
+	// field path, whose type has to be looked up.
+	key := valueTypeKey(route, name)
+	if key == "" {
+		key = name
+	}
+	impls := implementersOfExternal(route.Metadata, key)
+	if len(impls) != 1 {
+		return ""
+	}
+	i := strings.LastIndexByte(impls[0], '.')
+	if i < 0 {
+		return ""
+	}
+	for _, hm := range handlerMethods {
+		if m := findMethodByName(route.Metadata, impls[0][:i], impls[0][i+1:], hm); m != nil {
+			return getStringFromPool(route.Metadata, m.Comments)
+		}
+	}
+	return ""
+}
+
+// valueTypeKey returns the fully-qualified type key ("net/http.Handler") of the
+// handler value named by the rendered argument, or "" when it does not resolve
+// to a field whose type is known. Only the field-path form carries an external
+// type — a bare type name is by definition declared in the analyzed package.
+func valueTypeKey(route *RouteInfo, name string) string {
+	i := strings.LastIndexByte(name, '.')
+	if i < 0 {
+		return ""
+	}
+	owner, field := name[:i], name[i+1:]
+	t := findType(route.Metadata, route.Package, owner)
+	if t == nil {
+		return ""
+	}
+	for _, f := range t.Fields {
+		if route.Metadata.StringPool.GetString(f.Name) != field {
+			continue
+		}
+		if core := route.Metadata.TypeRefOf(f.Type).Core(); core.IsNamed() && core.Pkg != "" {
+			return core.Pkg + "." + core.Name
+		}
+	}
 	return ""
 }
 

--- a/internal/spec/tracker.go
+++ b/internal/spec/tracker.go
@@ -248,6 +248,11 @@ type TrackerTree struct {
 	roots     []*TrackerNode
 	limits    metadata.TrackerLimits
 
+	// handlerMethods are the framework's handler-interface methods (net/http's
+	// "ServeHTTP"), used to expand a handler passed as a value. Kept at parity
+	// with LazyTree so both engines resolve the same routes (issue #204).
+	handlerMethods []string
+
 	// logger receives traversal-time warnings (limit truncations, etc.).
 	// May be nil; callers should reach it via t.warn / t.info.
 	logger metadata.VerboseLogger
@@ -402,7 +407,17 @@ func (k interfaceKey) String() string {
 // NewTrackerTree constructs a TrackerTree from metadata and limits.
 // logger may be nil — warnings then route directly to stderr so the CLI
 // behaviour callers had before this parameter existed is preserved.
-func NewTrackerTree(meta *metadata.Metadata, limits metadata.TrackerLimits, logger metadata.VerboseLogger) *TrackerTree {
+// TrackerTreeOption configures an optional capability, keeping the existing
+// three-argument constructor working for callers that need none.
+type TrackerTreeOption func(*TrackerTree)
+
+// WithEagerHandlerInterfaceMethods is the eager tree's counterpart to
+// WithHandlerInterfaceMethods (issue #204).
+func WithEagerHandlerInterfaceMethods(methods []string) TrackerTreeOption {
+	return func(t *TrackerTree) { t.handlerMethods = methods }
+}
+
+func NewTrackerTree(meta *metadata.Metadata, limits metadata.TrackerLimits, logger metadata.VerboseLogger, opts ...TrackerTreeOption) *TrackerTree {
 	t := &TrackerTree{
 		meta:          meta,
 		positions:     make(map[string]bool, 100), // Pre-allocate with estimated capacity
@@ -416,6 +431,9 @@ func NewTrackerTree(meta *metadata.Metadata, limits metadata.TrackerLimits, logg
 		// Initialize performance optimization caches with pre-allocated capacity
 		nodeMap: make(map[string]*TrackerNode, 200),
 		idCache: make(map[string]string, 100),
+	}
+	for _, opt := range opts {
+		opt(t)
 	}
 
 	// Pre-allocate roots slice with estimated capacity
@@ -908,6 +926,12 @@ func processArguments(tree *TrackerTree, meta *metadata.Metadata, parentNode *Tr
 		argNode.IsArgument = true
 		argNode.ArgIndex = i
 		argNode.ArgContext = fmt.Sprintf("%s.%s", getString(meta, edge.Caller.Name), getString(meta, edge.Callee.Name))
+
+		// Handler *value* (mux.Handle("/x", h) / r.Method(GET, "/health", deps.Health)):
+		// the argument names no method, so the framework's handler interface
+		// supplies it — LazyTree's handlerValueKeys, mirrored here so both
+		// engines resolve the same routes (issue #204).
+		attachHandlerValueChildren(tree, meta, argNode, arg, visited, assignmentIndex, limits)
 
 		switch argType {
 		case ArgTypeFunctionCall:

--- a/testdata/handler_doc_comments/main.go
+++ b/testdata/handler_doc_comments/main.go
@@ -75,9 +75,13 @@ func main() {
 	mux.HandleFunc("PATCH /accounts", h.PatchAccount)
 	mux.HandleFunc("GET /accounts", listAccounts)
 	mux.HandleFunc("GET /accounts/search", h.SearchAccounts)
-	// A handler *value* names no method, so nothing is resolved for it — and in
-	// particular the traced origin type must not leak in as the summary.
+	// A handler *value* names no method: the framework's handler interface
+	// supplies it (#204). The traced origin type must not leak in as the summary.
 	mux.Handle("OPTIONS /accounts", h)
+	// An INTERFACE-typed value: resolving it needs the concrete implementers of
+	// a stdlib interface, which metadata records via Implements (issue #178).
+	var iface http.Handler = h
+	mux.Handle("GET /accounts/direct", iface)
 	// A func literal has no doc comment to source from.
 	mux.HandleFunc("PUT /accounts", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/testdata/handler_doc_comments/main.go
+++ b/testdata/handler_doc_comments/main.go
@@ -34,9 +34,9 @@ func (h *Handler) PatchAccount(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-// ServeHTTP is documented, but a route registered with the handler *value*
-// (mux.Handle("...", h)) names no method, so nothing resolves it — the
-// operation keeps an empty summary rather than a guessed one. See issue #204.
+// ServeHTTP serves the account resource directly.
+// A route registered with the handler *value* (mux.Handle("...", h)) names no
+// method, so the framework's handler interface supplies it (issue #204).
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }

--- a/testdata/mux/main.go
+++ b/testdata/mux/main.go
@@ -26,6 +26,11 @@ func main() {
 	r.HandleFunc("/users/{id}", updateUser).Methods("PUT")
 	r.HandleFunc("/users/{id}", deleteUser).Methods("DELETE")
 
+	// Handler value: names no method, so the framework's handler interface
+	// (http.Handler → ServeHTTP) supplies it — issue #204.
+	sh := &statusHandler{}
+	r.Handle("/status", sh).Methods("GET")
+
 	// Subrouter
 	api := r.PathPrefix("/api/v1").Subrouter()
 	api.HandleFunc("/health", healthCheck).Methods("GET")
@@ -81,4 +86,17 @@ func deleteUser(w http.ResponseWriter, r *http.Request) {
 func healthCheck(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("OK"))
+}
+
+// statusHandler is registered as an http.Handler value rather than a func.
+type statusHandler struct{}
+
+// ServeHTTP reports the service status.
+func (h *statusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode(Status{State: "ok"})
+}
+
+// Status is the /status response body.
+type Status struct {
+	State string `json:"state"`
 }


### PR DESCRIPTION
Closes #204. Closes #178.

A route registered with a handler **value** rather than a func — `mux.Handle("/x", h)`, `r.Method(GET, "/health", deps.Health)`, `r.Handle("/status", sh)` — names no method anywhere in the registration, so nothing resolved it: the operation had no params, no request body, no response, and no summary. In one fixture the route was not emitted at all.

## Why neither existing mechanism could serve it

Both interface mechanisms are keyed on a method-call **receiver** and reuse the method name already present in the source; a passed value has no such name:

- the `ImplementedBy` fan-out (`tracker.go`, `lazytree.go` `implementerKeys`) reuses the called method's name;
- the `(iface, struct, pkg) → concrete` registry normalizes a receiver *type*, not a method selection.

And `lazytree.methodBaseKeys` builds its key from `arg.Sel`, which for `deps.Health` is the **field** name — `pkg.Deps.Health`, matching nothing. `grep -rn ServeHTTP internal/` returned zero hits in the analysis pipeline.

## The fix, in three parts

**1. Config-driven method selection.** A new `FrameworkConfig.HandlerInterfaceMethods` — `["ServeHTTP"]` for net/http, chi and gorilla/mux, empty for the func-handler frameworks (gin, echo, fiber). Never a hardcoded `ServeHTTP` (golden rule #5). Expansion emits a key only for a method the concrete type **actually declares**; `ServeHTTP` is declared on two types in `testdata/chi_method_handle`, so a name-only match would pick arbitrarily (golden rules #7/#9). Types are read through `TypeRef`, never by parsing type strings (golden rule #2).

**2. Metadata records external-interface implementation (#178).** An interface-typed value (`http.Handler` field or var) needs the interface's implementers, but a stdlib interface has no `Type` entry to carry `ImplementedBy`. #178 was **closed as completed while still live** — verified with a probe whose type implementing `http.Handler` had an empty `Implements` list. Now computed with `go/types.Implements` (option 2 from that issue); the relation is read from the concrete side. Details and the two scope decisions are in the issue comment.

**3. Both tracker engines.** Handler-value expansion first landed in `LazyTree` alone, so `--legacy-tracker` resolved the summary (shared mapper code) but not the body. The shared resolution now lives in `handler_value.go`, and `TestHandlerValueEngineParity` runs the fixtures through both engines requiring identical summaries and response sets.

## Result

Every handler-value shape now resolves its body **and** its doc comment, identically under both engines:

| shape | before | after |
|---|---|---|
| concrete value, local var | nothing | summary + body |
| concrete value, struct field | nothing | summary + body |
| interface-typed, struct field | nothing | summary + body |
| interface-typed, local var | nothing | summary + body |
| `r.Handle` (gorilla/mux) | route not emitted | summary + body |

For the **summary** specifically, an interface must have exactly one implementer: expansion may fan out to all of them, but a doc comment cannot, and with two implementers there is no basis to choose between two different comments.

## Tests

- `TestTestdata_HandlerValueRoutes` — net/http, chi and gorilla/mux, so this cannot regress for one framework alone.
- `TestHandlerValueEngineParity` — lazy vs eager, summaries and response sets.
- `TestExternalInterfaceImplementations` — stdlib + local + unreferenced + constraint cases, plus a determinism test for the ordering invariant.
- `testdata/handler_doc_comments` gains interface-typed and value shapes; `testdata/mux` gains an `r.Handle` value route; the #205 change detectors are flipped to assert the working behavior.
- Metadata goldens unchanged.

Full suite green, `make lint` clean, no output drift on two large real projects.

## Reviewer notes

- The **referenced-interfaces-only** scope in #178 is a deliberate boundary (asserted in tests, not implicit): a type implementing `io.Writer` in a program that never mentions `io.Writer` is not recorded. It covers the motivating cases because the interface is always in the registration's signature.
- `buildPathsFromRoutes`/`handlerDoc` take the handler methods **variadically** to avoid churning ~15 existing test call sites. If you'd rather have an explicit parameter, say so and I'll thread it through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenAPI generation for routes registered with handler values across supported frameworks.
  * Handler documentation now correctly populates operation summaries and descriptions.
  * Response definitions, including status codes and handler-derived details, are now generated for handler-value routes.

* **Tests**
  * Added coverage for handler-value expansion, metadata interface detection, documentation resolution, and consistency between generation engines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->