### PR TITLE
feat(insight): dashboard shows frameworks, CLI entry points and per-status body resolution

### DIFF
--- a/cmd/apispecui/analysis_test.go
+++ b/cmd/apispecui/analysis_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/insight"
+	"github.com/ehabterra/apispec/internal/spec"
+)
+
+// TestAnalysisInfo covers what the Insight view is told about the run. The one
+// case that matters beyond plumbing: a project that declares no entry points
+// reports none at all, rather than a block of zeros. "The gate found nothing" and
+// "there was nothing for the gate to find" are different statements, and only the
+// second is true of an ordinary web service.
+func TestAnalysisInfo(t *testing.T) {
+	t.Run("no entrypoints declared", func(t *testing.T) {
+		got := analysisInfo("chi", []string{"chi"}, true, spec.EntrypointStats{})
+		want := insight.AnalysisInfo{Frameworks: []string{"chi"}, Primary: "chi", Engine: "lazy"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("analysisInfo = %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("entrypoints declared", func(t *testing.T) {
+		got := analysisInfo("mux", []string{"mux", "gin"}, true,
+			spec.EntrypointStats{Declared: 53, Rooted: 1, AlreadyReachable: 0, NoRoutes: 52})
+		if got.Entrypoints == nil {
+			t.Fatal("entrypoints not reported")
+		}
+		want := insight.EntrypointInfo{Declared: 53, Rooted: 1, AlreadyReachable: 0, NoRoutes: 52}
+		if *got.Entrypoints != want {
+			t.Errorf("entrypoints = %+v, want %+v", *got.Entrypoints, want)
+		}
+	})
+
+	t.Run("the tracker engine is named", func(t *testing.T) {
+		if got := analysisInfo("chi", nil, false, spec.EntrypointStats{}); got.Engine != "eager" {
+			t.Errorf("engine = %q, want eager", got.Engine)
+		}
+	})
+}
+
+// TestBuildAPISpecConfigKeepsEverySection guards the other half of the config
+// round-trip: the editor may offer a section, but the server builds the config it
+// hands to the engine, and a section it forgets to copy is silently dropped —
+// edits appear to save and change nothing. This failed for entrypoints, security
+// patterns, handler methods and response context before it was fixed.
+func TestBuildAPISpecConfigKeepsEverySection(t *testing.T) {
+	req := &GenerateRequest{
+		Framework: "chi",
+		FrameworkConfig: &spec.FrameworkConfig{
+			RoutePatterns:           []spec.RoutePattern{{CallRegex: "^Get$"}},
+			RequestBodyPatterns:     []spec.RequestBodyPattern{{CallRegex: "^Decode$"}},
+			ResponsePatterns:        []spec.ResponsePattern{{CallRegex: "^Encode$"}},
+			ParamPatterns:           []spec.ParamPattern{{CallRegex: "^Param$", ParamIn: "path"}},
+			MountPatterns:           []spec.MountPattern{{CallRegex: "^Mount$"}},
+			SecurityPatterns:        []spec.SecurityPattern{{CallRegex: "^Use$", Scope: spec.SecurityScopeRouter}},
+			EntrypointPatterns:      []spec.EntrypointPattern{{FieldRegex: "^Action$", RecvType: "example.com/cli.Command"}},
+			HandlerInterfaceMethods: []string{"ServeHTTP"},
+			RequestContext:          spec.RequestContextConfig{TypeRegexes: []string{`^net/http\.\*Request$`}},
+			ResponseContext:         spec.ResponseContextConfig{WriterTypeRegexes: []string{`^net/http\.ResponseWriter$`}},
+		},
+	}
+
+	cfg, _, err := buildAPISpecConfig(req, t.TempDir())
+	if err != nil {
+		t.Fatalf("buildAPISpecConfig: %v", err)
+	}
+
+	fc := cfg.Framework
+	checks := []struct {
+		section string
+		got     int
+	}{
+		{"routePatterns", len(fc.RoutePatterns)},
+		{"requestBodyPatterns", len(fc.RequestBodyPatterns)},
+		{"responsePatterns", len(fc.ResponsePatterns)},
+		{"paramPatterns", len(fc.ParamPatterns)},
+		{"mountPatterns", len(fc.MountPatterns)},
+		{"securityPatterns", len(fc.SecurityPatterns)},
+		{"entrypointPatterns", len(fc.EntrypointPatterns)},
+		{"handlerInterfaceMethods", len(fc.HandlerInterfaceMethods)},
+		{"requestContext.typeRegexes", len(fc.RequestContext.TypeRegexes)},
+		{"responseContext.writerTypeRegexes", len(fc.ResponseContext.WriterTypeRegexes)},
+	}
+	for _, c := range checks {
+		if c.got != 1 {
+			t.Errorf("%s: %d entries survived, want the 1 that was submitted", c.section, c.got)
+		}
+	}
+
+	// The submitted values reach the engine as written, not merely in the right
+	// count.
+	if len(fc.EntrypointPatterns) == 1 && fc.EntrypointPatterns[0].FieldRegex != "^Action$" {
+		t.Errorf("entrypoint fieldRegex = %q, want ^Action$", fc.EntrypointPatterns[0].FieldRegex)
+	}
+}

--- a/cmd/apispecui/assets/js/insight.js
+++ b/cmd/apispecui/assets/js/insight.js
@@ -10,9 +10,11 @@ import { Donut, Gauge, Info, TraceDiagram } from "/assets/js/components/charts.j
 
 function normalizeReport(d) {
   d = d || {};
-  for (const k of ["issues", "endpoints", "byMethod", "byStatus", "byContentType", "byTag", "topTypes", "taxonomy", "verbDispatch"]) {
+  for (const k of ["issues", "endpoints", "byMethod", "byStatus", "statusBodies", "byContentType", "byTag", "topTypes", "taxonomy", "verbDispatch"]) {
     if (!Array.isArray(d[k])) d[k] = [];
   }
+  d.analysis = d.analysis || {};
+  if (!Array.isArray(d.analysis.frameworks)) d.analysis.frameworks = [];
   d.health = d.health || { score: 0, cleanRoutes: 0, totalRoutes: 0 };
   d.callGraph = d.callGraph || { packages: 0, functions: 0, edges: 0 };
   d.security = d.security || { schemesDefined: 0, schemes: [], protected: 0, public: 0, unsecured: 0, bySchemeUsage: [] };
@@ -61,6 +63,12 @@ const INFO = {
   operations: "Method + path combinations (one path can have GET, POST, …).",
   methods: "HTTP methods across all operations.",
   status: "Response status codes declared across the API.",
+  statusbodies:
+    "For each status code: how many of its responses carry a resolved schema, how many were found but whose Go type could not be mapped, and how many document no body at all. At a 2xx an empty body usually means the write wasn't followed; an unresolved type means it was found but needs a type mapping.",
+  analysis:
+    "How this spec was produced rather than what's in it: the frameworks detected in the project, which one's patterns take precedence, the tracker engine, and what the entry-point gate did.",
+  entrypoints:
+    "Functions parked in a struct field that a library calls back — a urfave/cli Action, a cobra Run/RunE. Nothing in your code calls them, so their routes are only reachable if apispec roots them. It roots one only when its subtree actually registers a route.",
   ctype: "Request/response content types declared across the API.",
   tags: "OpenAPI tags grouping the routes.",
   toptypes: "Schemas referenced most often across request/response bodies.",
@@ -216,6 +224,132 @@ function Alerts({ rep }) {
   `;
 }
 
+// AnalysisCard answers "what was this spec read from?" — the frameworks found,
+// which one's patterns led, the tracker engine, and what the entrypoint gate did.
+// None of it is in the spec, so the server supplies it; and all of it is the first
+// thing you want when a route count looks wrong.
+function AnalysisCard({ rep }) {
+  const a = rep.analysis || {};
+  const ep = a.entrypoints;
+  if (!a.frameworks.length && !a.primary && !ep) return "";
+
+  // The gate's outcome, said in words. "0 rooted" is the interesting case: it
+  // means apispec DID look and found nothing that registers a route, which is a
+  // different problem from not looking.
+  const epStory = ep
+    ? ep.rooted > 0
+      ? `${ep.rooted} of ${ep.declared} led to route registration and ${ep.rooted === 1 ? "was" : "were"} analysed as${ep.rooted === 1 ? " an" : ""} extra entry point${ep.rooted === 1 ? "" : "s"}.`
+      : `none of the ${ep.declared} register a route, so no extra entry point was needed — if routes are missing, they are being registered somewhere this gate cannot see.`
+    : "";
+
+  return html`
+    ${SectionHead("How this was read", "Analysis", "what the spec was derived from", INFO.analysis)}
+    <div class="card" style="margin-bottom:var(--sp-3)">
+      <div class="row" style="gap:var(--sp-2);flex-wrap:wrap;align-items:center">
+        ${a.frameworks.length
+          ? html`<span class="muted" style="font-size:var(--fs-sm)">Frameworks</span>
+              <div class="chips">
+                ${a.frameworks.map(
+                  (f) => html`<span class="chip" title=${f === a.primary ? "primary — its patterns lead where two frameworks could match the same call" : "secondary — merged in, receiver-scoped"}>
+                    ${f}${f === a.primary ? html`<span class="chip-count">primary</span>` : ""}
+                  </span>`,
+                )}
+              </div>`
+          : html`<span class="muted" style="font-size:var(--fs-sm)">No framework detected — the configured patterns were used as-is.</span>`}
+        <span class="spacer"></span>
+        ${a.engine ? html`<span class="muted" style="font-size:var(--fs-xs)">${a.engine} tracker</span>` : ""}
+      </div>
+      ${a.frameworks.length > 1
+        ? html`<p class="muted" style="font-size:var(--fs-xs);margin:var(--sp-2) 0 0">
+            More than one framework is in play: every one contributes its patterns, and the primary decides where they overlap.
+          </p>`
+        : ""}
+      ${ep
+        ? html`<div style="margin-top:var(--sp-3);padding-top:var(--sp-2);border-top:1px solid var(--border)">
+            <div class="row" style="gap:6px"><strong style="font-size:var(--fs-sm)">CLI-dispatched entry points</strong><${Info} text=${INFO.entrypoints} /></div>
+            <p class="muted" style="font-size:var(--fs-sm);margin:var(--sp-2) 0 0">
+              ${ep.declared} function${ep.declared === 1 ? "" : "s"} stored in a field a library calls back (a CLI
+              <span class="mono">Action</span>/<span class="mono">RunE</span>). ${epStory}
+            </p>
+            <div class="res-legend" style="margin-top:var(--sp-2)">
+              <span class="it"><span class="sw" style="background:var(--accent-2)"></span>Rooted <b>${ep.rooted}</b></span>
+              <span class="it"><span class="sw" style="background:var(--info)"></span>Already reachable <b>${ep.alreadyReachable}</b></span>
+              <span class="it"><span class="sw" style="background:var(--muted)"></span>Register no route <b>${ep.noRoutes}</b></span>
+            </div>
+          </div>`
+        : ""}
+    </div>
+  `;
+}
+
+// ResponseBodies breaks each status code into how well its body resolved. The
+// split is the diagnosis: at a 2xx, "no body" usually means the write was not
+// followed, while "unresolved" means it WAS found and the Go type could not be
+// mapped — different fixes, and the bare status histogram hides both.
+function ResponseBodies({ rep }) {
+  const rows = rep.statusBodies;
+  if (!rows.length) return "";
+
+  const is2xx = (s) => s[0] === "2";
+  const sum = (f, pred) => rows.filter((r) => (pred ? pred(r.status) : true)).reduce((a, r) => a + f(r), 0);
+  // 204/304 mean "no body" by definition, so they are not evidence of anything
+  // missing; a 200 that documents nothing is.
+  const bodyExpected = (s) => is2xx(s) && s !== "204";
+  const emptyOK = sum((r) => r.empty, (s) => !bodyExpected(s));
+  const emptySuspicious = sum((r) => r.empty, bodyExpected);
+  const unresolved = sum((r) => r.unresolved);
+  const freeForm = sum((r) => r.freeForm || 0);
+  const withSchema = sum((r) => r.withSchema);
+
+  const bar = (r) => {
+    const t = Math.max(1, r.total);
+    const seg = (n, color, title) => (n ? html`<span style=${`width:${(n / t) * 100}%;background:${color}`} title=${title}></span>` : "");
+    return html`<div class="resbar" style="height:8px">
+      ${seg(r.withSchema, "var(--accent-2)", `${r.withSchema} describe their fields`)}
+      ${seg(r.freeForm || 0, "var(--info)", `${r.freeForm || 0} free-form object (a Go map) — resolved, but no declared fields`)}
+      ${seg(r.unresolved, "var(--warn)", `${r.unresolved} body found, type unresolved`)}
+      ${seg(r.empty, bodyExpected(r.status) ? "var(--danger)" : "var(--muted)", `${r.empty} with no body`)}
+    </div>`;
+  };
+
+  return html`
+    <div class="card" style="margin-bottom:var(--sp-3)">
+      <div class="row" style="gap:6px"><h3 style="margin:0">Response bodies by status</h3><${Info} text=${INFO.statusbodies} /></div>
+      <div class="status-bodies" style="margin-top:var(--sp-3);display:grid;grid-template-columns:auto 1fr auto;gap:var(--sp-2) var(--sp-3);align-items:center">
+        ${rows.map(
+          (r) => html`
+            <span class="mono" style=${`color:${statusColor(r.status)};font-weight:600`}>${r.status}</span>
+            ${bar(r)}
+            <span class="muted" style="font-size:var(--fs-xs);white-space:nowrap">
+              ${r.withSchema}/${r.total} typed${r.freeForm ? ` · ${r.freeForm} free-form` : ""}${r.unresolved ? ` · ${r.unresolved} unresolved` : ""}${r.empty ? ` · ${r.empty} empty` : ""}
+            </span>
+          `,
+        )}
+      </div>
+      <div class="res-legend" style="margin-top:var(--sp-3)">
+        <span class="it"><span class="sw" style="background:var(--accent-2)"></span>Fields described <b>${withSchema}</b></span>
+        <span class="it"><span class="sw" style="background:var(--info)"></span>Free-form object <b>${freeForm}</b></span>
+        <span class="it"><span class="sw" style="background:var(--warn)"></span>Type unresolved <b>${unresolved}</b></span>
+        <span class="it"><span class="sw" style="background:var(--danger)"></span>No body where one is expected <b>${emptySuspicious}</b></span>
+        <span class="it"><span class="sw" style="background:var(--muted)"></span>No body by design <b>${emptyOK}</b></span>
+      </div>
+      ${emptySuspicious || unresolved || freeForm
+        ? html`<p class="muted" style="font-size:var(--fs-xs);margin:var(--sp-2) 0 0;line-height:1.6">
+            ${emptySuspicious
+              ? html`<b>${emptySuspicious}</b> success response${emptySuspicious === 1 ? "" : "s"} document no body at all: the route was found but the value it writes was not — open the endpoint and read its trace. `
+              : ""}
+            ${unresolved
+              ? html`<b>${unresolved}</b> ${unresolved === 1 ? "body was" : "bodies were"} found but ${unresolved === 1 ? "its" : "their"} Go type did not become a schema — a type mapping or an external type fixes those, not more tracing. `
+              : ""}
+            ${freeForm
+              ? html`<b>${freeForm}</b> return a free-form object (a <span class="mono">map[string]any</span>): that IS the type, so nothing is missing — but clients learn nothing about the fields, which is a choice in the API rather than a gap here.`
+              : ""}
+          </p>`
+        : html`<p class="muted" style="font-size:var(--fs-xs);margin:var(--sp-2) 0 0">Every documented response describes its fields, or is empty by design.</p>`}
+    </div>
+  `;
+}
+
 // Meter — a coverage bar coloured by how complete it is.
 function Meter({ label, m, foot }) {
   const pct = m.total ? Math.round((m.have / m.total) * 100) : 0;
@@ -340,6 +474,7 @@ function Overview({ rep, onTag }) {
       <div class="stat"><div class="num">${rep.components}</div><div class="lbl">components <${Info} text=${INFO.components} /></div></div>
     </div>
 
+    <${AnalysisCard} rep=${rep} />
     <${Alerts} rep=${rep} />
     <${ResolutionQuality} rep=${rep} />
     <${TreeInsights} rep=${rep} />
@@ -363,6 +498,8 @@ function Overview({ rep, onTag }) {
           </div>`
         : ""}
     </div>
+
+    <${ResponseBodies} rep=${rep} />
 
     <${SecurityCard} rep=${rep} />
 

--- a/cmd/apispecui/assets/js/insight.js
+++ b/cmd/apispecui/assets/js/insight.js
@@ -231,7 +231,9 @@ function Alerts({ rep }) {
 function AnalysisCard({ rep }) {
   const a = rep.analysis || {};
   const ep = a.entrypoints;
-  if (!a.frameworks.length && !a.primary && !ep) return "";
+  // Engine counts: it is the one fact always known about a run, and "which
+  // tracker" is the first question a surprising result raises.
+  if (!a.frameworks.length && !a.primary && !a.engine && !ep) return "";
 
   // The gate's outcome, said in words. "0 rooted" is the interesting case: it
   // means apispec DID look and found nothing that registers a route, which is a
@@ -255,7 +257,11 @@ function AnalysisCard({ rep }) {
                   </span>`,
                 )}
               </div>`
-          : html`<span class="muted" style="font-size:var(--fs-sm)">No framework detected — the configured patterns were used as-is.</span>`}
+          : a.primary
+            ? // Chosen rather than detected: a hand-authored config states its own
+              // patterns, so detection has no say in what was used.
+              html`<span class="muted" style="font-size:var(--fs-sm)">Framework <b>${a.primary}</b> <span style="opacity:.8">— configured, not auto-detected</span></span>`
+            : html`<span class="muted" style="font-size:var(--fs-sm)">No framework detected — the configured patterns were used as-is.</span>`}
         <span class="spacer"></span>
         ${a.engine ? html`<span class="muted" style="font-size:var(--fs-xs)">${a.engine} tracker</span>` : ""}
       </div>

--- a/cmd/apispecui/main.go
+++ b/cmd/apispecui/main.go
@@ -228,8 +228,12 @@ type UIServer struct {
 	currentSpec *pubspec.OpenAPISpec
 	currentCfg  *spec.APISpecConfig
 	currentMeta *metadata.Metadata // retained for the insight view (call-graph stats)
-	lastGen     time.Time
-	lastErr     string
+	// currentAnalysis describes HOW the last spec was produced — detected
+	// frameworks, the tracker engine, what the entrypoint gate did. None of it is
+	// recoverable from the spec, so the Insight view is served it from here.
+	currentAnalysis insight.AnalysisInfo
+	lastGen         time.Time
+	lastErr         string
 
 	// metaCache is keyed by absolute input dir. Cleared on project switch.
 	metaCache map[string]*MetadataSummary
@@ -774,7 +778,7 @@ func (s *UIServer) handleGenerate(w http.ResponseWriter, r *http.Request) {
 	}
 	s.setDir(abs)
 
-	apiCfg, err := buildAPISpecConfig(&req, s.currentDir())
+	apiCfg, detectedFrameworks, err := buildAPISpecConfig(&req, s.currentDir())
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
@@ -963,6 +967,7 @@ func (s *UIServer) handleGenerate(w http.ResponseWriter, r *http.Request) {
 		s.currentSpec = out
 		s.currentCfg = apiCfg
 		s.currentMeta = genMeta
+		s.currentAnalysis = analysisInfo(req.Framework, detectedFrameworks, !req.LegacyTracker, gen.GetEntrypointStats())
 		s.lastGen = now
 		s.lastErr = ""
 		s.genPhase = ""
@@ -1405,17 +1410,19 @@ func sortedKeys(m map[string]struct{}) []string {
 // framework alone. Selecting one framework and dropping the rest is what made a
 // gin project whose primary detects as `mux` document zero routes here while the
 // CLI documented 107 (issue #212's failure mode, reaching the UI).
-func buildAPISpecConfig(req *GenerateRequest, dir string) (*spec.APISpecConfig, error) {
+func buildAPISpecConfig(req *GenerateRequest, dir string) (*spec.APISpecConfig, []string, error) {
 
 	if req.UseRawConfig && strings.TrimSpace(req.RawConfig) != "" {
 		cfg := &spec.APISpecConfig{}
 		if err := yaml.Unmarshal([]byte(req.RawConfig), cfg); err != nil {
-			return nil, fmt.Errorf("invalid YAML in rawConfig: %w", err)
+			return nil, nil, fmt.Errorf("invalid YAML in rawConfig: %w", err)
 		}
 		if err := cfg.ValidateSecurity(); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return cfg, nil
+		// A hand-authored config states its own patterns, so detection has no say
+		// in what was used — reporting a detected list here would misdescribe it.
+		return cfg, nil, nil
 	}
 
 	cfg, frameworks, err := engine.ComposeFrameworkConfigWithPrimary(dir, req.Framework)
@@ -1476,19 +1483,57 @@ func buildAPISpecConfig(req *GenerateRequest, dir string) (*spec.APISpecConfig, 
 		if fc.MountPatterns != nil {
 			cfg.Framework.MountPatterns = fc.MountPatterns
 		}
+		if fc.SecurityPatterns != nil {
+			cfg.Framework.SecurityPatterns = fc.SecurityPatterns
+		}
+		if fc.EntrypointPatterns != nil {
+			cfg.Framework.EntrypointPatterns = fc.EntrypointPatterns
+		}
+		if fc.HandlerInterfaceMethods != nil {
+			cfg.Framework.HandlerInterfaceMethods = fc.HandlerInterfaceMethods
+		}
 		// Request-context describes how to detect the request body source
 		// for generic decoders (json.Decode / Unmarshal / render.DecodeJSON).
 		// Only override defaults when the UI submitted something.
 		if len(fc.RequestContext.TypeRegexes) > 0 || len(fc.RequestContext.BodyAccessors) > 0 {
 			cfg.Framework.RequestContext = fc.RequestContext
 		}
+		// Response-context is its mirror: which types are the response writer,
+		// for patterns gated on write destination.
+		if len(fc.ResponseContext.WriterTypeRegexes) > 0 || len(fc.ResponseContext.WriterCompatibleTypeRegexes) > 0 {
+			cfg.Framework.ResponseContext = fc.ResponseContext
+		}
 	}
 	// Enforce the same security-config checks LoadAPISpecConfig applies, so
 	// structured securityMappings from the UI can't bypass validation.
 	if err := cfg.ValidateSecurity(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return cfg, nil
+	return cfg, frameworks, nil
+}
+
+// analysisInfo assembles what the Insight view reports about the run itself.
+// primary is the framework whose patterns led (the request's choice, or the first
+// detected one, which buildAPISpecConfig has already filled in).
+func analysisInfo(primary string, detected []string, lazy bool, ep spec.EntrypointStats) insight.AnalysisInfo {
+	info := insight.AnalysisInfo{Frameworks: detected, Primary: primary}
+	if lazy {
+		info.Engine = "lazy"
+	} else {
+		info.Engine = "eager"
+	}
+	// Only when the project actually declares entrypoints: a zeroed block would
+	// read as "the gate ran and found nothing", which is a different claim from
+	// "this project has no dispatcher-called functions at all".
+	if ep.Declared > 0 {
+		info.Entrypoints = &insight.EntrypointInfo{
+			Declared:         ep.Declared,
+			Rooted:           ep.Rooted,
+			AlreadyReachable: ep.AlreadyReachable,
+			NoRoutes:         ep.NoRoutes,
+		}
+	}
+	return info
 }
 
 // handleRenderConfig accepts the same body as /api/generate and returns the
@@ -1504,7 +1549,7 @@ func (s *UIServer) handleRenderConfig(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
 		return
 	}
-	cfg, err := buildAPISpecConfig(&req, s.currentDir())
+	cfg, _, err := buildAPISpecConfig(&req, s.currentDir())
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
@@ -1552,7 +1597,13 @@ func (s *UIServer) handleInsightOverview(w http.ResponseWriter, r *http.Request)
 		writeError(w, http.StatusConflict, "no spec yet — generate first")
 		return
 	}
-	writeJSON(w, http.StatusOK, insight.BuildOverview(sp, mt))
+	rep := insight.BuildOverview(sp, mt)
+	// Supplied rather than derived: the spec does not record which frameworks
+	// were detected or what the entrypoint gate did.
+	s.mu.RLock()
+	rep.Analysis = s.currentAnalysis
+	s.mu.RUnlock()
+	writeJSON(w, http.StatusOK, rep)
 }
 
 // handleInsightEndpoint returns the per-route insight report for
@@ -1723,6 +1774,11 @@ func (s *UIServer) handleInsightExport(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rep := insight.BuildOverview(sp, mt)
+	// The export is what gets handed to an AI or pasted into an issue, so it
+	// carries the same analysis context the view shows.
+	s.mu.RLock()
+	rep.Analysis = s.currentAnalysis
+	s.mu.RUnlock()
 	if jsonFmt {
 		writeJSON(w, http.StatusOK, rep)
 		return
@@ -1813,7 +1869,7 @@ func (s *UIServer) handleSaveConfig(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	cfg, err := buildAPISpecConfig(&req.GenerateRequest, s.currentDir())
+	cfg, _, err := buildAPISpecConfig(&req.GenerateRequest, s.currentDir())
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -250,6 +250,12 @@ type Engine struct {
 	// error message.
 	skipped []SkippedPackage
 
+	// entrypointStats records what the entrypoint gate decided during the last
+	// generation (issue #220): how many field-stored functions were found and how
+	// many earned a root. Surfaced in the UI, where "0 rooted" is the difference
+	// between "never looked" and "looked, nothing registers a route".
+	entrypointStats intspec.EntrypointStats
+
 	// unresolvedSecurity lists auth middleware detected during the last
 	// generation that matched no SecurityMapping. Surfaced to callers (the UI)
 	// so the user can map it to a scheme.
@@ -779,6 +785,13 @@ func (e *Engine) GenerateOpenAPI() (*spec.OpenAPISpec, error) {
 		e.unresolvedSecurity = secDiag.UnresolvedMiddleware
 		e.pathParamMismatches = secDiag.PathParamMismatches
 	}
+	// Read after mapping: with the lazy tree the entrypoint gate runs during
+	// expansion, which mapping is what triggers.
+	if reporter, ok := tree.(interface {
+		EntrypointStats() intspec.EntrypointStats
+	}); ok {
+		e.entrypointStats = reporter.EntrypointStats()
+	}
 	e.reportPhase(fmt.Sprintf("spec mapped (%d paths)", len(openAPISpec.Paths)), time.Since(tSpec))
 
 	// Handle metadata writing if requested
@@ -1130,6 +1143,12 @@ func (e *Engine) GetMetadata() *metadata.Metadata {
 // generation that matched no SecurityMapping (deduped). Empty when none.
 func (e *Engine) GetUnresolvedSecurity() []intspec.MiddlewareRef {
 	return e.unresolvedSecurity
+}
+
+// GetEntrypointStats returns what the entrypoint gate decided during the most
+// recent generation. Zero when the project declares no entrypoints.
+func (e *Engine) GetEntrypointStats() intspec.EntrypointStats {
+	return e.entrypointStats
 }
 
 // GetPathParamMismatches returns map-key path-variable reads (e.g.

--- a/internal/insight/analysis_line_test.go
+++ b/internal/insight/analysis_line_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package insight
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestAnalysisLine covers the export's one-line account of how the spec was
+// produced, including the case that must stay silent: nothing supplied. The
+// report cannot derive any of this, so inventing a line would be a claim about a
+// run nobody described.
+func TestAnalysisLine(t *testing.T) {
+	tests := []struct {
+		name string
+		info AnalysisInfo
+		want string
+	}{
+		{
+			name: "nothing supplied",
+			info: AnalysisInfo{},
+			want: "",
+		},
+		{
+			name: "one framework needs no primary",
+			info: AnalysisInfo{Frameworks: []string{"chi"}, Primary: "chi", Engine: "lazy"},
+			want: "Analysed with frameworks chi, lazy tracker.",
+		},
+		{
+			name: "several frameworks name the primary",
+			info: AnalysisInfo{Frameworks: []string{"mux", "gin"}, Primary: "mux", Engine: "lazy"},
+			want: "Analysed with frameworks mux + gin (primary: mux), lazy tracker.",
+		},
+		{
+			name: "a configured framework with no detection",
+			info: AnalysisInfo{Primary: "echo", Engine: "eager"},
+			want: "Analysed with framework echo, eager tracker.",
+		},
+		{
+			name: "entry points are spelled out, including why most were skipped",
+			info: AnalysisInfo{
+				Frameworks:  []string{"mux"},
+				Primary:     "mux",
+				Engine:      "lazy",
+				Entrypoints: &EntrypointInfo{Declared: 53, Rooted: 1, AlreadyReachable: 0, NoRoutes: 52},
+			},
+			want: "Analysed with frameworks mux, lazy tracker, 53 CLI entry point(s) declared, 1 rooted (0 already reachable, 52 register no route).",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rep := &OverviewReport{Analysis: tc.info}
+			if got := rep.AnalysisLine(); got != tc.want {
+				t.Errorf("AnalysisLine =\n  %q\nwant\n  %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBodyLine covers the export's body-resolution line, whose whole job is to
+// say which KIND of gap is in play — the fixes differ.
+func TestBodyLine(t *testing.T) {
+	if got := (&OverviewReport{}).BodyLine(); got != "" {
+		t.Errorf("no responses = %q, want empty", got)
+	}
+
+	rep := &OverviewReport{StatusBodies: []StatusBody{
+		{Status: "200", Total: 10, WithSchema: 6, FreeForm: 2, Empty: 1, Unresolved: 1},
+		{Status: "204", Total: 3, Empty: 3}, // no body by definition
+		{Status: "500", Total: 2, WithSchema: 2},
+	}}
+	got := rep.BodyLine()
+	want := "Response bodies: 8 describe their fields, 2 free-form (a Go map), 1 found but unresolved, 1 missing where one is expected, 3 empty by design."
+	if got != want {
+		t.Errorf("BodyLine =\n  %q\nwant\n  %q", got, want)
+	}
+}
+
+// TestExportCarriesAnalysisContext pins that the export an AI (or an issue
+// report) receives states what was analysed, not only what went wrong: the same
+// unresolved type has a different fix depending on the framework and on whether
+// the body was found at all.
+func TestExportCarriesAnalysisContext(t *testing.T) {
+	rep := BuildOverview(sampleSpec(), nil)
+	rep.Analysis = AnalysisInfo{
+		Frameworks:  []string{"mux", "gin"},
+		Primary:     "mux",
+		Engine:      "lazy",
+		Entrypoints: &EntrypointInfo{Declared: 53, Rooted: 1, NoRoutes: 52},
+	}
+
+	md := BuildExportMarkdown(rep, ExportOptions{})
+	for _, want := range []string{
+		"frameworks mux + gin (primary: mux)",
+		"53 CLI entry point(s) declared, 1 rooted",
+		"Response bodies:",
+	} {
+		if !strings.Contains(md, want) {
+			t.Errorf("export is missing %q:\n%s", want, md)
+		}
+	}
+
+	// Redaction still applies to the context line — an export is meant to be
+	// shareable.
+	redacted := BuildExportMarkdown(rep, ExportOptions{Redact: true, ModulePath: "mux"})
+	if strings.Contains(redacted, "frameworks mux") {
+		t.Errorf("redaction skipped the analysis line:\n%s", redacted)
+	}
+}

--- a/internal/insight/analysis_line_test.go
+++ b/internal/insight/analysis_line_test.go
@@ -50,6 +50,15 @@ func TestAnalysisLine(t *testing.T) {
 			want: "Analysed with framework echo, eager tracker.",
 		},
 		{
+			// A hand-authored config states its own patterns, so detection has no
+			// say in what was used and the run reports no framework at all. The
+			// engine is still worth saying — it is what a surprising result is
+			// first blamed on (CodeRabbit, PR #227).
+			name: "engine only",
+			info: AnalysisInfo{Engine: "lazy"},
+			want: "Analysed with lazy tracker.",
+		},
+		{
 			name: "entry points are spelled out, including why most were skipped",
 			info: AnalysisInfo{
 				Frameworks:  []string{"mux"},

--- a/internal/insight/endpoint.go
+++ b/internal/insight/endpoint.go
@@ -180,7 +180,7 @@ func BuildEndpointWithSource(s *spec.OpenAPISpec, meta *metadata.Metadata, cfg *
 
 	// issues for this operation
 	comps := componentsMap(s)
-	rep.Issues = collectOperationIssues(rep.Method, path, op, comps, map[string]int{}, map[string]int{}, map[string]int{})
+	rep.Issues = collectOperationIssues(rep.Method, path, op, comps, map[string]int{}, map[string]int{}, map[string]int{}, map[string]StatusBody{})
 	if rep.Issues == nil {
 		rep.Issues = []Issue{}
 	}

--- a/internal/insight/export.go
+++ b/internal/insight/export.go
@@ -55,6 +55,15 @@ func BuildExportMarkdown(rep *OverviewReport, opts ExportOptions) string {
 	var b strings.Builder
 	b.WriteString("# apispec — issues to resolve\n\n")
 	fmt.Fprintf(&b, "%s\n\n", rep.Summary())
+	// Context before problems: which frameworks were read, and which KIND of body
+	// gap is in play. Both change the right fix, and neither is visible from the
+	// issue list alone.
+	if line := rep.AnalysisLine(); line != "" {
+		fmt.Fprintf(&b, "%s\n\n", red(line))
+	}
+	if line := rep.BodyLine(); line != "" {
+		fmt.Fprintf(&b, "%s\n\n", line)
+	}
 
 	// Nothing to fix → don't emit an AI prompt or dump the config. A clean
 	// spec needs no action, so the export is just a one-line clean bill.

--- a/internal/insight/overview.go
+++ b/internal/insight/overview.go
@@ -925,7 +925,11 @@ func (r *OverviewReport) Summary() string {
 // AnalysisInfo).
 func (r *OverviewReport) AnalysisLine() string {
 	a := r.Analysis
-	if len(a.Frameworks) == 0 && a.Primary == "" && a.Entrypoints == nil {
+	// Every field this renders has to be in the guard, engine included: a run with
+	// a hand-authored config reports no framework at all (detection has no say in
+	// what was used), and dropping the line then would lose the one fact that is
+	// always known about it.
+	if len(a.Frameworks) == 0 && a.Primary == "" && a.Engine == "" && a.Entrypoints == nil {
 		return ""
 	}
 	var parts []string

--- a/internal/insight/overview.go
+++ b/internal/insight/overview.go
@@ -89,6 +89,53 @@ type SecurityStats struct {
 	BySchemeUsage  []Count  `json:"bySchemeUsage"`  // operations requiring each scheme
 }
 
+// StatusBody is per-status response-body resolution: of the responses documented
+// at one status code, how many carry a usable schema, how many document no body
+// at all, and how many have a body whose type did not resolve.
+//
+// The buckets are separated because they mean different things to whoever reads
+// the spec, and they have different fixes:
+//
+//   - `empty` is correct for 204 and suspicious for 200 — a handler that
+//     certainly returns data but whose write apispec could not follow shows up
+//     exactly there (which is how the per-key instance cap was found).
+//   - `freeForm` is an object with no declared fields but unconstrained values:
+//     what a `map[string]any` response genuinely is. It resolved — that IS the
+//     type — so it is not a defect, but a client still learns nothing about the
+//     fields, which is a fact about the API rather than about apispec.
+//   - `unresolved` is a body that WAS found but whose Go type did not become a
+//     schema, so the fix is a type mapping or an external-type entry rather than
+//     more tracing.
+type StatusBody struct {
+	Status     string `json:"status"`
+	Total      int    `json:"total"`      // responses documented at this status
+	WithSchema int    `json:"withSchema"` // ...of which describe their fields
+	FreeForm   int    `json:"freeForm"`   // ...are an unconstrained object (a Go map)
+	Empty      int    `json:"empty"`      // ...document no content at all
+	Unresolved int    `json:"unresolved"` // ...have content, but the type didn't resolve
+}
+
+// EntrypointInfo reports what the entrypoint gate did: how many functions parked
+// in a struct field a library calls back were found, and how many became tree
+// roots. A project whose routes hang off a CLI dispatcher lives or dies on this,
+// so it is worth showing rather than leaving in a --verbose line.
+type EntrypointInfo struct {
+	Declared         int `json:"declared"`         // candidate field-stored functions found
+	Rooted           int `json:"rooted"`           // ...expanded as roots
+	AlreadyReachable int `json:"alreadyReachable"` // ...skipped: main already reaches them
+	NoRoutes         int `json:"noRoutes"`         // ...skipped: their subtree registers no route
+}
+
+// AnalysisInfo describes HOW the spec was produced rather than what is in it.
+// None of it is derivable from the spec, so BuildOverview leaves it empty and the
+// caller (the UI server, which ran the analysis) fills it in.
+type AnalysisInfo struct {
+	Frameworks  []string        `json:"frameworks,omitempty"` // detected, in config-composition order
+	Primary     string          `json:"primary,omitempty"`    // the one whose patterns lead
+	Engine      string          `json:"engine,omitempty"`     // tracker engine used
+	Entrypoints *EntrypointInfo `json:"entrypoints,omitempty"`
+}
+
 // CoverMetric is a have-of-total coverage tally.
 type CoverMetric struct {
 	Have  int `json:"have"`
@@ -140,6 +187,7 @@ type OverviewReport struct {
 	ByMethod      []Count        `json:"byMethod"`
 	ByTag         []Count        `json:"byTag"`
 	ByStatus      []Count        `json:"byStatus"`
+	StatusBodies  []StatusBody   `json:"statusBodies"` // per-status body resolution
 	ByContentType []Count        `json:"byContentType"`
 	Components    int            `json:"components"`
 	TopTypes      []Count        `json:"topTypes"`
@@ -152,6 +200,9 @@ type OverviewReport struct {
 	Interfaces    InterfaceStats `json:"interfaces"`   // tree insight: interface resolution (cheap read)
 	VerbDispatch  []VerbDispatch `json:"verbDispatch"` // tree insight: handlers split by verb (cheap read)
 	CallGraph     CallGraphStats `json:"callGraph"`
+
+	// Analysis is filled in by the caller — see AnalysisInfo.
+	Analysis AnalysisInfo `json:"analysis"`
 }
 
 // operationsOf returns the (method, *Operation) pairs declared on a path.
@@ -200,6 +251,7 @@ func BuildOverview(s *spec.OpenAPISpec, meta *metadata.Metadata) *OverviewReport
 	methodC := map[string]int{}
 	tagC := map[string]int{}
 	statusC := map[string]int{}
+	bodyC := map[string]StatusBody{}
 	ctC := map[string]int{}
 	typeC := map[string]int{}
 
@@ -225,7 +277,7 @@ func BuildOverview(s *spec.OpenAPISpec, meta *metadata.Metadata) *OverviewReport
 			}
 			rep.Endpoints = append(rep.Endpoints, RouteRef{Method: mo.Method, Path: p, Tags: mo.Op.Tags})
 
-			routeIssues := collectOperationIssues(mo.Method, p, mo.Op, componentNames, statusC, ctC, typeC)
+			routeIssues := collectOperationIssues(mo.Method, p, mo.Op, componentNames, statusC, ctC, typeC, bodyC)
 			rep.Issues = append(rep.Issues, routeIssues...)
 			if !hasWarn(routeIssues) {
 				clean++
@@ -257,6 +309,7 @@ func BuildOverview(s *spec.OpenAPISpec, meta *metadata.Metadata) *OverviewReport
 	rep.ByMethod = sortedCounts(methodC, true)
 	rep.ByTag = sortedCounts(tagC, true)
 	rep.ByStatus = sortedCounts(statusC, false) // status: by name (numeric-ish) asc
+	rep.StatusBodies = sortedStatusBodies(bodyC)
 	rep.ByContentType = sortedCounts(ctC, true)
 	rep.TopTypes = topN(sortedCounts(typeC, true), 10)
 
@@ -523,7 +576,7 @@ func securityStats(s *spec.OpenAPISpec) SecurityStats {
 	return st
 }
 
-func collectOperationIssues(method, path string, op *spec.Operation, comps map[string]*spec.Schema, statusC, ctC, typeC map[string]int) []Issue {
+func collectOperationIssues(method, path string, op *spec.Operation, comps map[string]*spec.Schema, statusC, ctC, typeC map[string]int, bodyC map[string]StatusBody) []Issue {
 	var issues []Issue
 
 	if len(op.Responses) == 0 {
@@ -544,6 +597,7 @@ func collectOperationIssues(method, path string, op *spec.Operation, comps map[s
 	// responses
 	for status, resp := range op.Responses {
 		statusC[status]++
+		bodyC[status] = addStatusBody(bodyC[status], resp, comps)
 		for ct, mt := range resp.Content {
 			ctC[ct]++
 			issues = append(issues, refIssues(method, path, "response "+status, mt.Schema, comps, typeC)...)
@@ -571,6 +625,89 @@ func collectOperationIssues(method, path string, op *spec.Operation, comps map[s
 		issues = append(issues, refIssues(method, path, "parameter "+prm.Name, prm.Schema, comps, typeC)...)
 	}
 	return issues
+}
+
+// addStatusBody folds one response into its status's body tally. A response is
+// counted once, in the state that describes it best: no content at all, a schema
+// that resolved, or a body whose type did not.
+func addStatusBody(acc StatusBody, resp spec.Response, comps map[string]*spec.Schema) StatusBody {
+	acc.Total++
+	if len(resp.Content) == 0 {
+		acc.Empty++
+		return acc
+	}
+	// One response, one bucket: the best state any of its media types reaches.
+	best := bodyUnresolved
+	for _, mt := range resp.Content {
+		if state := bodyResolution(mt.Schema, comps); bodyRank[state] > bodyRank[best] {
+			best = state
+		}
+	}
+	switch best {
+	case bodySchema:
+		acc.WithSchema++
+	case bodyFreeForm:
+		acc.FreeForm++
+	default:
+		acc.Unresolved++
+	}
+	return acc
+}
+
+// How well a body describes itself, best first.
+const (
+	bodySchema     = "schema"     // fields, an element type, a scalar, a composition
+	bodyFreeForm   = "freeform"   // an object with unconstrained values — a Go map
+	bodyUnresolved = "unresolved" // nothing usable: a bare object, a dangling ref, a placeholder
+)
+
+var bodyRank = map[string]int{bodyUnresolved: 0, bodyFreeForm: 1, bodySchema: 2}
+
+// bodyResolution classifies what a schema says about the body it describes.
+//
+// The distinction that matters is between "apispec could not read this type" and
+// "the type genuinely has no declared fields". Both render as an object, but only
+// the first is a defect: `map[string]any` really is an object with unconstrained
+// values, and calling that unresolved would blame apispec for the API's own shape.
+func bodyResolution(sc *spec.Schema, comps map[string]*spec.Schema) string {
+	if sc == nil {
+		return bodyUnresolved
+	}
+	if name := strings.TrimPrefix(sc.Ref, refPrefix); name != "" && name != sc.Ref {
+		target, ok := comps[name]
+		if !ok || strings.Contains(target.Description, placeholderMarker) {
+			return bodyUnresolved
+		}
+		// A named, non-placeholder component means the Go type resolved: the name
+		// itself is the answer. Its schema is not re-judged, because an empty one
+		// is as likely to be an empty struct — a real, documented shape — as a
+		// mapping gap, and reading it as a gap would blame resolution for the
+		// type's own shape.
+		return bodySchema
+	}
+	// A list is only as resolved as its element type: `type: array` with no items
+	// says a list comes back, but not of what.
+	if sc.Type == "array" {
+		if sc.Items == nil {
+			return bodyUnresolved
+		}
+		return bodyResolution(sc.Items, comps)
+	}
+	if len(sc.OneOf) > 0 || len(sc.AnyOf) > 0 || len(sc.AllOf) > 0 || len(sc.Properties) > 0 || len(sc.Enum) > 0 {
+		return bodySchema
+	}
+	if sc.Type == "object" {
+		// additionalProperties is what a map's value type renders to; without it,
+		// a bare `type: object` is what an unreadable type collapses to.
+		if sc.AdditionalProperties != nil {
+			return bodyFreeForm
+		}
+		return bodyUnresolved
+	}
+	if sc.Type != "" {
+		return bodySchema
+	}
+	return bodyUnresolved
 }
 
 // refIssues records every component ref reachable from a schema, tallies
@@ -744,6 +881,26 @@ func sortedCounts(m map[string]int, byCount bool) []Count {
 	return out
 }
 
+// sortedStatusBodies orders the per-status tallies by status code, with
+// `default` last — it is not a code, and it reads as the residue it is when it
+// follows the concrete ones. Sorting is what keeps the report deterministic
+// (golden rule #1).
+func sortedStatusBodies(m map[string]StatusBody) []StatusBody {
+	out := make([]StatusBody, 0, len(m))
+	for status, sb := range m {
+		sb.Status = status
+		out = append(out, sb)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		a, b := out[i].Status, out[j].Status
+		if (a == "default") != (b == "default") {
+			return b == "default"
+		}
+		return a < b
+	})
+	return out
+}
+
 func topN(c []Count, n int) []Count {
 	if len(c) > n {
 		return c[:n]
@@ -761,4 +918,57 @@ func (r *OverviewReport) Summary() string {
 	}
 	return fmt.Sprintf("%d routes, %d ops, health %d%%, %d warnings",
 		r.Routes, r.Operations, r.Health.Score, warns)
+}
+
+// AnalysisLine states how the spec was produced, for the export. Empty when the
+// caller supplied no analysis context (nothing is inferred here — see
+// AnalysisInfo).
+func (r *OverviewReport) AnalysisLine() string {
+	a := r.Analysis
+	if len(a.Frameworks) == 0 && a.Primary == "" && a.Entrypoints == nil {
+		return ""
+	}
+	var parts []string
+	if len(a.Frameworks) > 0 {
+		frameworks := strings.Join(a.Frameworks, " + ")
+		if a.Primary != "" && len(a.Frameworks) > 1 {
+			frameworks += " (primary: " + a.Primary + ")"
+		}
+		parts = append(parts, "frameworks "+frameworks)
+	} else if a.Primary != "" {
+		parts = append(parts, "framework "+a.Primary)
+	}
+	if a.Engine != "" {
+		parts = append(parts, a.Engine+" tracker")
+	}
+	if ep := a.Entrypoints; ep != nil {
+		parts = append(parts, fmt.Sprintf("%d CLI entry point(s) declared, %d rooted (%d already reachable, %d register no route)",
+			ep.Declared, ep.Rooted, ep.AlreadyReachable, ep.NoRoutes))
+	}
+	return "Analysed with " + strings.Join(parts, ", ") + "."
+}
+
+// BodyLine summarises response-body resolution across every status, so the
+// export says which kind of gap is in play: bodies never found, bodies found but
+// unmapped, or an API that is simply free-form. Empty when no response is
+// documented at all.
+func (r *OverviewReport) BodyLine() string {
+	var typed, freeForm, unresolved, emptyExpected, emptyByDesign int
+	for _, sb := range r.StatusBodies {
+		typed += sb.WithSchema
+		freeForm += sb.FreeForm
+		unresolved += sb.Unresolved
+		// 204/304 mean "no body" by definition; an empty 200 is a body that was
+		// never found.
+		if strings.HasPrefix(sb.Status, "2") && sb.Status != "204" {
+			emptyExpected += sb.Empty
+		} else {
+			emptyByDesign += sb.Empty
+		}
+	}
+	if typed+freeForm+unresolved+emptyExpected+emptyByDesign == 0 {
+		return ""
+	}
+	return fmt.Sprintf("Response bodies: %d describe their fields, %d free-form (a Go map), %d found but unresolved, %d missing where one is expected, %d empty by design.",
+		typed, freeForm, unresolved, emptyExpected, emptyByDesign)
 }

--- a/internal/insight/status_bodies_test.go
+++ b/internal/insight/status_bodies_test.go
@@ -1,0 +1,132 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package insight
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/spec"
+)
+
+// bodySpec pairs every interesting body state with a status that makes its
+// meaning clear: a resolved schema, a body whose type did not resolve, and no
+// body at all — the last one both where it is correct (204) and where it is the
+// symptom of a write apispec could not follow (200).
+func bodySpec() *spec.OpenAPISpec {
+	return &spec.OpenAPISpec{
+		Paths: map[string]spec.PathItem{
+			"/resolved":   {Get: &spec.Operation{Responses: jsonResp("200", ref("Order"))}},
+			"/list":       {Get: &spec.Operation{Responses: jsonResp("200", &spec.Schema{Type: "array", Items: ref("Order")})}},
+			"/scalar":     {Get: &spec.Operation{Responses: jsonResp("200", &spec.Schema{Type: "string"})}},
+			"/unresolved": {Get: &spec.Operation{Responses: jsonResp("200", ref("Placeholder"))}},
+			"/dangling":   {Get: &spec.Operation{Responses: jsonResp("200", ref("Missing"))}},
+			"/opaque":     {Get: &spec.Operation{Responses: jsonResp("200", &spec.Schema{Type: "object"})}},
+			// A map[string]any response: no declared fields, but the values are
+			// constrained — the type resolved, the API is just free-form.
+			"/freeform": {Get: &spec.Operation{Responses: jsonResp("200", &spec.Schema{Type: "object", AdditionalProperties: &spec.Schema{Type: "string"}})}},
+			"/nobody":   {Get: &spec.Operation{Responses: map[string]spec.Response{"200": {Description: "OK"}}}},
+			"/deleted":  {Delete: &spec.Operation{Responses: map[string]spec.Response{"204": {Description: "No Content"}}}},
+			"/failing": {Get: &spec.Operation{Responses: map[string]spec.Response{
+				"500":     {Content: map[string]spec.MediaType{"application/json": {Schema: ref("Order")}}},
+				"default": {Description: "error"},
+			}}},
+		},
+		Components: &spec.Components{Schemas: map[string]*spec.Schema{
+			"Order":       {Type: "object", Properties: map[string]*spec.Schema{"id": {Type: "string"}}},
+			"Placeholder": {Type: "object", Description: "External or unresolved type: foo.Bar"},
+		}},
+	}
+}
+
+// TestStatusBodies pins the per-status split the dashboard reports. The buckets
+// are different diagnoses, so a response must land in the right one: `empty` at
+// 200 means the body was never found, `unresolved` means it was found and the type
+// could not be mapped, `freeForm` means the type resolved and genuinely has no
+// declared fields.
+func TestStatusBodies(t *testing.T) {
+	rep := BuildOverview(bodySpec(), nil)
+
+	want := []StatusBody{
+		// 200: Order ref, array of Order, plain string resolve; placeholder,
+		// dangling ref and bare `type: object` do not; one documents no body.
+		{Status: "200", Total: 8, WithSchema: 3, FreeForm: 1, Empty: 1, Unresolved: 3},
+		{Status: "204", Total: 1, Empty: 1},
+		{Status: "500", Total: 1, WithSchema: 1},
+		// `default` last: it is not a status code but the residue of one that
+		// could not be pinned down.
+		{Status: "default", Total: 1, Empty: 1},
+	}
+	if !reflect.DeepEqual(rep.StatusBodies, want) {
+		t.Errorf("statusBodies =\n  %+v\nwant\n  %+v", rep.StatusBodies, want)
+	}
+
+	// Every response is counted exactly once, and the totals agree with the
+	// plain status histogram the same walk produces.
+	for _, sb := range rep.StatusBodies {
+		if sb.WithSchema+sb.FreeForm+sb.Empty+sb.Unresolved != sb.Total {
+			t.Errorf("status %s: buckets %d+%d+%d+%d != total %d", sb.Status, sb.WithSchema, sb.FreeForm, sb.Empty, sb.Unresolved, sb.Total)
+		}
+		if got := countOf(rep.ByStatus, sb.Status); got != sb.Total {
+			t.Errorf("status %s: byStatus=%d, statusBodies total=%d", sb.Status, got, sb.Total)
+		}
+	}
+}
+
+// TestBodyResolution covers the classifier directly, and above all the line
+// between "apispec could not read this type" and "the type has no fields to
+// read" — the two render alike and mean opposite things.
+func TestBodyResolution(t *testing.T) {
+	comps := map[string]*spec.Schema{
+		"Order":       {Type: "object", Properties: map[string]*spec.Schema{"id": {Type: "string"}}},
+		"Empty":       {Type: "object"}, // an empty struct is a real, documented shape
+		"Placeholder": {Type: "object", Description: "External or unresolved type: foo.Bar"},
+	}
+
+	cases := []struct {
+		name string
+		sc   *spec.Schema
+		want string
+	}{
+		{"named component", ref("Order"), bodySchema},
+		{"named empty struct", ref("Empty"), bodySchema},
+		{"scalar", &spec.Schema{Type: "string"}, bodySchema},
+		{"list of a named type", &spec.Schema{Type: "array", Items: ref("Order")}, bodySchema},
+		{"inline object with fields", &spec.Schema{Type: "object", Properties: map[string]*spec.Schema{"id": {Type: "string"}}}, bodySchema},
+		{"composition", &spec.Schema{OneOf: []*spec.Schema{ref("Order")}}, bodySchema},
+		{"enum", &spec.Schema{Type: "string", Enum: []interface{}{"a"}}, bodySchema},
+
+		// A Go map: the values are constrained, the keys are open. Resolved, but
+		// it tells a client nothing about fields.
+		{"map with a value type", &spec.Schema{Type: "object", AdditionalProperties: &spec.Schema{Type: "string"}}, bodyFreeForm},
+		{"map of anything", &spec.Schema{Type: "object", AdditionalProperties: &spec.Schema{}}, bodyFreeForm},
+		{"list of maps", &spec.Schema{Type: "array", Items: &spec.Schema{Type: "object", AdditionalProperties: &spec.Schema{}}}, bodyFreeForm},
+
+		{"nil", nil, bodyUnresolved},
+		{"dangling ref", ref("Missing"), bodyUnresolved},
+		{"placeholder component", ref("Placeholder"), bodyUnresolved},
+		{"bare object", &spec.Schema{Type: "object"}, bodyUnresolved},
+		{"nothing at all", &spec.Schema{}, bodyUnresolved},
+		{"list of what?", &spec.Schema{Type: "array"}, bodyUnresolved},
+		{"list of an unknown component", &spec.Schema{Type: "array", Items: ref("Missing")}, bodyUnresolved},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := bodyResolution(tc.sc, comps); got != tc.want {
+				t.Errorf("bodyResolution = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/spec/entrypoint_roots.go
+++ b/internal/spec/entrypoint_roots.go
@@ -44,34 +44,47 @@ import (
 //
 // Returned keys are sorted: they become tree roots, and root order reaches the
 // output (golden rule #1).
-func entrypointRoots(meta *metadata.Metadata, candidates []string, routeMatch func(*metadata.CallGraphEdge) bool, logger metadata.VerboseLogger) []string {
+func entrypointRoots(meta *metadata.Metadata, candidates []string, routeMatch func(*metadata.CallGraphEdge) bool, logger metadata.VerboseLogger) ([]string, EntrypointStats) {
 	if meta == nil || len(candidates) == 0 {
-		return nil
+		return nil, EntrypointStats{}
 	}
 
 	reachedFromMain := functionsReachableFromMains(meta)
 	registers := reachesMatch(meta, routeMatch)
 
 	var out []string
-	var skippedReachable, skippedNoRoutes int
+	stats := EntrypointStats{Declared: len(candidates)}
 	for _, key := range candidates {
 		switch {
 		case reachedFromMain[key]:
-			skippedReachable++
+			stats.AlreadyReachable++
 		case !registers[key]:
-			skippedNoRoutes++
+			stats.NoRoutes++
 		default:
 			out = append(out, key)
 		}
 	}
 	sort.Strings(out)
-	if logger != nil && len(candidates) > 0 {
+	stats.Rooted = len(out)
+	if logger != nil {
 		// Bounded is fine; silent is not. A project whose routes hang off a
 		// dispatcher should be able to see that apispec noticed.
 		logger.Printf("Entrypoints: %d declared, %d rooted (%d already reachable, %d register no routes)\n",
-			len(candidates), len(out), skippedReachable, skippedNoRoutes)
+			stats.Declared, stats.Rooted, stats.AlreadyReachable, stats.NoRoutes)
 	}
-	return out
+	return out, stats
+}
+
+// EntrypointStats records what the entrypoint gate decided, so the same numbers
+// the --verbose line reports can be shown in the UI: a project whose routes hang
+// off a CLI dispatcher stands or falls on this, and "0 rooted, N register no
+// routes" is the difference between "apispec never looked" and "apispec looked
+// and nothing there registers a route".
+type EntrypointStats struct {
+	Declared         int
+	Rooted           int
+	AlreadyReachable int
+	NoRoutes         int
 }
 
 // functionsReachableFromMains returns every function base key reachable from a

--- a/internal/spec/entrypoint_roots_test.go
+++ b/internal/spec/entrypoint_roots_test.go
@@ -87,17 +87,23 @@ func TestEntrypointRoots(t *testing.T) {
 		key("reachableCmd"), // registers but main reaches it   -> skipped
 		pkg + ".missingCmd", // not in the graph at all         -> skipped
 	}
-	got := entrypointRoots(meta, candidates, match, nil)
+	got, stats := entrypointRoots(meta, candidates, match, nil)
 	if want := []string{key("webCmd")}; !reflect.DeepEqual(got, want) {
 		t.Errorf("entrypointRoots = %v, want %v", got, want)
 	}
+	// The same numbers the UI reports: every candidate is accounted for in
+	// exactly one bucket, so "0 rooted" can be read as a reason.
+	want := EntrypointStats{Declared: 4, Rooted: 1, AlreadyReachable: 1, NoRoutes: 2}
+	if stats != want {
+		t.Errorf("stats = %+v, want %+v", stats, want)
+	}
 
 	t.Run("no candidates, no metadata, no matcher", func(t *testing.T) {
-		if got := entrypointRoots(meta, nil, match, nil); got != nil {
-			t.Errorf("no candidates = %v, want nil", got)
+		if got, stats := entrypointRoots(meta, nil, match, nil); got != nil || stats != (EntrypointStats{}) {
+			t.Errorf("no candidates = (%v, %+v), want (nil, zero)", got, stats)
 		}
-		if got := entrypointRoots(nil, candidates, match, nil); got != nil {
-			t.Errorf("nil metadata = %v, want nil", got)
+		if got, stats := entrypointRoots(nil, candidates, match, nil); got != nil || stats != (EntrypointStats{}) {
+			t.Errorf("nil metadata = (%v, %+v), want (nil, zero)", got, stats)
 		}
 	})
 }

--- a/internal/spec/lazytree.go
+++ b/internal/spec/lazytree.go
@@ -58,6 +58,10 @@ type LazyTree struct {
 	// handlerValueKeys and issue #204. Empty for func-handler frameworks.
 	handlerMethods []string
 
+	// entrypointStats records what the entrypoint gate decided, so the UI can
+	// report it (the numbers otherwise live only in a --verbose line).
+	entrypointStats EntrypointStats
+
 	// calleeEdges memoizes, per function base key, the filtered+ordered call
 	// edges used to expand any node of that function. Computed once.
 	calleeEdges map[string][]*metadata.CallGraphEdge
@@ -444,7 +448,9 @@ func (t *LazyTree) addEntrypointRoots(candidates []string) {
 	for _, r := range t.roots {
 		existing[metadata.StripToBase(r.GetKey())] = true
 	}
-	for _, key := range entrypointRoots(t.meta, candidates, t.routeMatch, t.logger) {
+	rooted, stats := entrypointRoots(t.meta, candidates, t.routeMatch, t.logger)
+	t.entrypointStats = stats
+	for _, key := range rooted {
 		if existing[key] {
 			continue
 		}
@@ -507,6 +513,13 @@ func (t *LazyTree) edgesFor(baseKey string) []*metadata.CallGraphEdge {
 // the extractor asks for roots BEFORE it expands anything. Deferring left the
 // extra roots invisible — the tree had them, nobody ever saw them. The call is
 // memoized, so this only moves work that every expansion path pays anyway.
+// EntrypointStats reports what the entrypoint gate decided during this tree's
+// build. Zero when the project declares no entrypoints.
+func (t *LazyTree) EntrypointStats() EntrypointStats {
+	t.buildRelations() // the gate runs there; asking first would report zeros
+	return t.entrypointStats
+}
+
 func (t *LazyTree) GetRoots() []TrackerNodeInterface {
 	if t == nil {
 		return nil

--- a/internal/spec/tracker.go
+++ b/internal/spec/tracker.go
@@ -264,6 +264,7 @@ type TrackerTree struct {
 	entrypointPatterns []EntrypointPattern
 	routeMatch         func(*metadata.CallGraphEdge) bool
 	entrypointKeys     []string
+	entrypointStats    EntrypointStats
 
 	// logger receives traversal-time warnings (limit truncations, etc.).
 	// May be nil; callers should reach it via t.warn / t.info.
@@ -617,7 +618,9 @@ func NewTrackerTree(meta *metadata.Metadata, limits metadata.TrackerLimits, logg
 		for _, r := range t.roots {
 			existing[metadata.StripToBase(r.Key())] = true
 		}
-		for _, key := range entrypointRoots(meta, t.entrypointKeys, t.routeMatch, t.logger) {
+		rooted, stats := entrypointRoots(meta, t.entrypointKeys, t.routeMatch, t.logger)
+		t.entrypointStats = stats
+		for _, key := range rooted {
 			if existing[key] {
 				continue
 			}
@@ -1739,6 +1742,13 @@ func NewTrackerNode(tree *TrackerTree, meta *metadata.Metadata, parentID, id str
 	}
 
 	return node
+}
+
+// EntrypointStats reports what the entrypoint gate decided during this tree's
+// build (the eager build runs it up front). Zero when the project declares no
+// entrypoints.
+func (t *TrackerTree) EntrypointStats() EntrypointStats {
+	return t.entrypointStats
 }
 
 // GetRoots returns the root nodes of the tracker tree.


### PR DESCRIPTION
## What

Two gaps in the Insight dashboard, plus a config round-trip bug found on the way.

### Per-status response-body resolution

The status histogram counted responses without saying whether they document anything. Each status now splits four ways, because these are four different diagnoses:

| state | meaning | fix |
|---|---|---|
| fields described | a schema naming its fields | — |
| free-form | `map[string]any` — that IS the type | nothing missing; an API choice |
| type unresolved | body found, type never became a schema | a type mapping / external type |
| no body | correct at 204; at 200 the write wasn't followed | read the endpoint trace |

Measured on a ~330-route chi service: what used to be one "99 unresolved" number reads **84 free-form, 15 genuinely unresolved** — the difference between a config gap and an API that is simply free-form.

### How the spec was read

Frameworks detected (primary marked), tracker engine, and what the entrypoint gate did (#220). On photoprism: *"53 functions stored in a field a library calls back; 1 of 53 led to route registration"* — numbers that previously existed only in a `--verbose` line. `entrypointRoots` now returns them, both tracker engines keep them, and the engine exposes them alongside its other diagnostics.

None of this is derivable from the spec, so `insight` stays a pure function of spec + metadata and the caller fills in an `Analysis` block. Both new lines also go into the AI export, which previously listed problems without stating what had been analysed.

### Config round-trip fix

The editor offers `securityPatterns`, `entrypointPatterns`, `handlerInterfaceMethods` and `responseContext`, but `buildAPISpecConfig` never copied them into the config handed to the engine — those edits appeared to save and changed nothing. A test now submits every section and asserts each survives.

## Verification

- Full suite, `go vet`, `gofmt`, `golangci-lint` (0 issues); coverage 96.0% against the 96% floor.
- Zero spec drift across all 67 fixtures (this is read-only reporting).
- Verified live in the browser against two real projects (chi service, photoprism) — cards render, no console errors.
- New tests: body classification (every shape, including the free-form/unresolved line), per-status tallies summing to the histogram, the export lines, entrypoint stats through the gate, and the config-section round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an analysis summary showing detected frameworks, processing mode, and entrypoint results.
  * Added response-body analytics grouped by HTTP status, including resolved, free-form, unresolved, and empty bodies.
  * Improved dashboard guidance and tooltips for analysis and response-body insights.
  * Included analysis and response-body summaries in exported reports.
* **Bug Fixes**
  * Preserved all framework configuration sections and entrypoint pattern settings during generation.
  * Improved handling of empty analysis and entrypoint results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->