### PR TITLE
fix(spec): an enum is built from the constants of that type, deterministically (#229)

### DIFF
--- a/generator/testdata_enum_alias_ambiguity_test.go
+++ b/generator/testdata_enum_alias_ambiguity_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	intspec "github.com/ehabterra/apispec/internal/spec"
+)
+
+// TestTestdata_EnumAliasAmbiguity pins which constants an enum may be built from.
+//
+// Every named type in this fixture has `string` underneath, and that used to be
+// enough to make one type's constants a candidate for another's: `Status` was
+// documented with a *different* type's four values and never with its own three.
+// Which wrong answer appeared depended on map order, so the same code produced a
+// different spec per run (issue #229).
+//
+// The rule is type identity: constants belong to the type they are declared with.
+func TestTestdata_EnumAliasAmbiguity(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "enum_alias_ambiguity", nil)
+	noDanglingRefs(t, out)
+	noUnresolvedPlaceholders(t, out)
+
+	var model *intspec.Schema
+	for name, sc := range out.Components.Schemas {
+		if strings.HasSuffix(name, "Model") {
+			model = sc
+		}
+	}
+	if model == nil {
+		t.Fatalf("Model schema missing; have %v", enumComponentNames(out))
+	}
+
+	enumOf := func(prop string) []interface{} {
+		p := model.Properties[prop]
+		if p == nil {
+			t.Fatalf("property %q missing; have %v", prop, propNames(model))
+		}
+		return p.Enum
+	}
+
+	// Declared `Status`, a distinct type: its own values, and only those.
+	if got, want := enumOf("status"), []interface{}{"active", "paused", "retired"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("status enum = %v, want %v — a type is documented with the constants declared for IT", got, want)
+	}
+
+	// Declared `ModelType`: the constants written as ModelType, not the equally
+	// large ApiFormat group that also has `string` underneath.
+	if got, want := enumOf("type"), []interface{}{"caption", "face", "labels", "nsfw"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("type enum = %v, want %v — the other group of four is a different type", got, want)
+	}
+
+	// A plain `string` field names no type, so no constant group can claim it.
+	if got := enumOf("name"); len(got) != 0 {
+		t.Errorf("name enum = %v, want none — a plain string field is not an enum", got)
+	}
+}
+
+// enumComponentNames lists the generated component schema names, for failure output.
+func enumComponentNames(out *intspec.OpenAPISpec) []string {
+	if out.Components == nil {
+		return nil
+	}
+	names := make([]string, 0, len(out.Components.Schemas))
+	for name := range out.Components.Schemas {
+		names = append(names, name)
+	}
+	return names
+}

