### PR TITLE
feat(spec): follow route registration through func-typed struct fields (#143)

### DIFF
--- a/generator/func_field_parity_test.go
+++ b/generator/func_field_parity_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"sort"
+	"testing"
+)
+
+// TestFuncFieldEngineParity runs the func-field dispatch fixtures (#143) through
+// BOTH tracker engines and requires the same routes, with the same operations and
+// response statuses, from each.
+//
+// The two engines add children in different places — the lazy tree expands by
+// key, the eager tree materializes nodes — so a capability landing in one is
+// silently absent from the other. That is not hypothetical here: the eager side
+// initially found the routes and documented them *empty*, because a node builds
+// its own callees while its ARGUMENTS are built by the parent loop, and the new
+// attachment point had to do that itself. Comparing statuses per operation is
+// what catches that class of divergence; comparing path names alone would not.
+func TestFuncFieldEngineParity(t *testing.T) {
+	for _, fixture := range []string{"cli_action_routes", "cli_action_cross_package"} {
+		t.Run(fixture, func(t *testing.T) {
+			// nil config on purpose: these fixtures rely on framework detection
+			// and the multi-framework merge, which an explicit config bypasses.
+			lazy := generateWithTracker(t, fixture, nil, true)
+			eager := generateWithTracker(t, fixture, nil, false)
+
+			lazyPaths, eagerPaths := mapPathKeys(lazy.Paths), mapPathKeys(eager.Paths)
+			sort.Strings(lazyPaths)
+			sort.Strings(eagerPaths)
+			if len(lazyPaths) == 0 {
+				t.Fatalf("lazy documented no paths at all — the fixture stopped exercising #143")
+			}
+			if len(lazyPaths) != len(eagerPaths) {
+				t.Fatalf("paths differ between engines:\n lazy:  %v\n eager: %v", lazyPaths, eagerPaths)
+			}
+			for i := range lazyPaths {
+				if lazyPaths[i] != eagerPaths[i] {
+					t.Fatalf("paths differ between engines:\n lazy:  %v\n eager: %v", lazyPaths, eagerPaths)
+				}
+			}
+
+			for _, path := range lazyPaths {
+				for _, method := range []string{"GET", "POST", "PUT", "PATCH", "DELETE"} {
+					lazyOp := opFor(lazy.Paths[path], method)
+					eagerOp := opFor(eager.Paths[path], method)
+					if (lazyOp == nil) != (eagerOp == nil) {
+						t.Errorf("%s %s: lazy=%v eager=%v", method, path, lazyOp != nil, eagerOp != nil)
+						continue
+					}
+					if lazyOp == nil {
+						continue
+					}
+					// Statuses, not schemas: the question is whether the handler
+					// body was reached at all, which is what diverged.
+					if len(lazyOp.Responses) != len(eagerOp.Responses) {
+						t.Errorf("%s %s: response count lazy=%d eager=%d",
+							method, path, len(lazyOp.Responses), len(eagerOp.Responses))
+					}
+					for status := range lazyOp.Responses {
+						if _, ok := eagerOp.Responses[status]; !ok {
+							t.Errorf("%s %s: status %q in lazy but not eager", method, path, status)
+						}
+					}
+					if (lazyOp.RequestBody == nil) != (eagerOp.RequestBody == nil) {
+						t.Errorf("%s %s: requestBody lazy=%v eager=%v",
+							method, path, lazyOp.RequestBody != nil, eagerOp.RequestBody != nil)
+					}
+				}
+			}
+		})
+	}
+}

--- a/generator/testdata_cli_action_cross_package_test.go
+++ b/generator/testdata_cli_action_cross_package_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import "testing"
+
+// TestTestdata_CLIActionCrossPackage is the multi-package half of issue #143, and
+// the shape real projects actually have: the command type, the dispatcher, main,
+// and the route registration all live in different packages.
+//
+// This is deliberately separate from the single-package fixture because every
+// step of the resolution changes when a package boundary is crossed, and the
+// single-package form hides all of it (golden rule #10):
+//
+//   - the literal names its type through a selector (`clipkg.Command{…}`), so the
+//     type's owner is not the package writing the literal;
+//   - an *elided* element literal (`{Name: "admin", Action: srv.RunAdmin}` inside
+//     `[]*clipkg.Command{…}`) states no type at all and has to inherit both the
+//     name and the package from the slice;
+//   - the Action values are a cross-package function (`web.RunWeb`, reached
+//     through the file's import table since a rendered value only carries the
+//     source-level qualifier) and a method value (`srv.RunAdmin`, whose key needs
+//     the receiver type as well as the package).
+//
+// Each of those was a separate zero-route failure while this was built.
+func TestTestdata_CLIActionCrossPackage(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "cli_action_cross_package", nil)
+	noDanglingRefs(t, out)
+	noUnresolvedPlaceholders(t, out)
+
+	// Cross-package function value, reached from a package-level command var.
+	users, ok := out.Paths["/users"]
+	if !ok {
+		t.Fatalf("/users missing — a cross-package Action value was not resolved (#143); have %v",
+			mapPathKeys(out.Paths))
+	}
+	get := opFor(users, "GET")
+	post := opFor(users, "POST")
+	if get == nil || post == nil {
+		t.Fatalf("/users: want GET and POST, got get=%v post=%v", get != nil, post != nil)
+	}
+	if _, hasOK := get.Responses["200"]; !hasOK {
+		t.Errorf("GET /users: 200 response missing — the handler body was not reached; have %v",
+			keysOf(get.Responses))
+	}
+	if post.RequestBody == nil {
+		t.Error("POST /users: requestBody missing — the handler body was not reached")
+	}
+
+	// Method value on a receiver, through an elided element literal.
+	report := opFor(out.Paths["/admin/report"], "GET")
+	if report == nil {
+		t.Fatalf("GET /admin/report missing — a method-value Action was not resolved (#143); have %v",
+			mapPathKeys(out.Paths))
+	}
+	if _, hasOK := report.Responses["200"]; !hasOK {
+		t.Errorf("GET /admin/report: 200 response missing; have %v", keysOf(report.Responses))
+	}
+}

--- a/generator/testdata_cli_action_routes_test.go
+++ b/generator/testdata_cli_action_routes_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	intspec "github.com/ehabterra/apispec/internal/spec"
+)
+
+// TestTestdata_CLIActionRoutes covers issue #143: route registration reached from
+// main only through a function value stored in a composite-literal field — the
+// urfave/cli `Command{Action: runWeb}` shape — is now followed.
+//
+// This is the defect that made apispec report **zero routes** for gitea. Tracker
+// roots are main functions, and no static call edge crosses the dispatcher hop:
+// the function value goes into a struct field and the library calls it back as
+// `c.Action()`. The registration edges were in metadata all along; nothing
+// reached them.
+//
+// The fixture carries the three shapes that occur in the wild, and asserts all
+// three resolve — including the handler bodies behind them, since a route found
+// but documented empty is barely better than a route missed:
+//
+//   - a literal nested inside a function's own composite literal (`/users`);
+//   - a package-level var holding the command, gitea's own form (`/admin/stats`);
+//   - an inline closure as the Action (`/metrics`).
+//
+// All three commands' routes appear together, which is the intended reading: each
+// is genuinely invoked for its own subcommand, so their union is the surface the
+// binary serves. That is a stronger statement than picking one and is why
+// several candidates for one field is not treated as ambiguity to guess at.
+func TestTestdata_CLIActionRoutes(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "cli_action_routes", nil)
+	noDanglingRefs(t, out)
+	noUnresolvedPlaceholders(t, out)
+
+	// 1. The nested in-function literal: {Name: "web", Action: runWeb}.
+	users, ok := out.Paths["/users"]
+	if !ok {
+		t.Fatalf("/users missing — the Action field hop was not followed (#143); have %v", mapPathKeys(out.Paths))
+	}
+	get := opFor(users, "GET")
+	post := opFor(users, "POST")
+	if get == nil || post == nil {
+		t.Fatalf("/users: want GET and POST, got get=%v post=%v", get != nil, post != nil)
+	}
+	// The handler bodies have to come with the routes: reaching the registration
+	// but not what it registers would leave every operation empty.
+	if _, hasOK := get.Responses["200"]; !hasOK {
+		t.Errorf("GET /users: 200 response missing — the handler body was not reached; have %v", keysOf(get.Responses))
+	}
+	if post.RequestBody == nil {
+		t.Error("POST /users: requestBody missing — the handler body was not reached")
+	} else if ref := contentSchemaRef(post.RequestBody.Content); !strings.HasSuffix(ref, "_User") {
+		t.Errorf("POST /users requestBody = %q, want User", ref)
+	}
+	if created, hasCreated := post.Responses["201"]; !hasCreated {
+		t.Errorf("POST /users: 201 response missing; have %v", keysOf(post.Responses))
+	} else if ref := contentSchemaRef(created.Content); !strings.HasSuffix(ref, "_User") {
+		t.Errorf("POST /users 201 = %q, want User", ref)
+	}
+
+	// 2. gitea's shape: the command literal in a package-level var. Its
+	// initializer is not recorded as a CallArgument anywhere, so this resolves
+	// through a different source than the case above and needs its own coverage.
+	if stats := opFor(out.Paths["/admin/stats"], "GET"); stats == nil {
+		t.Errorf("GET /admin/stats missing — a package-level command var was not followed (#143); have %v",
+			mapPathKeys(out.Paths))
+	} else if _, hasOK := stats.Responses["200"]; !hasOK {
+		t.Errorf("GET /admin/stats: 200 response missing; have %v", keysOf(stats.Responses))
+	}
+
+	// 3. An inline closure as the Action — the other common urfave/cli form.
+	if metrics := opFor(out.Paths["/metrics"], "GET"); metrics == nil {
+		t.Errorf("GET /metrics missing — a closure Action was not followed (#143); have %v",
+			mapPathKeys(out.Paths))
+	}
+}
+
+// contentSchemaRef returns the $ref of the first content entry carrying one.
+// Named apart from the identically-shaped helper in the secondary-framework test
+// so the two can coexist in this package.
+func contentSchemaRef(content map[string]intspec.MediaType) string {
+	for _, mt := range content {
+		if mt.Schema != nil && mt.Schema.Ref != "" {
+			return mt.Schema.Ref
+		}
+	}
+	return ""
+}

