### PR TITLE
fix(spec): make the generated spec independent of framework file order (#212)

### DIFF
--- a/generator/primary_framework_order_test.go
+++ b/generator/primary_framework_order_test.go
@@ -1,0 +1,171 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestPrimaryFrameworkOrderInvariance covers issue #212: the generated spec must
+// not depend on which framework the detector happens to see first.
+//
+// Detection walks files in lexical order and treats the first framework it finds
+// as the primary one, so the choice is a property of the *filenames*, not of the
+// API. That is only acceptable if being secondary costs a framework nothing —
+// which is the property under test here, and which was false twice over: unscoped
+// patterns were dropped (#211) and ExternalTypes were dropped (#212), so a
+// `git mv` could quietly rewrite the documentation.
+//
+// The test generates the multi-framework fixture twice from two copies whose
+// framework files are renamed to reverse the sort order, and compares the two
+// specs in full. Not a snapshot: it asserts A == B, so schema evolution moves
+// both sides and only an asymmetry fails.
+func TestPrimaryFrameworkOrderInvariance(t *testing.T) {
+	const fixture = "secondary_framework_params"
+	src := filepath.Join("..", "testdata", fixture)
+
+	// The fixture's own names put chi first (gin secondary); swapping the
+	// prefixes puts gin first (chi secondary). Same bytes either way — only the
+	// order the detector meets them in changes.
+	chiPrimary := copyFixture(t, src, map[string]string{
+		"a_admin_chi.go": "a_admin_chi.go",
+		"z_api_gin.go":   "z_api_gin.go",
+	})
+	ginPrimary := copyFixture(t, src, map[string]string{
+		"a_admin_chi.go": "z_admin_chi.go",
+		"z_api_gin.go":   "a_api_gin.go",
+	})
+
+	chiFirst, err := NewGenerator(nil).GenerateFromDirectory(chiPrimary)
+	if err != nil {
+		t.Fatalf("GenerateFromDirectory(chi first): %v", err)
+	}
+	ginFirst, err := NewGenerator(nil).GenerateFromDirectory(ginPrimary)
+	if err != nil {
+		t.Fatalf("GenerateFromDirectory(gin first): %v", err)
+	}
+
+	// Sanity: the run really did exercise both orderings, i.e. the fixture still
+	// has one file per framework and both frameworks still route. Without this,
+	// a fixture that stopped importing chi would make the comparison vacuous.
+	for _, want := range []string{"/admin/health", "/items", "/items/status"} {
+		if _, ok := chiFirst.Paths[want]; !ok {
+			t.Fatalf("fixture no longer documents %s; have %v", want, mapPathKeys(chiFirst.Paths))
+		}
+	}
+
+	a, err := yaml.Marshal(chiFirst)
+	if err != nil {
+		t.Fatalf("marshal chi-first spec: %v", err)
+	}
+	b, err := yaml.Marshal(ginFirst)
+	if err != nil {
+		t.Fatalf("marshal gin-first spec: %v", err)
+	}
+	if normalizeFuncLitIDs(string(a)) != normalizeFuncLitIDs(string(b)) {
+		t.Errorf("spec depends on which framework sorts first (#212):\n%s",
+			firstDiffLines(normalizeFuncLitIDs(string(a)), normalizeFuncLitIDs(string(b))))
+	}
+}
+
+// normalizeFuncLitIDs strips the file path out of a closure handler's
+// operationId (`…FuncLit:/abs/path/file.go:20:25` -> `…FuncLit:<pos>`).
+//
+// That path is a separate, real defect — the operationId of any closure handler
+// carries the *absolute* source path, so the same code documents differently on
+// two machines — filed as #216 rather than absorbed here. It has to be
+// normalized for this test because renaming a file is exactly what the test
+// does, so the id would differ for a reason that has nothing to do with which
+// framework is primary. Delete this when #216 is fixed.
+func normalizeFuncLitIDs(spec string) string {
+	return funcLitPathRE.ReplaceAllString(spec, "FuncLit:<pos>")
+}
+
+var funcLitPathRE = regexp.MustCompile(`FuncLit:\S+`)
+
+// copyFixture copies a fixture project into a temp dir, renaming files per the
+// given map (unlisted files keep their name). Test writes stay inside
+// t.TempDir() — a `go test` run must never dirty the working tree.
+func copyFixture(t *testing.T, src string, rename map[string]string) string {
+	t.Helper()
+	dst := t.TempDir()
+
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		t.Fatalf("ReadDir(%s): %v", src, err)
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		// Only the project's own sources and module files; openapi*.yaml and
+		// used-config.yaml are gitignored compare artifacts that would change
+		// what is being generated.
+		if !strings.HasSuffix(name, ".go") && name != "go.mod" && name != "go.sum" {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(src, name))
+		if err != nil {
+			t.Fatalf("ReadFile(%s): %v", name, err)
+		}
+		out := name
+		if renamed, ok := rename[name]; ok {
+			out = renamed
+		}
+		if err := os.WriteFile(filepath.Join(dst, out), data, 0o600); err != nil {
+			t.Fatalf("WriteFile(%s): %v", out, err)
+		}
+	}
+	// A rename map naming a file the fixture no longer has means the test is
+	// pointing at something stale, and the "invariance" it proves is empty.
+	for from := range rename {
+		if _, err := os.Stat(filepath.Join(src, from)); err != nil {
+			t.Fatalf("rename source %q missing from fixture %s", from, src)
+		}
+	}
+	return dst
+}
+
+// firstDiffLines reports the first differing line with a little context, so a
+// failure names the drifting field instead of printing two whole specs.
+func firstDiffLines(a, b string) string {
+	al, bl := strings.Split(a, "\n"), strings.Split(b, "\n")
+	for i := 0; i < len(al) || i < len(bl); i++ {
+		x, y := "", ""
+		if i < len(al) {
+			x = al[i]
+		}
+		if i < len(bl) {
+			y = bl[i]
+		}
+		if x != y {
+			var ctx strings.Builder
+			for j := max(0, i-3); j < i; j++ {
+				ctx.WriteString("  " + al[j] + "\n")
+			}
+			ctx.WriteString("- chi first: " + x + "\n")
+			ctx.WriteString("+ gin first: " + y + "\n")
+			return ctx.String()
+		}
+	}
+	return "(no line-level difference)"
+}

