### PR TITLE
fix(ui): compose the same multi-framework config the engine does

### DIFF
--- a/cmd/apispecui/main.go
+++ b/cmd/apispecui/main.go
@@ -34,7 +34,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ehabterra/apispec/internal/core"
 	"github.com/ehabterra/apispec/internal/diagserver"
 	"github.com/ehabterra/apispec/internal/engine"
 	"github.com/ehabterra/apispec/internal/insight"
@@ -118,10 +117,16 @@ type ServerConfig struct {
 // DetectResponse is what GET /api/detect returns: information the UI needs
 // to pre-fill the configuration form.
 type DetectResponse struct {
-	InputDir            string                         `json:"inputDir"`
-	ModuleRoot          string                         `json:"moduleRoot"`
-	ModulePath          string                         `json:"modulePath"`
-	DetectedFramework   string                         `json:"detectedFramework"`
+	InputDir          string `json:"inputDir"`
+	ModuleRoot        string `json:"moduleRoot"`
+	ModulePath        string `json:"modulePath"`
+	DetectedFramework string `json:"detectedFramework"`
+	// DetectedFrameworks is every framework found, in first-seen order. The
+	// first is the primary; the rest are merged as receiver-scoped views. The
+	// UI shows the whole set because a project's primary is decided by
+	// file-walk order (issue #212), so naming only the primary is misleading —
+	// photoprism reports `mux` while serving gin.
+	DetectedFrameworks  []string                       `json:"detectedFrameworks,omitempty"`
 	SupportedFrameworks []string                       `json:"supportedFrameworks"`
 	OpenAPIVersion      string                         `json:"openapiVersion"`
 	Info                spec.Info                      `json:"info"`
@@ -547,10 +552,16 @@ func validateProjectDir(dir string) (string, error) {
 func (s *UIServer) buildDetectResponse(dir string) DetectResponse {
 	root, modPath := findModuleRoot(dir)
 
-	det := core.NewFrameworkDetector()
-	framework, err := det.Detect(root)
-	if err != nil || framework == "" {
-		framework = "net/http"
+	// Compose exactly what the engine composes: the primary's config plus every
+	// other detected framework as a receiver-scoped view plus the net/http
+	// surface. Using the primary alone is what made a real project document zero
+	// routes here while the CLI documented all of them — photoprism's primary is
+	// `mux` (one dummy file imports gorilla/mux and sorts first, issue #212) but
+	// every route it serves is gin.
+	composed, frameworks, cerr := engine.ComposeFrameworkConfig(root)
+	framework := "net/http"
+	if cerr == nil && len(frameworks) > 0 {
+		framework = frameworks[0]
 	}
 
 	var base *spec.APISpecConfig
@@ -562,7 +573,11 @@ func (s *UIServer) buildDetectResponse(dir string) DetectResponse {
 		}
 	}
 	if base == nil {
-		base = defaultConfigForFramework(framework)
+		if composed != nil {
+			base = composed
+		} else {
+			base = defaultConfigForFramework(framework)
+		}
 	}
 
 	if base.Info.Title == "" {
@@ -593,6 +608,7 @@ func (s *UIServer) buildDetectResponse(dir string) DetectResponse {
 		ModuleRoot:          root,
 		ModulePath:          modPath,
 		DetectedFramework:   framework,
+		DetectedFrameworks:  frameworks,
 		SupportedFrameworks: supportedFrameworks,
 		OpenAPIVersion:      "3.1.0",
 		Info:                base.Info,
@@ -737,9 +753,9 @@ func (s *UIServer) handleGenerate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.Framework == "" {
-		req.Framework = "net/http"
-	}
+	// An unspecified framework means "detect it", not net/http: defaulting to
+	// the stdlib made a gin or chi project analysed with net/http patterns and
+	// documented as empty. buildAPISpecConfig fills it in from detection.
 	if req.OpenAPIVersion == "" {
 		req.OpenAPIVersion = "3.1.0"
 	}
@@ -758,7 +774,7 @@ func (s *UIServer) handleGenerate(w http.ResponseWriter, r *http.Request) {
 	}
 	s.setDir(abs)
 
-	apiCfg, err := buildAPISpecConfig(&req)
+	apiCfg, err := buildAPISpecConfig(&req, s.currentDir())
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
@@ -1383,10 +1399,13 @@ func sortedKeys(m map[string]struct{}) []string {
 // buildAPISpecConfig merges a GenerateRequest into a full *APISpecConfig
 // using the same rules as handleGenerate. Used by /api/generate (to drive
 // the engine) and /api/render-config (to render the YAML preview).
-func buildAPISpecConfig(req *GenerateRequest) (*spec.APISpecConfig, error) {
-	if req.Framework == "" {
-		req.Framework = "net/http"
-	}
+// buildAPISpecConfig turns a generate request into the config the engine runs
+// with. dir is the project being analysed: the framework patterns are composed
+// for it (detected set, scoped views, net/http underneath), not for the selected
+// framework alone. Selecting one framework and dropping the rest is what made a
+// gin project whose primary detects as `mux` document zero routes here while the
+// CLI documented 107 (issue #212's failure mode, reaching the UI).
+func buildAPISpecConfig(req *GenerateRequest, dir string) (*spec.APISpecConfig, error) {
 
 	if req.UseRawConfig && strings.TrimSpace(req.RawConfig) != "" {
 		cfg := &spec.APISpecConfig{}
@@ -1399,7 +1418,15 @@ func buildAPISpecConfig(req *GenerateRequest) (*spec.APISpecConfig, error) {
 		return cfg, nil
 	}
 
-	cfg := defaultConfigForFramework(req.Framework)
+	cfg, frameworks, err := engine.ComposeFrameworkConfigWithPrimary(dir, req.Framework)
+	if err != nil || cfg == nil {
+		// Detection failed (unreadable dir): fall back to the selection alone
+		// rather than failing the run.
+		cfg = defaultConfigForFramework(req.Framework)
+	}
+	if req.Framework == "" && len(frameworks) > 0 {
+		req.Framework = frameworks[0]
+	}
 	cfg.Info = req.Info
 	cfg.Servers = req.Servers
 	cfg.Security = req.Security
@@ -1477,7 +1504,7 @@ func (s *UIServer) handleRenderConfig(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
 		return
 	}
-	cfg, err := buildAPISpecConfig(&req)
+	cfg, err := buildAPISpecConfig(&req, s.currentDir())
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
@@ -1786,7 +1813,7 @@ func (s *UIServer) handleSaveConfig(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	cfg, err := buildAPISpecConfig(&req.GenerateRequest)
+	cfg, err := buildAPISpecConfig(&req.GenerateRequest, s.currentDir())
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return

--- a/internal/engine/compose_config_test.go
+++ b/internal/engine/compose_config_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestComposeFrameworkConfig pins the composition every consumer must share.
+//
+// The UI used to build its config from the detected *primary alone*. That is
+// broken for any project whose primary is decided by file-walk order (issue
+// #212): photoprism's primary detects as `mux` because one dummy file imports
+// gorilla/mux and sorts first, so a mux-only config recognises none of its gin
+// routes — the CLI documented 107 paths while the UI documented zero.
+func TestComposeFrameworkConfig(t *testing.T) {
+	dir := filepath.Join("..", "..", "testdata", "mixed_gin_mux")
+
+	cfg, frameworks, err := ComposeFrameworkConfig(dir)
+	if err != nil {
+		t.Fatalf("ComposeFrameworkConfig: %v", err)
+	}
+	if len(frameworks) < 2 {
+		t.Fatalf("expected both frameworks detected, got %v", frameworks)
+	}
+
+	recvs := make([]string, 0, len(cfg.Framework.RoutePatterns))
+	for _, p := range cfg.Framework.RoutePatterns {
+		recvs = append(recvs, p.RecvType+p.RecvTypeRegex)
+	}
+	joined := strings.Join(recvs, "\n")
+
+	// Every detected framework must be recognisable, not just the one that
+	// happened to sort first.
+	for _, want := range []string{"gin-gonic/gin", "gorilla/mux"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("composed config cannot recognise %s registrations; receivers:\n%s", want, joined)
+		}
+	}
+	// The stdlib surface is layered underneath for mixed projects.
+	if !strings.Contains(joined, "net/http") {
+		t.Errorf("composed config is missing the net/http surface; receivers:\n%s", joined)
+	}
+}
+
+// TestComposeFrameworkConfigWithPrimary covers the UI's framework selector: the
+// user picks which framework leads, and the others must still merge in — picking
+// one must not silently discard the rest, which is the bug this replaces.
+func TestComposeFrameworkConfigWithPrimary(t *testing.T) {
+	dir := filepath.Join("..", "..", "testdata", "mixed_gin_mux")
+
+	for _, primary := range []string{"gin", "mux", "chi"} {
+		cfg, frameworks, err := ComposeFrameworkConfigWithPrimary(dir, primary)
+		if err != nil {
+			t.Fatalf("primary %s: %v", primary, err)
+		}
+		if frameworks[0] != primary {
+			t.Errorf("primary %s: leading framework = %s", primary, frameworks[0])
+		}
+
+		var joined strings.Builder
+		for _, p := range cfg.Framework.RoutePatterns {
+			joined.WriteString(p.RecvType + p.RecvTypeRegex + "\n")
+		}
+		// Both detected frameworks survive whichever one the user selected —
+		// including "chi", which this project does not use at all: an explicit
+		// choice leads, the detected ones still merge under it.
+		for _, want := range []string{"gin-gonic/gin", "gorilla/mux"} {
+			if !strings.Contains(joined.String(), want) {
+				t.Errorf("primary %s: %s registrations became unrecognisable:\n%s", primary, want, joined.String())
+			}
+		}
+	}
+}
+
+// TestComposeFrameworkConfigSingleFramework checks the ordinary case is
+// unchanged: one framework, plus the net/http layer.
+func TestComposeFrameworkConfigSingleFramework(t *testing.T) {
+	cfg, frameworks, err := ComposeFrameworkConfig(filepath.Join("..", "..", "testdata", "gin"))
+	if err != nil {
+		t.Fatalf("ComposeFrameworkConfig: %v", err)
+	}
+	if len(frameworks) != 1 || frameworks[0] != "gin" {
+		t.Fatalf("frameworks = %v, want [gin]", frameworks)
+	}
+	if len(cfg.Framework.RoutePatterns) == 0 {
+		t.Fatal("no route patterns composed")
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -514,6 +514,75 @@ func (e *Engine) GenerateMetadataOnlyWithLogger(logger *VerboseLogger) (*metadat
 
 // defaultFrameworkConfig maps a detected framework name to its built-in
 // config; unknown names (and "net/http") get the net/http config.
+// ComposeFrameworkConfig builds the effective framework config for a directory:
+// the detected primary's config, every other detected framework merged in as a
+// receiver-scoped view, and the stdlib net/http surface layered underneath. It
+// returns the config and the detected frameworks in first-seen order.
+//
+// Exported because the UI must not compose this itself. It used to build a
+// config from the *primary alone* — and a project whose primary is decided by
+// file-walk order (issue #212) then loses every other framework's patterns: a
+// single dummy file importing gorilla/mux inside photoprism makes mux primary,
+// so a UI-built mux-only config documents zero of its gin routes while the CLI
+// documents 107. One composition path, one answer.
+func ComposeFrameworkConfig(dir string) (*spec.APISpecConfig, []string, error) {
+	return ComposeFrameworkConfigWithPrimary(dir, "")
+}
+
+// ComposeFrameworkConfigWithPrimary is ComposeFrameworkConfig with the primary
+// chosen by the caller — the UI's framework selector, where a user overrides
+// what detection picked. Every OTHER detected framework still merges in as a
+// scoped view, because overriding which framework leads must not silently
+// discard the ones the project also uses.
+func ComposeFrameworkConfigWithPrimary(dir, primary string) (*spec.APISpecConfig, []string, error) {
+	frameworks, err := core.NewFrameworkDetector().DetectAll(dir)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to detect framework: %w", err)
+	}
+	if len(frameworks) == 0 {
+		frameworks = []string{"net/http"}
+	}
+	if primary == "" {
+		primary = frameworks[0]
+	} else {
+		// The returned list always leads with the primary in effect — callers
+		// (the UI's selector, its "detected" label) read frameworks[0] as the
+		// one that leads. An explicit choice detection did not see (a house
+		// router, or a framework used somewhere the walk missed) is added
+		// rather than rejected; everything detected still merges under it.
+		rest := make([]string, 0, len(frameworks))
+		for _, fw := range frameworks {
+			if fw != primary {
+				rest = append(rest, fw)
+			}
+		}
+		frameworks = append([]string{primary}, rest...)
+	}
+
+	cfg := defaultFrameworkConfig(primary)
+	// Additional recognised frameworks (a gin API next to a gorilla/mux admin
+	// router, half-migrated projects): merge each one's receiver-scoped view so
+	// its registrations are traced too. Scoped patterns cannot claim another
+	// framework's calls, so the merge is inert where the secondary framework is
+	// imported but not routing.
+	for _, fw := range frameworks {
+		if fw == primary {
+			continue
+		}
+		cfg = spec.MergeFrameworkConfigs(cfg, spec.SecondaryView(defaultFrameworkConfig(fw)))
+	}
+	// Layer the stdlib net/http surface under the detected framework: mixed
+	// projects (a framework API plus plain ServeMux ops endpoints in one binary)
+	// are common, and net/http never appears in go.mod, so import-based
+	// detection cannot pick it as a second framework. Every merged pattern is
+	// receiver- or package-scoped, which keeps the merge inert for
+	// pure-framework projects.
+	if primary != "net/http" {
+		cfg = spec.MergeFrameworkConfigs(cfg, spec.HTTPSecondaryConfig())
+	}
+	return cfg, frameworks, nil
+}
+
 func defaultFrameworkConfig(framework string) *spec.APISpecConfig {
 	switch framework {
 	case "gin":
@@ -578,8 +647,7 @@ func (e *Engine) GenerateOpenAPI() (*spec.OpenAPISpec, error) {
 	// today. TestPrimaryFrameworkOrderInvariance pins the property, so a preset
 	// that reintroduces a primary-only asymmetry fails there rather than in
 	// someone's spec after a rename.
-	detector := core.NewFrameworkDetector()
-	frameworks, err := detector.DetectAll(e.config.moduleRoot)
+	frameworks, err := core.NewFrameworkDetector().DetectAll(e.config.moduleRoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to detect framework: %w", err)
 	}
@@ -603,25 +671,10 @@ func (e *Engine) GenerateOpenAPI() (*spec.OpenAPISpec, error) {
 			return nil, fmt.Errorf("failed to load config: %w", err)
 		}
 	} else {
-		// Auto-detect framework and use defaults
-		apispecConfig = defaultFrameworkConfig(framework)
-		// Additional recognised frameworks (a gin API next to a gorilla/mux
-		// admin router, half-migrated projects): merge each one's
-		// receiver-scoped view so its registrations are traced too. Scoped
-		// patterns cannot claim another framework's calls, so the merge is
-		// inert where the secondary framework is imported but not routing.
-		for _, fw := range frameworks[1:] {
-			apispecConfig = spec.MergeFrameworkConfigs(apispecConfig, spec.SecondaryView(defaultFrameworkConfig(fw)))
-		}
-		// Layer the stdlib net/http surface under the detected framework:
-		// mixed projects (a framework API plus plain ServeMux ops endpoints
-		// in one binary) are common, and net/http never appears in go.mod,
-		// so import-based detection cannot pick it as a second framework.
-		// Every merged pattern is receiver- or package-scoped, which keeps
-		// the merge inert for pure-framework projects; user-supplied configs
-		// (the branches above) are never augmented.
-		if framework != "net/http" {
-			apispecConfig = spec.MergeFrameworkConfigs(apispecConfig, spec.HTTPSecondaryConfig())
+		// Detected frameworks, composed the one way everything composes them.
+		apispecConfig, _, err = ComposeFrameworkConfig(e.config.moduleRoot)
+		if err != nil {
+			return nil, err
 		}
 	}
 


### PR DESCRIPTION
**Stacked on #222** (`feature/220-entrypoint-dispatch`) — the diff here is just this commit. Fixes a UI bug that is independent of, and older than, that work.

## The symptom

apispecui documented **zero routes** for photoprism while the CLI documented **107** from the same code, same branch, same machine.

## The cause

`buildAPISpecConfig` built the config from the detected **primary alone**:

```go
if req.Framework == "" { req.Framework = "net/http" }   // "unspecified" meant stdlib
cfg := defaultConfigForFramework(req.Framework)          // ONE framework
```

and handed it to the engine — which, given an explicit config, skips detection, the scoped-secondary merge and the net/http layer entirely.

This is **issue #212's failure mode reaching the UI**. photoprism's primary detects as `mux` because one file — `docker/dummy/oidc/app/server.go`, a dummy OIDC app — imports `gorilla/mux` and sorts first in file-walk order. Every route photoprism actually serves is gin. The CLI is immune because it merges gin back in as a receiver-scoped secondary (#211/#212); the UI, holding a mux-only config, could not recognise a single one.

Measured:

| config the UI sent | paths |
|---|---|
| `mux` only (what it built) | **0** |
| `net/http` only (what an untouched selector produced) | **0** |
| composed: primary + scoped secondaries + net/http | **107** |

## The fix

`ComposeFrameworkConfig(dir)` now owns the composition, and **both** the engine and the UI call it. One path, one answer, no way to drift apart again.

`ComposeFrameworkConfigWithPrimary(dir, primary)` serves the framework selector: the user picks which framework *leads*, and the others still merge under it — picking one must not discard the rest. An explicit choice detection never saw is added rather than rejected, and the returned list always leads with the primary in effect, since the UI reads `frameworks[0]` as the effective one.

`DetectResponse` gains `detectedFrameworks`, so the UI can show the whole set instead of a misleading single name. An unspecified framework now means *detect it* rather than net/http.

## Verified through the UI's own API

Not just the library — the actual HTTP path the browser uses:

```
POST /api/generate {"info":{"title":"photoprism","version":"1.0.0"}}
  ->  {"ok":true,"framework":"mux","pathCount":107}      # was pathCount: 0
GET  /api/detect
  ->  {"detectedFramework":"mux","detectedFrameworks":["mux","gin"]}
```

## Tests

`TestComposeFrameworkConfig` asserts a mixed gin+mux project composes patterns that can recognise **both** frameworks plus net/http — the property whose absence caused this. `TestComposeFrameworkConfigWithPrimary` covers the selector: for each of `gin`, `mux` and `chi` as primary (including a framework the project does not use), both detected frameworks stay recognisable and the primary leads. `TestComposeFrameworkConfigSingleFramework` pins that the ordinary one-framework case is unchanged.

Full suite green, `golangci-lint` 0 issues.

## Note

This is why #222 looked broken when tested in the UI: photoprism resolves 107 paths there only once *both* changes are present — #222 makes the CLI-dispatched routes reachable, and this makes the UI analyse them with the right framework patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