--- a/internal/spec/enum_identity_test.go
+++ b/internal/spec/enum_identity_test.go
@@ -1,0 +1,109 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// enumMeta builds one package declaring several string-underlying types, each with
+// its own constants — the shape that made every type a candidate for every other
+// (issue #229).
+func enumMeta() *metadata.Metadata {
+	sp := metadata.NewStringPool()
+	constant := func(name, declaredType, value string, group int) *metadata.Variable {
+		return &metadata.Variable{
+			Name:          sp.Get(name),
+			Type:          sp.Get(declaredType),
+			ResolvedType:  sp.Get("string"),
+			Tok:           sp.Get("const"),
+			Value:         sp.Get(value),
+			ComputedValue: value,
+			GroupIndex:    group,
+		}
+	}
+	return &metadata.Metadata{
+		StringPool: sp,
+		Packages: map[string]*metadata.Package{
+			"app": {Files: map[string]*metadata.File{
+				// Two files, so the walk cannot rely on one map's order.
+				"status.go": {
+					Types: map[string]*metadata.Type{"Status": {Name: sp.Get("Status"), Kind: sp.Get("string")}},
+					Variables: map[string]*metadata.Variable{
+						"StatusActive":  constant("StatusActive", "Status", "active", 1),
+						"StatusRetired": constant("StatusRetired", "Status", "retired", 1),
+					},
+				},
+				"format.go": {
+					Types: map[string]*metadata.Type{"ApiFormat": {Name: sp.Get("ApiFormat"), Kind: sp.Get("string")}},
+					Variables: map[string]*metadata.Variable{
+						// A larger group, which is what used to win.
+						"FormatUrl":    constant("FormatUrl", "ApiFormat", "url", 2),
+						"FormatImages": constant("FormatImages", "ApiFormat", "images", 2),
+						"FormatVision": constant("FormatVision", "ApiFormat", "vision", 2),
+					},
+				},
+			}},
+		},
+	}
+}
+
+// TestDetectEnumUsesTypeIdentity pins the rule: constants belong to the type they
+// are declared with. `Status` and `ApiFormat` are both `string` underneath, and
+// that used to be enough for the bigger group to be documented as Status's enum —
+// so a type's own values never appeared and the answer changed with map order.
+func TestDetectEnumUsesTypeIdentity(t *testing.T) {
+	meta := enumMeta()
+
+	if got, want := detectEnumFromConstants("Status", "app", meta), []interface{}{"active", "retired"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("Status enum = %v, want %v — its own constants, not the larger group's", got, want)
+	}
+	if got, want := detectEnumFromConstants("ApiFormat", "app", meta), []interface{}{"images", "url", "vision"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("ApiFormat enum = %v, want %v", got, want)
+	}
+	// A type with no constants gets no enum, rather than the nearest group's.
+	if got := detectEnumFromConstants("Role", "app", meta); len(got) != 0 {
+		t.Errorf("Role enum = %v, want none", got)
+	}
+
+	// Repeated calls agree: the choice must not depend on map iteration order.
+	first := detectEnumFromConstants("Status", "app", meta)
+	for i := 0; i < 20; i++ {
+		if got := detectEnumFromConstants("Status", "app", meta); !reflect.DeepEqual(got, first) {
+			t.Fatalf("call %d returned %v, want %v — the answer depends on map order", i, got, first)
+		}
+	}
+}
+
+// TestTypeMatchesRejectsSharedUnderlyingType covers the predicate change on its
+// own: an alias NAME for the target still matches (a constant declared `Status`
+// belongs to a field whose type resolves to `Status`), while a merely shared
+// underlying type does not.
+func TestTypeMatchesRejectsSharedUnderlyingType(t *testing.T) {
+	meta := enumMeta()
+
+	if typeMatches("Status", "ApiFormat", meta) {
+		t.Error("two distinct types sharing `string` matched — their constants are not interchangeable")
+	}
+	if typeMatches("ApiFormat", "Status", meta) {
+		t.Error("the same mistake in the other direction")
+	}
+	if !typeMatches("Status", "Status", meta) {
+		t.Error("a type no longer matches itself")
+	}
+}

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -2338,10 +2338,16 @@ func detectEnumFromConstants(goType string, pkgName string, meta *metadata.Metad
 		targetPkgName = goTypePkgName
 	}
 
