### PR TITLE
perf(metadata): intern positions once per location, not once per record (#226)

### DIFF
--- a/internal/metadata/analysis.go
+++ b/internal/metadata/analysis.go
@@ -15,7 +15,6 @@
 package metadata
 
 import (
-	"fmt"
 	"go/ast"
 	"go/token"
 	"go/types"
@@ -74,12 +73,12 @@ func getEnclosingFunctionName(file *ast.File, pos token.Pos, info *types.Info, f
 	funcLit := findEnclosingFunctionLiteral(file, pos)
 	if funcLit != nil {
 		// Return the function literal identifier (e.g., "FuncLitmain.go:42:15")
-		position := getPosition(funcLit.Pos(), fset)
+		position := meta.positionString(funcLit.Pos(), fset)
 		var signatureStr string
 		if fnType := info.TypeOf(funcLit.Type); fnType != nil {
 			signatureStr = typeStringOf(meta, fnType)
 		}
-		return fmt.Sprintf("FuncLit:%s", position), "", signatureStr
+		return funcLitName(position), "", signatureStr
 	}
 
 	// Fallback to declared functions
@@ -211,7 +210,7 @@ func isTypeConversion(call *ast.CallExpr, info *types.Info) bool {
 }
 
 // getCalleeFunctionNameAndPackage extracts function name, package, and receiver type from a call expression
-func getCalleeFunctionNameAndPackage(expr ast.Expr, file *ast.File, pkgName string, fileToInfo map[*ast.File]*types.Info, funcMap map[string]*ast.FuncDecl, fset *token.FileSet) (string, string, string) {
+func getCalleeFunctionNameAndPackage(expr ast.Expr, file *ast.File, pkgName string, fileToInfo map[*ast.File]*types.Info, funcMap map[string]*ast.FuncDecl, fset *token.FileSet, meta *Metadata) (string, string, string) {
 	switch x := expr.(type) {
 	case *ast.Ident:
 		// Simple identifier - assume it's a function in the current package
@@ -272,19 +271,19 @@ func getCalleeFunctionNameAndPackage(expr ast.Expr, file *ast.File, pkgName stri
 		return x.Sel.Name, pkgName, ""
 
 	case *ast.CallExpr:
-		return getCalleeFunctionNameAndPackage(x.Fun, file, pkgName, fileToInfo, funcMap, fset)
+		return getCalleeFunctionNameAndPackage(x.Fun, file, pkgName, fileToInfo, funcMap, fset, meta)
 
 	case *ast.IndexExpr:
 		// Handle indexed expressions like array[index] or map[key]
 		// Recursively analyze the indexed expression (X) to find function calls
-		return getCalleeFunctionNameAndPackage(x.X, file, pkgName, fileToInfo, funcMap, fset)
+		return getCalleeFunctionNameAndPackage(x.X, file, pkgName, fileToInfo, funcMap, fset, meta)
 
 	case *ast.IndexListExpr:
 		// Handle generic function or type instantiations like Func[T1, T2]
 		// Recursively analyze the X field to find function calls
-		return getCalleeFunctionNameAndPackage(x.X, file, pkgName, fileToInfo, funcMap, fset)
+		return getCalleeFunctionNameAndPackage(x.X, file, pkgName, fileToInfo, funcMap, fset, meta)
 	case *ast.FuncLit:
-		return fmt.Sprintf("FuncLit:%s", getPosition(x.Pos(), fset)), pkgName, ""
+		return funcLitName(meta.positionString(x.Pos(), fset)), pkgName, ""
 
 	}
 	return "", "", ""

--- a/internal/metadata/coverage_helpers_test.go
+++ b/internal/metadata/coverage_helpers_test.go
@@ -174,20 +174,21 @@ func TestCovmetaGetImportPath(t *testing.T) {
 func TestCovmetaGetPositions(t *testing.T) {
 	file, fset := covmetaParse(t, covmetaHelperSrc)
 	fn, _, varSpec, _, _ := covmetaFindNodes(file)
+	m := &Metadata{StringPool: NewStringPool()}
 
-	if got := getFuncPosition(fn, fset); got == "" {
-		t.Error("func position should be non-empty")
+	if got := m.funcPositionIndex(fn, fset); got < 0 {
+		t.Error("func position should resolve to a pooled string")
 	}
-	if got := getFuncPosition(nil, fset); got != "" {
-		t.Errorf("nil func position should be empty, got %q", got)
+	if got := m.funcPositionIndex(nil, fset); got != -1 {
+		t.Errorf("nil func position = %d, want -1", got)
 	}
 
 	ident := varSpec.Names[0]
-	if got := getVarPosition(ident, fset); got == "" {
-		t.Error("var position should be non-empty")
+	if got := m.varPositionIndex(ident, fset); got < 0 {
+		t.Error("var position should resolve to a pooled string")
 	}
-	if got := getVarPosition(nil, fset); got != "" {
-		t.Errorf("nil var position should be empty, got %q", got)
+	if got := m.varPositionIndex(nil, fset); got != -1 {
+		t.Errorf("nil var position = %d, want -1", got)
 	}
 }
 

--- a/internal/metadata/expression.go
+++ b/internal/metadata/expression.go
@@ -74,10 +74,10 @@ func ExprToCallArgument(expr ast.Expr, info *types.Info, pkgName string, fset *t
 	case *ast.TypeAssertExpr:
 		return handleTypeAssertExpr(e, info, pkgName, fset, meta)
 	case *ast.FuncLit:
-		position := getPosition(e.Pos(), fset)
+		position := meta.positionString(e.Pos(), fset)
 		arg := NewCallArgument(meta)
 		arg.SetKind(KindFuncLit)
-		arg.SetName(fmt.Sprintf("FuncLit:%s", position))
+		arg.SetName(funcLitName(position))
 		arg.SetPkg(pkgName)
 		typ := ExprToCallArgument(e.Type, info, pkgName, fset, meta)
 		typeStr := callArgToString(typ, nil)
@@ -164,7 +164,7 @@ func handleIdent(e *ast.Ident, info *types.Info, pkgName string, fset *token.Fil
 	arg.SetName(name)
 	arg.SetPkg(pkg)
 	arg.SetType(typeStr)
-	arg.SetPosition(getPosition(e.Pos(), fset))
+	arg.SetPosition(meta.positionString(e.Pos(), fset))
 	setConstStringValue(arg, e, info)
 	return arg
 }
@@ -234,7 +234,7 @@ func handleSelector(e *ast.SelectorExpr, info *types.Info, pkgName string, fset 
 	arg.Sel = sel
 	arg.SetPkg(pkg)
 	arg.SetType(typeStr)
-	arg.SetPosition(getPosition(e.Pos(), fset))
+	arg.SetPosition(meta.positionString(e.Pos(), fset))
 	arg.ReceiverType = receiverArg
 	setConstStringValue(arg, e, info)
 
@@ -253,7 +253,7 @@ func handleCallExpr(e *ast.CallExpr, info *types.Info, pkgName string, fset *tok
 	arg := NewCallArgument(meta)
 	arg.Fun = fun
 	arg.Args = args
-	arg.SetPosition(getPosition(e.Pos(), fset))
+	arg.SetPosition(meta.positionString(e.Pos(), fset))
 
 	// Check if this is a type conversion rather than a function call
 	if isTypeConversion(e, info) {
@@ -299,7 +299,7 @@ func handleUnaryExpr(e *ast.UnaryExpr, info *types.Info, pkgName string, fset *t
 	arg.SetKind(KindUnary)
 	arg.X = x
 	arg.SetValue(op)
-	arg.SetPosition(getPosition(e.Pos(), fset))
+	arg.SetPosition(meta.positionString(e.Pos(), fset))
 	return arg
 }
 
@@ -314,7 +314,7 @@ func handleBinaryExpr(e *ast.BinaryExpr, info *types.Info, pkgName string, fset 
 	arg.X = x
 	arg.Fun = y
 	arg.SetValue(op)
-	arg.SetPosition(getPosition(e.Pos(), fset))
+	arg.SetPosition(meta.positionString(e.Pos(), fset))
 	return arg
 }
 
@@ -327,7 +327,7 @@ func handleIndexExpr(e *ast.IndexExpr, info *types.Info, pkgName string, fset *t
 	arg.SetKind(KindIndex)
 	arg.X = x
 	arg.Fun = index
-	arg.SetPosition(getPosition(e.Pos(), fset))
+	arg.SetPosition(meta.positionString(e.Pos(), fset))
 	return arg
 }
 
@@ -344,7 +344,7 @@ func handleIndexListExpr(e *ast.IndexListExpr, info *types.Info, pkgName string,
 	arg.SetKind(KindIndexList)
 	arg.X = x
 	arg.Args = indices
-	arg.SetPosition(getPosition(e.Pos(), fset))
+	arg.SetPosition(meta.positionString(e.Pos(), fset))
 	return arg
 }
 
@@ -355,7 +355,7 @@ func handleParenExpr(e *ast.ParenExpr, info *types.Info, pkgName string, fset *t
 	arg := NewCallArgument(meta)
 	arg.SetKind(KindParen)
 	arg.X = x
-	arg.SetPosition(getPosition(e.Pos(), fset))
+	arg.SetPosition(meta.positionString(e.Pos(), fset))
 	return arg
 }
 
@@ -366,7 +366,7 @@ func handleStarExpr(e *ast.StarExpr, info *types.Info, pkgName string, fset *tok
 	arg := NewCallArgument(meta)
 	arg.SetKind(KindStar)
 	arg.X = x
-	arg.SetPosition(getPosition(e.Pos(), fset))
+	arg.SetPosition(meta.positionString(e.Pos(), fset))
 	return arg
 }
 
@@ -385,7 +385,7 @@ func handleArrayType(e *ast.ArrayType, info *types.Info, pkgName string, fset *t
 	if lenArg != nil {
 		arg.SetValue(lenArg.GetValue())
 	}
-	arg.SetPosition(getPosition(e.Pos(), fset))
+	arg.SetPosition(meta.positionString(e.Pos(), fset))
 	return arg
 }
 
@@ -410,7 +410,7 @@ func handleSliceExpr(e *ast.SliceExpr, info *types.Info, pkgName string, fset *t
 	arg.SetKind(KindSlice)
 	arg.X = x
 	arg.Args = args
-	arg.SetPosition(getPosition(e.Pos(), fset))
+	arg.SetPosition(meta.positionString(e.Pos(), fset))
 	return arg
 }
 
@@ -426,7 +426,7 @@ func handleCompositeLit(e *ast.CompositeLit, info *types.Info, pkgName string, f
 	arg.SetKind(KindCompositeLit)
 	arg.X = typeExpr
 	arg.Args = elts
-	arg.SetPosition(getPosition(e.Pos(), fset))
+	arg.SetPosition(meta.positionString(e.Pos(), fset))
 	return arg
 }
 
@@ -439,7 +439,7 @@ func handleKeyValueExpr(e *ast.KeyValueExpr, info *types.Info, pkgName string, f
 	arg.SetKind(KindKeyValue)
 	arg.X = key
 	arg.Fun = value
-	arg.SetPosition(getPosition(e.Pos(), fset))
+	arg.SetPosition(meta.positionString(e.Pos(), fset))
 	return arg
 }
 
@@ -452,7 +452,7 @@ func handleTypeAssertExpr(e *ast.TypeAssertExpr, info *types.Info, pkgName strin
 	arg.SetKind(KindTypeAssert)
 	arg.X = x
 	arg.Fun = typeExpr
-	arg.SetPosition(getPosition(e.Pos(), fset))
+	arg.SetPosition(meta.positionString(e.Pos(), fset))
 	return arg
 }
 
@@ -474,7 +474,7 @@ func handleChanType(e *ast.ChanType, info *types.Info, pkgName string, fset *tok
 	arg.SetKind(KindChanType)
 	arg.X = elt
 	arg.SetValue(dir)
-	arg.SetPosition(getPosition(e.Pos(), fset))
+	arg.SetPosition(meta.positionString(e.Pos(), fset))
 	return arg
 }
 
@@ -487,7 +487,7 @@ func handleMapType(e *ast.MapType, info *types.Info, pkgName string, fset *token
 	arg.SetKind(KindMapType)
 	arg.X = key
 	arg.Fun = value
-	arg.SetPosition(getPosition(e.Pos(), fset))
+	arg.SetPosition(meta.positionString(e.Pos(), fset))
 	return arg
 }
 
@@ -519,7 +519,7 @@ func handleStructType(e *ast.StructType, info *types.Info, pkgName string, fset 
 	arg := NewCallArgument(meta)
 	arg.SetKind(KindStructType)
 	arg.Args = fields
-	arg.SetPosition(getPosition(e.Pos(), fset))
+	arg.SetPosition(meta.positionString(e.Pos(), fset))
 	return arg
 }
 
@@ -548,7 +548,7 @@ func handleEllipsis(e *ast.Ellipsis, info *types.Info, pkgName string, fset *tok
 	arg := NewCallArgument(meta)
 	arg.SetKind(KindEllipsis)
 	arg.X = elt
-	arg.SetPosition(getPosition(e.Pos(), fset))
+	arg.SetPosition(meta.positionString(e.Pos(), fset))
 	return arg
 }
 

--- a/internal/metadata/helpers.go
+++ b/internal/metadata/helpers.go
@@ -17,7 +17,6 @@ package metadata
 import (
 	"fmt"
 	"go/ast"
-	"go/token"
 	"go/types"
 	"strings"
 
@@ -66,30 +65,6 @@ func getTypeName(nd ast.Node, info *types.Info) string {
 		return typemodel.FromExpr(e, info).String()
 	}
 	return ""
-}
-
-// getPosition returns a string representation of a position
-func getPosition(pos token.Pos, fset *token.FileSet) string {
-	if !pos.IsValid() || fset == nil {
-		return ""
-	}
-	return fset.Position(pos).String()
-}
-
-// getFuncPosition returns the position of a function declaration
-func getFuncPosition(fn *ast.FuncDecl, fset *token.FileSet) string {
-	if fn == nil {
-		return ""
-	}
-	return getPosition(fn.Pos(), fset)
-}
-
-// getVarPosition returns the position of a variable identifier
-func getVarPosition(ident *ast.Ident, fset *token.FileSet) string {
-	if ident == nil {
-		return ""
-	}
-	return getPosition(ident.Pos(), fset)
 }
 
 // getComments extracts comments from AST nodes

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -314,7 +314,7 @@ func GenerateMetadataWithLogger(pkgs map[string]map[string]*ast.File, fileToInfo
 					Name:          metadata.StringPool.Get(fn.Name.Name),
 					Receiver:      metadata.StringPool.Get(recvType),
 					Signature:     *ExprToCallArgument(fn.Type, info, pkgName, fset, metadata),
-					Position:      metadata.StringPool.Get(getFuncPosition(fn, fset)),
+					Position:      metadata.funcPositionIndex(fn, fset),
 					Scope:         metadata.StringPool.Get(getScope(fn.Name.Name)),
 					Comments:      metadata.StringPool.Get(getComments(fn)),
 					AssignmentMap: assignmentsInFunc,
@@ -1204,7 +1204,7 @@ func processFunctions(file *ast.File, info *types.Info, pkgName string, fset *to
 			Name:           metadata.StringPool.Get(fn.Name.Name),
 			Pkg:            metadata.StringPool.Get(pkgName),
 			Signature:      *ExprToCallArgument(fn.Type, info, pkgName, fset, metadata),
-			Position:       metadata.StringPool.Get(getFuncPosition(fn, fset)),
+			Position:       metadata.funcPositionIndex(fn, fset),
 			Scope:          metadata.StringPool.Get(getScope(fn.Name.Name)),
 			Comments:       metadata.StringPool.Get(comments),
 			TypeParams:     typeParams,
@@ -1251,7 +1251,7 @@ func processVariables(file *ast.File, info *types.Info, pkgName string, fset *to
 					Pkg:        metadata.StringPool.Get(pkgName),
 					Tok:        metadata.StringPool.Get(tok),
 					Type:       metadata.StringPool.Get(getTypeName(vspec.Type, info)),
-					Position:   metadata.StringPool.Get(getVarPosition(name, fset)),
+					Position:   metadata.varPositionIndex(name, fset),
 					Comments:   metadata.StringPool.Get(comments),
 					GroupIndex: groupIndex,
 				}
@@ -1326,7 +1326,7 @@ func processStructInstance(cl *ast.CompositeLit, info *types.Info, pkgName strin
 	f.StructInstances = append(f.StructInstances, StructInstance{
 		Type:     metadata.StringPool.Get(typeName),
 		Pkg:      metadata.StringPool.Get(pkgName),
-		Position: metadata.StringPool.Get(getPosition(cl.Pos(), fset)),
+		Position: metadata.positionIndex(cl.Pos(), fset),
 		Fields:   fields,
 	})
 }
@@ -1378,7 +1378,7 @@ func processAssignment(assign *ast.AssignStmt, file *ast.File, info *types.Info,
 					VariableName: metadata.StringPool.Get(expr.Name),
 					Pkg:          metadata.StringPool.Get(pkgName),
 					ConcreteType: metadata.StringPool.Get(concreteType),
-					Position:     metadata.StringPool.Get(getPosition(assign.Pos(), fset)),
+					Position:     metadata.positionIndex(assign.Pos(), fset),
 					Scope:        metadata.StringPool.Get(getScope(expr.Name)),
 					Value:        val,
 					Lhs:          *ExprToCallArgument(lhsExpr, info, pkgName, fset, metadata),
@@ -1386,7 +1386,7 @@ func processAssignment(assign *ast.AssignStmt, file *ast.File, info *types.Info,
 				}
 				// If RHS is a function call, record callee info
 				if callExpr, ok := rhsExpr.(*ast.CallExpr); ok {
-					calleeFunc, calleePkg, _ := getCalleeFunctionNameAndPackage(callExpr.Fun, file, pkgName, fileToInfo, funcMap, fset)
+					calleeFunc, calleePkg, _ := getCalleeFunctionNameAndPackage(callExpr.Fun, file, pkgName, fileToInfo, funcMap, fset, metadata)
 					assignment.CalleeFunc = calleeFunc
 					assignment.CalleePkg = calleePkg
 					assignment.ReturnIndex = 0 // For now, always first return value
@@ -1403,7 +1403,7 @@ func processAssignment(assign *ast.AssignStmt, file *ast.File, info *types.Info,
 					VariableName: metadata.StringPool.Get(CallArgToString(&lhsArg)),
 					Pkg:          metadata.StringPool.Get(pkgName),
 					ConcreteType: lhsArg.Type,
-					Position:     metadata.StringPool.Get(getPosition(assign.Pos(), fset)),
+					Position:     metadata.positionIndex(assign.Pos(), fset),
 					Scope:        metadata.StringPool.Get("selector"),
 					Value:        *ExprToCallArgument(rhsExpr, info, pkgName, fset, metadata),
 					Lhs:          *ExprToCallArgument(lhsExpr, info, pkgName, fset, metadata),
@@ -1416,7 +1416,7 @@ func processAssignment(assign *ast.AssignStmt, file *ast.File, info *types.Info,
 					VariableName: metadata.StringPool.Get(CallArgToString(ExprToCallArgument(lhsExpr, info, pkgName, fset, metadata))),
 					Pkg:          metadata.StringPool.Get(pkgName),
 					ConcreteType: metadata.StringPool.Get("index"),
-					Position:     metadata.StringPool.Get(getPosition(assign.Pos(), fset)),
+					Position:     metadata.positionIndex(assign.Pos(), fset),
 					Scope:        metadata.StringPool.Get("index"),
 					Value:        *ExprToCallArgument(rhsExpr, info, pkgName, fset, metadata),
 					Lhs:          *ExprToCallArgument(lhsExpr, info, pkgName, fset, metadata),
@@ -1429,7 +1429,7 @@ func processAssignment(assign *ast.AssignStmt, file *ast.File, info *types.Info,
 					VariableName: metadata.StringPool.Get(CallArgToString(ExprToCallArgument(lhsExpr, info, pkgName, fset, metadata))),
 					Pkg:          metadata.StringPool.Get(pkgName),
 					ConcreteType: metadata.StringPool.Get("raw"),
-					Position:     metadata.StringPool.Get(getPosition(assign.Pos(), fset)),
+					Position:     metadata.positionIndex(assign.Pos(), fset),
 					Scope:        metadata.StringPool.Get("raw"),
 					Value:        *ExprToCallArgument(rhsExpr, info, pkgName, fset, metadata),
 					Lhs:          *ExprToCallArgument(lhsExpr, info, pkgName, fset, metadata),
@@ -1579,7 +1579,7 @@ func processCallExpression(call *ast.CallExpr, file *ast.File, pkgs map[string]m
 	}
 
 	callerFunc, callerParts, callerSignatureStr := getEnclosingFunctionName(file, call.Pos(), info, fset, metadata)
-	calleeFunc, calleePkg, calleeParts := getCalleeFunctionNameAndPackage(call.Fun, file, pkgName, fileToInfo, funcMap, fset)
+	calleeFunc, calleePkg, calleeParts := getCalleeFunctionNameAndPackage(call.Fun, file, pkgName, fileToInfo, funcMap, fset, metadata)
 
 	// Skip mock calls
 	if isMockName(calleeFunc) || isMockName(calleePkg) || isMockName(callerFunc) {
@@ -1596,7 +1596,7 @@ func processCallExpression(call *ast.CallExpr, file *ast.File, pkgs map[string]m
 		// Determine if the caller is a function literal
 		var parentFunction *Call
 
-		if strings.HasPrefix(callerFunc, "FuncLit:") {
+		if strings.HasPrefix(callerFunc, FuncLitPrefix) {
 			callerInstance := pkgName + "." + callerFunc + "@" + callerFunc[strings.Index(callerFunc, ":")+1:]
 
 			if _, ok := calleeMap[callerInstance]; !ok {
@@ -1635,7 +1635,7 @@ func processCallExpression(call *ast.CallExpr, file *ast.File, pkgs map[string]m
 
 		cgEdge := &CallGraphEdge{
 			Args:           args,
-			Position:       metadata.StringPool.Get(getPosition(call.Pos(), fset)),
+			Position:       metadata.positionIndex(call.Pos(), fset),
 			ParamArgMap:    paramArgMap,
 			TypeParamMap:   typeParamMap,
 			ParentFunction: parentFunction,
@@ -1664,7 +1664,7 @@ func processCallExpression(call *ast.CallExpr, file *ast.File, pkgs map[string]m
 		cgEdge.Callee = *cgEdge.NewCall(
 			metadata.StringPool.Get(calleeFunc),
 			metadata.StringPool.Get(calleePkg),
-			metadata.StringPool.Get(getPosition(call.Pos(), fset)),
+			metadata.positionIndex(call.Pos(), fset),
 			metadata.StringPool.Get(calleeParts),
 			metadata.StringPool.Get(calleeScope),
 		)
@@ -2304,7 +2304,7 @@ func registerEmbeddedInterfaceResolution(kv *ast.KeyValueExpr, structTypeName, p
 	}
 
 	if concreteType != "" && fieldName != "" {
-		position := getPosition(kv.Pos(), fset)
+		position := metadata.positionString(kv.Pos(), fset)
 		metadata.RegisterInterfaceResolution(fieldName, structTypeName, pkgName, concreteType, position)
 	}
 }

--- a/internal/metadata/metadata_sweep_test.go
+++ b/internal/metadata/metadata_sweep_test.go
@@ -297,7 +297,7 @@ func TestSweepGetCalleeFunctionNameAndPackageArms(t *testing.T) {
 		identX: types.NewVar(token.NoPos, nil, "r", ifaceType),
 	}}
 	name, pkg, recv := getCalleeFunctionNameAndPackage(mkSel(identX, "Read"), file, "p",
-		map[*ast.File]*types.Info{file: infoVar}, nil, fset)
+		map[*ast.File]*types.Info{file: infoVar}, nil, fset, sweepMeta())
 	if name != "Read" || pkg != "p" || recv != "interface" {
 		t.Errorf("iface var receiver: got (%q,%q,%q)", name, pkg, recv)
 	}
@@ -308,7 +308,7 @@ func TestSweepGetCalleeFunctionNameAndPackageArms(t *testing.T) {
 		callX: {Type: types.Universe.Lookup("error").Type()},
 	}}
 	name, pkg, recv = getCalleeFunctionNameAndPackage(mkSel(callX, "Error"), file, "p",
-		map[*ast.File]*types.Info{file: infoErr}, nil, fset)
+		map[*ast.File]*types.Info{file: infoErr}, nil, fset, sweepMeta())
 	if name != "Error" || pkg != "p" || recv != "error" {
 		t.Errorf("error receiver: got (%q,%q,%q)", name, pkg, recv)
 	}
@@ -319,7 +319,7 @@ func TestSweepGetCalleeFunctionNameAndPackageArms(t *testing.T) {
 		callX2: {Type: ifaceType},
 	}}
 	name, pkg, recv = getCalleeFunctionNameAndPackage(mkSel(callX2, "Do"), file, "p",
-		map[*ast.File]*types.Info{file: infoIface}, nil, fset)
+		map[*ast.File]*types.Info{file: infoIface}, nil, fset, sweepMeta())
 	if name != "Do" || pkg != "p" || recv != "interface" {
 		t.Errorf("iface complex receiver: got (%q,%q,%q)", name, pkg, recv)
 	}
@@ -330,25 +330,25 @@ func TestSweepGetCalleeFunctionNameAndPackageArms(t *testing.T) {
 		callX3: {Type: types.Typ[types.Int]},
 	}}
 	name, pkg, recv = getCalleeFunctionNameAndPackage(mkSel(callX3, "Do"), file, "p",
-		map[*ast.File]*types.Info{file: infoBasic}, nil, fset)
+		map[*ast.File]*types.Info{file: infoBasic}, nil, fset, sweepMeta())
 	if name != "Do" || pkg != "p" || recv != "" {
 		t.Errorf("basic receiver fallback: got (%q,%q,%q)", name, pkg, recv)
 	}
 
 	// CallExpr recurses into its Fun.
-	name, _, _ = getCalleeFunctionNameAndPackage(&ast.CallExpr{Fun: ast.NewIdent("mk")}, file, "p", nil, nil, fset)
+	name, _, _ = getCalleeFunctionNameAndPackage(&ast.CallExpr{Fun: ast.NewIdent("mk")}, file, "p", nil, nil, fset, sweepMeta())
 	if name != "mk" {
 		t.Errorf("call expr recursion: got %q", name)
 	}
 
 	// IndexListExpr recurses into X.
-	name, _, _ = getCalleeFunctionNameAndPackage(&ast.IndexListExpr{X: ast.NewIdent("gen")}, file, "p", nil, nil, fset)
+	name, _, _ = getCalleeFunctionNameAndPackage(&ast.IndexListExpr{X: ast.NewIdent("gen")}, file, "p", nil, nil, fset, sweepMeta())
 	if name != "gen" {
 		t.Errorf("index list recursion: got %q", name)
 	}
 
 	// Unhandled expression kinds resolve to nothing.
-	name, pkg, recv = getCalleeFunctionNameAndPackage(&ast.BasicLit{Kind: token.INT, Value: "1"}, file, "p", nil, nil, fset)
+	name, pkg, recv = getCalleeFunctionNameAndPackage(&ast.BasicLit{Kind: token.INT, Value: "1"}, file, "p", nil, nil, fset, sweepMeta())
 	if name != "" || pkg != "" || recv != "" {
 		t.Errorf("unhandled expr: got (%q,%q,%q)", name, pkg, recv)
 	}

--- a/internal/metadata/position.go
+++ b/internal/metadata/position.go
@@ -1,0 +1,131 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"go/ast"
+	"go/token"
+	"strconv"
+)
+
+// positionIndex returns the string-pool index of a source position, formatting it
+// at most once per distinct location.
+//
+// Every call argument, call, function, assignment and struct instance records a
+// position, and the same location is recorded many times over — once per node
+// that mentions it, and again each time a node is revisited. Formatting per
+// record cost 1.03GB, 13.5% of all allocation on a 360-package project (issue
+// #226): the string was built with fmt and only then interned, so interning saved
+// nothing. Here the pool index is remembered, so a repeat costs one map lookup.
+//
+// The cache keys on token.Pos, which is a byte offset within the FileSet and so
+// identifies a location exactly — no heuristic, and no way for two locations to
+// collide.
+//
+// Returns -1 (the pool's "no string") for a position that does not exist, which
+// is what interning the empty string produced before.
+func (m *Metadata) positionIndex(pos token.Pos, fset *token.FileSet) int {
+	if m == nil || m.StringPool == nil {
+		return -1
+	}
+	if !pos.IsValid() || fset == nil {
+		return -1
+	}
+
+	m.posMutex.RLock()
+	idx, ok := m.posCache[pos]
+	m.posMutex.RUnlock()
+	if ok {
+		return idx
+	}
+
+	idx = m.StringPool.Get(formatPosition(fset.Position(pos)))
+
+	m.posMutex.Lock()
+	if m.posCache == nil {
+		m.posCache = make(map[token.Pos]int, 4096)
+	}
+	m.posCache[pos] = idx
+	m.posMutex.Unlock()
+	return idx
+}
+
+// positionString returns the same rendering as positionIndex, for the callers
+// that build a name out of it (a function literal is identified by where it is
+// written). The string comes from the pool, so a repeat allocates nothing.
+func (m *Metadata) positionString(pos token.Pos, fset *token.FileSet) string {
+	idx := m.positionIndex(pos, fset)
+	if idx < 0 {
+		return ""
+	}
+	return m.StringPool.GetString(idx)
+}
+
+// FuncLitPrefix marks a name that identifies a function literal. A closure has no
+// declared name, so it is identified by where it is written: `FuncLit:<position>`.
+// The name reaches tracker keys and a closure route's operationId, so the three
+// sites that mint it all go through funcLitName.
+const FuncLitPrefix = "FuncLit:"
+
+// funcLitName builds the identifier for a function literal written at position.
+func funcLitName(position string) string {
+	return FuncLitPrefix + position
+}
+
+// funcPositionIndex is positionIndex for a function declaration.
+func (m *Metadata) funcPositionIndex(fn *ast.FuncDecl, fset *token.FileSet) int {
+	if fn == nil {
+		return -1
+	}
+	return m.positionIndex(fn.Pos(), fset)
+}
+
+// varPositionIndex is positionIndex for a variable's identifier.
+func (m *Metadata) varPositionIndex(ident *ast.Ident, fset *token.FileSet) int {
+	if ident == nil {
+		return -1
+	}
+	return m.positionIndex(ident.Pos(), fset)
+}
+
+// formatPosition renders a position as `file:line:column`.
+//
+// This is go/token.Position.String's output, reproduced deliberately rather than
+// called: that method builds the result with fmt and string concatenation, and it
+// was the single largest allocation site in metadata generation. The behaviour
+// must stay identical down to the empty-filename and zero-column cases, because
+// positions are part of tracker keys, of a closure's identity, and of the
+// byte-compared metadata goldens.
+func formatPosition(p token.Position) string {
+	if !p.IsValid() {
+		if p.Filename == "" {
+			return "-"
+		}
+		return p.Filename
+	}
+
+	// file:line:col, sized up front: a path plus two numbers.
+	buf := make([]byte, 0, len(p.Filename)+12)
+	buf = append(buf, p.Filename...)
+	if p.Filename != "" {
+		buf = append(buf, ':')
+	}
+	buf = strconv.AppendInt(buf, int64(p.Line), 10)
+	if p.Column != 0 {
+		buf = append(buf, ':')
+		buf = strconv.AppendInt(buf, int64(p.Column), 10)
+	}
+	return string(buf)
+}

--- a/internal/metadata/position.go
+++ b/internal/metadata/position.go
@@ -51,7 +51,18 @@ func (m *Metadata) positionIndex(pos token.Pos, fset *token.FileSet) int {
 		return idx
 	}
 
-	idx = m.StringPool.Get(formatPosition(fset.Position(pos)))
+	// A Pos is only meaningful in the FileSet that issued it: for anything else
+	// — a Pos from another FileSet, or one past the end of this one —
+	// fset.Position returns the zero value, which renders as "-". Pooling that
+	// would record a position of "-" on the node, so it is treated as no position
+	// at all. The check is here rather than up front because Position already does
+	// the file lookup, and a location that resolves pays for it once.
+	p := fset.Position(pos)
+	if !p.IsValid() {
+		return -1
+	}
+
+	idx = m.StringPool.Get(formatPosition(p))
 
 	m.posMutex.Lock()
 	if m.posCache == nil {

--- a/internal/metadata/position_test.go
+++ b/internal/metadata/position_test.go
@@ -100,6 +100,22 @@ func TestPositionIndexRejectsNothing(t *testing.T) {
 		t.Errorf("invalid position string = %q, want empty", got)
 	}
 
+	// A Pos only means something in the FileSet that issued it. An empty FileSet
+	// knows no positions, and a Pos past the end of a known file belongs to no
+	// file either; both render as "-" through token, which must not be recorded as
+	// a position (CodeRabbit, PR #228).
+	if got := m.positionIndex(token.Pos(1), token.NewFileSet()); got != -1 {
+		t.Errorf("position in an empty fileset = %d, want -1", got)
+	}
+	populated := token.NewFileSet()
+	f := populated.AddFile("p.go", -1, 10)
+	if got := m.positionIndex(f.Pos(3), populated); got < 0 {
+		t.Error("a position inside a known file did not resolve")
+	}
+	if got := m.positionIndex(token.Pos(f.Base()+1000), populated); got != -1 {
+		t.Errorf("position past the end of every file = %d, want -1", got)
+	}
+
 	var nilMeta *Metadata
 	if got := nilMeta.positionIndex(token.Pos(1), fset); got != -1 {
 		t.Errorf("nil metadata = %d, want -1", got)

--- a/internal/metadata/position_test.go
+++ b/internal/metadata/position_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// TestFormatPositionMatchesToken is the load-bearing test of this change: the
+// rendering is reproduced by hand instead of calling token.Position.String, and
+// the output is observable in tracker keys, in a closure's identity, and in the
+// byte-compared metadata goldens. Every shape token handles specially is checked
+// against token itself, so the two can never drift silently.
+func TestFormatPositionMatchesToken(t *testing.T) {
+	positions := []token.Position{
+		{Filename: "main.go", Line: 12, Column: 34},
+		{Filename: "a/b/main.go", Line: 1, Column: 1},
+		{Filename: "/abs/path/main.go", Line: 4321, Column: 7},
+		// No column: token omits it rather than printing ":0".
+		{Filename: "main.go", Line: 9},
+		// No filename: token prints the line without a leading colon.
+		{Line: 9, Column: 2},
+		{Line: 9},
+		// Invalid (line 0): token prints the filename alone...
+		{Filename: "main.go"},
+		// ...or "-" when there is not even a filename.
+		{},
+	}
+	for _, p := range positions {
+		if got, want := formatPosition(p), p.String(); got != want {
+			t.Errorf("formatPosition(%+v) = %q, want %q (token.Position.String)", p, got, want)
+		}
+	}
+}
+
+// TestPositionIndexMemoizes pins the behaviour the allocation win rests on: a
+// repeated location is formatted once and interned once, and distinct locations
+// stay distinct. Sharing an index between two locations would merge two call
+// sites in the tracker.
+func TestPositionIndexMemoizes(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "main.go", "package p\n\nvar a = 1\nvar b = 2\n", 0)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	m := &Metadata{StringPool: NewStringPool()}
+
+	posA, posB := file.Decls[0].Pos(), file.Decls[1].Pos()
+
+	idxA := m.positionIndex(posA, fset)
+	if idxA < 0 {
+		t.Fatal("a valid position did not resolve to a pooled string")
+	}
+	if again := m.positionIndex(posA, fset); again != idxA {
+		t.Errorf("second lookup = %d, want the memoized %d", again, idxA)
+	}
+	if idxB := m.positionIndex(posB, fset); idxB == idxA {
+		t.Error("two different locations share one pool index — they would collapse in tracker keys")
+	}
+
+	// The pooled string is what token would have produced.
+	if got, want := m.positionString(posA, fset), fset.Position(posA).String(); got != want {
+		t.Errorf("positionString = %q, want %q", got, want)
+	}
+
+	// Two distinct positions, cached once each.
+	if len(m.posCache) != 2 {
+		t.Errorf("cache holds %d entries, want 2", len(m.posCache))
+	}
+}
+
+// TestPositionIndexRejectsNothing covers the paths that must yield "no string"
+// rather than a bogus pool entry — the callers store the result directly on a
+// node, where -1 means "no position recorded".
+func TestPositionIndexRejectsNothing(t *testing.T) {
+	fset := token.NewFileSet()
+	m := &Metadata{StringPool: NewStringPool()}
+
+	if got := m.positionIndex(token.NoPos, fset); got != -1 {
+		t.Errorf("invalid position = %d, want -1", got)
+	}
+	if got := m.positionIndex(token.Pos(1), nil); got != -1 {
+		t.Errorf("nil fileset = %d, want -1", got)
+	}
+	if got := m.positionString(token.NoPos, fset); got != "" {
+		t.Errorf("invalid position string = %q, want empty", got)
+	}
+
+	var nilMeta *Metadata
+	if got := nilMeta.positionIndex(token.Pos(1), fset); got != -1 {
+		t.Errorf("nil metadata = %d, want -1", got)
+	}
+	if got := (&Metadata{}).positionIndex(token.Pos(1), fset); got != -1 {
+		t.Errorf("metadata without a pool = %d, want -1", got)
+	}
+}
+
+// TestFuncLitName pins the closure identifier. It is not cosmetic: it becomes a
+// tracker key and the operationId of a closure route, so the shape has to be
+// stated in one place rather than formatted at each of the three sites that mint
+// it.
+func TestFuncLitName(t *testing.T) {
+	if got, want := funcLitName("main.go:12:34"), "FuncLit:main.go:12:34"; got != want {
+		t.Errorf("funcLitName = %q, want %q", got, want)
+	}
+	if got := funcLitName(""); got != FuncLitPrefix {
+		t.Errorf("funcLitName(\"\") = %q, want %q", got, FuncLitPrefix)
+	}
+}

--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -16,6 +16,7 @@ package metadata
 
 import (
 	"fmt"
+	"go/token"
 	"go/types"
 	"maps"
 	"regexp"
@@ -145,6 +146,10 @@ type Metadata struct {
 	// typeStrCache memoizes go/types rendering — see typeStringOf.
 	typeStrCache map[types.Type]string
 	typeStrMutex sync.RWMutex
+
+	// posCache memoizes position rendering — see positionIndex.
+	posCache map[token.Pos]int
+	posMutex sync.RWMutex
 	// implementersCache memoizes ImplementersOf, which otherwise re-scans every
 	// package and type (with two sorts) on every call.
 	implementersCache map[string][]string


### PR DESCRIPTION
Closes #226.

## The problem

`getPosition` called `go/token.Position.String` for **every recorded node** — every `CallArgument`, `Call`, function, assignment and struct instance — and the result was interned afterwards, so interning saved nothing. The string was already allocated by then.

On gitea (360 packages) that was **1012MB of a 4766MB run — 21% of all allocation**, second only to `NewCallArgument`.

## The fix

The same source location is recorded many times: once per node that mentions it, and again each time a node is revisited. So the pool index is memoized per `token.Pos` — a byte offset within the `FileSet`, which identifies a location *exactly*, so the cache cannot collide two call sites — and a repeat costs one map lookup.

`Position.String` is reproduced by hand rather than called, because it builds its result with `fmt`.

## Why the hand-rolled formatter is safe

That rendering is observable in tracker keys, in a closure's identity (`FuncLit:<position>`) and in the byte-compared metadata goldens. `TestFormatPositionMatchesToken` checks every shape `token` treats specially — no column, no filename, invalid position, neither — **against `token` itself**, so the two cannot drift silently.

## Measured (gitea, 360 packages)

| | before | after |
|---|---|---|
| total `alloc_space` | 4766 MB | **3805 MB** (−20%) |
| `token.Position.String` | 1012 MB (21.2%) | **absent** |
| position formatting | 1035 MB cum | 72 MB (−93%) |

Wall clock is unchanged **within this machine's noise** — the same binary varied 52–85s across runs — so the win claimed here is allocation and GC pressure, not time. The metadata stage averaged ~10% faster over three interleaved pairs, with run-to-run spread of the same order; not claimed as a result.

## Verification

- Output **byte-identical** on gitea and across all 67 fixtures.
- **Goldens needed no regeneration** (the issue expected one): they were already written with relative filenames, and the rendering is unchanged.
- Full suite, `go test -race`, `go vet`, `gofmt`, `golangci-lint` (0 issues); coverage 96.0% against the 96% floor.

## Incidental

The three sites that mint a closure's `FuncLit:<position>` name now share `funcLitName`, so the shape is stated once — that name is what #216 (non-reproducible operationIds) is about, and it is the next PR.

**Found while verifying this, unrelated to it:** the unmodified binary produces *different specs on consecutive runs* on photoprism — an enum inferred from constants of a `type X = string` **alias**, where two aliases in one package are the same type, so the group is picked by map order. Filed separately; half the runs document the wrong enum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved source-position tracking across generated metadata, including functions, variables, assignments, calls, and interface resolutions.
  - Added consistent naming for anonymous functions, making them easier to identify.
  - Reduced repeated position processing to improve metadata generation efficiency and consistency.

- **Bug Fixes**
  - Corrected handling of missing or invalid source positions.
  - Improved position handling for generic expressions and nested call analysis.

- **Tests**
  - Added coverage for position formatting, caching, anonymous-function naming, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->