--- a/generator/testdata_secondary_framework_params_test.go
+++ b/generator/testdata_secondary_framework_params_test.go
@@ -78,6 +78,27 @@ func TestTestdata_SecondaryFrameworkParams(t *testing.T) {
 		t.Errorf("POST /items 201 = %q, want Item (#211)", ref)
 	}
 
+	// gin's own ExternalTypes entry for gin.H, which SecondaryView used to drop
+	// along with the rest of the non-pattern config (#212). noUnresolvedPlaceholders
+	// above is what actually fails when it regresses; this pins the mapped shape.
+	status := opFor(out.Paths["/items/status"], "GET")
+	if status == nil {
+		t.Fatalf("GET /items/status missing; have %v", mapPathKeys(out.Paths))
+	}
+	okResp, found := status.Responses["200"]
+	if !found {
+		t.Fatalf("GET /items/status: 200 response missing; have %v", responseCodes(status))
+	}
+	ref := bodyRef(okResp.Content)
+	if !strings.HasSuffix(ref, "_gin_H") {
+		t.Errorf("GET /items/status 200 = %q, want the gin.H component (#212)", ref)
+	}
+	if schema := out.Components.Schemas[strings.TrimPrefix(ref, "#/components/schemas/")]; schema == nil {
+		t.Errorf("gin.H component %q not defined (#212)", ref)
+	} else if schema.Type != "object" {
+		t.Errorf("gin.H component type = %q, want object (#212)", schema.Type)
+	}
+
 	// gin's Param, on the second operation.
 	get := opFor(out.Paths["/items/{id}"], "GET")
 	if get == nil {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -568,12 +568,29 @@ func (e *Engine) GenerateOpenAPI() (*spec.OpenAPISpec, error) {
 	// Detect frameworks and load configuration. The first-seen framework is
 	// the primary (whose Defaults/Info and unscoped helper patterns apply);
 	// any further recognised frameworks merge in below as scoped views.
+	//
+	// "First-seen" is file-walk order, so it is a property of the filenames
+	// rather than of the API (issue #212). That is only tolerable because the
+	// merge is symmetric for extraction: every framework's own patterns are
+	// receiver-scoped (#211) and its ExternalTypes are carried, so a framework
+	// documents the same surface whether or not it leads. What the primary
+	// still decides is Info/Defaults — identical across the built-in presets
+	// today. TestPrimaryFrameworkOrderInvariance pins the property, so a preset
+	// that reintroduces a primary-only asymmetry fails there rather than in
+	// someone's spec after a rename.
 	detector := core.NewFrameworkDetector()
 	frameworks, err := detector.DetectAll(e.config.moduleRoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to detect framework: %w", err)
 	}
 	framework := frameworks[0]
+	if len(frameworks) > 1 {
+		// Which framework led was previously invisible; if a primary-only
+		// asymmetry ever does reach the output, this is what makes it
+		// diagnosable instead of mysterious.
+		NewVerboseLogger(e.config.Verbose).Printf("Frameworks detected: %v (primary: %s, merged as scoped views: %v)\n",
+			frameworks, framework, frameworks[1:])
+	}
 
 	var apispecConfig *spec.APISpecConfig
 	if e.config.APISpecConfig != nil {

--- a/internal/spec/config_merge.go
+++ b/internal/spec/config_merge.go
@@ -132,6 +132,14 @@ func HTTPSecondaryConfig() *APISpecConfig {
 // not be traced — scoping those patterns in their home config is the
 // eventual fix (tracked with cross-framework mount composition in issue
 // #138). The receiving config is untouched; a filtered copy is returned.
+//
+// ExternalTypes survive unfiltered: they are keyed by a fully-qualified type
+// name (`github.com/gin-gonic/gin.H`), which is a scope no weaker than a
+// receiver constraint — the entry can only ever claim its own framework's
+// type. Dropping them was the last thing that still made the *output* depend
+// on which framework happened to be primary (issue #212): a gin.H body
+// documented as a config-mapped object when gin led, and as the generic
+// "External or unresolved type" fallback when it did not.
 func SecondaryView(cfg *APISpecConfig) *APISpecConfig {
 	if cfg == nil {
 		return nil
@@ -139,6 +147,9 @@ func SecondaryView(cfg *APISpecConfig) *APISpecConfig {
 	out := &APISpecConfig{Framework: FrameworkConfig{
 		RequestContext: cfg.Framework.RequestContext,
 	}}
+	// Copied rather than aliased so an append by a later caller cannot reach
+	// the source config's backing array.
+	out.ExternalTypes = append(out.ExternalTypes, cfg.ExternalTypes...)
 	for _, p := range cfg.Framework.RoutePatterns {
 		if p.RecvType != "" || p.RecvTypeRegex != "" {
 			out.Framework.RoutePatterns = append(out.Framework.RoutePatterns, p)
@@ -175,8 +186,11 @@ func SecondaryView(cfg *APISpecConfig) *APISpecConfig {
 // MergeFrameworkConfigs layers secondary framework configs under the primary:
 // pattern lists are appended in order with first-occurrence-wins dedupe (the
 // primary's variant of a pattern always beats a secondary's), and the request
-// context accumulates unique type regexes and body accessors. Info, Defaults,
-// overrides and mappings stay the primary's alone. The primary is mutated and
+// context accumulates unique type regexes and body accessors. ExternalTypes
+// merge the same way, keyed by type name (issue #212) — every other framework
+// preset carries only its own types, so the union is what "both frameworks are
+// present" means. Info, Defaults, overrides and mappings stay the primary's
+// alone. The primary is mutated and
 // returned; a nil primary returns nil (mirroring SecondaryView's guard, since
 // both are exported through the public spec package).
 func MergeFrameworkConfigs(primary *APISpecConfig, secondaries ...*APISpecConfig) *APISpecConfig {
@@ -206,6 +220,10 @@ func MergeFrameworkConfigs(primary *APISpecConfig, secondaries ...*APISpecConfig
 	seenSec := map[string]bool{}
 	for _, p := range primary.Framework.SecurityPatterns {
 		seenSec[patternKey(p.CallRegex, p.RecvTypeRegex, string(p.Scope))] = true
+	}
+	seenExt := map[string]bool{}
+	for _, e := range primary.ExternalTypes {
+		seenExt[e.Name] = true
 	}
 
 	for _, sec := range secondaries {
@@ -246,6 +264,14 @@ func MergeFrameworkConfigs(primary *APISpecConfig, secondaries ...*APISpecConfig
 			if k := patternKey(p.CallRegex, p.RecvTypeRegex, string(p.Scope)); !seenSec[k] {
 				seenSec[k] = true
 				primary.Framework.SecurityPatterns = append(primary.Framework.SecurityPatterns, p)
+			}
+		}
+		// Type-name-keyed, so a secondary's entry cannot shadow a type it does
+		// not own; the primary's entry still wins a genuine name collision.
+		for _, e := range sec.ExternalTypes {
+			if !seenExt[e.Name] {
+				seenExt[e.Name] = true
+				primary.ExternalTypes = append(primary.ExternalTypes, e)
 			}
 		}
 		primary.Framework.RequestContext.TypeRegexes = appendUniqueStrings(

--- a/internal/spec/config_merge_test.go
+++ b/internal/spec/config_merge_test.go
@@ -135,6 +135,59 @@ func TestMergeFrameworkConfigs(t *testing.T) {
 		}
 	})
 
+	t.Run("framework ExternalTypes survive and merge by name (#212)", func(t *testing.T) {
+		// gin.H and fiber.Map are known only to their own framework's preset. A
+		// secondary that loses them documents its map bodies as the generic
+		// "External or unresolved type" placeholder, which made the output
+		// depend on which framework the detector happened to see first.
+		if got := SecondaryView(DefaultGinConfig()).ExternalTypes; len(got) == 0 {
+			t.Error("gin: SecondaryView dropped ExternalTypes (gin.H)")
+		}
+		if got := SecondaryView(DefaultFiberConfig()).ExternalTypes; len(got) == 0 {
+			t.Error("fiber: SecondaryView dropped ExternalTypes (fiber.Map)")
+		}
+
+		// A chi-primary project that also imports gin must end up knowing gin.H.
+		primary := DefaultChiConfig()
+		MergeFrameworkConfigs(primary, SecondaryView(DefaultGinConfig()))
+		var foundGinH bool
+		for _, e := range primary.ExternalTypes {
+			if e.Name == "github.com/gin-gonic/gin.H" {
+				foundGinH = true
+			}
+		}
+		if !foundGinH {
+			t.Errorf("gin.H missing after merge into a chi primary; have %v", primary.ExternalTypes)
+		}
+
+		// Merging twice must not duplicate, and the primary's own entry wins a
+		// genuine name collision.
+		before := len(primary.ExternalTypes)
+		MergeFrameworkConfigs(primary, SecondaryView(DefaultGinConfig()))
+		if got := len(primary.ExternalTypes); got != before {
+			t.Errorf("ExternalTypes grew %d -> %d on a repeat merge; must dedupe by name", before, got)
+		}
+		primary.ExternalTypes = []ExternalType{{
+			Name:        "github.com/gin-gonic/gin.H",
+			Description: "primary's own entry",
+		}}
+		MergeFrameworkConfigs(primary, SecondaryView(DefaultGinConfig()))
+		if len(primary.ExternalTypes) != 1 || primary.ExternalTypes[0].Description != "primary's own entry" {
+			t.Errorf("secondary's entry overrode the primary's for the same type name: %v", primary.ExternalTypes)
+		}
+
+		// The view holds a copy, not an alias. Spare capacity in the source is
+		// what makes aliasing observable at all: an append through an aliased
+		// view would write into the source's backing array.
+		src := &APISpecConfig{ExternalTypes: make([]ExternalType, 1, 4)}
+		src.ExternalTypes[0] = ExternalType{Name: "own"}
+		//nolint:gocritic // appendAssign: writing through the view's slice is the test.
+		_ = append(SecondaryView(src).ExternalTypes, ExternalType{Name: "clobber"})
+		if spare := src.ExternalTypes[:2]; spare[1].Name == "clobber" {
+			t.Error("SecondaryView aliased the source config's ExternalTypes backing array")
+		}
+	})
+
 	t.Run("nil secondaries are ignored", func(t *testing.T) {
 		primary := DefaultMuxConfig()
 		before := len(primary.Framework.RoutePatterns)

--- a/testdata/secondary_framework_params/z_api_gin.go
+++ b/testdata/secondary_framework_params/z_api_gin.go
@@ -32,11 +32,21 @@ func getItem(c *gin.Context) {
 	c.JSON(http.StatusOK, Item{})
 }
 
+// itemStatus answers with a gin.H map. gin.H is only understood through gin's
+// own ExternalTypes entry, which SecondaryView used to drop along with the rest
+// of the non-pattern config — so this body documented itself as the generic
+// "External or unresolved type" placeholder whenever gin was not the primary
+// framework (issue #212).
+func itemStatus(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"ok": true})
+}
+
 func main() {
 	_ = adminRouter()
 
 	r := gin.New()
 	r.POST("/items", createItem)
 	r.GET("/items/:id", getItem)
+	r.GET("/items/status", itemStatus)
 	_ = r.Run(":8080")
 }


### PR DESCRIPTION
Closes #212. **Stacked on #215** (`fix/211-scope-secondary-patterns`) — base is that branch, so the diff here is just this commit; GitHub retargets to `main` when #215 merges.

The primary framework is whichever one the detector meets first in file-walk order, so it is a property of the *filenames*, not of the API. #215 made extraction symmetric by receiver-scoping every framework's patterns; this closes the last thing that still made the output depend on which framework led, and adds the property test the issue asks for.

## What was left

`SecondaryView` filters a framework config to its merge-safe subset, and it dropped `ExternalTypes` along with the unscoped patterns. Only gin and fiber carry any (`gin.H`, `fiber.Map`), so a `gin.H` body documented itself two different ways depending on filenames:

| gin secondary (chi file sorts first) | gin primary |
|---|---|
| <pre>github_com_gin-gonic_gin_H:<br>  type: object<br>  description: 'External or unresolved<br>    type: github.com/gin-gonic/gin.H'</pre> | <pre>github_com_gin-gonic_gin_H:<br>  type: object</pre> |

`ExternalTypes` are keyed by a **fully-qualified type name** — a scope no weaker than a receiver constraint, since the entry can only ever claim its own framework's type — so they survive the view unfiltered, and merge by name with the primary winning a genuine collision.

## The property test

`TestPrimaryFrameworkOrderInvariance` generates the multi-framework fixture twice, from two `t.TempDir()` copies whose framework files are renamed to reverse the sort order, and compares the two specs **in full**. It asserts `A == B` rather than either against a snapshot, so ordinary schema evolution moves both sides and only an asymmetry fails.

It fails without the `ExternalTypes` change, and so does the existing #211 structural test (`noUnresolvedPlaceholders` catches the placeholder) — verified by reverting just `config_merge.go`:

```
--- FAIL: TestPrimaryFrameworkOrderInvariance
    spec depends on which framework sorts first (#212):
        - chi first:   description: 'External or unresolved type: github.com/gin-gonic/gin.H'
        + gin first:
--- FAIL: TestTestdata_SecondaryFrameworkParams
    unresolved-type placeholder leaked into components: github_com_gin-gonic_gin_H
```

The fixture gains one endpoint (`GET /items/status`, answering `gin.H`) so a fixture — not only a unit test — covers the retention. Unit coverage at the changed layer is in `TestMergeFrameworkConfigs`: view keeps gin's and fiber's entries, merge into a chi primary yields `gin.H`, repeat merges dedupe, the primary's entry wins a name collision, and the view is a copy rather than an alias (checked through spare capacity, where aliasing is actually observable).

## Also: the choice is no longer silent

With `--verbose` the engine now names the primary and the frameworks merged as scoped views. Which framework led was previously invisible, which is what made this class of defect mysterious instead of diagnosable.

## What I did *not* do, and why

The issue offers **(1) rank by usage** as a stopgap and **(3) make the merge symmetric** as the real fix, noting (3) makes (1) unnecessary. With #215 + this, (3) holds: what the primary still decides is `Info`/`Defaults`, and those are identical across all six built-in presets today (`stdDefaults(200)`; chi's `defaultResponseStatus` is also 200). So counting route registrations to pick a "dominant" framework would add a metadata-order dependency to buy nothing measurable — and the invariance test is what keeps that true: a preset that reintroduces a primary-only asymmetry fails there rather than in someone's spec after a `git mv`.

## Found while doing this — filed, not absorbed

**#216** — a closure handler's `operationId` embeds the **absolute** source path:

```yaml
operationId: …secondary_framework_params.FuncLit:/Users/me/src/apispec/testdata/…/a_admin_chi.go:20:25
```

so the same code produces different specs on two machines, and renaming a file changes every closure operationId in it. That is a genuine reason a rename changes the spec today, independent of framework order, and it is a metadata-fact identity key rather than a formatting choice — so it gets its own issue. This test normalizes `FuncLit:` ids and says why; the normalizer is deleted when #216 is fixed.

## Verification

Full suite green, `golangci-lint` 0 issues, `gofmt`/`vet` clean. No changes to any golden or existing expectation — the only output difference anywhere is the `gin.H` placeholder disappearing when gin is secondary, which is the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