-	// Collect all constants and group them
+	// Collect all constants and group them. Files in sorted order: a constant
+	// group can span files, and map order must never reach the output (golden
+	// rule #1).
 	if pkg, exist := meta.Packages[targetPkgName]; exist {
-		for _, file := range pkg.Files {
-			for _, variable := range file.Variables {
+		for _, fileName := range meta.SortedFileNames(targetPkgName) {
+			file := pkg.Files[fileName]
+			if file == nil {
+				continue
+			}
+			for _, variable := range sortedVariables(meta, file.Variables) {
 				if getStringFromPool(meta, variable.Tok) == "const" {
 					varType := getStringFromPool(meta, variable.Type)
 					resolvedType := getStringFromPool(meta, variable.ResolvedType)
@@ -2356,12 +2362,25 @@ func detectEnumFromConstants(goType string, pkgName string, meta *metadata.Metad
 
 					// Check if this constant's type matches our target enum type
 					// For iota constants, we also need to check if they're in the same group as a typed constant
-					if typeMatches(targetType, goType, meta) ||
-						(varType == "" && isInSameGroupAsTypedConstant(variable.GroupIndex, goType, file.Variables, meta)) {
+					sameGroupAsTyped := varType == "" &&
+						isInSameGroupAsTypedConstant(variable.GroupIndex, goType, file.Variables, meta)
+					if typeMatches(targetType, goType, meta) || sameGroupAsTyped {
 						groupIndex := variable.GroupIndex
 
-						if constantGroups[targetType] == nil {
-							constantGroups[targetType] = make(map[int][]EnumConstant)
+						// Key on the type the constant BELONGS to, not on what its
+						// own declaration happens to say. Only the first member of
+						// an iota block carries the type (`Low Priority = iota`,
+						// then Medium, High, Critical); keying those by their
+						// resolved `int` split one enum across two keys, which cost
+						// `Priority` the value 0 — the typed member sat alone in its
+						// own group and lost the "biggest group" contest.
+						groupType := targetType
+						if sameGroupAsTyped {
+							groupType = goType
+						}
+
+						if constantGroups[groupType] == nil {
+							constantGroups[groupType] = make(map[int][]EnumConstant)
 						}
 
 						enumConst := EnumConstant{
@@ -2372,8 +2391,8 @@ func detectEnumFromConstants(goType string, pkgName string, meta *metadata.Metad
 							Group:    groupIndex,
 						}
 
-						constantGroups[targetType][groupIndex] = append(
-							constantGroups[targetType][groupIndex],
+						constantGroups[groupType][groupIndex] = append(
+							constantGroups[groupType][groupIndex],
 							enumConst,
 						)
 					}
@@ -2382,13 +2401,24 @@ func detectEnumFromConstants(goType string, pkgName string, meta *metadata.Metad
 		}
 	}
 
-	// Find the best enum group for this type
+	// One declared type, or none. Constants of two different declared types are
+	// not interchangeable, so if more than one type still qualifies here the
+	// values cannot be attributed and no enum is honest — documenting one of them
+	// would validate clients against the wrong value set (golden rule #7, issue
+	// #229). This happens when the target is reachable through several alias
+	// names; it is rare, and guessing was what produced a different enum per run.
+	if len(constantGroups) > 1 {
+		return nil
+	}
+
+	// The largest group of that type, chosen over sorted keys so the answer cannot
+	// depend on map order, and ties resolve to the earliest declaration.
 	var bestEnumValues []interface{}
 	var maxGroupSize int
-
-	for _, groups := range constantGroups {
-		for _, group := range groups {
-			if len(group) > maxGroupSize {
+	for _, declaredType := range slices.Sorted(maps.Keys(constantGroups)) {
+		groups := constantGroups[declaredType]
+		for _, groupIndex := range slices.Sorted(maps.Keys(groups)) {
+			if group := groups[groupIndex]; len(group) > maxGroupSize {
 				maxGroupSize = len(group)
 				bestEnumValues = extractEnumValues(group)
 			}
@@ -2396,6 +2426,19 @@ func detectEnumFromConstants(goType string, pkgName string, meta *metadata.Metad
 	}
 
 	return bestEnumValues
+}
+
+// sortedVariables returns a file's variables in name order. Enum detection reads
+// them to build constant groups, and a group's membership must not depend on map
+// order.
+func sortedVariables(meta *metadata.Metadata, vars map[string]*metadata.Variable) []*metadata.Variable {
+	out := make([]*metadata.Variable, 0, len(vars))
+	for _, name := range slices.Sorted(maps.Keys(vars)) {
+		if v := vars[name]; v != nil {
+			out = append(out, v)
+		}
+	}
+	return out
 }
 
 // EnumConstant represents a constant that might be part of an enum
@@ -2490,16 +2533,18 @@ func typeMatches(constantType, targetType string, meta *metadata.Metadata) bool 
 		return true
 	}
 
-	// Check if constantType is an alias of targetType
+	// The constant's declared type may be an alias NAME for the target: a constant
+	// declared `Status` belongs to a field whose type resolves to `Status`.
+	//
+	// What is deliberately NOT accepted is a shared underlying type. `type Status
+	// string` and `type ApiFormat = string` both resolve to `string`, but they are
+	// different types and their constants are not interchangeable — accepting that
+	// made every string-based type in a package a candidate for every other, so a
+	// named type was documented with another type's values and the winner was
+	// picked by map order (issue #229).
 	if resolvedConstType := resolveUnderlyingType(constantType, meta); resolvedConstType != "" {
 		if resolvedConstType == targetType {
 			return true
-		}
-		// Also check if the resolved type matches the target's underlying type
-		if resolvedTargetType := resolveUnderlyingType(targetType, meta); resolvedTargetType != "" {
-			if resolvedConstType == resolvedTargetType {
-				return true
-			}
 		}
 	}
 

--- a/testdata/enum_alias_ambiguity/go.mod
+++ b/testdata/enum_alias_ambiguity/go.mod
@@ -1,0 +1,3 @@
+module github.com/ehabterra/apispec/testdata/enum_alias_ambiguity
+
+go 1.20

--- a/testdata/enum_alias_ambiguity/main.go
+++ b/testdata/enum_alias_ambiguity/main.go
@@ -1,0 +1,61 @@
+// Fixture: two string ALIASES in one package, each with its own constants.
+//
+// `type ModelType = string` is an alias, not a new type, so a field declared
+// `ModelType` has the type `string` — exactly like a field declared `ApiFormat`.
+// Both constant groups are therefore candidates for the same field's enum, and
+// nothing in the types can separate them.
+//
+// Seen on a real project (photoprism, internal/ai/vision): the spec documented
+// `enum: [images, ollama, url, vision]` on some runs and
+// `enum: [caption, face, labels, nsfw]` on others — the same code, a different
+// answer per run, and wrong in at least one of them.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type ApiFormat = string
+
+const (
+	ApiFormatUrl    ApiFormat = "url"
+	ApiFormatImages ApiFormat = "images"
+	ApiFormatVision ApiFormat = "vision"
+	ApiFormatOllama ApiFormat = "ollama"
+)
+
+type ModelType = string
+
+const (
+	ModelTypeLabels  ModelType = "labels"
+	ModelTypeNsfw    ModelType = "nsfw"
+	ModelTypeFace    ModelType = "face"
+	ModelTypeCaption ModelType = "caption"
+)
+
+// Status is a real named type — a distinct type, so its constants are the only
+// candidates for a Status field and the enum is knowable.
+type Status string
+
+const (
+	StatusActive  Status = "active"
+	StatusPaused  Status = "paused"
+	StatusRetired Status = "retired"
+)
+
+type Model struct {
+	Name   string    `json:"name"`
+	Type   ModelType `json:"type"`
+	Status Status    `json:"status"`
+}
+
+func getModel(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode(Model{})
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /models", getModel)
+	_ = http.ListenAndServe(":8080", mux)
+}


### PR DESCRIPTION
Closes #229. Found while verifying #226's output was byte-identical: gitea was, photoprism was not.

## Two bugs in generated specs

**A named type was documented with another type's values.** `detectEnumFromConstants` accepted any constant whose type merely *shared an underlying type* with the target, so every string-based type in a package was a candidate for every other. `type Status string` with three constants of its own was handed a different type's four — its own values never appeared, on any run.

**The output was not reproducible.** Among equal-sized groups the winner came from a map iteration with a strict `>` tie-break:

```go
for _, groups := range constantGroups {   // map
    for _, group := range groups {        // map
        if len(group) > maxGroupSize {    // a tie keeps whatever came first
```

Six consecutive runs of the same binary on `testdata/enum_alias_ambiguity` (before):

```
run 1: type=[images, ollama, url, vision]  status=[images, ollama, url, vision]
run 2: type=[caption, face, labels, nsfw]  status=[images, ollama, url, vision]
run 4: type=[caption, face, labels, nsfw]  status=[caption, face, labels, nsfw]
...
```

`status` is never `[active, paused, retired]`. Reproduced on photoprism, where `internal/ai/vision.Model.Type` alternated between two unrelated value sets across runs of an unmodified build.

## The fix

Type identity: constants belong to the type they are **declared with**. An alias *name* for the target still matches (a constant declared `Status` belongs to a field whose type resolves to `Status`); a shared underlying type does not. When more than one declared type still qualifies, the values are not attributable and **no** enum is emitted — one that validates clients against the wrong value set is worse than none (golden rule #7). Iteration is sorted throughout (golden rule #1).

## A second, older bug it exposed

Only the first member of an iota block carries the type (`Low Priority = iota`, then Medium, High, Critical). The untyped members were keyed by their resolved `int` while the typed one sat alone under `Priority` — two keys for one enum, and the three-member group beat the one-member group. So `Priority` was documented as `[1, 2, 3]`: **its own first value, 0, was the one being dropped.** Grouping now keys on the type a constant belongs to → `[0, 1, 2, 3]`.

That correction is the *only* spec drift across all 67 fixtures.

## Verification

- `testdata/enum_alias_ambiguity`: a distinct named type, an alias-typed field, and a plain `string` field that must get no enum — all three correct and stable over 5 runs.
- photoprism **byte-identical across three consecutive runs**, with `vision.Model.Type` now the `ModelType` constants.
- Unit tests at the layer that changed (`typeMatches` identity, `detectEnumFromConstants` stability over 20 calls).
- Full suite, `go vet`, `gofmt`, `golangci-lint` (0 issues); coverage 96.0% against the 96% floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)