### PR TITLE
fix(spec): resolve interface-typed request bodies to the concrete type (#164)

### DIFF
--- a/generator/testdata_interface_request_body_test.go
+++ b/generator/testdata_interface_request_body_test.go
@@ -1,0 +1,107 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	intspec "github.com/ehabterra/apispec/internal/spec"
+	"github.com/ehabterra/apispec/spec"
+)
+
+// TestTestdata_InterfaceRequestBody locks in interface-typed REQUEST body
+// resolution (issue #164), the mirror of TestTestdata_InterfaceResponse: a
+// handler that decodes into an interface-typed variable resolves to the
+// concrete type statically assigned to it, and falls back to the interface when
+// the concrete type is ambiguous.
+//
+// Before the fix the request path emitted a `$ref` to the bare interface, whose
+// schema is an empty object — strictly worse than omitting the body, since it
+// documents a payload with no fields.
+func TestTestdata_InterfaceRequestBody(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "interface_request_body", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+	noUnresolvedPlaceholders(t, out)
+
+	findSchema := func(suffix string) *intspec.Schema {
+		for k, v := range out.Components.Schemas {
+			if strings.HasSuffix(k, suffix) {
+				return v
+			}
+		}
+		return nil
+	}
+	// requestRef returns the component name a path's POST request body resolves to.
+	requestRef := func(path string) string {
+		item, ok := out.Paths[path]
+		if !ok {
+			t.Fatalf("path %q missing; have %v", path, mapPathKeys(out.Paths))
+		}
+		op := opFor(item, "POST")
+		if op == nil {
+			t.Fatalf("POST %s missing", path)
+		}
+		if op.RequestBody == nil {
+			t.Fatalf("POST %s has no requestBody", path)
+		}
+		for _, mt := range op.RequestBody.Content {
+			if mt.Schema != nil && mt.Schema.Ref != "" {
+				return mt.Schema.Ref
+			}
+		}
+		return ""
+	}
+
+	// /dogs: `var a Animal = Dog{}` → concrete Dog (with breed).
+	if ref := requestRef("/dogs"); !strings.HasSuffix(ref, "_Dog") {
+		t.Errorf("POST /dogs requestBody = %q, want the concrete Dog (#164)", ref)
+	}
+	if dog := findSchema("_request_body_Dog"); dog == nil || dog.Properties["breed"] == nil {
+		t.Errorf("Dog schema missing 'breed'; got %+v", dog)
+	}
+
+	// /cats: `var a Animal; a = Cat{}` → concrete Cat (with lives).
+	if ref := requestRef("/cats"); !strings.HasSuffix(ref, "_Cat") {
+		t.Errorf("POST /cats requestBody = %q, want the concrete Cat (#164)", ref)
+	}
+	if cat := findSchema("_request_body_Cat"); cat == nil || cat.Properties["lives"] == nil {
+		t.Errorf("Cat schema missing 'lives'; got %+v", cat)
+	}
+
+	// /either: two concrete types assigned → ambiguous → keep the interface
+	// rather than guessing one of them (golden rule #7).
+	if ref := requestRef("/either"); !strings.HasSuffix(ref, "_Animal") {
+		t.Errorf("POST /either requestBody = %q, want the Animal interface kept when ambiguous", ref)
+	}
+
+	// /concrete: the pre-existing concrete path must be unaffected.
+	if ref := requestRef("/concrete"); !strings.HasSuffix(ref, "_Dog") {
+		t.Errorf("POST /concrete requestBody = %q, want Dog", ref)
+	}
+
+	// /via-param: the concrete is bound at the call site entering the helper
+	// whose parameter is the interface.
+	if ref := requestRef("/via-param"); !strings.HasSuffix(ref, "_Cat") {
+		t.Errorf("POST /via-param requestBody = %q, want the bound Cat (#164)", ref)
+	}
+
+	// /pointer: `var a Animal = &Dog{}` decoded via Decode(a) — the pointer
+	// shape the response fixture never exercises, since responses encode the
+	// value rather than decoding into a pointer.
+	if ref := requestRef("/pointer"); !strings.HasSuffix(ref, "_Dog") {
+		t.Errorf("POST /pointer requestBody = %q, want the concrete Dog (#164)", ref)
+	}
+}

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -2962,7 +2962,7 @@ func (r *ResponsePatternMatcherImpl) resolveTypeOrigin(arg *metadata.CallArgumen
 // original type is a known interface and the enclosing function assigns exactly
 // one concrete (non-interface) type to the variable — an ambiguous set of
 // concrete assignments keeps the interface (honest over wrong).
-func (r *ResponsePatternMatcherImpl) concreteFromEnclosingFunc(arg *metadata.CallArgument, edge *metadata.CallGraphEdge, originalType string) string {
+func (r *BasePatternMatcher) concreteFromEnclosingFunc(arg *metadata.CallArgument, edge *metadata.CallGraphEdge, originalType string) string {
 	if edge == nil {
 		return ""
 	}
@@ -3002,7 +3002,7 @@ func (r *ResponsePatternMatcherImpl) concreteFromEnclosingFunc(arg *metadata.Cal
 // immediate parent, whose own parameters can shadow the name — and reads that
 // edge's ParamArgMap. Non-interface / unresolvable arguments are ignored so the
 // interface is kept.
-func (r *ResponsePatternMatcherImpl) concreteFromParamBinding(arg *metadata.CallArgument, node TrackerNodeInterface, originalType string) string {
+func (r *BasePatternMatcher) concreteFromParamBinding(arg *metadata.CallArgument, node TrackerNodeInterface, originalType string) string {
 	edge := node.GetEdge()
 	if edge == nil {
 		return ""
@@ -3038,7 +3038,7 @@ func (r *ResponsePatternMatcherImpl) concreteFromParamBinding(arg *metadata.Call
 // (`Encode(makeAnimal())` where makeAnimal() Animal { return Dog{} } → Dog). If
 // the callee's captured return values name more than one concrete type it is
 // ambiguous, so the interface is kept.
-func (r *ResponsePatternMatcherImpl) concreteFromCalleeReturn(arg *metadata.CallArgument, edge *metadata.CallGraphEdge, originalType string) string {
+func (r *BasePatternMatcher) concreteFromCalleeReturn(arg *metadata.CallArgument, edge *metadata.CallGraphEdge, originalType string) string {
 	if edge == nil || arg.Fun == nil {
 		return ""
 	}

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -1011,11 +1011,20 @@ func (r *RequestPatternMatcherImpl) resolveTypeOrigin(arg *metadata.CallArgument
 		}
 	}
 
+	// A request body is decoded into a POINTER (`Decode(&v)`), so the variable
+	// is the unary's operand — unlike the response path, which encodes the value
+	// itself. Peel it, or the ident-keyed resolution below never fires (this is
+	// why interface-typed request bodies stayed unresolved, issue #164).
+	target := arg
+	if target.GetKind() == metadata.KindUnary && target.X != nil {
+		target = target.X
+	}
+
 	// Original logic for type resolution
-	if arg.GetKind() == metadata.KindIdent || arg.GetKind() == metadata.KindFuncLit {
+	if target.GetKind() == metadata.KindIdent || target.GetKind() == metadata.KindFuncLit {
 		// Check if this variable has assignments that might give us more type information
 		edge := node.GetEdge()
-		if assignments, exists := edge.AssignmentMap[arg.GetName()]; exists {
+		if assignments, exists := edge.AssignmentMap[target.GetName()]; exists {
 			for _, assignment := range assignments {
 				if assignment.ConcreteType != 0 {
 					concreteType := r.contextProvider.GetString(assignment.ConcreteType)
@@ -1024,6 +1033,19 @@ func (r *RequestPatternMatcherImpl) resolveTypeOrigin(arg *metadata.CallArgument
 					}
 				}
 			}
+		}
+		// Interface-typed body: the concrete value is assigned in the enclosing
+		// handler (`var a Animal = Dog{}; Decode(&a)`), not on this call's edge.
+		// Resolve it so the schema documents Dog rather than the empty Animal
+		// interface — the same resolution the response path already applies
+		// (issue #164). An ambiguous set of assignments keeps the interface.
+		if concrete := r.concreteFromEnclosingFunc(target, edge, originalType); concrete != "" {
+			return concrete
+		}
+		// Interface-typed function parameter: the concrete value is bound at the
+		// call site that entered the enclosing function (`decodeAnimal(r, Dog{})`).
+		if concrete := r.concreteFromParamBinding(target, node, originalType); concrete != "" {
+			return concrete
 		}
 	}
 

--- a/internal/spec/request_interface_body_test.go
+++ b/internal/spec/request_interface_body_test.go
@@ -1,0 +1,124 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// TestRequestResolveTypeOriginInterface covers issue #164: the request path now
+// applies the same interface→concrete resolution the response path already did.
+//
+// Two things had to be true for this to work, and both are asserted here. The
+// resolvers must be reachable from the request matcher at all (they used to hang
+// off the response matcher), and the argument must be peeled first: a request
+// body is decoded into a POINTER (`Decode(&a)`), so the variable is the unary's
+// operand, whereas the response encodes the value itself (`Encode(a)`). Without
+// the peel the ident-keyed lookup never fires and the bare interface survives.
+func TestRequestResolveTypeOriginInterface(t *testing.T) {
+	meta := sweepInterfaceMeta()
+	pool := meta.StringPool
+	appFile := meta.Packages["app"].Files["app/main.go"]
+	appFile.Functions["handler"] = &metadata.Function{
+		AssignmentMap: map[string][]metadata.Assignment{
+			"a": {{ConcreteType: pool.Get("app.Dog")}},
+		},
+	}
+	appFile.Functions["ambiguous"] = &metadata.Function{
+		AssignmentMap: map[string][]metadata.Assignment{
+			"a": {
+				{ConcreteType: pool.Get("app.Dog")},
+				{ConcreteType: pool.Get("app.Cat")},
+			},
+		},
+	}
+
+	m := NewRequestPatternMatcher(RequestBodyPattern{}, &APISpecConfig{}, NewContextProvider(meta), nil)
+
+	// unary wraps an ident the way `&a` does in Decode(&a).
+	unaryOf := func(name string) *metadata.CallArgument {
+		u := metadata.NewCallArgument(meta)
+		u.SetKind(metadata.KindUnary)
+		u.X = sweepIdent(meta, name)
+		return u
+	}
+
+	for _, tc := range []struct {
+		name, caller, original string
+		arg                    *metadata.CallArgument
+		want                   string
+	}{
+		{
+			name:     "pointer-to-interface resolves to the concrete",
+			caller:   "handler",
+			original: "app.Animal",
+			arg:      unaryOf("a"),
+			want:     "app.Dog",
+		},
+		{
+			// The response shape (bare ident) must keep working through the
+			// shared resolver too.
+			name:     "bare ident resolves to the concrete",
+			caller:   "handler",
+			original: "app.Animal",
+			arg:      sweepIdent(meta, "a"),
+			want:     "app.Dog",
+		},
+		{
+			name:     "ambiguous keeps the interface",
+			caller:   "ambiguous",
+			original: "app.Animal",
+			arg:      unaryOf("a"),
+			want:     "app.Animal",
+		},
+		{
+			// A concrete body type must pass through untouched: the resolver is
+			// gated on the original type being an interface.
+			name:     "concrete type is untouched",
+			caller:   "handler",
+			original: "app.Dog",
+			arg:      unaryOf("a"),
+			want:     "app.Dog",
+		},
+		{
+			name:     "unknown variable keeps the interface",
+			caller:   "handler",
+			original: "app.Animal",
+			arg:      unaryOf("nosuch"),
+			want:     "app.Animal",
+		},
+		{
+			name:     "unary with no operand keeps the interface",
+			caller:   "handler",
+			original: "app.Animal",
+			arg: func() *metadata.CallArgument {
+				u := metadata.NewCallArgument(meta)
+				u.SetKind(metadata.KindUnary)
+				return u
+			}(),
+			want: "app.Animal",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			edge := sweepEdge(meta, tc.caller, "app", "Decode", "json", "", "")
+			node := sweepNode(edge)
+			if got := m.resolveTypeOrigin(tc.arg, node, tc.original); got != tc.want {
+				t.Errorf("resolveTypeOrigin = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/testdata/interface_request_body/go.mod
+++ b/testdata/interface_request_body/go.mod
@@ -1,0 +1,3 @@
+module interface_request_body
+
+go 1.26

--- a/testdata/interface_request_body/main.go
+++ b/testdata/interface_request_body/main.go
@@ -1,0 +1,93 @@
+// Package main exercises interface-typed REQUEST body resolution (issue #164):
+// when a handler decodes into a value whose static type is an interface, the
+// request schema should document the concrete type actually assigned to it,
+// mirroring what testdata/interface_response already does for responses. When
+// more than one concrete type is assigned the resolution is ambiguous, and the
+// interface is kept (honest over wrong).
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type Cat struct {
+	Name  string `json:"name"`
+	Lives int    `json:"lives"`
+}
+
+type Dog struct {
+	Name  string `json:"name"`
+	Breed string `json:"breed"`
+}
+
+// Animal is an interface; both Cat and Dog implement it.
+type Animal interface{ Sound() string }
+
+func (Cat) Sound() string { return "meow" }
+func (Dog) Sound() string { return "woof" }
+
+// createDog: `var a Animal = Dog{}` (declaration with init) → resolves to Dog.
+func createDog(w http.ResponseWriter, r *http.Request) {
+	var a Animal = Dog{}
+	_ = json.NewDecoder(r.Body).Decode(&a)
+	w.WriteHeader(http.StatusCreated)
+}
+
+// createCat: declared then assigned (`var a Animal; a = Cat{}`) → resolves to Cat.
+func createCat(w http.ResponseWriter, r *http.Request) {
+	var a Animal
+	a = Cat{}
+	_ = json.NewDecoder(r.Body).Decode(&a)
+	w.WriteHeader(http.StatusCreated)
+}
+
+// createEither assigns two different concrete types on different branches, so
+// the concrete type is ambiguous — resolution keeps the Animal interface.
+func createEither(w http.ResponseWriter, r *http.Request) {
+	var a Animal = Dog{}
+	if r.URL.Query().Get("x") == "1" {
+		a = Cat{}
+	}
+	_ = json.NewDecoder(r.Body).Decode(&a)
+	w.WriteHeader(http.StatusCreated)
+}
+
+// createConcrete is the baseline: a concrete decode target, which already
+// resolved before this change and must keep working.
+func createConcrete(w http.ResponseWriter, r *http.Request) {
+	var d Dog
+	_ = json.NewDecoder(r.Body).Decode(&d)
+	w.WriteHeader(http.StatusCreated)
+}
+
+// createViaParam passes a concrete value into a helper whose parameter is the
+// interface — the param-binding shape (`decodeAnimal(r, Dog{})`).
+func createViaParam(w http.ResponseWriter, r *http.Request) {
+	decodeAnimal(r, Cat{})
+	w.WriteHeader(http.StatusCreated)
+}
+
+func decodeAnimal(r *http.Request, a Animal) {
+	_ = json.NewDecoder(r.Body).Decode(&a)
+}
+
+// createPointer holds a POINTER to the concrete type and decodes into it
+// directly (`Decode(a)` rather than `Decode(&a)`) — a shape the response
+// fixture never exercises, since responses encode the value itself.
+func createPointer(w http.ResponseWriter, r *http.Request) {
+	var a Animal = &Dog{}
+	_ = json.NewDecoder(r.Body).Decode(a)
+	w.WriteHeader(http.StatusCreated)
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /dogs", createDog)
+	mux.HandleFunc("POST /cats", createCat)
+	mux.HandleFunc("POST /either", createEither)
+	mux.HandleFunc("POST /concrete", createConcrete)
+	mux.HandleFunc("POST /via-param", createViaParam)
+	mux.HandleFunc("POST /pointer", createPointer)
+	_ = http.ListenAndServe(":8080", mux)
+}


### PR DESCRIPTION
Closes #164.

An interface-typed request body emitted a `$ref` to the bare interface, whose schema is an empty object — strictly worse than omitting the body, since it documents a payload with no fields.

```yaml
# var a Animal = Dog{}; json.NewDecoder(r.Body).Decode(&a)
requestBody:
  content:
    application/json:
      schema:
        $ref: '#/components/schemas/pkg_Animal'
components:
  schemas:
    pkg_Animal: {type: object}     # Dog's fields never appear
```

The **response** path already resolved exactly this shape to its concrete type (`testdata/interface_response`), so this was a request/response asymmetry rather than a missing capability.

## Two things were in the way

**The resolvers were unreachable.** `concreteFromEnclosingFunc`, `concreteFromParamBinding` and `concreteFromCalleeReturn` hung off `ResponsePatternMatcherImpl`. They use only `contextProvider`, which lives on the embedded `BasePatternMatcher`, so moving the receiver makes them shared without changing behavior — the response fixtures pass untouched.

**The argument has a different shape, and this is the half that actually mattered.** A request body is decoded into a *pointer* — `Decode(&a)` — so the argument is a `unary` whose operand is the variable. A response encodes the value itself (`Encode(a)`), an ident. The ident-keyed lookup therefore never fired on the request side; sharing the resolvers alone would have accomplished nothing. Verified by probing the real argument rather than assuming:

```
DBGREQ kind=unary orig="*pkg-->Animal" | X.kind=ident X.name="a" X.type="Animal"
```

The generic branch (`traceGenericOrigin`) is deliberately left alone — it differs from the response side's type-parameter lookup, so unifying the two resolvers wholesale would change generic behavior. The change is additive.

## Result

| route | shape | before | after |
|---|---|---|---|
| `/dogs` | `var a Animal = Dog{}` | `Animal` | **`Dog`** |
| `/cats` | `var a Animal; a = Cat{}` | `Animal` | **`Cat`** |
| `/via-param` | concrete bound through a helper param | `Animal` | **`Cat`** |
| `/pointer` | `var a Animal = &Dog{}` | `Animal` | **`Dog`** |
| `/either` | two concretes assigned | `Animal` | `Animal` (unchanged) |
| `/concrete` | plain concrete decode | `Dog` | `Dog` (unchanged) |

Ambiguity is preserved: two different concrete types keep the interface (golden rule #7), pinned by both the fixture and a unit test.

## Tests

- `testdata/interface_request_body` + `TestTestdata_InterfaceRequestBody`, mirroring `TestTestdata_InterfaceResponse` — asserts the resolved `$ref` **and** the schema contents (`breed`/`lives`), so a ref pointing at the wrong concrete is caught.
- Two shapes responses structurally cannot exercise are included: a pointer held in the interface variable, and a concrete bound through a helper whose parameter is the interface.
- `TestRequestResolveTypeOriginInterface` unit-tests the matcher directly: the unary peel, the bare-ident path through the now-shared resolver, ambiguity, a concrete type passing through untouched, an unknown variable, and a unary with no operand.

## Verification

Full suite green, `make lint` clean, coverage holding at 96.0% (the floor). Generating two large real projects before and after produces **byte-identical output** — this fires only on a shape they don't use, which is the expected blast radius for a resolution fix.

## Note for the reviewer

Moving three method receivers from `ResponsePatternMatcherImpl` to `BasePatternMatcher` is the one change that touches existing behavior in principle. It is mechanical (no body edits), and `TestTestdata_InterfaceResponse` plus the `TestSweepConcreteFrom*` unit tests all pass unchanged — but it is the part worth a second pair of eyes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request-body schema resolution when interfaces are assigned to a single concrete type.
  * Correctly preserves interface schemas when assignments are ambiguous or cannot be resolved.
  * Enhanced type detection for decoded request bodies and parameter-bound values.

* **Tests**
  * Added coverage for concrete, ambiguous, pointer, parameter-based, and unresolved request-body type scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->