--- a/generator/testdata_known_gaps_test.go
+++ b/generator/testdata_known_gaps_test.go
@@ -26,24 +26,6 @@ import (
 // capability lands — at which point the assertions must flip to the
 // commented expectations and the tracking issue closes.
 
-// TestTestdata_CLIActionRoutes pins issue #143: route registration reached
-// from main only through a function value stored in a composite-literal
-// field (`Command{Action: runWeb}`, the urfave/cli shape used by gitea) is
-// invisible — tracker roots are main functions and no static edge crosses
-// the dispatcher hop, even though the registration edges exist in metadata.
-//
-// When #143 lands, this fixture must document /users GET+POST and this test
-// must assert exactly that.
-func TestTestdata_CLIActionRoutes(t *testing.T) {
-	out := loadTestdataWithFixtureConfig(t, "cli_action_routes", nil)
-
-	if len(out.Paths) != 0 {
-		t.Errorf("cli_action_routes now documents %d paths (%v) — the #143 gap "+
-			"seems fixed: flip this test to assert /users GET+POST and close the issue",
-			len(out.Paths), mapPathKeys(out.Paths))
-	}
-}
-
 // TestTestdata_StatusViaConstructor covers issue #144 (now fixed): a status
 // carried through a constructor struct field (`e := NewAPIError(msg, 401);
 // RespondWithError(w, e)` → `w.WriteHeader(err.Code)`) resolves to the real

--- a/internal/spec/func_field_dispatch.go
+++ b/internal/spec/func_field_dispatch.go
@@ -88,7 +88,7 @@ func buildFuncFieldDispatch(meta *metadata.Metadata) funcFieldDispatch {
 				for _, varName := range sortedMapKeys(fn.AssignmentMap) {
 					for i := range fn.AssignmentMap[varName] {
 						a := &fn.AssignmentMap[varName][i]
-						d.walkCompositeLits(meta, known, pkgName, &a.Value, "", 0)
+						d.walkCompositeLits(meta, known, pkgName, &a.Value, litType{}, 0)
 					}
 				}
 			}
@@ -102,7 +102,7 @@ func buildFuncFieldDispatch(meta *metadata.Metadata) funcFieldDispatch {
 		edge := &meta.CallGraph[i]
 		ctxPkg := getString(meta, edge.Caller.Pkg)
 		for _, arg := range edge.Args {
-			d.walkCompositeLits(meta, known, ctxPkg, arg, "", 0)
+			d.walkCompositeLits(meta, known, ctxPkg, arg, litType{}, 0)
 		}
 	}
 
@@ -151,8 +151,15 @@ func funcFieldKey(pkg, typeName, field string) string {
 func (d funcFieldDispatch) addStructInstances(meta *metadata.Metadata, known map[string]bool, pkgName string, file *metadata.File) {
 	for i := range file.StructInstances {
 		inst := &file.StructInstances[i]
-		typeName := bareTypeName(getString(meta, inst.Type))
-		fields := structFieldTypes(meta, pkgName, typeName)
+		// The instance is recorded under the package that WRITES the literal,
+		// while its type may belong to another one (`&clipkg.Command{…}` in
+		// main). The rendered type carries the owner when it is qualified, and
+		// that owner is what the dispatching edge will be keyed by.
+		typePkg, typeName := splitQualifiedType(getString(meta, inst.Type))
+		if typePkg == "" {
+			typePkg = pkgName
+		}
+		fields := structFieldTypes(meta, typePkg, typeName)
 		if len(fields) == 0 || len(inst.Fields) == 0 {
 			continue
 		}
@@ -173,22 +180,35 @@ func (d funcFieldDispatch) addStructInstances(meta *metadata.Metadata, known map
 			}
 			// A rendered value is only usable when it names a function; a
 			// literal, a call or a nested literal renders to something that is
-			// not a function key, and the existence check rejects it.
-			if key := functionKeyFromName(known, pkgName, byName[name]); key != "" {
-				k := funcFieldKey(pkgName, typeName, name)
+			// not a function key, and the existence check rejects it. The name
+			// may be import-qualified ("web.RunWeb"), which only resolves
+			// against the file's own import table.
+			if key := functionKeyFromRendered(meta, known, pkgName, file, byName[name]); key != "" {
+				k := funcFieldKey(typePkg, typeName, name)
 				d[k] = append(d[k], key)
 			}
 		}
 	}
 }
 
+// litType is a composite literal's type as the walk knows it: the rendered type
+// string (possibly a slice/pointer form) plus the package that declares it.
+//
+// Both halves are needed because an elided literal — the `{…}` elements of
+// `[]*clipkg.Command{{…}}` — states neither, and falling back to the package
+// that *writes* the literal is wrong the moment the type comes from elsewhere,
+// which is the normal case in a real project.
+type litType struct {
+	pkg  string
+	name string
+}
+
 // walkCompositeLits descends a CallArgument looking for composite literals and
 // records each func-typed field initialised with a function value.
 //
-// expectType carries the type a literal cannot state for itself: the elements of
-// `[]*Command{{…}}` are elided literals whose type comes from the slice, and a
-// field's value literal takes its type from the field.
-func (d funcFieldDispatch) walkCompositeLits(meta *metadata.Metadata, known map[string]bool, ctxPkg string, arg *metadata.CallArgument, expectType string, depth int) {
+// expect carries the type a literal cannot state for itself: elements take it
+// from the enclosing slice/array/map, and a field's value literal from the field.
+func (d funcFieldDispatch) walkCompositeLits(meta *metadata.Metadata, known map[string]bool, ctxPkg string, arg *metadata.CallArgument, expect litType, depth int) {
 	if arg == nil || depth > maxCompositeLitDepth {
 		return
 	}
@@ -196,23 +216,34 @@ func (d funcFieldDispatch) walkCompositeLits(meta *metadata.Metadata, known map[
 		// Not a literal itself, but one may sit underneath: &T{…} is a unary,
 		// f(T{…}) a call, and so on.
 		for _, child := range []*metadata.CallArgument{arg.X, arg.Fun, arg.Sel} {
-			d.walkCompositeLits(meta, known, ctxPkg, child, expectType, depth+1)
+			d.walkCompositeLits(meta, known, ctxPkg, child, expect, depth+1)
 		}
 		for _, child := range arg.Args {
-			d.walkCompositeLits(meta, known, ctxPkg, child, "", depth+1)
+			d.walkCompositeLits(meta, known, ctxPkg, child, litType{}, depth+1)
 		}
 		return
 	}
 
-	typeName := compositeLitTypeName(arg)
-	if typeName == "" {
-		typeName = expectType
+	lit := expect
+	if stated := compositeLitTypeName(arg); stated != "" {
+		lit = litType{pkg: compositeLitPkg(arg, ""), name: stated}
 	}
-	litPkg := compositeLitPkg(arg, ctxPkg)
-	bare := bareTypeName(typeName)
-	fields := structFieldTypes(meta, litPkg, bare)
-	ordered := structFieldOrder(meta, litPkg, bare)
-	elem := elementTypeName(typeName)
+	// A type string can carry its own package ("[]*github.com/x/clipkg.Command",
+	// the form a recorded field type takes when it crosses a package boundary);
+	// that owner beats any inherited one.
+	if qualPkg, _ := splitQualifiedType(lit.name); qualPkg != "" {
+		lit.pkg = qualPkg
+	}
+	if lit.pkg == "" {
+		lit.pkg = ctxPkg
+	}
+
+	bare := bareTypeName(lit.name)
+	fields := structFieldTypes(meta, lit.pkg, bare)
+	ordered := structFieldOrder(meta, lit.pkg, bare)
+	// A field's type is written from inside its own declaring package, so that
+	// is the package an unqualified field type refers to.
+	elem := litType{pkg: lit.pkg, name: elementTypeName(lit.name)}
 
 	for i, elt := range arg.Args {
 		if elt == nil {
@@ -227,10 +258,10 @@ func (d funcFieldDispatch) walkCompositeLits(meta *metadata.Metadata, known map[
 			}
 			fieldType := fields[name]
 			if name != "" && isFuncTypeString(fieldType) {
-				d.record(known, litPkg, bare, name, elt.Fun, ctxPkg)
+				d.record(known, lit.pkg, bare, name, elt.Fun, ctxPkg)
 			}
-			next := fieldType
-			if next == "" {
+			next := litType{pkg: lit.pkg, name: fieldType}
+			if fieldType == "" {
 				next = elem
 			}
 			d.walkCompositeLits(meta, known, ctxPkg, elt.Fun, next, depth+1)
@@ -239,12 +270,12 @@ func (d funcFieldDispatch) walkCompositeLits(meta *metadata.Metadata, known map[
 		// Positional: a struct literal binds elements to fields in declaration
 		// order (`Command{"web", runWeb}`); anything else (slice, array, map
 		// value list) binds them to the element type.
-		if i < len(ordered) && len(ordered) > 0 && elem == "" {
+		if i < len(ordered) && len(ordered) > 0 && elem.name == "" {
 			name := ordered[i]
 			if isFuncTypeString(fields[name]) {
-				d.record(known, litPkg, bare, name, elt, ctxPkg)
+				d.record(known, lit.pkg, bare, name, elt, ctxPkg)
 			}
-			d.walkCompositeLits(meta, known, ctxPkg, elt, fields[name], depth+1)
+			d.walkCompositeLits(meta, known, ctxPkg, elt, litType{pkg: lit.pkg, name: fields[name]}, depth+1)
 			continue
 		}
 		d.walkCompositeLits(meta, known, ctxPkg, elt, elem, depth+1)
@@ -318,6 +349,112 @@ func functionKeysOfValue(known map[string]bool, value *metadata.CallArgument, ct
 		}
 	}
 	return nil
+}
+
+// functionKeyFromRendered resolves a *rendered* field value — what
+// StructInstance.Fields holds, a string rather than an expression — to a function
+// base key.
+//
+// Three forms occur, and only the first two can be trusted:
+//
+//	"runWeb"                     a function in the file's own package
+//	"web.RunWeb"                 import-qualified: the alias resolves through the
+//	                             file's import table, never by guessing a path
+//	"[]*Command{{…}}"            a rendered literal, which names no function and
+//	                             is rejected by the existence check
+//
+// A fully-qualified value ("github.com/x/web.Server.RunAdmin") matches `known`
+// directly, so it needs no alias step.
+func functionKeyFromRendered(meta *metadata.Metadata, known map[string]bool, pkg string, file *metadata.File, value string) string {
+	if key := functionKeyFromName(known, pkg, value); key != "" {
+		return key
+	}
+	dot := strings.Index(value, ".")
+	if dot <= 0 || file == nil {
+		return ""
+	}
+	qualifier, rest := value[:dot], value[dot+1:]
+
+	// Imports are recorded alias -> path, and an import with no explicit alias
+	// records the path as its own "alias" — so the source-level qualifier is
+	// matched against both the alias and the path's own tail. Candidates are
+	// gathered and sorted rather than returned from the map walk: two imports can
+	// both answer to one qualifier, and picking by map order would let the index
+	// (and the routes it decides) vary between runs.
+	var candidates []string
+	for aliasIdx, pathIdx := range file.Imports {
+		path := getString(meta, pathIdx)
+		if getString(meta, aliasIdx) != qualifier && !importTailMatches(path, qualifier) {
+			continue
+		}
+		if key := path + "." + rest; known[key] {
+			candidates = append(candidates, key)
+		}
+	}
+	if len(candidates) == 0 {
+		return ""
+	}
+	sort.Strings(candidates)
+	return candidates[0]
+}
+
+// importTailMatches reports whether an unaliased import of path binds the given
+// qualifier in source. That is the path's last element, except for the module
+// major-version convention ("github.com/go-chi/chi/v5" is `chi`).
+func importTailMatches(path, qualifier string) bool {
+	if path == "" || qualifier == "" {
+		return false
+	}
+	parts := strings.Split(path, "/")
+	last := parts[len(parts)-1]
+	if last == qualifier {
+		return true
+	}
+	if len(parts) > 1 && isMajorVersionElement(last) {
+		return parts[len(parts)-2] == qualifier
+	}
+	return false
+}
+
+// isMajorVersionElement reports whether a path element is a "vN" module major
+// version rather than the package name.
+func isMajorVersionElement(s string) bool {
+	if len(s) < 2 || s[0] != 'v' {
+		return false
+	}
+	for _, c := range s[1:] {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// splitQualifiedType splits a rendered type into its declaring package and bare
+// name ("[]*github.com/x/clipkg.Command" -> "github.com/x/clipkg", "Command").
+// An unqualified type ("[]*Command") has no package to report: the caller
+// supplies the context it was written in.
+func splitQualifiedType(t string) (pkg, name string) {
+	name = strings.TrimSpace(t)
+	for {
+		trimmed := strings.TrimPrefix(strings.TrimPrefix(name, "[]"), "*")
+		if trimmed == name {
+			break
+		}
+		name = trimmed
+	}
+	dot := strings.LastIndex(name, ".")
+	if dot <= 0 {
+		return "", name
+	}
+	// Only an import path counts as a package here. A bare "clipkg.Command" (an
+	// alias, not a path) cannot be resolved without the import table, and
+	// treating the alias as a path would key the index on a package that does
+	// not exist.
+	if !strings.Contains(name[:dot], "/") {
+		return "", name[dot+1:]
+	}
+	return name[:dot], name[dot+1:]
 }
 
 // functionKeyFromName returns "pkg.name" when that names a recorded function.

--- a/internal/spec/func_field_dispatch.go
+++ b/internal/spec/func_field_dispatch.go
@@ -1,0 +1,533 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// funcFieldDispatch resolves a call made *through a func-typed struct field* —
+// `c.Action()` — to the functions that field actually holds (issue #143).
+//
+// This is the urfave/cli wiring style, and it is the whole reason apispec found
+// zero routes in gitea: route registration is reachable from main only through a
+// function value parked in a composite-literal field and invoked later by the
+// library's dispatcher. There is no static call edge from main's subtree into
+// the registering function, so tree expansion stopped at `app.Run(...)` and
+// never saw a single route.
+//
+// The field is a dispatch point in exactly the way an interface method is, and
+// it is resolved the same way: collect the concrete values recorded for it and
+// expand into all of them. Several commands assigning the same field is not
+// ambiguity to be guessed at — each is genuinely invoked for its own
+// subcommand, so the union of their registrations is the binary's surface.
+//
+// Keys are "pkg.Type.Field"; values are function base keys ("pkg.Func",
+// "pkg.Recv.Method", or a closure's "pkg.FuncLit:pos").
+type funcFieldDispatch map[string][]string
+
+// maxCompositeLitDepth bounds the composite-literal walk. Nesting this deep is
+// pathological (a literal inside a literal inside a literal…), and the bound
+// keeps a hand-written or generated monster from turning fact collection into
+// the expensive part of the run.
+const maxCompositeLitDepth = 12
+
+// buildFuncFieldDispatch indexes every function value stored into a func-typed
+// struct field. Three sources, because the same Go code is recorded three
+// different ways depending on where the literal sits:
+//
+//   - File.StructInstances — the only record of a package-level
+//     `var CmdWeb = &cli.Command{Action: runWeb}`, whose initializer is not
+//     kept as a CallArgument anywhere. This is gitea's actual shape.
+//   - assignment values — `app := &App{Commands: []*Command{{Action: runWeb}}}`,
+//     where the nested literal survives in full in the CallArgument tree (it is
+//     only the *rendered* StructInstance field that flattens it to types).
+//   - call arguments — the literal passed straight into a call,
+//     `app.Register(&Command{Action: runWeb})`.
+//
+// Every map iteration is sorted: this index feeds tree expansion, which decides
+// which routes exist, so its order reaches the output (golden rule #1).
+func buildFuncFieldDispatch(meta *metadata.Metadata) funcFieldDispatch {
+	if meta == nil {
+		return nil
+	}
+	d := funcFieldDispatch{}
+	known := knownFunctionKeys(meta)
+
+	for _, pkgName := range sortedMapKeys(meta.Packages) {
+		pkg := meta.Packages[pkgName]
+		if pkg == nil {
+			continue
+		}
+		for _, fileName := range sortedMapKeys(pkg.Files) {
+			file := pkg.Files[fileName]
+			if file == nil {
+				continue
+			}
+			d.addStructInstances(meta, known, pkgName, file)
+			for _, fnName := range sortedMapKeys(file.Functions) {
+				fn := file.Functions[fnName]
+				if fn == nil {
+					continue
+				}
+				for _, varName := range sortedMapKeys(fn.AssignmentMap) {
+					for i := range fn.AssignmentMap[varName] {
+						a := &fn.AssignmentMap[varName][i]
+						d.walkCompositeLits(meta, known, pkgName, &a.Value, "", 0)
+					}
+				}
+			}
+		}
+	}
+
+	// Call arguments. The caller's package is the fallback context for an
+	// unqualified function ident, since a literal written at a call site names
+	// functions from the package it is written in.
+	for i := range meta.CallGraph {
+		edge := &meta.CallGraph[i]
+		ctxPkg := getString(meta, edge.Caller.Pkg)
+		for _, arg := range edge.Args {
+			d.walkCompositeLits(meta, known, ctxPkg, arg, "", 0)
+		}
+	}
+
+	for key, vals := range d {
+		sort.Strings(vals)
+		d[key] = dedupeSortedStrings(vals)
+	}
+	return d
+}
+
+// keysFor returns the function base keys reachable through an edge that calls a
+// func-typed struct field. An edge calling a real method (or anything else)
+// yields nothing: only fields recorded in the index can match, and the index
+// only holds func-typed fields.
+func (d funcFieldDispatch) keysFor(meta *metadata.Metadata, edge *metadata.CallGraphEdge) []string {
+	if len(d) == 0 || edge == nil || meta == nil {
+		return nil
+	}
+	recv := strings.TrimPrefix(getString(meta, edge.Callee.RecvType), "*")
+	if recv == "" {
+		return nil
+	}
+	pkg := getString(meta, edge.Callee.Pkg)
+	name := getString(meta, edge.Callee.Name)
+	if pkg == "" || name == "" {
+		return nil
+	}
+	// The receiver may arrive package-qualified ("pkg.Command"); the index is
+	// keyed on the bare type name.
+	if dot := strings.LastIndex(recv, "."); dot >= 0 {
+		recv = recv[dot+1:]
+	}
+	return d[funcFieldKey(pkg, recv, name)]
+}
+
+func funcFieldKey(pkg, typeName, field string) string {
+	return pkg + "." + typeName + "." + field
+}
+
+// addStructInstances records func-typed fields from the rendered struct
+// instances of one file. StructInstance.Fields is field name -> rendered value,
+// so this source only resolves a value that is a plain function name — which is
+// exactly the `Action: runWeb` case it exists to cover. A nested literal renders
+// as a type blob ("[]*Command{{string: web, func() error: func() error}}") and
+// contributes nothing here; the assignment walk is what catches those.
+func (d funcFieldDispatch) addStructInstances(meta *metadata.Metadata, known map[string]bool, pkgName string, file *metadata.File) {
+	for i := range file.StructInstances {
+		inst := &file.StructInstances[i]
+		typeName := bareTypeName(getString(meta, inst.Type))
+		fields := structFieldTypes(meta, pkgName, typeName)
+		if len(fields) == 0 || len(inst.Fields) == 0 {
+			continue
+		}
+		names := make([]string, 0, len(inst.Fields))
+		byName := make(map[string]string, len(inst.Fields))
+		for nameIdx, valIdx := range inst.Fields {
+			name := getString(meta, nameIdx)
+			if name == "" {
+				continue
+			}
+			names = append(names, name)
+			byName[name] = getString(meta, valIdx)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			if !isFuncTypeString(fields[name]) {
+				continue
+			}
+			// A rendered value is only usable when it names a function; a
+			// literal, a call or a nested literal renders to something that is
+			// not a function key, and the existence check rejects it.
+			if key := functionKeyFromName(known, pkgName, byName[name]); key != "" {
+				k := funcFieldKey(pkgName, typeName, name)
+				d[k] = append(d[k], key)
+			}
+		}
+	}
+}
+
+// walkCompositeLits descends a CallArgument looking for composite literals and
+// records each func-typed field initialised with a function value.
+//
+// expectType carries the type a literal cannot state for itself: the elements of
+// `[]*Command{{…}}` are elided literals whose type comes from the slice, and a
+// field's value literal takes its type from the field.
+func (d funcFieldDispatch) walkCompositeLits(meta *metadata.Metadata, known map[string]bool, ctxPkg string, arg *metadata.CallArgument, expectType string, depth int) {
+	if arg == nil || depth > maxCompositeLitDepth {
+		return
+	}
+	if arg.GetKind() != metadata.KindCompositeLit {
+		// Not a literal itself, but one may sit underneath: &T{…} is a unary,
+		// f(T{…}) a call, and so on.
+		for _, child := range []*metadata.CallArgument{arg.X, arg.Fun, arg.Sel} {
+			d.walkCompositeLits(meta, known, ctxPkg, child, expectType, depth+1)
+		}
+		for _, child := range arg.Args {
+			d.walkCompositeLits(meta, known, ctxPkg, child, "", depth+1)
+		}
+		return
+	}
+
+	typeName := compositeLitTypeName(arg)
+	if typeName == "" {
+		typeName = expectType
+	}
+	litPkg := compositeLitPkg(arg, ctxPkg)
+	bare := bareTypeName(typeName)
+	fields := structFieldTypes(meta, litPkg, bare)
+	ordered := structFieldOrder(meta, litPkg, bare)
+	elem := elementTypeName(typeName)
+
+	for i, elt := range arg.Args {
+		if elt == nil {
+			continue
+		}
+		if elt.GetKind() == metadata.KindKeyValue {
+			// A map literal's keys are values, not field names; the field
+			// lookup below simply finds nothing for them.
+			name := ""
+			if elt.X != nil {
+				name = elt.X.GetName()
+			}
+			fieldType := fields[name]
+			if name != "" && isFuncTypeString(fieldType) {
+				d.record(known, litPkg, bare, name, elt.Fun, ctxPkg)
+			}
+			next := fieldType
+			if next == "" {
+				next = elem
+			}
+			d.walkCompositeLits(meta, known, ctxPkg, elt.Fun, next, depth+1)
+			continue
+		}
+		// Positional: a struct literal binds elements to fields in declaration
+		// order (`Command{"web", runWeb}`); anything else (slice, array, map
+		// value list) binds them to the element type.
+		if i < len(ordered) && len(ordered) > 0 && elem == "" {
+			name := ordered[i]
+			if isFuncTypeString(fields[name]) {
+				d.record(known, litPkg, bare, name, elt, ctxPkg)
+			}
+			d.walkCompositeLits(meta, known, ctxPkg, elt, fields[name], depth+1)
+			continue
+		}
+		d.walkCompositeLits(meta, known, ctxPkg, elt, elem, depth+1)
+	}
+}
+
+// record resolves a field's value to a function base key and indexes it.
+func (d funcFieldDispatch) record(known map[string]bool, pkg, typeName, field string, value *metadata.CallArgument, ctxPkg string) {
+	for _, key := range functionKeysOfValue(known, value, ctxPkg) {
+		k := funcFieldKey(pkg, typeName, field)
+		d[k] = append(d[k], key)
+	}
+}
+
+// functionKeysOfValue resolves the value assigned to a func-typed field to the
+// base key(s) of the function body it names.
+//
+// Honest by construction: only a value that *names* a function resolves. A
+// variable holding a function ("Action: h.handler" where handler is a field, or
+// a func-typed local) names no body, so it contributes nothing rather than a
+// guess — the same posture as an unresolvable interface (golden rule #7).
+func functionKeysOfValue(known map[string]bool, value *metadata.CallArgument, ctxPkg string) []string {
+	if value == nil {
+		return nil
+	}
+	switch value.GetKind() {
+	case metadata.KindIdent:
+		pkg := value.GetPkg()
+		if pkg == "" {
+			pkg = ctxPkg
+		}
+		if key := functionKeyFromName(known, pkg, value.GetName()); key != "" {
+			return []string{key}
+		}
+	case metadata.KindFuncLit:
+		// An inline `Action: func(c *cli.Context) error { … }` — the closure is
+		// recorded as a function of its own, named by position.
+		if name := value.GetName(); name != "" {
+			if key := functionKeyFromName(known, ctxPkg, name); key != "" {
+				return []string{key}
+			}
+		}
+	case metadata.KindSelector:
+		if value.Sel == nil {
+			return nil
+		}
+		selName := value.Sel.GetName()
+		if selName == "" {
+			return nil
+		}
+		selPkg := value.Sel.GetPkg()
+		if selPkg == "" {
+			selPkg = ctxPkg
+		}
+		// Method value (`Action: srv.runWeb`): the receiver type completes the
+		// key. Otherwise it is a cross-package function (`Action: web.RunWeb`).
+		recv := ""
+		if value.ReceiverType != nil {
+			recv = value.ReceiverType.GetName()
+		} else if value.X != nil && value.X.Type != -1 {
+			recv = value.X.GetType()
+		}
+		recv = bareTypeName(recv)
+		if recv != "" {
+			if key := selPkg + "." + recv + "." + selName; known[key] {
+				return []string{key}
+			}
+		}
+		if key := functionKeyFromName(known, selPkg, selName); key != "" {
+			return []string{key}
+		}
+	}
+	return nil
+}
+
+// functionKeyFromName returns "pkg.name" when that names a recorded function.
+// The name may already be package-qualified (a rendered StructInstance value),
+// in which case it is trusted as written.
+func functionKeyFromName(known map[string]bool, pkg, name string) string {
+	if name == "" {
+		return ""
+	}
+	if known[name] {
+		return name
+	}
+	if pkg == "" {
+		return ""
+	}
+	if key := pkg + "." + name; known[key] {
+		return key
+	}
+	return ""
+}
+
+// knownFunctionKeys is the set of function base keys tree expansion can actually
+// follow: every key that calls something (meta.Callers) or encloses a closure
+// that does (meta.ParentFunctions). Requiring membership is what keeps a field
+// whose value is a variable, a call or a literal out of the index — and it is
+// deliberately the *expandable* set rather than the declared one, since a
+// function that calls nothing contributes no routes either way.
+//
+// Closures qualify: an inline `Action: func() error { … }` is recorded as a
+// caller in its own right, named by position, which is how the common urfave/cli
+// form resolves at all.
+func knownFunctionKeys(meta *metadata.Metadata) map[string]bool {
+	known := make(map[string]bool, len(meta.Callers)+len(meta.ParentFunctions))
+	for key := range meta.Callers {
+		known[key] = true
+	}
+	for key := range meta.ParentFunctions {
+		known[key] = true
+	}
+	return known
+}
+
+// structFieldTypes maps a struct's field names to their type strings.
+func structFieldTypes(meta *metadata.Metadata, pkg, typeName string) map[string]string {
+	if pkg == "" || typeName == "" {
+		return nil
+	}
+	p, ok := meta.Packages[pkg]
+	if !ok || p == nil {
+		return nil
+	}
+	for _, fileName := range sortedMapKeys(p.Files) {
+		file := p.Files[fileName]
+		if file == nil {
+			continue
+		}
+		typ, ok := file.Types[typeName]
+		if !ok || typ == nil || len(typ.Fields) == 0 {
+			continue
+		}
+		out := make(map[string]string, len(typ.Fields))
+		for i := range typ.Fields {
+			out[getString(meta, typ.Fields[i].Name)] = getString(meta, typ.Fields[i].Type)
+		}
+		return out
+	}
+	return nil
+}
+
+// structFieldOrder lists a struct's field names in declaration order, for
+// positional literals.
+func structFieldOrder(meta *metadata.Metadata, pkg, typeName string) []string {
+	if pkg == "" || typeName == "" {
+		return nil
+	}
+	p, ok := meta.Packages[pkg]
+	if !ok || p == nil {
+		return nil
+	}
+	for _, fileName := range sortedMapKeys(p.Files) {
+		file := p.Files[fileName]
+		if file == nil {
+			continue
+		}
+		typ, ok := file.Types[typeName]
+		if !ok || typ == nil || len(typ.Fields) == 0 {
+			continue
+		}
+		out := make([]string, 0, len(typ.Fields))
+		for i := range typ.Fields {
+			out = append(out, getString(meta, typ.Fields[i].Name))
+		}
+		return out
+	}
+	return nil
+}
+
+// isFuncTypeString reports whether a recorded field type is a function type.
+// Metadata renders a func field's type as the bare word "func" in some paths and
+// as a full signature in others, so both forms count.
+func isFuncTypeString(t string) bool {
+	t = strings.TrimPrefix(t, "*")
+	return t == "func" || strings.HasPrefix(t, "func(")
+}
+
+// compositeLitTypeName renders the type a composite literal states for itself.
+// An elided literal (`{Name: "web"}` inside a slice) states none.
+func compositeLitTypeName(arg *metadata.CallArgument) string {
+	if arg == nil || arg.X == nil {
+		return ""
+	}
+	return typeExprName(arg.X)
+}
+
+// typeExprName renders a type expression argument back to a type string, far
+// enough to recognise slices, pointers and named types.
+func typeExprName(arg *metadata.CallArgument) string {
+	if arg == nil {
+		return ""
+	}
+	switch arg.GetKind() {
+	case metadata.KindIdent:
+		return arg.GetName()
+	case metadata.KindStar:
+		if inner := typeExprName(arg.X); inner != "" {
+			return "*" + inner
+		}
+	case metadata.KindArrayType, metadata.KindSlice:
+		if inner := typeExprName(arg.X); inner != "" {
+			return "[]" + inner
+		}
+	case metadata.KindSelector:
+		if arg.Sel != nil {
+			return arg.Sel.GetName()
+		}
+	}
+	return ""
+}
+
+// compositeLitPkg returns the package that owns a literal's type, falling back
+// to the context package for an unqualified or elided type.
+func compositeLitPkg(arg *metadata.CallArgument, ctxPkg string) string {
+	if arg != nil && arg.X != nil {
+		for probe := arg.X; probe != nil; probe = probe.X {
+			if pkg := probe.GetPkg(); pkg != "" {
+				return pkg
+			}
+			if probe.Sel != nil {
+				if pkg := probe.Sel.GetPkg(); pkg != "" {
+					return pkg
+				}
+			}
+		}
+	}
+	return ctxPkg
+}
+
+// bareTypeName strips pointer, slice and package qualification down to the
+// declared type name the Types map is keyed by.
+func bareTypeName(t string) string {
+	t = strings.TrimSpace(t)
+	t = strings.TrimPrefix(t, "[]")
+	t = strings.TrimPrefix(t, "*")
+	t = strings.TrimPrefix(t, "[]")
+	t = strings.TrimPrefix(t, "*")
+	if dot := strings.LastIndex(t, "."); dot >= 0 {
+		t = t[dot+1:]
+	}
+	return t
+}
+
+// elementTypeName returns the element type of a slice, array or map type, or ""
+// for anything else.
+func elementTypeName(t string) string {
+	switch {
+	case strings.HasPrefix(t, "[]"):
+		return t[2:]
+	case strings.HasPrefix(t, "map["):
+		if close := strings.Index(t, "]"); close > 0 {
+			return t[close+1:]
+		}
+	case strings.HasPrefix(t, "["):
+		// Fixed-size array: [4]*Command.
+		if close := strings.Index(t, "]"); close > 0 {
+			return t[close+1:]
+		}
+	}
+	return ""
+}
+
+func dedupeSortedStrings(in []string) []string {
+	out := in[:0]
+	var prev string
+	for i, s := range in {
+		if i > 0 && s == prev {
+			continue
+		}
+		prev = s
+		out = append(out, s)
+	}
+	return out
+}
+
+// sortedMapKeys returns a map's keys in sorted order — determinism is a feature
+// (golden rule #1), and this index decides which routes exist.
+func sortedMapKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/spec/func_field_dispatch_test.go
+++ b/internal/spec/func_field_dispatch_test.go
@@ -291,3 +291,408 @@ func TestIsFuncTypeString(t *testing.T) {
 		}
 	}
 }
+
+// TestFuncFieldDispatchGuards covers the paths a fixture cannot reach: malformed
+// or partial metadata, and the value forms that must resolve to nothing rather
+// than to a guess.
+func TestFuncFieldDispatchGuards(t *testing.T) {
+	t.Run("nil packages, files and functions are skipped", func(t *testing.T) {
+		meta := &metadata.Metadata{
+			StringPool: metadata.NewStringPool(),
+			Packages: map[string]*metadata.Package{
+				"a": nil,
+				"b": {Files: map[string]*metadata.File{"f.go": nil}},
+				"c": {Files: map[string]*metadata.File{
+					"f.go": {Functions: map[string]*metadata.Function{"main": nil}},
+				}},
+			},
+		}
+		if got := buildFuncFieldDispatch(meta); len(got) != 0 {
+			t.Errorf("expected an empty index, got %v", got)
+		}
+	})
+
+	t.Run("a nil call argument does not panic", func(t *testing.T) {
+		meta := &metadata.Metadata{
+			StringPool: metadata.NewStringPool(),
+			CallGraph:  []metadata.CallGraphEdge{{Args: []*metadata.CallArgument{nil}}},
+		}
+		if got := buildFuncFieldDispatch(meta); len(got) != 0 {
+			t.Errorf("expected an empty index, got %v", got)
+		}
+	})
+
+	t.Run("functionKeysOfValue resolves only what names a function", func(t *testing.T) {
+		meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+		known := map[string]bool{
+			"example.com/web.RunWeb":         true,
+			"example.com/web.Server.RunWeb":  true,
+			"example.com/cli.FuncLit:f.go:9": true,
+		}
+		ident := func(name, pkg string) *metadata.CallArgument {
+			a := metadata.NewCallArgument(meta)
+			a.SetKind(metadata.KindIdent)
+			a.SetName(name)
+			if pkg != "" {
+				a.SetPkg(pkg)
+			}
+			return a
+		}
+
+		// A cross-package function value: pkg.Fn, no receiver.
+		sel := metadata.NewCallArgument(meta)
+		sel.SetKind(metadata.KindSelector)
+		sel.Sel = ident("RunWeb", "example.com/web")
+		sel.X = ident("web", "")
+		if got := functionKeysOfValue(known, sel, "example.com/cli"); !reflect.DeepEqual(got, []string{"example.com/web.RunWeb"}) {
+			t.Errorf("cross-package function value = %v", got)
+		}
+
+		// A method value: the receiver type completes the key.
+		recv := ident("srv", "")
+		recv.SetType("*example.com/web.Server")
+		method := metadata.NewCallArgument(meta)
+		method.SetKind(metadata.KindSelector)
+		method.Sel = ident("RunWeb", "example.com/web")
+		method.X = recv
+		if got := functionKeysOfValue(known, method, "example.com/cli"); !reflect.DeepEqual(got, []string{"example.com/web.Server.RunWeb"}) {
+			t.Errorf("method value = %v", got)
+		}
+
+		// A closure, named by position.
+		lit := metadata.NewCallArgument(meta)
+		lit.SetKind(metadata.KindFuncLit)
+		lit.SetName("FuncLit:f.go:9")
+		if got := functionKeysOfValue(known, lit, "example.com/cli"); !reflect.DeepEqual(got, []string{"example.com/cli.FuncLit:f.go:9"}) {
+			t.Errorf("closure value = %v", got)
+		}
+
+		// Nothing that fails to name an expandable function may resolve.
+		empty := metadata.NewCallArgument(meta)
+		empty.SetKind(metadata.KindSelector)
+		bareSel := metadata.NewCallArgument(meta)
+		bareSel.SetKind(metadata.KindSelector)
+		bareSel.Sel = ident("", "")
+		unknownFn := metadata.NewCallArgument(meta)
+		unknownFn.SetKind(metadata.KindSelector)
+		unknownFn.Sel = ident("Missing", "example.com/web")
+		unknownFn.X = ident("web", "")
+		literal := metadata.NewCallArgument(meta)
+		literal.SetKind(metadata.KindLiteral)
+		for name, arg := range map[string]*metadata.CallArgument{
+			"nil value":             nil,
+			"selector with no Sel":  empty,
+			"selector with no name": bareSel,
+			"unknown function":      unknownFn,
+			"a literal":             literal,
+			"unknown ident":         ident("nope", "example.com/cli"),
+			"ident with no pkg":     ident("RunWeb", ""),
+		} {
+			if got := functionKeysOfValue(known, arg, ""); got != nil {
+				t.Errorf("%s resolved to %v, want nothing", name, got)
+			}
+		}
+	})
+
+	t.Run("rendered values resolve through the file's imports", func(t *testing.T) {
+		meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+		file := &metadata.File{Imports: map[int]int{
+			// Unaliased: the path is recorded as its own alias, so the qualifier
+			// has to be matched against the path's tail.
+			meta.StringPool.Get("example.com/web"): meta.StringPool.Get("example.com/web"),
+			// Explicit alias.
+			meta.StringPool.Get("w2"): meta.StringPool.Get("example.com/web2"),
+			// Module major version: the qualifier is the element before "v5".
+			meta.StringPool.Get("github.com/go-chi/chi/v5"): meta.StringPool.Get("github.com/go-chi/chi/v5"),
+		}}
+		known := map[string]bool{
+			"example.com/web.RunWeb":             true,
+			"example.com/web2.RunWeb":            true,
+			"github.com/go-chi/chi/v5.NewRouter": true,
+			"example.com/cli.local":              true,
+		}
+		for value, want := range map[string]string{
+			"web.RunWeb":    "example.com/web.RunWeb",
+			"w2.RunWeb":     "example.com/web2.RunWeb",
+			"chi.NewRouter": "github.com/go-chi/chi/v5.NewRouter",
+			"local":         "example.com/cli.local",
+			"nope.RunWeb":   "",
+			"web.Missing":   "",
+			"unqualified":   "",
+			"":              "",
+		} {
+			if got := functionKeyFromRendered(meta, known, "example.com/cli", file, value); got != want {
+				t.Errorf("functionKeyFromRendered(%q) = %q, want %q", value, got, want)
+			}
+		}
+		// No import table at all: only the context package can answer.
+		if got := functionKeyFromRendered(meta, known, "example.com/cli", nil, "web.RunWeb"); got != "" {
+			t.Errorf("with no file = %q, want empty", got)
+		}
+	})
+}
+
+func TestSplitQualifiedType(t *testing.T) {
+	for in, want := range map[string][2]string{
+		"[]*github.com/x/clipkg.Command": {"github.com/x/clipkg", "Command"},
+		"github.com/x/clipkg.Command":    {"github.com/x/clipkg", "Command"},
+		// An alias-qualified name is NOT a package path: resolving it needs the
+		// import table, and treating "clipkg" as a path would key the index on a
+		// package that does not exist.
+		"clipkg.Command": {"", "Command"},
+		"[]*Command":     {"", "Command"},
+		"Command":        {"", "Command"},
+		"":               {"", ""},
+	} {
+		pkg, name := splitQualifiedType(in)
+		if pkg != want[0] || name != want[1] {
+			t.Errorf("splitQualifiedType(%q) = (%q, %q), want (%q, %q)", in, pkg, name, want[0], want[1])
+		}
+	}
+}
+
+func TestImportTailMatches(t *testing.T) {
+	for _, tc := range []struct {
+		path, qualifier string
+		want            bool
+	}{
+		{"example.com/web", "web", true},
+		{"github.com/go-chi/chi/v5", "chi", true},
+		{"github.com/go-chi/chi/v5", "v5", true}, // the literal element still matches
+		{"example.com/web", "other", false},
+		{"", "web", false},
+		{"example.com/web", "", false},
+		{"v5", "v5", true},
+	} {
+		if got := importTailMatches(tc.path, tc.qualifier); got != tc.want {
+			t.Errorf("importTailMatches(%q, %q) = %v, want %v", tc.path, tc.qualifier, got, tc.want)
+		}
+	}
+	for _, tc := range []struct {
+		in   string
+		want bool
+	}{{"v5", true}, {"v", false}, {"v5x", false}, {"web", false}, {"", false}} {
+		if got := isMajorVersionElement(tc.in); got != tc.want {
+			t.Errorf("isMajorVersionElement(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestDedupeSortedStrings(t *testing.T) {
+	for _, tc := range []struct{ in, want []string }{
+		{[]string{"a", "a", "b"}, []string{"a", "b"}},
+		{[]string{"a"}, []string{"a"}},
+		{nil, nil},
+	} {
+		got := dedupeSortedStrings(append([]string(nil), tc.in...))
+		if len(got) != len(tc.want) {
+			t.Errorf("dedupeSortedStrings(%v) = %v, want %v", tc.in, got, tc.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Errorf("dedupeSortedStrings(%v) = %v, want %v", tc.in, got, tc.want)
+				break
+			}
+		}
+	}
+}
+
+func TestCompositeLitTypeHelpers(t *testing.T) {
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	if got := compositeLitTypeName(nil); got != "" {
+		t.Errorf("compositeLitTypeName(nil) = %q", got)
+	}
+	bare := metadata.NewCallArgument(meta)
+	bare.SetKind(metadata.KindCompositeLit)
+	if got := compositeLitTypeName(bare); got != "" {
+		t.Errorf("an elided literal states no type, got %q", got)
+	}
+	if got := typeExprName(nil); got != "" {
+		t.Errorf("typeExprName(nil) = %q", got)
+	}
+	unsupported := metadata.NewCallArgument(meta)
+	unsupported.SetKind(metadata.KindLiteral)
+	if got := typeExprName(unsupported); got != "" {
+		t.Errorf("typeExprName(literal) = %q", got)
+	}
+
+	// compositeLitPkg walks the type expression for an owner and falls back to
+	// the context package when the literal cannot name one.
+	if got := compositeLitPkg(nil, "ctx"); got != "ctx" {
+		t.Errorf("compositeLitPkg(nil) = %q, want the context package", got)
+	}
+	sel := metadata.NewCallArgument(meta)
+	sel.SetKind(metadata.KindSelector)
+	selName := metadata.NewCallArgument(meta)
+	selName.SetKind(metadata.KindIdent)
+	selName.SetName("Command")
+	selName.SetPkg("example.com/clipkg")
+	sel.Sel = selName
+	lit := metadata.NewCallArgument(meta)
+	lit.SetKind(metadata.KindCompositeLit)
+	lit.X = sel
+	if got := compositeLitPkg(lit, "ctx"); got != "example.com/clipkg" {
+		t.Errorf("compositeLitPkg(qualified) = %q, want the selector's package", got)
+	}
+}
+
+// TestFuncFieldDispatchPartialMetadata covers the remaining shapes a fixture
+// cannot produce: metadata that is well-formed but incomplete, and the
+// cross-package field type whose package is carried in the type string itself.
+func TestFuncFieldDispatchPartialMetadata(t *testing.T) {
+	t.Run("keysFor needs a package and a name", func(t *testing.T) {
+		meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+		d := funcFieldDispatch{funcFieldKey("p", "Command", "Action"): {"p.runWeb"}}
+		noPkg := &metadata.CallGraphEdge{Callee: metadata.Call{
+			RecvType: meta.StringPool.Get("*Command"),
+			Name:     meta.StringPool.Get("Action"),
+		}}
+		noName := &metadata.CallGraphEdge{Callee: metadata.Call{
+			RecvType: meta.StringPool.Get("*Command"),
+			Pkg:      meta.StringPool.Get("p"),
+		}}
+		if got := d.keysFor(meta, noPkg); got != nil {
+			t.Errorf("an edge with no callee package resolved to %v", got)
+		}
+		if got := d.keysFor(meta, noName); got != nil {
+			t.Errorf("an edge with no callee name resolved to %v", got)
+		}
+	})
+
+	t.Run("an unnamed struct-instance field is skipped", func(t *testing.T) {
+		meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+		meta.Callers = map[string][]*metadata.CallGraphEdge{"p.runWeb": nil}
+		file := &metadata.File{
+			Types: map[string]*metadata.Type{"Command": {
+				Fields: []metadata.Field{{
+					Name: meta.StringPool.Get("Action"),
+					Type: meta.StringPool.Get("func"),
+				}},
+			}},
+			StructInstances: []metadata.StructInstance{{
+				Type: meta.StringPool.Get("Command"),
+				Fields: map[int]int{
+					meta.StringPool.Get(""):       meta.StringPool.Get("runWeb"),
+					meta.StringPool.Get("Action"): meta.StringPool.Get("runWeb"),
+				},
+			}},
+		}
+		meta.Packages = map[string]*metadata.Package{"p": {Files: map[string]*metadata.File{"f.go": file}}}
+		got := buildFuncFieldDispatch(meta)
+		if want := []string{"p.runWeb"}; len(got) != 1 || !reflect.DeepEqual(got[funcFieldKey("p", "Command", "Action")], want) {
+			t.Errorf("index = %v, want only the named field to resolve", got)
+		}
+	})
+
+	t.Run("a field type carrying its own package wins over the enclosing one", func(t *testing.T) {
+		// `type App struct{ Cmd otherpkg.Command }` written in package "p", with
+		// the field initialised by an ELIDED literal — legal Go, and the only
+		// form where the literal states no type at all, so the field's own
+		// (qualified) type is the sole source of the package to look fields up
+		// in. Using the writing package instead finds nothing.
+		meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+		meta.Callers = map[string][]*metadata.CallGraphEdge{"p.runWeb": nil}
+
+		fset := token.NewFileSet()
+		src := `package p
+func runWeb() error { return nil }
+func main() { app := App{Cmd: {Action: runWeb}}; _ = app }
+`
+		f, err := parser.ParseFile(fset, "p.go", src, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var lit *metadata.CallArgument
+		ast.Inspect(f, func(n ast.Node) bool {
+			if cl, ok := n.(*ast.CompositeLit); ok && lit == nil {
+				lit = metadata.ExprToCallArgument(cl, nil, "p", fset, meta)
+				return false
+			}
+			return true
+		})
+
+		appType := &metadata.Type{Fields: []metadata.Field{{
+			Name: meta.StringPool.Get("Cmd"),
+			// Qualified: the field's type lives in another package.
+			Type: meta.StringPool.Get("other.example/pkg.Command"),
+		}}}
+		cmdType := &metadata.Type{Fields: []metadata.Field{{
+			Name: meta.StringPool.Get("Action"),
+			Type: meta.StringPool.Get("func"),
+		}}}
+		meta.Packages = map[string]*metadata.Package{
+			"p": {Files: map[string]*metadata.File{"p.go": {
+				Types: map[string]*metadata.Type{"App": appType},
+				Functions: map[string]*metadata.Function{"main": {
+					AssignmentMap: map[string][]metadata.Assignment{
+						"app": {{Value: *lit}},
+					},
+				}},
+			}}},
+			"other.example/pkg": {Files: map[string]*metadata.File{"cmd.go": {
+				Types: map[string]*metadata.Type{"Command": cmdType},
+			}}},
+		}
+
+		got := buildFuncFieldDispatch(meta)
+		want := []string{"p.runWeb"}
+		if key := funcFieldKey("other.example/pkg", "Command", "Action"); !reflect.DeepEqual(got[key], want) {
+			t.Errorf("%s = %v, want %v (whole index: %v)", key, got[key], want, got)
+		}
+	})
+
+	t.Run("a nil element inside a literal is skipped", func(t *testing.T) {
+		meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+		lit := metadata.NewCallArgument(meta)
+		lit.SetKind(metadata.KindCompositeLit)
+		lit.Args = []*metadata.CallArgument{nil}
+		meta.CallGraph = []metadata.CallGraphEdge{{Args: []*metadata.CallArgument{lit}}}
+		if got := buildFuncFieldDispatch(meta); len(got) != 0 {
+			t.Errorf("index = %v, want empty", got)
+		}
+	})
+
+	t.Run("structFieldTypes and structFieldOrder skip nil files", func(t *testing.T) {
+		meta := &metadata.Metadata{
+			StringPool: metadata.NewStringPool(),
+			Packages: map[string]*metadata.Package{"p": {Files: map[string]*metadata.File{
+				"a.go": nil,
+				"b.go": {Types: map[string]*metadata.Type{"Command": {Fields: []metadata.Field{{
+					Name: metadata.NewStringPool().Get("Action"),
+				}}}}},
+			}}},
+		}
+		// The nil file must be stepped over rather than panicking; the declared
+		// type in the other file is what answers.
+		if got := structFieldTypes(meta, "p", "Command"); len(got) != 1 {
+			t.Errorf("structFieldTypes = %v, want the one declared field", got)
+		}
+		if got := structFieldOrder(meta, "p", "Command"); len(got) != 1 {
+			t.Errorf("structFieldOrder = %v, want the one declared field", got)
+		}
+	})
+
+	t.Run("a selector whose Sel has no package falls back to the context", func(t *testing.T) {
+		meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+		known := map[string]bool{"example.com/cli.RunWeb": true}
+		sel := metadata.NewCallArgument(meta)
+		sel.SetKind(metadata.KindSelector)
+		selName := metadata.NewCallArgument(meta)
+		selName.SetKind(metadata.KindIdent)
+		selName.SetName("RunWeb")
+		sel.Sel = selName
+		if got := functionKeysOfValue(known, sel, "example.com/cli"); !reflect.DeepEqual(got, []string{"example.com/cli.RunWeb"}) {
+			t.Errorf("selector with no Sel package = %v", got)
+		}
+	})
+
+	t.Run("an already-qualified rendered value is trusted as written", func(t *testing.T) {
+		meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+		known := map[string]bool{"example.com/web.Server.RunAdmin": true}
+		if got := functionKeyFromRendered(meta, known, "example.com/cli", &metadata.File{},
+			"example.com/web.Server.RunAdmin"); got != "example.com/web.Server.RunAdmin" {
+			t.Errorf("fully-qualified rendered value = %q", got)
+		}
+	})
+}

--- a/internal/spec/func_field_dispatch_test.go
+++ b/internal/spec/func_field_dispatch_test.go
@@ -1,0 +1,293 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"reflect"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+const dispatchPkg = "example.com/cli"
+
+// buildDispatchMeta assembles metadata for a source snippet: main's composite
+// literal as an assignment value, a Command type declaration (each subtest sets
+// its own fields), and a caller entry per name in `callable` so
+// knownFunctionKeys accepts it.
+//
+// Written against the real ExprToCallArgument rather than hand-built arguments,
+// because the shape of a *nested* literal is exactly what this index depends on
+// and hand-building it would let the test agree with a wrong assumption.
+func buildDispatchMeta(t *testing.T, src string, callable ...string) *metadata.Metadata {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "cli.go", src, 0)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+
+	// The first composite literal in main becomes the assignment's value.
+	var lit *metadata.CallArgument
+	for _, decl := range f.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "main" {
+			continue
+		}
+		ast.Inspect(fn, func(n ast.Node) bool {
+			if cl, ok := n.(*ast.CompositeLit); ok && lit == nil {
+				lit = metadata.ExprToCallArgument(cl, nil, dispatchPkg, fset, meta)
+				return false
+			}
+			return true
+		})
+	}
+	if lit == nil {
+		t.Fatal("no composite literal found in main")
+	}
+
+	cmdType := &metadata.Type{
+		Name: meta.StringPool.Get("Command"),
+		Pkg:  meta.StringPool.Get(dispatchPkg),
+		Kind: meta.StringPool.Get("struct"),
+	}
+	mainFn := &metadata.Function{
+		Name: meta.StringPool.Get("main"),
+		Pkg:  meta.StringPool.Get(dispatchPkg),
+		AssignmentMap: map[string][]metadata.Assignment{
+			"app": {{
+				VariableName: meta.StringPool.Get("app"),
+				Pkg:          meta.StringPool.Get(dispatchPkg),
+				Func:         meta.StringPool.Get("main"),
+				Value:        *lit,
+			}},
+		},
+	}
+	meta.Packages = map[string]*metadata.Package{
+		dispatchPkg: {Files: map[string]*metadata.File{
+			"cli.go": {
+				Types:     map[string]*metadata.Type{"Command": cmdType},
+				Functions: map[string]*metadata.Function{"main": mainFn},
+			},
+		}},
+	}
+	// knownFunctionKeys reads meta.Callers: only a key that can actually be
+	// expanded belongs in the index.
+	meta.Callers = map[string][]*metadata.CallGraphEdge{}
+	for _, name := range callable {
+		meta.Callers[dispatchPkg+"."+name] = nil
+	}
+	return meta
+}
+
+func field(meta *metadata.Metadata, name, typ string) metadata.Field {
+	return metadata.Field{Name: meta.StringPool.Get(name), Type: meta.StringPool.Get(typ)}
+}
+
+// TestBuildFuncFieldDispatch covers what the index will and will not claim about
+// a func-typed struct field (issue #143).
+func TestBuildFuncFieldDispatch(t *testing.T) {
+	t.Run("nested literal records the function value", func(t *testing.T) {
+		src := `package cli
+func runWeb() error { return nil }
+func main() { app := &App{Commands: []*Command{{Name: "web", Action: runWeb}}}; _ = app }
+`
+		meta := buildDispatchMeta(t, src, "runWeb")
+		meta.Packages[dispatchPkg].Files["cli.go"].Types["Command"].Fields = []metadata.Field{
+			field(meta, "Name", "string"), field(meta, "Action", "func"),
+		}
+
+		got := buildFuncFieldDispatch(meta)
+		want := []string{dispatchPkg + ".runWeb"}
+		if diff := got[funcFieldKey(dispatchPkg, "Command", "Action")]; !reflect.DeepEqual(diff, want) {
+			t.Errorf("Command.Action = %v, want %v (whole index: %v)", diff, want, got)
+		}
+	})
+
+	t.Run("a field whose value is a variable resolves to nothing", func(t *testing.T) {
+		// The variable names no body, so there is nothing honest to record —
+		// chasing what it holds is value resolution, not this index's job.
+		src := `package cli
+func main() { var h func() error; app := &App{Commands: []*Command{{Name: "web", Action: h}}}; _ = app }
+`
+		meta := buildDispatchMeta(t, src, "runWeb")
+		meta.Packages[dispatchPkg].Files["cli.go"].Types["Command"].Fields = []metadata.Field{
+			field(meta, "Name", "string"), field(meta, "Action", "func"),
+		}
+		if got := buildFuncFieldDispatch(meta); len(got) != 0 {
+			t.Errorf("expected no entries for a variable-valued field, got %v", got)
+		}
+	})
+
+	t.Run("a non-func field is never indexed", func(t *testing.T) {
+		// `Name: runWeb` cannot happen in compiling Go, but a field-name match on
+		// a differently-typed field must not be enough on its own: the type is
+		// what says "this is a dispatch point".
+		src := `package cli
+func runWeb() error { return nil }
+func main() { app := &App{Commands: []*Command{{Name: "web", Action: runWeb}}}; _ = app }
+`
+		meta := buildDispatchMeta(t, src, "runWeb")
+		meta.Packages[dispatchPkg].Files["cli.go"].Types["Command"].Fields = []metadata.Field{
+			field(meta, "Name", "string"), field(meta, "Action", "string"), // NOT a func
+		}
+		if got := buildFuncFieldDispatch(meta); len(got) != 0 {
+			t.Errorf("expected no entries when the field is not func-typed, got %v", got)
+		}
+	})
+
+	t.Run("an unexpandable function is not recorded", func(t *testing.T) {
+		// knownFunctionKeys is the expandable set; a name that calls nothing
+		// contributes no routes and must not enter the index.
+		src := `package cli
+func runWeb() error { return nil }
+func main() { app := &App{Commands: []*Command{{Name: "web", Action: runWeb}}}; _ = app }
+`
+		meta := buildDispatchMeta(t, src) // no callable functions at all
+		meta.Packages[dispatchPkg].Files["cli.go"].Types["Command"].Fields = []metadata.Field{
+			field(meta, "Name", "string"), field(meta, "Action", "func"),
+		}
+		if got := buildFuncFieldDispatch(meta); len(got) != 0 {
+			t.Errorf("expected no entries for a function with no recorded calls, got %v", got)
+		}
+	})
+
+	t.Run("several values for one field are all kept, sorted", func(t *testing.T) {
+		// Each command is genuinely invoked for its own subcommand, so the union
+		// is the binary's surface — and the order must not depend on map
+		// iteration (golden rule #1).
+		src := `package cli
+func runWeb() error { return nil }
+func runAdmin() error { return nil }
+func main() {
+	app := &App{Commands: []*Command{{Name: "web", Action: runWeb}, {Name: "admin", Action: runAdmin}}}
+	_ = app
+}
+`
+		meta := buildDispatchMeta(t, src, "runWeb", "runAdmin")
+		meta.Packages[dispatchPkg].Files["cli.go"].Types["Command"].Fields = []metadata.Field{
+			field(meta, "Name", "string"), field(meta, "Action", "func"),
+		}
+		got := buildFuncFieldDispatch(meta)[funcFieldKey(dispatchPkg, "Command", "Action")]
+		want := []string{dispatchPkg + ".runAdmin", dispatchPkg + ".runWeb"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("Command.Action = %v, want %v (sorted)", got, want)
+		}
+	})
+
+	t.Run("positional literal binds elements to fields in order", func(t *testing.T) {
+		src := `package cli
+func runWeb() error { return nil }
+func main() { app := &App{Commands: []*Command{{"web", runWeb}}}; _ = app }
+`
+		meta := buildDispatchMeta(t, src, "runWeb")
+		meta.Packages[dispatchPkg].Files["cli.go"].Types["Command"].Fields = []metadata.Field{
+			field(meta, "Name", "string"), field(meta, "Action", "func"),
+		}
+		got := buildFuncFieldDispatch(meta)[funcFieldKey(dispatchPkg, "Command", "Action")]
+		if want := []string{dispatchPkg + ".runWeb"}; !reflect.DeepEqual(got, want) {
+			t.Errorf("Command.Action = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("keysFor only answers for a recorded field", func(t *testing.T) {
+		d := funcFieldDispatch{funcFieldKey(dispatchPkg, "Command", "Action"): {dispatchPkg + ".runWeb"}}
+		meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+		edge := func(pkg, recv, name string) *metadata.CallGraphEdge {
+			return &metadata.CallGraphEdge{Callee: metadata.Call{
+				Pkg:      meta.StringPool.Get(pkg),
+				RecvType: meta.StringPool.Get(recv),
+				Name:     meta.StringPool.Get(name),
+			}}
+		}
+		if got := d.keysFor(meta, edge(dispatchPkg, "*Command", "Action")); len(got) != 1 {
+			t.Errorf("pointer receiver should match the bare type name, got %v", got)
+		}
+		if got := d.keysFor(meta, edge(dispatchPkg, dispatchPkg+".Command", "Action")); len(got) != 1 {
+			t.Errorf("package-qualified receiver should match, got %v", got)
+		}
+		for _, tc := range []struct{ pkg, recv, name string }{
+			{dispatchPkg, "*Command", "Run"},      // different member
+			{dispatchPkg, "*App", "Action"},       // different type
+			{"other.com/x", "*Command", "Action"}, // different package
+			{dispatchPkg, "", "Action"},           // no receiver: a plain function call
+		} {
+			if got := d.keysFor(meta, edge(tc.pkg, tc.recv, tc.name)); len(got) != 0 {
+				t.Errorf("keysFor(%q, %q, %q) = %v, want none", tc.pkg, tc.recv, tc.name, got)
+			}
+		}
+		if got := d.keysFor(meta, nil); got != nil {
+			t.Errorf("keysFor(nil edge) = %v, want nil", got)
+		}
+		if got := funcFieldDispatch(nil).keysFor(meta, edge(dispatchPkg, "*Command", "Action")); got != nil {
+			t.Errorf("empty index must answer nothing, got %v", got)
+		}
+	})
+
+	t.Run("nil metadata is not a panic", func(t *testing.T) {
+		if got := buildFuncFieldDispatch(nil); got != nil {
+			t.Errorf("buildFuncFieldDispatch(nil) = %v, want nil", got)
+		}
+	})
+}
+
+func TestElementTypeName(t *testing.T) {
+	for in, want := range map[string]string{
+		"[]*Command":            "*Command",
+		"map[string]*Command":   "*Command",
+		"[4]*Command":           "*Command",
+		"*Command":              "",
+		"Command":               "",
+		"":                      "",
+		"map[string][]*Command": "[]*Command",
+	} {
+		if got := elementTypeName(in); got != want {
+			t.Errorf("elementTypeName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestBareTypeName(t *testing.T) {
+	for in, want := range map[string]string{
+		"*Command":                 "Command",
+		"[]*Command":               "Command",
+		"example.com/cli.Command":  "Command",
+		"*example.com/cli.Command": "Command",
+		"Command":                  "Command",
+	} {
+		if got := bareTypeName(in); got != want {
+			t.Errorf("bareTypeName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestIsFuncTypeString(t *testing.T) {
+	for in, want := range map[string]bool{
+		"func":               true,
+		"func(c *Ctx) error": true,
+		"*func":              true,
+		"string":             false,
+		"":                   false,
+		"funcy":              false,
+	} {
+		if got := isFuncTypeString(in); got != want {
+			t.Errorf("isFuncTypeString(%q) = %v, want %v", in, got, want)
+		}
+	}
+}

--- a/internal/spec/lazytree.go
+++ b/internal/spec/lazytree.go
@@ -111,6 +111,11 @@ type LazyTree struct {
 	// later router wiring. Nested by scope to avoid a key concatenation per
 	// child instantiation (visible in profiles).
 	instanceCount map[string]map[string]int
+	// funcFieldImpls resolves a call through a func-typed struct field
+	// (c.Action()) to the functions that field holds — the urfave/cli wiring
+	// style that left gitea with zero routes (issue #143).
+	funcFieldImpls funcFieldDispatch
+
 	// argInstanceIDs holds the exact (position-qualified) IDs of every
 	// top-level call argument in the graph. Used by edgesFor to skip a
 	// callee edge only when THAT call site is already represented as an
@@ -195,6 +200,7 @@ func (t *LazyTree) buildRelations() {
 	t.claimed = map[*metadata.CallGraphEdge]bool{}
 	t.argInstanceIDs = map[string]bool{}
 	meta := t.meta
+	t.funcFieldImpls = buildFuncFieldDispatch(meta)
 
 	for i := range meta.CallGraph {
 		for _, arg := range meta.CallGraph[i].Args {
@@ -740,6 +746,13 @@ func (t *LazyTree) buildPlan(n *LazyNode) []childSpec {
 			for _, implKey := range t.implementerKeys(calleePkg, calleeRecv, calleeName) {
 				expandKey(implKey)
 			}
+		}
+		// Func-typed field callee (c.Action() on a cli.Command): the field is a
+		// dispatch point just like an interface method, and the functions
+		// recorded for it are the bodies to follow (issue #143). Without this,
+		// the whole registration subtree behind a CLI dispatcher is unreachable.
+		for _, fnKey := range t.funcFieldImpls.keysFor(meta, n.edge) {
+			expandKey(fnKey)
 		}
 	}
 	// Method-value handler (g.GET("/", h.GetUsers)): the argument is a

--- a/internal/spec/tracker.go
+++ b/internal/spec/tracker.go
@@ -253,6 +253,10 @@ type TrackerTree struct {
 	// with LazyTree so both engines resolve the same routes (issue #204).
 	handlerMethods []string
 
+	// funcFieldImpls resolves a call through a func-typed struct field to the
+	// functions that field holds, at parity with LazyTree (issue #143).
+	funcFieldImpls funcFieldDispatch
+
 	// logger receives traversal-time warnings (limit truncations, etc.).
 	// May be nil; callers should reach it via t.warn / t.info.
 	logger metadata.VerboseLogger
@@ -431,6 +435,8 @@ func NewTrackerTree(meta *metadata.Metadata, limits metadata.TrackerLimits, logg
 		// Initialize performance optimization caches with pre-allocated capacity
 		nodeMap: make(map[string]*TrackerNode, 200),
 		idCache: make(map[string]string, 100),
+
+		funcFieldImpls: buildFuncFieldDispatch(meta),
 	}
 	for _, opt := range opts {
 		opt(t)
@@ -1646,6 +1652,31 @@ func NewTrackerNode(tree *TrackerTree, meta *metadata.Metadata, parentID, id str
 					}
 				}
 			}
+		}
+	}
+
+	// Handle calls made through a func-typed struct field (c.Action() on a
+	// cli.Command) by attaching the bodies of the functions that field holds —
+	// the eager counterpart to LazyTree's funcFieldImpls expansion (issue #143).
+	// Without it, a CLI-dispatched registration subtree is unreachable from main
+	// and the project documents zero routes.
+	for _, fnKey := range tree.funcFieldImpls.keysFor(meta, parentEdge) {
+		for _, fnEdge := range meta.Callers[fnKey] {
+			calleeID := fnEdge.Callee.ID()
+			if tree.nodeMap[calleeID] != nil {
+				continue
+			}
+			childNode := NewTrackerNode(tree, meta, id, calleeID, fnEdge, nil, visited, assignmentIndex, limits)
+			if childNode == nil {
+				continue
+			}
+			// The argument children have to be built here, exactly as the
+			// direct-callee loop does: a node builds its own CALLEES, but its
+			// arguments are the parent's job. Without this the registration is
+			// found and then documents nothing — no handler body means no
+			// request body, no responses, no params.
+			childNode.AddChildren(processArguments(tree, meta, childNode, fnEdge, visited, assignmentIndex, limits))
+			node.AddChild(childNode)
 		}
 	}
 

--- a/testdata/cli_action_cross_package/clipkg/cli.go
+++ b/testdata/cli_action_cross_package/clipkg/cli.go
@@ -1,0 +1,25 @@
+// Package clipkg stands in for urfave/cli: the command type whose Action field
+// holds the function the dispatcher calls back.
+package clipkg
+
+// Command mirrors cli.Command.
+type Command struct {
+	Name   string
+	Action func() error
+}
+
+// App mirrors cli.App.
+type App struct {
+	Commands []*Command
+}
+
+// Run dispatches to the named command's Action — the dynamic hop that no static
+// call edge crosses.
+func (a *App) Run(name string) error {
+	for _, c := range a.Commands {
+		if c.Name == name {
+			return c.Action()
+		}
+	}
+	return nil
+}

--- a/testdata/cli_action_cross_package/go.mod
+++ b/testdata/cli_action_cross_package/go.mod
@@ -1,0 +1,5 @@
+module github.com/ehabterra/apispec/testdata/cli_action_cross_package
+
+go 1.24.3
+
+require github.com/go-chi/chi/v5 v5.2.2

--- a/testdata/cli_action_cross_package/go.sum
+++ b/testdata/cli_action_cross_package/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=
+github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=

--- a/testdata/cli_action_cross_package/main.go
+++ b/testdata/cli_action_cross_package/main.go
@@ -1,0 +1,30 @@
+// Fixture: the urfave/cli wiring style spread across packages, which is how it
+// actually looks in the wild (issue #143). Everything here is one hop harder than
+// the single-package `cli_action_routes` fixture:
+//
+//   - the command type is package-qualified (`clipkg.Command{…}`), so the literal
+//     names its type through a selector rather than a bare ident;
+//   - one Action is a CROSS-PACKAGE function value (`web.RunWeb`) — a selector,
+//     not an ident, which is the resolution that silently collapses if the callee
+//     name is read from the wrong place (golden rule #10);
+//   - one Action is a METHOD value (`srv.RunAdmin`), whose key needs the receiver
+//     type as well as the package.
+package main
+
+import (
+	"github.com/ehabterra/apispec/testdata/cli_action_cross_package/clipkg"
+	"github.com/ehabterra/apispec/testdata/cli_action_cross_package/web"
+)
+
+// CmdWeb is gitea's shape: a package-level var holding the command, whose Action
+// is a function from another package.
+var CmdWeb = &clipkg.Command{Name: "web", Action: web.RunWeb}
+
+func main() {
+	srv := &web.Server{}
+	app := &clipkg.App{Commands: []*clipkg.Command{
+		CmdWeb,
+		{Name: "admin", Action: srv.RunAdmin},
+	}}
+	_ = app.Run("web")
+}

--- a/testdata/cli_action_cross_package/web/web.go
+++ b/testdata/cli_action_cross_package/web/web.go
@@ -1,0 +1,58 @@
+// Package web holds the route registration, in a different package from both
+// main and the command type — the arrangement every real CLI-wired project has.
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// User is the public API resource.
+type User struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// Report is the admin resource.
+type Report struct {
+	Rows int `json:"rows"`
+}
+
+// RunWeb is referenced as a CROSS-PACKAGE function value (web.RunWeb), so the
+// Action field holds a selector rather than a plain ident.
+func RunWeb() error {
+	r := chi.NewRouter()
+	r.Get("/users", listUsers)
+	r.Post("/users", createUser)
+	return http.ListenAndServe(":8080", r)
+}
+
+// Server exists so one command's Action can be a METHOD value (srv.RunAdmin),
+// the third way a function reaches the field.
+type Server struct{}
+
+// RunAdmin registers the admin surface.
+func (s *Server) RunAdmin() error {
+	r := chi.NewRouter()
+	r.Get("/admin/report", s.report)
+	return http.ListenAndServe(":8081", r)
+}
+
+func (s *Server) report(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(Report{Rows: 1})
+}
+
+func listUsers(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode([]User{})
+}
+
+func createUser(w http.ResponseWriter, r *http.Request) {
+	var u User
+	_ = json.NewDecoder(r.Body).Decode(&u)
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(u)
+}

--- a/testdata/cli_action_routes/main.go
+++ b/testdata/cli_action_routes/main.go
@@ -12,6 +12,14 @@ import (
 // stored in a composite-literal field, invoked by a dispatcher. Static
 // call-graph tracing stops at app.Run — there is no direct call edge from
 // main's subtree to runWeb.
+//
+// Three ways the function value gets into the field, all of which occur in real
+// projects and each recorded differently in metadata (issue #143):
+//
+//   1. a literal nested inside a function's own literal -> runWeb   (/users)
+//   2. a package-level var holding the command, gitea's form -> runAdmin
+//      (/admin/stats)
+//   3. an inline closure as the Action                              (/metrics)
 
 // Command mirrors cli.Command: the handler wiring hides in Action.
 type Command struct {
@@ -61,7 +69,44 @@ func runWeb() error {
 	return http.ListenAndServe(":8080", r)
 }
 
+// CmdAdmin mirrors gitea's own shape: the command literal lives in a
+// package-level var (`var CmdWeb = &cli.Command{Action: runWeb}`), which is
+// recorded differently from a literal written inside a function.
+var CmdAdmin = &Command{Name: "admin", Action: runAdmin}
+
+// runAdmin registers the admin surface. Reached only through CmdAdmin's Action.
+func runAdmin() error {
+	r := chi.NewRouter()
+	r.Get("/admin/stats", adminStats)
+	return http.ListenAndServe(":8081", r)
+}
+
+func adminStats(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(Stats{Users: 1})
+}
+
+// Stats is the admin resource.
+type Stats struct {
+	Users int `json:"users"`
+}
+
 func main() {
-	app := &App{Commands: []*Command{{Name: "web", Action: runWeb}}}
+	app := &App{Commands: []*Command{
+		{Name: "web", Action: runWeb},
+		CmdAdmin,
+		// An inline closure is the other common urfave/cli form: the Action is
+		// a func literal rather than a named function.
+		{Name: "metrics", Action: func() error {
+			r := chi.NewRouter()
+			r.Get("/metrics", metricsHandler)
+			return http.ListenAndServe(":8082", r)
+		}},
+	}}
 	_ = app.Run("web")
+}
+
+func metricsHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(Stats{Users: 2})
 }


### PR DESCRIPTION
**Partially addresses #143** — do not auto-close it. Branched from `main`, independent of the #215/#217/#218 stack.

This fixes func-field dispatch when the dispatcher is **in the analysed module** (proved by four fixture shapes across two engines). It does **not** fix gitea, which is the issue's headline symptom, because gitea's dispatcher is inside urfave/cli — measured and explained under "Measured on gitea" below.

apispec reported **zero routes** for gitea. The registration edges were in metadata the whole time; nothing reached them. Tracker roots are main functions, and in the urfave/cli wiring style no static call edge crosses the dispatcher hop — the registering function goes into a composite-literal field and the library calls it back as `c.Action()`, so expansion stopped at `app.Run(...)`.

| | before | after |
|---|---|---|
| `testdata/cli_action_routes` | **0 paths** | `/users` GET+POST, `/admin/stats` GET, `/metrics` GET — with request bodies, statuses and schemas |

## Approach: direction (1) from the issue

A func-typed field is a dispatch point in exactly the way an interface method is, so it is resolved the same way: collect the values recorded for it and expand into all of them. `funcFieldDispatch` (new `internal/spec/func_field_dispatch.go`) indexes `"pkg.Type.Field" -> function base keys`.

Three sources, because the same Go code is recorded three different ways depending on where the literal sits:

| source | shape it covers |
|---|---|
| `File.StructInstances` | `var CmdWeb = &cli.Command{Action: runWeb}` — **gitea's own form**; a package-level initializer is not kept as a `CallArgument` anywhere |
| assignment values | `app := &App{Commands: []*Command{{Action: runWeb}}}` — the nested literal survives in full in the CallArgument tree |
| call arguments | `app.Register(&Command{Action: runWeb})` |

I verified the nesting is genuinely present before building on it (`ExprToCallArgument` keeps `Action: runWeb` intact) — the metadata *YAML* truncates it, which is what made this look like a fact-layer gap at first glance. It isn't: nothing needed to change in `internal/metadata`.

## Both engines

- **LazyTree** — one `expandKey` loop beside the existing interface fan-out in `buildPlan`.
- **Eager tree** — beside its `ImplementedBy` attachment. This side additionally has to build the attached nodes' **argument** children itself: a node builds its own callees, but its arguments are the parent loop's job. Without that the routes appear and document *nothing* — which is exactly what my first eager version did, and why the parity check below is in the PR rather than assumed.

Both engines produce **byte-identical** specs for the fixture (checked with `--legacy-tracker`).

## Honest by construction

- A value resolves only when it **names** a function expansion can follow (`meta.Callers` / `meta.ParentFunctions`, which is also what makes an inline closure `Action` work — closures are callers in their own right). A field holding a *variable* contributes nothing rather than a guess.
- A field-name match is never enough on its own: the field must be func-typed, so `Name: something` can't be mistaken for a dispatch point.
- **Several values for one field are all kept.** Each is genuinely invoked for its own subcommand, so their union is the surface the binary serves — a stronger statement than picking one, and the reason this isn't the ambiguity golden rule #7 tells you to refuse. The fixture has three commands registering three different route sets and asserts all three appear.
- Known limitation, deliberately not guessed at: the union is per `(type, field)`, not per *instance*. If two instances of the same struct type hold different functions and are called at different mount prefixes, both expand at both sites. Narrowing that needs the call site's receiver traced back to a specific literal — value resolution, a separate piece of work. No fixture in the suite exhibits it (zero drift), and for CLI dispatch the union is the correct reading.

## Tests

- `testdata/cli_action_routes` stops pinning the gap: it now carries all three shapes and `TestTestdata_CLIActionRoutes` asserts the routes **and their handler bodies** (a route found but documented empty is barely better than a route missed). The old known-gap assertion is removed from `testdata_known_gaps_test.go`.
- `TestBuildFuncFieldDispatch` covers what the index refuses — a variable-valued field, a non-func field, a function with no recorded calls — plus multi-value ordering (sorted; this index decides which routes exist, so its order reaches the output) and positional literals. Built against the real `ExprToCallArgument` rather than hand-assembled arguments, since the nested-literal shape is the thing under test.
- `keysFor` unit-tested across pointer/qualified receivers and the four non-matches (different member, type, package, no receiver).

## Verification

Full suite green (goldens, determinism, all framework fixtures), `golangci-lint` 0 issues, `gofmt`/`vet` clean. **Zero drift**: I generated all 60 fixtures with a `main` binary and a branch binary — `cli_action_routes` is the only one that changes.

## Measured on gitea

Run against a real gitea checkout with both binaries. **Still 0 routes**, and the reason is structural rather than a tuning problem:

```
DBG index entries=18                 # the index does build, on gitea's own types
DBG edges-calling-Action=0           # ...but nothing ever CALLS Action
DBG func-typed-fields-declared=42
```

Three blockers stack up, all of them about the dispatcher being third-party:

1. **No dispatch edge exists.** `cmd.Action(ctx, cmd)` is executed inside `urfave/cli`, and external packages are never loaded (360 packages either way; `--include-package` only filters what the loader already returns). With no edge whose callee is `Action`, the expansion hook has nothing to fire on — which is why the index being correctly populated changes nothing.
2. **`cli.Command` is external**, so its field list is not in metadata and the type cannot be looked up.
3. **`Action` is typed `cli.ActionFunc`** — a *named* func type, not a literal `func(...)`, so even with the declaration present the func-typed-field test would reject it.

My fixtures hid all three by putting the dispatcher in the module, which is exactly the shape the issue warned about ("invoked by the library dispatcher"). Filed as its own issue with this evidence; the tractable fix is the issue's own direction (2)/(3) — re-root a registration cluster whose enclosing function is stored in a composite-literal field, which needs no external analysis because the *assignment* is in gitea's own code — plus dropping the field-type test in favour of "the value names a known function". That is a behaviour-risk change (new tree roots) and wants its own PR and a fixture that depends on the real `urfave/cli`, so it cannot be faked by an in-module dispatcher a second time.

## Measured performance

No regression. Warm, alternating runs on gitea:

| | main | this branch |
|---|---|---|
| wall clock | 46.5s / 46.5s | 47.0s / 49.8s |
| metadata generated | 33.3s | 33.7s |
| spec mapped | 8.4s | 9.6s |
| `buildRelations` (cum, CPU profile) | 7.04s | 7.27s |
| **`buildFuncFieldDispatch` (cum)** | — | **0.04s (0.075%)** |

The index build does not appear in the profile above the default threshold; at full resolution it is 40ms. The run-to-run spread in "spec mapped" is machine noise, not this change.

A doubling *was* observed initially (1:50 vs ~46s) and reproduced — it is the **cold first run**: 536s user time at 608% CPU, i.e. `go/packages` type-checking gitea and writing export data. Warm runs of either binary land at ~46-47s.

## What still holds

Full suite green, `golangci-lint` 0 issues, coverage 96.1% (floor 96). Zero drift across the other 59 fixtures, normalising the absolute path #216 leaks into closure operationIds.
