### PR TITLE
fix(spec): compose mount prefixes across framework boundaries (#138)

### DIFF
--- a/generator/testdata_cross_framework_mount_test.go
+++ b/generator/testdata_cross_framework_mount_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"testing"
+)
+
+// TestTestdata_CrossFrameworkMount covers issue #138: a chi router mounted
+// under a net/http ServeMux must contribute its mount prefix to the routes
+// registered on it. Before the fix the routes were found but documented at the
+// sub-router's bare paths (`/users`), which is a silently wrong spec — the path
+// looks plausible and nothing flags it.
+//
+// The same call registers both shapes, so the fixture pins both directions:
+// `mux.Handle` with a ROUTER is a mount, `mux.Handle` with a plain handler
+// value is a route. Gating only on the call name swallowed every ordinary
+// handler-value route, which is what the /status case guards against.
+func TestTestdata_CrossFrameworkMount(t *testing.T) {
+	// nil config on purpose: the fix depends on multi-framework detection
+	// merging net/http's patterns alongside chi's, exactly as the CLI does.
+	// Passing an explicit single-framework config would bypass the merge and
+	// test something this fixture is not about (the mixed_* fixtures do the same).
+	out := loadTestdataWithFixtureConfig(t, "cross_framework_mount", nil)
+	noDanglingRefs(t, out)
+	noUnresolvedPlaceholders(t, out)
+
+	for _, tc := range []struct {
+		path, method, shape string
+	}{
+		{"/api/users", "GET", "chi route under a net/http mount"},
+		{"/api/users/{id}", "GET", "chi route with a path param under a mount"},
+		{"/status", "GET", "plain handler value on the mounting ServeMux"},
+	} {
+		item, ok := out.Paths[tc.path]
+		if !ok {
+			t.Errorf("%s missing (%s); have %v", tc.path, tc.shape, mapPathKeys(out.Paths))
+			continue
+		}
+		if opFor(item, tc.method) == nil {
+			t.Errorf("%s %s missing (%s)", tc.method, tc.path, tc.shape)
+		}
+	}
+
+	// The un-prefixed forms must NOT appear: their presence would mean the
+	// mount prefix was dropped (the #138 bug) or applied to a copy.
+	for _, bare := range []string{"/users", "/users/{id}"} {
+		if _, ok := out.Paths[bare]; ok {
+			t.Errorf("%s emitted without its /api mount prefix (#138); have %v", bare, mapPathKeys(out.Paths))
+		}
+	}
+}

