### PR TITLE
feat(spec): map an ambiguous interface body to oneOf (#201)

### DIFF
--- a/generator/testdata_interface_request_body_test.go
+++ b/generator/testdata_interface_request_body_test.go
@@ -92,6 +92,17 @@ func TestTestdata_InterfaceRequestBody(t *testing.T) {
 	// to the bare interface, whose schema describes nothing.
 	assertOneOf(t, requestSchema("/either"), "_Cat", "_Dog")
 
+	// /unknown: an interface with no traceable assignment stays the interface —
+	// the honest answer — and its component must still be emitted. This is the
+	// counterweight to the orphan check below: component marking follows what
+	// the operations actually reference, rather than pruning interfaces wholesale.
+	if ref := requestRef("/unknown"); !strings.HasSuffix(ref, "_Animal") {
+		t.Errorf("POST /unknown requestBody = %q, want the Animal interface kept", ref)
+	}
+	if findSchema("_body_Animal") == nil {
+		t.Error("Animal component missing though /unknown references it")
+	}
+
 	// /concrete: the pre-existing concrete path must be unaffected.
 	if ref := requestRef("/concrete"); !strings.HasSuffix(ref, "_Dog") {
 		t.Errorf("POST /concrete requestBody = %q, want Dog", ref)

--- a/generator/testdata_interface_request_body_test.go
+++ b/generator/testdata_interface_request_body_test.go
@@ -44,8 +44,8 @@ func TestTestdata_InterfaceRequestBody(t *testing.T) {
 		}
 		return nil
 	}
-	// requestRef returns the component name a path's POST request body resolves to.
-	requestRef := func(path string) string {
+	// requestSchema returns the schema of a path's POST request body.
+	requestSchema := func(path string) *intspec.Schema {
 		item, ok := out.Paths[path]
 		if !ok {
 			t.Fatalf("path %q missing; have %v", path, mapPathKeys(out.Paths))
@@ -58,9 +58,15 @@ func TestTestdata_InterfaceRequestBody(t *testing.T) {
 			t.Fatalf("POST %s has no requestBody", path)
 		}
 		for _, mt := range op.RequestBody.Content {
-			if mt.Schema != nil && mt.Schema.Ref != "" {
-				return mt.Schema.Ref
+			if mt.Schema != nil {
+				return mt.Schema
 			}
+		}
+		return nil
+	}
+	requestRef := func(path string) string {
+		if s := requestSchema(path); s != nil {
+			return s.Ref
 		}
 		return ""
 	}
@@ -81,11 +87,10 @@ func TestTestdata_InterfaceRequestBody(t *testing.T) {
 		t.Errorf("Cat schema missing 'lives'; got %+v", cat)
 	}
 
-	// /either: two concrete types assigned → ambiguous → keep the interface
-	// rather than guessing one of them (golden rule #7).
-	if ref := requestRef("/either"); !strings.HasSuffix(ref, "_Animal") {
-		t.Errorf("POST /either requestBody = %q, want the Animal interface kept when ambiguous", ref)
-	}
+	// /either: two concrete types assigned → the payload really is one of them,
+	// so it maps to `oneOf` (issue #201) rather than to a guessed single type or
+	// to the bare interface, whose schema describes nothing.
+	assertOneOf(t, requestSchema("/either"), "_Cat", "_Dog")
 
 	// /concrete: the pre-existing concrete path must be unaffected.
 	if ref := requestRef("/concrete"); !strings.HasSuffix(ref, "_Dog") {

--- a/generator/testdata_interface_response_test.go
+++ b/generator/testdata_interface_response_test.go
@@ -89,6 +89,14 @@ func TestTestdata_InterfaceResponse(t *testing.T) {
 	// — described nothing at all.
 	assertOneOf(t, responseSchema("/either"), "_Cat", "_Dog")
 
+	// The bare interface must not linger as a component: the operation now
+	// references the members, so emitting Animal too would leave a schema
+	// nothing points at. (An interface that stays unresolved DOES keep its
+	// component — testdata/interface_request_body /unknown covers that side.)
+	if animal := findSchema("_response_Animal"); animal != nil {
+		t.Errorf("bare interface Animal emitted as an orphan component: %+v", animal)
+	}
+
 	// /made: `Encode(makeDog())` where makeDog() Animal { return Dog{} } →
 	// resolves to the concrete Dog via return-value tracing.
 	if ref := responseRef("/made"); !strings.HasSuffix(ref, "_Dog") {

--- a/generator/testdata_interface_response_test.go
+++ b/generator/testdata_interface_response_test.go
@@ -41,7 +41,8 @@ func TestTestdata_InterfaceResponse(t *testing.T) {
 	}
 	// responseRef returns the trailing component name a path's POST response
 	// resolves to.
-	responseRef := func(path string) string {
+	// responseSchema returns the schema of a path's POST response body.
+	responseSchema := func(path string) *intspec.Schema {
 		item, ok := out.Paths[path]
 		if !ok {
 			t.Fatalf("path %q missing; have %v", path, mapPathKeys(out.Paths))
@@ -52,10 +53,16 @@ func TestTestdata_InterfaceResponse(t *testing.T) {
 		}
 		for _, resp := range op.Responses {
 			for _, mt := range resp.Content {
-				if mt.Schema != nil && mt.Schema.Ref != "" {
-					return mt.Schema.Ref
+				if mt.Schema != nil {
+					return mt.Schema
 				}
 			}
+		}
+		return nil
+	}
+	responseRef := func(path string) string {
+		if s := responseSchema(path); s != nil {
+			return s.Ref
 		}
 		return ""
 	}
@@ -76,11 +83,11 @@ func TestTestdata_InterfaceResponse(t *testing.T) {
 		t.Errorf("Cat schema missing 'lives'; got %+v", cat)
 	}
 
-	// /either: two concrete types assigned → ambiguous → keep the Animal
-	// interface (an empty-object schema), NOT one of the concretes.
-	if ref := responseRef("/either"); !strings.HasSuffix(ref, "_Animal") {
-		t.Errorf("POST /either response = %q, want the Animal interface (ambiguous concrete)", ref)
-	}
+	// /either: two concrete types assigned → the payload really is one of them,
+	// so it maps to `oneOf` (issue #201). Narrowing to one would be a guess, but
+	// the previous fallback — the bare Animal interface, an empty-object schema
+	// — described nothing at all.
+	assertOneOf(t, responseSchema("/either"), "_Cat", "_Dog")
 
 	// /made: `Encode(makeDog())` where makeDog() Animal { return Dog{} } →
 	// resolves to the concrete Dog via return-value tracing.
@@ -92,5 +99,28 @@ func TestTestdata_InterfaceResponse(t *testing.T) {
 	// → resolves to Dog via the named-interface parameter binding.
 	if ref := responseRef("/passed"); !strings.HasSuffix(ref, "_Dog") {
 		t.Errorf("POST /passed response = %q, want the concrete Dog (param binding)", ref)
+	}
+}
+
+// assertOneOf checks that a schema is a `oneOf` whose members are exactly the
+// expected component suffixes, in order. Order matters: the concrete set is
+// sorted so the output cannot vary between runs (golden rule #1).
+func assertOneOf(t *testing.T, schema *intspec.Schema, wantSuffixes ...string) {
+	t.Helper()
+	if schema == nil {
+		t.Fatalf("no schema; want oneOf %v", wantSuffixes)
+	}
+	if len(schema.OneOf) != len(wantSuffixes) {
+		t.Fatalf("oneOf has %d members, want %d: %+v", len(schema.OneOf), len(wantSuffixes), schema.OneOf)
+	}
+	for i, want := range wantSuffixes {
+		if got := schema.OneOf[i].Ref; !strings.HasSuffix(got, want) {
+			t.Errorf("oneOf[%d] = %q, want a ref ending %q", i, got, want)
+		}
+	}
+	// A polymorphic schema must not also carry a direct $ref — that would be
+	// two conflicting statements about the same payload.
+	if schema.Ref != "" {
+		t.Errorf("oneOf schema also carries $ref %q", schema.Ref)
 	}
 }

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -122,6 +122,13 @@ type RequestInfo struct {
 	BodyType    string
 	Schema      *Schema
 
+	// OneOfTypes holds the concrete types a polymorphic body resolves to
+	// (issue #201). BodyType stays the interface — it is the Go type, and
+	// several consumers key off it — but component collection marks these
+	// instead, so the interface is not emitted as a component that nothing
+	// references.
+	OneOfTypes []string
+
 	// File and Line locate the call site that produced this request body, used
 	// to attribute it to an r.Method dispatch branch (see splitMethodDispatchRoutes).
 	File string
@@ -134,6 +141,13 @@ type ResponseInfo struct {
 	ContentType string
 	BodyType    string
 	Schema      *Schema
+
+	// OneOfTypes holds the concrete types a polymorphic body resolves to
+	// (issue #201). BodyType stays the interface — it is the Go type, and
+	// several consumers key off it — but component collection marks these
+	// instead, so the interface is not emitted as a component that nothing
+	// references.
+	OneOfTypes []string
 
 	// File and Line locate the call site that produced this response, used to
 	// attribute it to an r.Method dispatch branch (see splitMethodDispatchRoutes).
@@ -2406,9 +2420,15 @@ func (r *ResponsePatternMatcherImpl) ExtractResponse(node TrackerNodeInterface, 
 
 		respInfo.BodyType = preprocessingBodyType(bodyType)
 
-		schema, _ := mapGoTypeToOpenAPISchema(route.UsedTypes, bodyType, route.Metadata, r.cfg, nil)
-		if oneOf := oneOfSchemaFor(route.UsedTypes, oneOfTypes, route.Metadata, r.cfg); oneOf != nil {
-			schema = oneOf
+		// Build the polymorphic schema FIRST and skip the single-type mapping
+		// when it applies: mapping the bare interface would register it as a
+		// component that nothing then references, leaving an orphan
+		// `{type: object}` in the output.
+		schema := oneOfSchemaFor(route.UsedTypes, oneOfTypes, route.Metadata, r.cfg)
+		if schema != nil {
+			respInfo.OneOfTypes = oneOfTypes
+		} else {
+			schema, _ = mapGoTypeToOpenAPISchema(route.UsedTypes, bodyType, route.Metadata, r.cfg, nil)
 		}
 
 		// Wrapper specialisation: when the body resolves to a struct

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -17,6 +17,7 @@ package spec
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -2332,6 +2333,9 @@ func (r *ResponsePatternMatcherImpl) ExtractResponse(node TrackerNodeInterface, 
 		// Fun directly rather than peeling to the inner ident — otherwise a
 		// const ident's literal value can leak into the schema as a $ref.
 		var bodyType string
+		// Concrete types assigned to an interface-typed body, when there is more
+		// than one — see oneOfSchemaFor (issue #201).
+		var oneOfTypes []string
 		if arg.GetKind() == metadata.KindTypeConversion && arg.Fun != nil {
 			bodyType = r.contextProvider.GetArgumentInfo(arg.Fun)
 		} else {
@@ -2379,7 +2383,14 @@ func (r *ResponsePatternMatcherImpl) ExtractResponse(node TrackerNodeInterface, 
 
 			// Trace type origin for non-literal arguments
 			if !resolvedConcrete {
-				bodyType = r.resolveTypeOrigin(arg, typeNode, bodyType)
+				resolved := r.resolveTypeOrigin(arg, typeNode, bodyType)
+				if resolved == bodyType {
+					// Unchanged means the type did not narrow — when that is
+					// because several concrete types are assigned, the body is
+					// polymorphic and `oneOf` says so (issue #201).
+					oneOfTypes = r.ambiguousConcreteSet(arg, typeNode, bodyType)
+				}
+				bodyType = resolved
 			}
 
 			// Apply dereferencing if needed
@@ -2396,6 +2407,9 @@ func (r *ResponsePatternMatcherImpl) ExtractResponse(node TrackerNodeInterface, 
 		respInfo.BodyType = preprocessingBodyType(bodyType)
 
 		schema, _ := mapGoTypeToOpenAPISchema(route.UsedTypes, bodyType, route.Metadata, r.cfg, nil)
+		if oneOf := oneOfSchemaFor(route.UsedTypes, oneOfTypes, route.Metadata, r.cfg); oneOf != nil {
+			schema = oneOf
+		}
 
 		// Wrapper specialisation: when the body resolves to a struct
 		// whose fields are bound to constructor parameters at the
@@ -2974,11 +2988,41 @@ func (r *BasePatternMatcher) concreteFromEnclosingFunc(arg *metadata.CallArgumen
 	if callerName == "" {
 		return ""
 	}
+	set := r.concreteSetFromEnclosingFunc(arg, edge, originalType)
+	if len(set) == 1 {
+		return set[0]
+	}
+	// Zero (nothing resolvable) or more than one (ambiguous) keeps the
+	// interface. The ambiguous set is not discarded, though — callers that can
+	// express polymorphism read it via concreteSetFromEnclosingFunc and emit
+	// `oneOf` instead (issue #201).
+	return ""
+}
+
+// concreteSetFromEnclosingFunc returns every distinct concrete type assigned to
+// the variable in the enclosing handler, sorted.
+//
+// One element means the type is unambiguous and callers can narrow to it;
+// several mean the payload is genuinely one of them, which `oneOf` expresses
+// exactly where a bare interface schema (`{type: object}`) expresses nothing.
+// The result is sorted because it reaches the output (golden rule #1).
+func (r *BasePatternMatcher) concreteSetFromEnclosingFunc(arg *metadata.CallArgument, edge *metadata.CallGraphEdge, originalType string) []string {
+	if edge == nil {
+		return nil
+	}
+	meta := edge.Callee.Meta
+	if meta == nil || !isInterfaceTypeName(originalType, meta) {
+		return nil
+	}
+	callerName := r.contextProvider.GetString(edge.Caller.Name)
+	if callerName == "" {
+		return nil
+	}
 	fn := findFunctionByName(meta, r.contextProvider.GetString(edge.Caller.Pkg), callerName)
 	if fn == nil {
-		return ""
+		return nil
 	}
-	concrete := ""
+	var set []string
 	for _, a := range fn.AssignmentMap[arg.GetName()] {
 		if a.ConcreteType == 0 {
 			continue
@@ -2987,12 +3031,12 @@ func (r *BasePatternMatcher) concreteFromEnclosingFunc(arg *metadata.CallArgumen
 		if ct == "" || isInterfaceTypeName(ct, meta) {
 			continue
 		}
-		if concrete != "" && concrete != ct {
-			return "" // more than one concrete type assigned — ambiguous
+		if !slices.Contains(set, ct) {
+			set = append(set, ct)
 		}
-		concrete = ct
 	}
-	return concrete
+	slices.Sort(set)
+	return set
 }
 
 // concreteFromParamBinding resolves an interface-typed parameter used as a

--- a/internal/spec/handler_value.go
+++ b/internal/spec/handler_value.go
@@ -27,6 +27,66 @@ import (
 // names no method anywhere in the registration, so the framework's handler
 // interface supplies it.
 
+// ambiguousConcreteSet returns the concrete types assigned to an interface-typed
+// body when there is more than one — the case where narrowing is impossible but
+// `oneOf` can still say exactly what the payload may be (issue #201).
+//
+// It mirrors resolveTypeOrigin's argument handling: a request body is decoded
+// into a pointer (`Decode(&v)`), so the variable is the unary's operand, while a
+// response encodes the value itself.
+func (r *BasePatternMatcher) ambiguousConcreteSet(arg *metadata.CallArgument, node TrackerNodeInterface, originalType string) []string {
+	if arg == nil || node == nil {
+		return nil
+	}
+	target := arg
+	if target.GetKind() == metadata.KindUnary && target.X != nil {
+		target = target.X
+	}
+	if target.GetKind() != metadata.KindIdent && target.GetKind() != metadata.KindFuncLit {
+		return nil
+	}
+	set := r.concreteSetFromEnclosingFunc(target, node.GetEdge(), originalType)
+	if len(set) < 2 {
+		return nil
+	}
+	return set
+}
+
+// oneOfSchemaFor builds a `oneOf` schema from a set of concrete types, or
+// returns nil when there is nothing polymorphic to express (issue #201).
+//
+// This is the ambiguous branch of interface resolution. When a handler assigns
+// more than one concrete type to an interface-typed variable, narrowing to one
+// of them would be a guess, but falling back to the bare interface emits
+// `{type: object}` — a schema that describes nothing. `oneOf: [Cat, Dog]` states
+// exactly what is known, so it is the stronger form of "honest over wrong"
+// (golden rule #7), not a relaxation of it.
+//
+// The set is the types assigned *in this handler*, deliberately not every
+// recorded implementer of the interface: enumerating implementers the handler
+// never assigns would over-claim.
+//
+// Each member is mapped through mapGoTypeToOpenAPISchema so it registers as a
+// component and the `$ref`s resolve; a member that maps to nothing is dropped,
+// and if fewer than two survive there is no polymorphism to express.
+func oneOfSchemaFor(usedTypes map[string]*Schema, concretes []string, meta *metadata.Metadata, cfg *APISpecConfig) *Schema {
+	if len(concretes) < 2 {
+		return nil
+	}
+	members := make([]*Schema, 0, len(concretes))
+	for _, ct := range concretes {
+		schema, _ := mapGoTypeToOpenAPISchema(usedTypes, ct, meta, cfg, nil)
+		if schema == nil {
+			continue
+		}
+		members = append(members, schema)
+	}
+	if len(members) < 2 {
+		return nil
+	}
+	return &Schema{OneOf: members}
+}
+
 // handlerMethodKeys returns the base IDs ("pkg.Type.Method") of the configured
 // handler methods declared by the type (pkg, name), fanning an interface out to
 // its implementers.

--- a/internal/spec/handler_value_test.go
+++ b/internal/spec/handler_value_test.go
@@ -16,6 +16,7 @@ package spec
 
 import (
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/ehabterra/apispec/internal/metadata"
@@ -133,4 +134,42 @@ func TestHandlerMethodKeys(t *testing.T) {
 	if got := handlerMethodKeys(nil, methods, "app", "H"); got != nil {
 		t.Errorf("nil metadata: got %v, want nil", got)
 	}
+}
+
+// TestOneOfSchemaFor covers the polymorphic schema builder (issue #201): it
+// emits `oneOf` only when there is genuine polymorphism to express, and each
+// member registers as a component so the refs resolve.
+func TestOneOfSchemaFor(t *testing.T) {
+	meta := sweepInterfaceMeta()
+	cfg := &APISpecConfig{}
+
+	t.Run("fewer than two yields nothing", func(t *testing.T) {
+		for _, in := range [][]string{nil, {}, {"app.Dog"}} {
+			if got := oneOfSchemaFor(map[string]*Schema{}, in, meta, cfg); got != nil {
+				t.Errorf("oneOfSchemaFor(%v) = %+v, want nil", in, got)
+			}
+		}
+	})
+
+	t.Run("two concretes yield oneOf and register components", func(t *testing.T) {
+		used := map[string]*Schema{}
+		got := oneOfSchemaFor(used, []string{"app.Cat", "app.Dog"}, meta, cfg)
+		if got == nil {
+			t.Fatal("got nil, want a oneOf schema")
+		}
+		if len(got.OneOf) != 2 {
+			t.Fatalf("oneOf has %d members, want 2: %+v", len(got.OneOf), got.OneOf)
+		}
+		// Order follows the input, which the resolver sorts — the output must
+		// not vary between runs (golden rule #1).
+		for i, want := range []string{"Cat", "Dog"} {
+			if !strings.HasSuffix(got.OneOf[i].Ref, want) {
+				t.Errorf("oneOf[%d] ref = %q, want it to end %q", i, got.OneOf[i].Ref, want)
+			}
+		}
+		// A polymorphic schema states one thing; it must not also carry a $ref.
+		if got.Ref != "" {
+			t.Errorf("oneOf schema also carries $ref %q", got.Ref)
+		}
+	})
 }

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -959,16 +959,30 @@ func collectUsedTypesFromRoutes(routes []*RouteInfo) map[string]*Schema {
 	usedTypes := make(map[string]*Schema)
 
 	for _, route := range routes {
-		// Add request body types
-		if route.Request != nil && route.Request.BodyType != "" {
-			// addTypeAndDependenciesWithMetadata(route.Request.BodyType, usedTypes, meta, cfg)
-			markUsedType(usedTypes, route.Request.BodyType, nil)
+		// Add request body types. A polymorphic body marks its concrete members
+		// rather than the interface: the operation references the members, so
+		// emitting the interface too would leave a component nothing points at
+		// (issue #201).
+		if route.Request != nil {
+			if len(route.Request.OneOfTypes) > 0 {
+				for _, ct := range route.Request.OneOfTypes {
+					markUsedType(usedTypes, ct, nil)
+				}
+			} else if route.Request.BodyType != "" {
+				markUsedType(usedTypes, route.Request.BodyType, nil)
+			}
 		}
 
 		// Add response types
 		for _, res := range route.Response {
-			if route.Response != nil && res.BodyType != "" {
-				// addTypeAndDependenciesWithMetadata(res.BodyType, usedTypes, meta, cfg)
+			if res == nil {
+				continue
+			}
+			if len(res.OneOfTypes) > 0 {
+				for _, ct := range res.OneOfTypes {
+					markUsedType(usedTypes, ct, nil)
+				}
+			} else if res.BodyType != "" {
 				markUsedType(usedTypes, res.BodyType, nil)
 			}
 		}

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -854,6 +854,9 @@ func (r *RequestPatternMatcherImpl) ExtractRequest(node TrackerNodeInterface, ro
 			typeNode = rnode
 		}
 		bodyType := r.contextProvider.GetArgumentInfo(arg)
+		// Concrete types assigned to an interface-typed body, when there is more
+		// than one — see oneOfSchemaFor (issue #201).
+		var oneOfTypes []string
 
 		// Check if this is a literal value - if so, determine appropriate type
 		if arg.GetKind() == metadata.KindLiteral {
@@ -882,7 +885,14 @@ func (r *RequestPatternMatcherImpl) ExtractRequest(node TrackerNodeInterface, ro
 
 			// Trace type origin (in the scope the arg was resolved into, so a
 			// wrapper-passed local's assignment is found at the call site).
-			bodyType = r.resolveTypeOrigin(arg, typeNode, bodyType)
+			resolved := r.resolveTypeOrigin(arg, typeNode, bodyType)
+			if resolved == bodyType {
+				// Unchanged means the type did not narrow — when that is because
+				// several concrete types are assigned, the body is polymorphic
+				// and `oneOf` says so (issue #201).
+				oneOfTypes = r.ambiguousConcreteSet(arg, typeNode, bodyType)
+			}
+			bodyType = resolved
 
 			// Apply dereferencing if needed
 			if r.pattern.Deref && strings.HasPrefix(bodyType, "*") {
@@ -897,6 +907,9 @@ func (r *RequestPatternMatcherImpl) ExtractRequest(node TrackerNodeInterface, ro
 
 		reqInfo.BodyType = preprocessingBodyType(bodyType)
 		schema, _ := mapGoTypeToOpenAPISchema(route.UsedTypes, bodyType, route.Metadata, r.cfg, nil)
+		if oneOf := oneOfSchemaFor(route.UsedTypes, oneOfTypes, route.Metadata, r.cfg); oneOf != nil {
+			schema = oneOf
+		}
 		reqInfo.Schema = schema
 	}
 

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -906,9 +906,15 @@ func (r *RequestPatternMatcherImpl) ExtractRequest(node TrackerNodeInterface, ro
 		bodyType = normalizeGenericInstanceName(bodyType)
 
 		reqInfo.BodyType = preprocessingBodyType(bodyType)
-		schema, _ := mapGoTypeToOpenAPISchema(route.UsedTypes, bodyType, route.Metadata, r.cfg, nil)
-		if oneOf := oneOfSchemaFor(route.UsedTypes, oneOfTypes, route.Metadata, r.cfg); oneOf != nil {
-			schema = oneOf
+		// Build the polymorphic schema FIRST and skip the single-type mapping
+		// when it applies: mapping the bare interface would register it as a
+		// component that nothing then references, leaving an orphan
+		// `{type: object}` in the output.
+		schema := oneOfSchemaFor(route.UsedTypes, oneOfTypes, route.Metadata, r.cfg)
+		if schema != nil {
+			reqInfo.OneOfTypes = oneOfTypes
+		} else {
+			schema, _ = mapGoTypeToOpenAPISchema(route.UsedTypes, bodyType, route.Metadata, r.cfg, nil)
 		}
 		reqInfo.Schema = schema
 	}

--- a/internal/spec/request_interface_body_test.go
+++ b/internal/spec/request_interface_body_test.go
@@ -122,3 +122,123 @@ func TestRequestResolveTypeOriginInterface(t *testing.T) {
 		})
 	}
 }
+
+// TestConcreteSetFromEnclosingFunc covers the set the ambiguous branch now
+// returns instead of discarding (issue #201). One element means the type is
+// unambiguous and callers narrow to it; several mean the payload is genuinely
+// one of them and maps to `oneOf`.
+func TestConcreteSetFromEnclosingFunc(t *testing.T) {
+	meta := sweepInterfaceMeta()
+	pool := meta.StringPool
+	appFile := meta.Packages["app"].Files["app/main.go"]
+	appFile.Functions["single"] = &metadata.Function{
+		AssignmentMap: map[string][]metadata.Assignment{
+			"a": {
+				{ConcreteType: 0},                      // unset: skipped
+				{ConcreteType: pool.Get("app.Animal")}, // interface: skipped
+				{ConcreteType: pool.Get("app.Dog")},
+				{ConcreteType: pool.Get("app.Dog")}, // duplicate: one member
+			},
+		},
+	}
+	// Deliberately assigned Dog-then-Cat, so a sorted result proves the order
+	// does not follow assignment order (golden rule #1).
+	appFile.Functions["several"] = &metadata.Function{
+		AssignmentMap: map[string][]metadata.Assignment{
+			"a": {
+				{ConcreteType: pool.Get("app.Dog")},
+				{ConcreteType: pool.Get("app.Cat")},
+			},
+		},
+	}
+	m := NewRequestPatternMatcher(RequestBodyPattern{}, &APISpecConfig{}, NewContextProvider(meta), nil)
+	arg := sweepIdent(meta, "a")
+
+	for _, tc := range []struct {
+		name, caller, original string
+		want                   []string
+	}{
+		{"single concrete, duplicates collapsed", "single", "app.Animal", []string{"app.Dog"}},
+		{"several concretes are returned sorted", "several", "app.Animal", []string{"app.Cat", "app.Dog"}},
+		{"non-interface original yields nothing", "several", "app.Dog", nil},
+		{"unknown caller yields nothing", "nosuch", "app.Animal", nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			edge := sweepEdge(meta, tc.caller, "app", "Decode", "json", "", "")
+			got := m.concreteSetFromEnclosingFunc(arg, edge, tc.original)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("got %v, want %v", got, tc.want)
+					break
+				}
+			}
+		})
+	}
+
+	if got := m.concreteSetFromEnclosingFunc(arg, nil, "app.Animal"); got != nil {
+		t.Errorf("nil edge: got %v, want nil", got)
+	}
+
+	// The single-value resolver must still narrow only when unambiguous — the
+	// ambiguous case belongs to oneOf, not to a guess.
+	single := sweepEdge(meta, "single", "app", "Decode", "json", "", "")
+	if got := m.concreteFromEnclosingFunc(arg, single, "app.Animal"); got != "app.Dog" {
+		t.Errorf("single: got %q, want app.Dog", got)
+	}
+	several := sweepEdge(meta, "several", "app", "Decode", "json", "", "")
+	if got := m.concreteFromEnclosingFunc(arg, several, "app.Animal"); got != "" {
+		t.Errorf("several: got %q, want empty (oneOf handles it)", got)
+	}
+}
+
+// TestAmbiguousConcreteSet covers the argument handling in front of the set
+// lookup: a request body is decoded into a pointer, so the variable is the
+// unary's operand, and a single concrete is NOT polymorphic.
+func TestAmbiguousConcreteSet(t *testing.T) {
+	meta := sweepInterfaceMeta()
+	pool := meta.StringPool
+	appFile := meta.Packages["app"].Files["app/main.go"]
+	appFile.Functions["several"] = &metadata.Function{
+		AssignmentMap: map[string][]metadata.Assignment{
+			"a": {
+				{ConcreteType: pool.Get("app.Dog")},
+				{ConcreteType: pool.Get("app.Cat")},
+			},
+		},
+	}
+	appFile.Functions["single"] = &metadata.Function{
+		AssignmentMap: map[string][]metadata.Assignment{
+			"a": {{ConcreteType: pool.Get("app.Dog")}},
+		},
+	}
+	m := NewRequestPatternMatcher(RequestBodyPattern{}, &APISpecConfig{}, NewContextProvider(meta), nil)
+	unary := metadata.NewCallArgument(meta)
+	unary.SetKind(metadata.KindUnary)
+	unary.X = sweepIdent(meta, "a")
+
+	node := sweepNode(sweepEdge(meta, "several", "app", "Decode", "json", "", ""))
+	if got := m.ambiguousConcreteSet(unary, node, "app.Animal"); len(got) != 2 {
+		t.Errorf("pointer-to-interface: got %v, want two members", got)
+	}
+	if got := m.ambiguousConcreteSet(sweepIdent(meta, "a"), node, "app.Animal"); len(got) != 2 {
+		t.Errorf("bare ident: got %v, want two members", got)
+	}
+
+	singleNode := sweepNode(sweepEdge(meta, "single", "app", "Decode", "json", "", ""))
+	if got := m.ambiguousConcreteSet(unary, singleNode, "app.Animal"); got != nil {
+		t.Errorf("one concrete is not polymorphic: got %v, want nil", got)
+	}
+
+	if got := m.ambiguousConcreteSet(nil, node, "app.Animal"); got != nil {
+		t.Errorf("nil arg: got %v, want nil", got)
+	}
+	if got := m.ambiguousConcreteSet(unary, nil, "app.Animal"); got != nil {
+		t.Errorf("nil node: got %v, want nil", got)
+	}
+	if got := m.ambiguousConcreteSet(sweepLit(meta, "x"), node, "app.Animal"); got != nil {
+		t.Errorf("literal arg: got %v, want nil", got)
+	}
+}

--- a/testdata/interface_request_body/main.go
+++ b/testdata/interface_request_body/main.go
@@ -2,8 +2,9 @@
 // when a handler decodes into a value whose static type is an interface, the
 // request schema should document the concrete type actually assigned to it,
 // mirroring what testdata/interface_response already does for responses. When
-// more than one concrete type is assigned the resolution is ambiguous, and the
-// interface is kept (honest over wrong).
+// more than one concrete type is assigned, the payload is genuinely one of them
+// and maps to `oneOf` (issue #201) — honest over wrong, without discarding what
+// is known.
 package main
 
 import (
@@ -43,7 +44,8 @@ func createCat(w http.ResponseWriter, r *http.Request) {
 }
 
 // createEither assigns two different concrete types on different branches, so
-// the concrete type is ambiguous — resolution keeps the Animal interface.
+// the payload is genuinely one of them — the schema is a `oneOf` of both
+// (issue #201), not a guessed single type and not the bare interface.
 func createEither(w http.ResponseWriter, r *http.Request) {
 	var a Animal = Dog{}
 	if r.URL.Query().Get("x") == "1" {

--- a/testdata/interface_request_body/main.go
+++ b/testdata/interface_request_body/main.go
@@ -83,6 +83,15 @@ func createPointer(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusCreated)
 }
 
+// createUnknown decodes into an interface with no traceable assignment, so
+// nothing narrows it and the interface itself is the honest answer. Its
+// component must still be emitted — pruning it would be over-correction.
+func createUnknown(w http.ResponseWriter, r *http.Request) {
+	var a Animal
+	_ = json.NewDecoder(r.Body).Decode(&a)
+	w.WriteHeader(http.StatusCreated)
+}
+
 func main() {
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /dogs", createDog)
@@ -91,5 +100,6 @@ func main() {
 	mux.HandleFunc("POST /concrete", createConcrete)
 	mux.HandleFunc("POST /via-param", createViaParam)
 	mux.HandleFunc("POST /pointer", createPointer)
+	mux.HandleFunc("POST /unknown", createUnknown)
 	_ = http.ListenAndServe(":8080", mux)
 }

--- a/testdata/interface_response/main.go
+++ b/testdata/interface_response/main.go
@@ -1,8 +1,9 @@
 // Package main exercises interface-typed response resolution: when a handler
 // encodes a value whose static type is an interface, the schema should document
 // the concrete type actually assigned to it (traceable statically), not the
-// empty interface. When more than one concrete type is assigned, resolution is
-// ambiguous and the interface is kept (honest over wrong).
+// empty interface. When more than one concrete type is assigned, the payload is
+// genuinely one of them and maps to `oneOf` (issue #201) — honest over wrong,
+// without discarding what is known.
 package main
 
 import (
@@ -40,7 +41,8 @@ func getCat(w http.ResponseWriter, r *http.Request) {
 }
 
 // getEither assigns two different concrete types on different branches, so the
-// concrete type is ambiguous — resolution keeps the Animal interface.
+// payload is genuinely one of them — the schema is a `oneOf` of both
+// (issue #201), not a guessed single type and not the bare interface.
 func getEither(w http.ResponseWriter, r *http.Request) {
 	var a Animal = Dog{}
 	if r.URL.Query().Get("x") == "1" {


### PR DESCRIPTION
Implements sub-feature (4) of #201 — interface-driven polymorphism.

When a handler assigns more than one concrete type to an interface-typed body, resolution could not narrow to a single type and fell back to the bare interface, whose schema is `{type: object}` — a schema that describes nothing:

```go
var a Animal = Dog{}
if cond { a = Cat{} }
json.NewDecoder(r.Body).Decode(&a)
```

```yaml
# before
schema: {$ref: '#/components/schemas/pkg_Animal'}   # pkg_Animal: {type: object}

# after
schema:
  oneOf:
    - $ref: '#/components/schemas/pkg_Cat'
    - $ref: '#/components/schemas/pkg_Dog'
```

The payload genuinely *is* one of the assigned types, and OpenAPI can say exactly that. This is the stronger form of "honest over wrong" (golden rule #7), not a relaxation of it: narrowing to one would be a guess, but discarding the set threw away what was known.

## The set was already there

`concreteFromEnclosingFunc` already walked every concrete type assigned to the variable and returned `""` on the second distinct one:

```go
if concrete != "" && concrete != ct {
    return "" // more than one concrete type assigned — ambiguous
}
```

That walk is now `concreteSetFromEnclosingFunc`, returning the sorted set. The single-value resolver is a thin wrapper over it, so unambiguous narrowing is byte-for-byte unchanged — the existing `TestSweepConcreteFrom*` tests pass untouched.

`Schema.OneOf` already existed in the type model and was never generated; each member is mapped through `mapGoTypeToOpenAPISchema` so it registers as a component and the refs resolve.

## Which set

Deliberately the types assigned **in this handler**, not every recorded implementer of the interface. Enumerating implementers the handler never assigns would over-claim. The two sets suit different shapes — an interface-typed *field* with no assignment to trace is the case for the implementer set — and keeping them distinct is intentional rather than incidental. Discussion on #201.

## Both directions

Request and response reach the same resolvers (#208 moved them onto `BasePatternMatcher`), so this fixes both at once. `testdata/interface_response` `/either` moves from a bare-interface `$ref` to `oneOf`, alongside `testdata/interface_request_body` `/either`.

**This is a deliberate change to already-shipped response output** — it is why the change is here rather than folded into #208, whose scope was a resolution fix. The two affected assertions and both fixture comments are updated to match.

## Tests

- Both structural tests assert the `oneOf` member refs in order, via a shared `assertOneOf` helper that also checks the schema carries no competing `$ref`.
- `TestConcreteSetFromEnclosingFunc` — duplicates collapse to one member, several are returned **sorted**, a non-interface original yields nothing, and the single-value wrapper still narrows only when unambiguous.
- `TestAmbiguousConcreteSet` — the pointer/ident argument shapes, and that a single concrete is *not* polymorphic.
- `TestOneOfSchemaFor` — fewer than two members yields nil, two register components and produce ordered refs.

A fixture deliberately assigns Dog-then-Cat so the sorted output proves the order does not follow assignment order (golden rule #1).

## Verification

Full suite green — only the two expected `/either` assertions needed flipping, with no other drift. `make lint` clean, coverage holding at 96.0%.

Generating two large real projects with and without the change produces **byte-identical** output: neither assigns two concretes to an interface body, so `oneOf` correctly never fires there.

## Reviewer note

The behaviour change to response output is the part worth a second look. Everything else is additive, but `/either` in `testdata/interface_response` had a passing assertion pinning the old fallback, and that assertion is now inverted.

Not included, and worth deciding separately: `discriminator`, and auto-populating the document's top-level `tags:`/`oneOf` declarations. #201 lists `discriminator` alongside `oneOf`; it needs a designated discriminator property, which the Go shapes here do not carry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved OpenAPI schema generation for request and response bodies that may contain multiple concrete types.
  * Polymorphic bodies are now represented with `oneOf` schemas listing the applicable concrete types.

* **Bug Fixes**
  * Corrected ambiguous interface handling so generated schemas no longer default to an overly broad interface schema.
  * Ensured duplicate concrete type assignments are consolidated and output deterministically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->