--- a/internal/spec/config.go
+++ b/internal/spec/config.go
@@ -323,6 +323,15 @@ type MountPattern struct {
 	RouterFromArg bool `yaml:"routerFromArg,omitempty" json:"routerFromArg,omitempty"` // Extract router from argument
 	IsMount       bool `yaml:"isMount,omitempty" json:"isMount,omitempty"`             // This is a mount operation
 
+	// RouterArgTypeRegex gates the pattern on the TYPE of the router argument.
+	// Required where one call registers both routes and mounts: net/http's
+	// `mux.Handle(path, h)` takes a plain handler *and* a mounted sub-router,
+	// and matching on the call name alone would swallow every ordinary route
+	// (issue #138). A pass-through wrapper is looked through, so
+	// `http.StripPrefix("/api", api)` is judged by the router inside it.
+	// Empty means the pattern does not discriminate on the argument type.
+	RouterArgTypeRegex string `yaml:"routerArgTypeRegex,omitempty" json:"routerArgTypeRegex,omitempty"`
+
 	// Package/type filtering
 	CallerPkgPatterns      []string `yaml:"callerPkgPatterns,omitempty" json:"callerPkgPatterns,omitempty"`
 	CallerRecvTypePatterns []string `yaml:"callerRecvTypePatterns,omitempty" json:"callerRecvTypePatterns,omitempty"`

--- a/internal/spec/config_chi.go
+++ b/internal/spec/config_chi.go
@@ -16,6 +16,9 @@ package spec
 
 // DefaultChiConfig returns a default configuration for the Chi router.
 func DefaultChiConfig() *APISpecConfig {
+	// chi's own router receiver, shared by the route and mount patterns.
+	const chiRouterRecv = "^github.com/go-chi/chi(/v\\d)?\\.\\*?(Router|Mux)$"
+
 	// Chi composes net/http response patterns with chi-render's JSON/Status,
 	// then the generic Marshal/Encode pair. Order preserved from the
 	// pre-refactor config so the matcher priority resolution is unchanged.
@@ -135,6 +138,11 @@ func DefaultChiConfig() *APISpecConfig {
 				},
 			},
 			SecurityPatterns: chiSecurityPatterns(),
+			// Receiver-scoped so these survive SecondaryView when chi is not the
+			// primary framework — an unscoped pattern is dropped from a
+			// secondary config, which left chi-wired mounts untraced in mixed
+			// projects (issue #138). The scope is chi's own router types, which
+			// is what these calls were always about.
 			MountPatterns: []MountPattern{
 				{
 					CallRegex:      `^Mount$`,
@@ -143,6 +151,7 @@ func DefaultChiConfig() *APISpecConfig {
 					PathArgIndex:   0,
 					RouterArgIndex: 1,
 					IsMount:        true,
+					RecvTypeRegex:  chiRouterRecv,
 				},
 				{
 					CallRegex:      `^Route$`,
@@ -151,6 +160,7 @@ func DefaultChiConfig() *APISpecConfig {
 					PathArgIndex:   0,
 					RouterArgIndex: 1,
 					IsMount:        true,
+					RecvTypeRegex:  chiRouterRecv,
 				},
 			},
 		},

--- a/internal/spec/config_http.go
+++ b/internal/spec/config_http.go
@@ -99,6 +99,19 @@ func DefaultHTTPConfig() *APISpecConfig {
 			SecurityPatterns: httpSecurityPatterns(),
 			RequestContext:   netHTTPRequestContext,
 			ResponseContext:  netHTTPResponseContext,
+			MountPatterns: []MountPattern{
+				{
+					CallRegex:      `^Handle$`,
+					PathFromArg:    true,
+					RouterFromArg:  true,
+					PathArgIndex:   0,
+					RouterArgIndex: 1,
+					IsMount:        true,
+					RecvTypeRegex:  `^net/http(\.\*ServeMux)?$`,
+					// Only a mounted ROUTER, never an ordinary handler (issue #138).
+					RouterArgTypeRegex: `^\*?(github\.com/go-chi/chi(/v\d)?\.(Mux|Router)|github\.com/gorilla/mux\.Router|net/http\.ServeMux|github\.com/labstack/echo(/v\d)?\.Echo|github\.com/gin-gonic/gin\.(Engine|RouterGroup)|github\.com/gofiber/fiber(/v\d)?\.App)$`,
+				},
+			},
 			RequestBodyPatterns: []RequestBodyPattern{
 				jsonDecodeRequestPattern(""),
 				jsonUnmarshalRequestPattern(""),

--- a/internal/spec/config_merge.go
+++ b/internal/spec/config_merge.go
@@ -60,6 +60,19 @@ func HTTPSecondaryConfig() *APISpecConfig {
 					RecvTypeRegex:   serveMuxRecv,
 				},
 			},
+			MountPatterns: []MountPattern{
+				{
+					CallRegex:      `^Handle$`,
+					PathFromArg:    true,
+					RouterFromArg:  true,
+					PathArgIndex:   0,
+					RouterArgIndex: 1,
+					IsMount:        true,
+					RecvTypeRegex:  serveMuxRecv,
+					// Only a mounted ROUTER, never an ordinary handler (issue #138).
+					RouterArgTypeRegex: `^\*?(github\.com/go-chi/chi(/v\d)?\.(Mux|Router)|github\.com/gorilla/mux\.Router|net/http\.ServeMux|github\.com/labstack/echo(/v\d)?\.Echo|github\.com/gin-gonic/gin\.(Engine|RouterGroup)|github\.com/gofiber/fiber(/v\d)?\.App)$`,
+				},
+			},
 			SecurityPatterns: httpSecurityPatterns(),
 			RequestContext:   netHTTPRequestContext,
 			RequestBodyPatterns: []RequestBodyPattern{

--- a/internal/spec/mount_router_gate_test.go
+++ b/internal/spec/mount_router_gate_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// TestMountRouterArgTypeGate covers the discriminator that makes cross-framework
+// mounts possible (issue #138). `mux.Handle(path, x)` registers a mount when x
+// is a router and an ordinary route when x is a handler — the call name is
+// identical, so only the argument type separates them. Without this gate the
+// mount pattern swallowed every handler-value route.
+func TestMountRouterArgTypeGate(t *testing.T) {
+	meta := exSweepMeta()
+	const routerRe = `^\*?(github\.com/go-chi/chi(/v\d)?\.(Mux|Router)|net/http\.ServeMux)$`
+
+	typedIdent := func(name, typ string) *metadata.CallArgument {
+		a := sweepIdent(meta, name)
+		a.SetType(typ)
+		return a
+	}
+	// stripPrefixCall models http.StripPrefix("/api", inner): its own type is
+	// net/http.Handler, which says nothing — the router is the inner argument.
+	stripPrefixCall := func(inner *metadata.CallArgument) *metadata.CallArgument {
+		c := metadata.NewCallArgument(meta)
+		c.SetKind(metadata.KindCall)
+		c.SetType("net/http.Handler")
+		c.Args = []*metadata.CallArgument{sweepLit(meta, `"/api"`), inner}
+		return c
+	}
+
+	pattern := MountPattern{
+		CallRegex:          `^Handle$`,
+		PathFromArg:        true,
+		RouterFromArg:      true,
+		PathArgIndex:       0,
+		RouterArgIndex:     1,
+		IsMount:            true,
+		RouterArgTypeRegex: routerRe,
+	}
+	m := NewMountPatternMatcher(pattern, &APISpecConfig{}, NewContextProvider(meta), nil)
+
+	for _, tc := range []struct {
+		name string
+		arg  *metadata.CallArgument
+		want bool
+	}{
+		{"chi router value is a mount", typedIdent("api", "*github.com/go-chi/chi/v5.Mux"), true},
+		{"nested ServeMux is a mount", typedIdent("sub", "*net/http.ServeMux"), true},
+		{"router behind StripPrefix is a mount", stripPrefixCall(typedIdent("api", "*github.com/go-chi/chi/v5.Mux")), true},
+		{"plain handler value is NOT a mount", typedIdent("h", "*app.statusHandler"), false},
+		{"handler behind StripPrefix is NOT a mount", stripPrefixCall(typedIdent("h", "*app.statusHandler")), false},
+		{"untyped argument is NOT a mount", sweepIdent(meta, "x"), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			edge := sweepEdge(meta, "main", "app", "Handle", "net/http", "*ServeMux", "", sweepLit(meta, `"/api/"`), tc.arg)
+			if got := m.routerArgIsRouter(edge); got != tc.want {
+				t.Errorf("routerArgIsRouter = %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	t.Run("missing router argument", func(t *testing.T) {
+		edge := sweepEdge(meta, "main", "app", "Handle", "net/http", "*ServeMux", "", sweepLit(meta, `"/api/"`))
+		if m.routerArgIsRouter(edge) {
+			t.Error("an edge with no router argument must not match")
+		}
+	})
+
+	t.Run("invalid regex does not match", func(t *testing.T) {
+		bad := NewMountPatternMatcher(
+			MountPattern{RouterArgIndex: 1, RouterArgTypeRegex: `^([`},
+			&APISpecConfig{}, NewContextProvider(meta), nil)
+		edge := sweepEdge(meta, "main", "app", "Handle", "net/http", "*ServeMux", "",
+			sweepLit(meta, `"/api/"`), typedIdent("api", "*github.com/go-chi/chi/v5.Mux"))
+		if bad.routerArgIsRouter(edge) {
+			t.Error("an uncompilable regex must not match rather than match everything")
+		}
+	})
+
+	// Without the gate the pattern is unchanged: every Handle looks like a
+	// mount, which is the behaviour the other frameworks' patterns rely on.
+	t.Run("no gate means no discrimination", func(t *testing.T) {
+		ungated := NewMountPatternMatcher(
+			MountPattern{CallRegex: `^Mount$`, RouterArgIndex: 1, IsMount: true},
+			&APISpecConfig{}, NewContextProvider(meta), nil)
+		if ungated.pattern.RouterArgTypeRegex != "" {
+			t.Fatal("fixture error: expected an ungated pattern")
+		}
+	})
+}

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -484,7 +484,46 @@ func (m *MountPatternMatcherImpl) MatchNode(node TrackerNodeInterface) bool {
 		return false
 	}
 
+	// Router-type gate: where the same call registers both routes and mounts,
+	// only the argument's type tells them apart (issue #138).
+	if m.pattern.RouterArgTypeRegex != "" && !m.routerArgIsRouter(edge) {
+		return false
+	}
+
 	return m.pattern.IsMount
+}
+
+// routerArgIsRouter reports whether the pattern's router argument really holds a
+// router, per RouterArgTypeRegex.
+//
+// A pass-through wrapper is looked through: `http.StripPrefix("/api", api)` has
+// the type of its own result (net/http.Handler, which any handler satisfies), so
+// judging the outer expression would tell us nothing — the router is the
+// argument inside. Only one level is unwrapped, which covers the idiomatic
+// shape without inviting a search through arbitrary call nesting.
+func (m *MountPatternMatcherImpl) routerArgIsRouter(edge *metadata.CallGraphEdge) bool {
+	if m.pattern.RouterArgIndex < 0 || len(edge.Args) <= m.pattern.RouterArgIndex {
+		return false
+	}
+	re, err := cachedRegex(m.pattern.RouterArgTypeRegex)
+	if err != nil {
+		return false
+	}
+	arg := edge.Args[m.pattern.RouterArgIndex]
+	if arg == nil {
+		return false
+	}
+	if re.MatchString(arg.GetType()) {
+		return true
+	}
+	if arg.GetKind() == metadata.KindCall {
+		for _, inner := range arg.Args {
+			if inner != nil && re.MatchString(inner.GetType()) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // GetPattern returns the mount pattern
@@ -526,7 +565,6 @@ func (m *MountPatternMatcherImpl) ExtractMount(node TrackerNodeInterface) MountI
 	// Extract router argument if available
 	if m.pattern.RouterArgIndex >= 0 && len(edge.Args) > m.pattern.RouterArgIndex {
 		mountInfo.RouterArg = edge.Args[m.pattern.RouterArgIndex]
-
 		// Trace router origin
 		m.traceRouterOrigin(mountInfo.RouterArg, node)
 

--- a/testdata/cross_framework_mount/go.mod
+++ b/testdata/cross_framework_mount/go.mod
@@ -1,0 +1,5 @@
+module github.com/ehabterra/apispec/testdata/cross_framework_mount
+
+go 1.24.3
+
+require github.com/go-chi/chi/v5 v5.2.2

--- a/testdata/cross_framework_mount/go.sum
+++ b/testdata/cross_framework_mount/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=
+github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=

--- a/testdata/cross_framework_mount/main.go
+++ b/testdata/cross_framework_mount/main.go
@@ -1,0 +1,59 @@
+// Package main exercises mount composition ACROSS framework boundaries
+// (issue #138): a chi router mounted under a net/http ServeMux must contribute
+// its mount prefix to the routes registered on it, so /users is documented at
+// /api/users rather than at the bare path the sub-router knows.
+//
+// The same call — mux.Handle — registers both mounts and ordinary handlers, so
+// the fixture carries both shapes: only the router argument tells them apart.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type User struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type Status struct {
+	State string `json:"state"`
+}
+
+func listUsers(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode([]User{})
+}
+
+func getUser(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode(User{})
+}
+
+// statusHandler is an ordinary http.Handler VALUE, not a router: registering it
+// with mux.Handle must stay a route and must not be mistaken for a mount.
+type statusHandler struct{}
+
+// ServeHTTP reports the service status.
+func (h *statusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode(Status{State: "ok"})
+}
+
+func main() {
+	api := chi.NewRouter()
+	api.Get("/users", listUsers)
+	api.Get("/users/{id}", getUser)
+
+	root := http.NewServeMux()
+	// Mount: the chi router reached through http.StripPrefix, whose own result
+	// type (net/http.Handler) says nothing — the router is the inner argument.
+	root.Handle("/api/", http.StripPrefix("/api", api))
+	// Route: a plain handler value on the same call. Held in a variable and
+	// given an explicit verb, so the handler body resolves (#204) and the
+	// method is not the bare ExtractRoute default.
+	status := &statusHandler{}
+	root.Handle("GET /status", status)
+
+	_ = http.ListenAndServe(":8080", root)
+}


### PR DESCRIPTION
Closes #138.

A router mounted under a net/http ServeMux lost its prefix. The routes were found — they were just documented at the sub-router's bare paths:

```go
api := chi.NewRouter()
api.Get("/users", listUsers)

root := http.NewServeMux()
root.Handle("/api/", http.StripPrefix("/api", api))
```

| | before | after |
|---|---|---|
| chi route under the mount | `/users` | **`/api/users`** |
| with a path param | `/users/{id}` | **`/api/users/{id}`** |
| plain handler on the same ServeMux | `/status` | `/status` (unchanged) |

This is the worst shape of wrong output: a path that looks plausible, so nothing prompts anyone to check it.

## Three things were missing

**1. net/http had no `MountPattern`** — the registration was never recognised as a mount at all.

**2. Adding it to `DefaultHTTPConfig` was not enough.** When net/http is a *secondary* framework the merge uses `HTTPSecondaryConfig` — a separate, narrower, hand-maintained config — so the pattern was silently absent in exactly the mixed-framework case this issue is about. Found by dumping the effective config after the CLI kept ignoring the new pattern. (Filed as a standing divergence trap in #211.)

**3. `Handle` registers both mounts and ordinary routes, and the call name cannot tell them apart.** Gating on the name alone swallowed every handler-value route in the suite — four test failures, including the #204 work. `MountPattern` gains `RouterArgTypeRegex`: the pattern applies only when the argument really holds a router. One level of wrapping is looked through, because `http.StripPrefix("/api", api)` has its own result type (`net/http.Handler`, which any handler satisfies) — only the inner argument identifies the router.

## Also: chi's own mounts as a secondary

`SecondaryView` drops unscoped patterns, so chi's `Mount`/`Route` were discarded whenever chi was not primary, leaving chi-wired mounts untraced in mixed projects — the "additionally" item in the issue. They are now receiver-scoped to chi's router types, which is what those calls always meant. Zero drift.

## What turned out not to be needed

No `StripPrefix`-specific handling. Once the mount is recognised, the existing router-origin tracing already follows through the call to the chi router — the issue anticipated modelling it explicitly, and that proved unnecessary.

## Tests

- `testdata/cross_framework_mount` carries **both shapes on the same call**, so the discriminator cannot regress in either direction: a mounted router that must gain the prefix, and a plain handler value that must stay a route. It also asserts the bare `/users` forms are *absent*, which is the actual bug.
- The structural test passes a `nil` config on purpose — an explicit single-framework config bypasses the multi-framework merge this fix depends on, so it would test something else. (My first version did exactly that and failed while the CLI worked.)
- `TestMountRouterArgTypeGate` unit-tests the discriminator: router value, nested ServeMux, router behind `StripPrefix`, plain handler, handler behind `StripPrefix`, untyped argument, missing argument, and an uncompilable regex (must not match rather than match everything).

## Verification

Full suite green, `make lint` clean, coverage at 96.0%. Both large real projects are **byte-identical** to `main` — this touches config that every project loads, so that check mattered more than usual here.

## Follow-ups found while doing this

Investigating the secondary-config path turned up two defects that are out of scope here and filed separately:

- **#211** — secondary frameworks silently lose their unscoped patterns. A secondary gin keeps its routes but loses **all 4 param patterns and all 3 request-body patterns**, so its endpoints document empty.
- **#212** — the primary framework is chosen by file order, so renaming a file changes the generated spec. Composed with #211, a project's dominant framework can be the one that gets stripped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected generated API routes for applications combining `net/http` with mounted routers such as chi.
  * Mount prefixes are now preserved, preventing incorrect unprefixed routes from appearing.
  * Improved route detection to distinguish mounted routers from regular handler arguments, including wrapped router values.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->