### PR TITLE
fix(spec): a closure's identity is module-relative, so the spec is reproducible (#216)

### DIFF
--- a/generator/testdata_closure_operation_ids_test.go
+++ b/generator/testdata_closure_operation_ids_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestTestdata_ClosureOperationIDsAreReproducible pins the property that makes a
+// generated spec reviewable: the same source must produce the same spec wherever
+// it is checked out.
+//
+// A closure has no declared name, so apispec identifies it by where it is written,
+// and that identity becomes the route's operationId. While the position carried
+// the absolute path, every machine produced a different spec — 116 of
+// photoprism's 131 operations were named after someone's home directory (issue
+// #216).
+//
+// The fixture is generated twice from two different directories, because that is
+// the only way to state the property: comparing strings against expected values
+// would pass on the machine that wrote them.
+func TestTestdata_ClosureOperationIDsAreReproducible(t *testing.T) {
+	const fixture = "closure_operation_ids"
+	src := filepath.Join("..", "testdata", fixture)
+
+	original := operationIDsFrom(t, src)
+	moved := operationIDsFrom(t, copyFixture(t, src, nil))
+
+	if !reflect.DeepEqual(original, moved) {
+		t.Errorf("the same source produced different operationIds in two checkouts:\n  %v\n  %v", original, moved)
+	}
+
+	// Both closures are documented, and they stay distinct: the position is what
+	// separates two anonymous handlers in one file, so dropping too much of it
+	// would collapse them.
+	if len(original) != 2 {
+		t.Fatalf("expected 2 closure operations, got %d: %v", len(original), original)
+	}
+	if original[0] == original[1] {
+		t.Errorf("two closures share one operationId (%q) — they would collide in the spec", original[0])
+	}
+
+	for _, id := range original {
+		if !strings.Contains(id, "FuncLit:") {
+			t.Errorf("operationId %q does not identify a closure; the fixture stopped covering the case", id)
+		}
+		// The failure mode, stated directly: no operationId may name a location on
+		// the machine that generated it.
+		if path := closureIDPath(id); filepath.IsAbs(path) {
+			t.Errorf("operationId %q carries the absolute path %q, so the spec differs per machine", id, path)
+		}
+	}
+}
+
+// operationIDsFrom generates the spec for a directory and returns its
+// operationIds, sorted.
+func operationIDsFrom(t *testing.T, dir string) []string {
+	t.Helper()
+	out, err := NewGenerator(nil).GenerateFromDirectory(dir)
+	if err != nil {
+		t.Fatalf("GenerateFromDirectory(%s): %v", dir, err)
+	}
+	var ids []string
+	for _, item := range out.Paths {
+		for _, method := range []string{"GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"} {
+			if op := opFor(item, method); op != nil && op.OperationID != "" {
+				ids = append(ids, op.OperationID)
+			}
+		}
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// closureIDPath returns the file part of a closure operationId
+// (`pkg.FuncLit:<file>:<line>:<col>`).
+func closureIDPath(id string) string {
+	idx := strings.Index(id, "FuncLit:")
+	if idx < 0 {
+		return ""
+	}
+	rest := id[idx+len("FuncLit:"):]
+	// Drop the trailing `:line:col`, leaving the path.
+	for i := 0; i < 2; i++ {
+		if last := strings.LastIndex(rest, ":"); last >= 0 {
+			rest = rest[:last]
+		}
+	}
+	return rest
+}

--- a/generator/testdata_frameworks_test.go
+++ b/generator/testdata_frameworks_test.go
@@ -145,6 +145,16 @@ func TestTestdata_Frameworks(t *testing.T) {
 			},
 		},
 		{
+			// Closure handlers: the shared structural checks here, the
+			// cross-checkout reproducibility of their operationIds in
+			// TestTestdata_ClosureOperationIDsAreReproducible (issue #216).
+			name:     "closure_operation_ids",
+			fallback: spec.DefaultHTTPConfig(),
+			routes: []route{
+				{"/items", []string{"GET", "POST"}},
+			},
+		},
+		{
 			name:     "interface_response",
 			fallback: spec.DefaultHTTPConfig(),
 			routes: []route{

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -491,7 +491,7 @@ func (e *Engine) GenerateMetadataOnlyWithLogger(logger *VerboseLogger) (*metadat
 
 	// Generate metadata (now only on framework packages if auto-include is enabled)
 	tMeta := time.Now()
-	meta := metadata.GenerateMetadataWithLogger(pkgsMetadata, fileToInfo, importPaths, fset, logger, e.moduleImportPath())
+	meta := metadata.GenerateMetadataWithLogger(pkgsMetadata, fileToInfo, importPaths, fset, logger, e.moduleImportPath(), e.config.moduleRoot)
 	e.reportPhase(fmt.Sprintf("metadata generated (%d call edges, %d pkgs)", len(meta.CallGraph), len(meta.Packages)), time.Since(tMeta))
 	if err := e.ctx().Err(); err != nil {
 		return nil, err

--- a/internal/insight/endpoint.go
+++ b/internal/insight/endpoint.go
@@ -30,7 +30,12 @@ import (
 // ("pkg.FuncLit:internal/api/h.go:55:28"). The path is not required to be
 // absolute: a closure's identity is module-relative so that the generated spec is
 // the same in every checkout (issue #216), while a recorded position is absolute.
-var filePosRe = regexp.MustCompile(`([^\s:]+\.go):(\d+)`)
+//
+// The optional `C:` head keeps Windows absolute paths whole. It is anchored on a
+// word boundary so it cannot bite into the text before the path: without that,
+// the "t:" ending "FuncLit:" reads as a drive letter and the match becomes
+// "t:internal/api/h.go".
+var filePosRe = regexp.MustCompile(`((?:\b[A-Za-z]:)?[^\s:]+\.go):(\d+)`)
 
 // extractFilePos returns "file.go:line" from any string containing one,
 // or "" if none is present.

--- a/internal/insight/endpoint.go
+++ b/internal/insight/endpoint.go
@@ -15,6 +15,7 @@
 package insight
 
 import (
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
@@ -24,10 +25,12 @@ import (
 	"github.com/ehabterra/apispec/internal/spec"
 )
 
-// filePosRe finds a "<path>.go:<line>" inside a larger string — handles
-// both a bare position index and a func-literal base-ID that embeds its
-// position (e.g. "pkg.FuncLit:/abs/file.go:55:28").
-var filePosRe = regexp.MustCompile(`(/[^\s:]+\.go):(\d+)`)
+// filePosRe finds a "<path>.go:<line>" inside a larger string — handles both a
+// bare position index and a func-literal base-ID that embeds its position
+// ("pkg.FuncLit:internal/api/h.go:55:28"). The path is not required to be
+// absolute: a closure's identity is module-relative so that the generated spec is
+// the same in every checkout (issue #216), while a recorded position is absolute.
+var filePosRe = regexp.MustCompile(`([^\s:]+\.go):(\d+)`)
 
 // extractFilePos returns "file.go:line" from any string containing one,
 // or "" if none is present.
@@ -424,17 +427,44 @@ func candidateHandlerKeys(meta *metadata.Metadata, operationID string) (keys []s
 	return keys, file, line
 }
 
+// sameSourceFile reports whether two paths name the same file when one of them
+// may be module-relative and the other absolute — the two forms positions and
+// closure identities are written in.
+func sameSourceFile(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	a, b = filepath.ToSlash(a), filepath.ToSlash(b)
+	if a == b {
+		return true
+	}
+	// A relative path matches an absolute one that ends with it, on a path
+	// boundary: "api/h.go" matches "/src/app/api/h.go" but not "/src/xapi/h.go".
+	if strings.HasSuffix(a, "/"+b) {
+		return true
+	}
+	return strings.HasSuffix(b, "/"+a)
+}
+
 // findFuncLitInFile returns the FuncLit caller key declared in file at or
 // after afterLine (closest), or "".
 func findFuncLitInFile(meta *metadata.Metadata, file string, afterLine int) string {
 	best := ""
 	bestLine := 1 << 30
+	// Sorted, so two closures on the same line cannot be separated by map order.
+	keys := make([]string, 0, len(meta.Callers))
 	for k := range meta.Callers {
-		if !strings.Contains(k, "FuncLit:") {
-			continue
+		if strings.Contains(k, metadata.FuncLitPrefix) {
+			keys = append(keys, k)
 		}
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		// The location has to come from the key: a closure's caller edge often
+		// records no position of its own, which is why the key embeds one.
 		f, l := parsePos(extractFilePos(k))
-		if f != file || l < afterLine {
+		if !sameSourceFile(file, f) || l < afterLine {
 			continue
 		}
 		if l < bestLine {

--- a/internal/insight/endpoint_test.go
+++ b/internal/insight/endpoint_test.go
@@ -156,3 +156,53 @@ func TestParsePosAndSourceWindow(t *testing.T) {
 		t.Error("missing file should yield empty window")
 	}
 }
+
+// TestSameSourceFile covers the comparison that lets a module-relative closure
+// identity be matched against an absolute declaration file. Both forms occur in
+// one metadata set: a closure's key is relative so the generated spec is
+// reproducible (issue #216), while a recorded position is absolute.
+func TestSameSourceFile(t *testing.T) {
+	match := []struct{ a, b string }{
+		{"/src/app/internal/api/h.go", "internal/api/h.go"},
+		{"internal/api/h.go", "/src/app/internal/api/h.go"},
+		{"/src/app/main.go", "main.go"},
+		{"/src/app/main.go", "/src/app/main.go"},
+		{"main.go", "main.go"},
+	}
+	for _, c := range match {
+		if !sameSourceFile(c.a, c.b) {
+			t.Errorf("sameSourceFile(%q, %q) = false, want true", c.a, c.b)
+		}
+	}
+
+	// The suffix has to land on a path boundary, or unrelated files collide.
+	differ := []struct{ a, b string }{
+		{"/src/app/xapi/h.go", "api/h.go"},
+		{"/src/app/api/h.go", "other/h.go"},
+		{"/src/app/api/h.go", ""},
+		{"", "api/h.go"},
+		{"", ""},
+	}
+	for _, c := range differ {
+		if sameSourceFile(c.a, c.b) {
+			t.Errorf("sameSourceFile(%q, %q) = true, want false", c.a, c.b)
+		}
+	}
+}
+
+// TestExtractFilePosAcceptsRelativePaths pins that the position scanner reads
+// both forms. It required a leading slash, so a module-relative closure key
+// yielded nothing and the closure could not be located at all.
+func TestExtractFilePosAcceptsRelativePaths(t *testing.T) {
+	cases := map[string]string{
+		"pkg.FuncLit:internal/api/h.go:55:28":      "internal/api/h.go:55",
+		"pkg.FuncLit:/abs/src/internal/h.go:55:28": "/abs/src/internal/h.go:55",
+		"main.go:1:1":      "main.go:1",
+		"no position here": "",
+	}
+	for in, want := range cases {
+		if got := extractFilePos(in); got != want {
+			t.Errorf("extractFilePos(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/insight/endpoint_test.go
+++ b/internal/insight/endpoint_test.go
@@ -17,6 +17,7 @@ package insight
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -186,6 +187,16 @@ func TestSameSourceFile(t *testing.T) {
 	for _, c := range differ {
 		if sameSourceFile(c.a, c.b) {
 			t.Errorf("sameSourceFile(%q, %q) = true, want false", c.a, c.b)
+		}
+	}
+
+	// On Windows the recorded position uses backslashes while the identity uses
+	// forward slashes, and filepath.ToSlash bridges them. It is deliberately
+	// platform-specific: on Unix a backslash is a legal character in a filename,
+	// so rewriting one there would corrupt the path rather than normalise it.
+	if runtime.GOOS == "windows" {
+		if !sameSourceFile(`C:\src\app\internal\api\h.go`, "internal/api/h.go") {
+			t.Error("a Windows position did not match its module-relative identity")
 		}
 	}
 }

--- a/internal/metadata/analysis.go
+++ b/internal/metadata/analysis.go
@@ -73,7 +73,7 @@ func getEnclosingFunctionName(file *ast.File, pos token.Pos, info *types.Info, f
 	funcLit := findEnclosingFunctionLiteral(file, pos)
 	if funcLit != nil {
 		// Return the function literal identifier (e.g., "FuncLitmain.go:42:15")
-		position := meta.positionString(funcLit.Pos(), fset)
+		position := meta.stablePosition(funcLit.Pos(), fset)
 		var signatureStr string
 		if fnType := info.TypeOf(funcLit.Type); fnType != nil {
 			signatureStr = typeStringOf(meta, fnType)
@@ -283,7 +283,7 @@ func getCalleeFunctionNameAndPackage(expr ast.Expr, file *ast.File, pkgName stri
 		// Recursively analyze the X field to find function calls
 		return getCalleeFunctionNameAndPackage(x.X, file, pkgName, fileToInfo, funcMap, fset, meta)
 	case *ast.FuncLit:
-		return funcLitName(meta.positionString(x.Pos(), fset)), pkgName, ""
+		return funcLitName(meta.stablePosition(x.Pos(), fset)), pkgName, ""
 
 	}
 	return "", "", ""

--- a/internal/metadata/expression.go
+++ b/internal/metadata/expression.go
@@ -74,16 +74,19 @@ func ExprToCallArgument(expr ast.Expr, info *types.Info, pkgName string, fset *t
 	case *ast.TypeAssertExpr:
 		return handleTypeAssertExpr(e, info, pkgName, fset, meta)
 	case *ast.FuncLit:
-		position := meta.positionString(e.Pos(), fset)
+		// Two renderings of one location, deliberately: the closure's IDENTITY is
+		// module-relative so the generated spec is the same in every checkout
+		// (issue #216), while the position recorded on the node stays absolute
+		// because that is what opens the file.
 		arg := NewCallArgument(meta)
 		arg.SetKind(KindFuncLit)
-		arg.SetName(funcLitName(position))
+		arg.SetName(funcLitName(meta.stablePosition(e.Pos(), fset)))
 		arg.SetPkg(pkgName)
 		typ := ExprToCallArgument(e.Type, info, pkgName, fset, meta)
 		typeStr := callArgToString(typ, nil)
 		arg.SetType(typeStr)
 		arg.SetValue(valueFuncLit)
-		arg.SetPosition(position)
+		arg.SetPosition(meta.positionString(e.Pos(), fset))
 		return arg
 	case *ast.ChanType:
 		return handleChanType(e, info, pkgName, fset, meta)

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -146,7 +146,7 @@ var processAssignmentCount int
 
 // GenerateMetadata extracts all metadata and call graph info
 func GenerateMetadata(pkgs map[string]map[string]*ast.File, fileToInfo map[*ast.File]*types.Info, importPaths map[string]string, fset *token.FileSet) *Metadata {
-	return GenerateMetadataWithLogger(pkgs, fileToInfo, importPaths, fset, nil, "")
+	return GenerateMetadataWithLogger(pkgs, fileToInfo, importPaths, fset, nil, "", "")
 }
 
 // VerboseLogger is the cross-cutting logging contract for the analyzer
@@ -165,7 +165,7 @@ type VerboseLogger interface {
 // go.mod by the caller). It's preferred over inferring the path from import
 // paths, which is only a heuristic and mis-detects when third-party packages
 // are analyzed alongside the project (see the inference block below).
-func GenerateMetadataWithLogger(pkgs map[string]map[string]*ast.File, fileToInfo map[*ast.File]*types.Info, importPaths map[string]string, fset *token.FileSet, logger VerboseLogger, modulePath string) *Metadata {
+func GenerateMetadataWithLogger(pkgs map[string]map[string]*ast.File, fileToInfo map[*ast.File]*types.Info, importPaths map[string]string, fset *token.FileSet, logger VerboseLogger, modulePath, moduleDir string) *Metadata {
 	funcMap := BuildFuncMap(pkgs)
 
 	if logger != nil {
@@ -245,6 +245,10 @@ func GenerateMetadataWithLogger(pkgs map[string]map[string]*ast.File, fileToInfo
 
 		// Set the current module path
 		CurrentModulePath: currentModulePath,
+
+		// Where the module lives, so a closure's identity can be stated relative
+		// to it rather than to this machine (issue #216).
+		moduleDir: moduleDir,
 
 		// External-type facts discovered during the type walk.
 		ExternalTypes: make(map[string]ExternalTypeFact),

--- a/internal/metadata/position.go
+++ b/internal/metadata/position.go
@@ -17,7 +17,9 @@ package metadata
 import (
 	"go/ast"
 	"go/token"
+	"path/filepath"
 	"strconv"
+	"strings"
 )
 
 // positionIndex returns the string-pool index of a source position, formatting it
@@ -94,6 +96,58 @@ const FuncLitPrefix = "FuncLit:"
 func funcLitName(position string) string {
 	return FuncLitPrefix + position
 }
+
+// stablePosition renders a position the way a closure is identified by it: the
+// same `file:line:column`, but with a filename that does not depend on where the
+// checkout lives.
+//
+// A closure has no declared name, so `FuncLit:<position>` IS its identity — and
+// that identity reaches the generated spec as a route's operationId. With the
+// absolute filename in it, the same source produced a different spec on every
+// machine, so the output could not be diffed, reviewed or committed (issue #216).
+// The identity is what gets normalised; the Position recorded on each node stays
+// absolute, because that is what a reader needs to open the file.
+func (m *Metadata) stablePosition(pos token.Pos, fset *token.FileSet) string {
+	if m == nil || !pos.IsValid() || fset == nil {
+		return ""
+	}
+	p := fset.Position(pos)
+	if !p.IsValid() {
+		return ""
+	}
+	p.Filename = m.stableFilename(p.Filename)
+	return formatPosition(p)
+}
+
+// stableFilename maps a source path to a form that is the same in every checkout.
+//
+// Three cases, in order:
+//
+//   - inside the analysed module: relative to its root, with forward slashes so
+//     the answer does not depend on the OS either;
+//   - inside the module cache: the part after `pkg/mod/`, which already carries
+//     the module and its version (`github.com/x/y@v1.2.3/f.go`);
+//   - anything else: unchanged. A path outside both is left alone rather than
+//     rewritten into something that looks stable but is not (the depth of a
+//     `../../..` chain depends on where the module sits).
+func (m *Metadata) stableFilename(file string) string {
+	if file == "" {
+		return file
+	}
+	if m.moduleDir != "" {
+		if rel, err := filepath.Rel(m.moduleDir, file); err == nil && !strings.HasPrefix(rel, "..") {
+			return filepath.ToSlash(rel)
+		}
+	}
+	if idx := strings.LastIndex(file, modCacheMarker); idx >= 0 {
+		return filepath.ToSlash(file[idx+len(modCacheMarker):])
+	}
+	return file
+}
+
+// modCacheMarker is the path segment every module-cache file sits under, whatever
+// GOMODCACHE is set to.
+const modCacheMarker = "pkg/mod/"
 
 // funcPositionIndex is positionIndex for a function declaration.
 func (m *Metadata) funcPositionIndex(fn *ast.FuncDecl, fset *token.FileSet) int {

--- a/internal/metadata/position_test.go
+++ b/internal/metadata/position_test.go
@@ -17,6 +17,8 @@ package metadata
 import (
 	"go/parser"
 	"go/token"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -135,5 +137,107 @@ func TestFuncLitName(t *testing.T) {
 	}
 	if got := funcLitName(""); got != FuncLitPrefix {
 		t.Errorf("funcLitName(\"\") = %q, want %q", got, FuncLitPrefix)
+	}
+}
+
+// TestStableFilename covers the path normalisation a closure's identity depends
+// on. Each case is a class of source file apispec actually analyses, and the last
+// one is the honest refusal: a path that belongs to neither the module nor the
+// cache is left alone rather than rewritten into something that only looks stable.
+func TestStableFilename(t *testing.T) {
+	m := &Metadata{StringPool: NewStringPool(), moduleDir: filepath.FromSlash("/home/dev/project")}
+
+	cases := []struct {
+		name string
+		file string
+		want string
+	}{
+		{
+			name: "inside the module becomes relative",
+			file: filepath.FromSlash("/home/dev/project/internal/api/handler.go"),
+			want: "internal/api/handler.go",
+		},
+		{
+			name: "the module root itself",
+			file: filepath.FromSlash("/home/dev/project/main.go"),
+			want: "main.go",
+		},
+		{
+			// A dependency's file: the cache path already carries the module and
+			// its version, which is the same everywhere.
+			name: "module cache keeps module and version",
+			file: filepath.FromSlash("/home/dev/go/pkg/mod/github.com/labstack/echo/v4@v4.11.4/echo.go"),
+			want: "github.com/labstack/echo/v4@v4.11.4/echo.go",
+		},
+		{
+			// Outside both: relativising would produce a `../../..` chain whose
+			// depth depends on where the module sits, which is not more stable
+			// than the absolute path — so it is left as it is.
+			name: "elsewhere is left alone",
+			file: filepath.FromSlash("/opt/vendor/lib/thing.go"),
+			want: filepath.FromSlash("/opt/vendor/lib/thing.go"),
+		},
+		{
+			name: "empty stays empty",
+			file: "",
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := m.stableFilename(tc.file); got != tc.want {
+				t.Errorf("stableFilename(%q) = %q, want %q", tc.file, got, tc.want)
+			}
+		})
+	}
+
+	// With no module root known, an in-module path cannot be relativised — and is
+	// not guessed at.
+	noRoot := &Metadata{StringPool: NewStringPool()}
+	abs := filepath.FromSlash("/home/dev/project/main.go")
+	if got := noRoot.stableFilename(abs); got != abs {
+		t.Errorf("without a module root: %q, want it unchanged", got)
+	}
+}
+
+// TestStablePositionKeepsLineAndColumn pins that only the filename is normalised:
+// the line and column are what separate two closures in one file, so a fixture
+// with two handlers would collapse into one operation if they were dropped.
+func TestStablePositionKeepsLineAndColumn(t *testing.T) {
+	fset := token.NewFileSet()
+	dir := filepath.FromSlash("/home/dev/project")
+	src := "package p\n\nvar a = 1\nvar b = 2\n"
+	file, err := parser.ParseFile(fset, filepath.Join(dir, "main.go"), src, 0)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	m := &Metadata{StringPool: NewStringPool(), moduleDir: dir}
+
+	first := m.stablePosition(file.Decls[0].Pos(), fset)
+	second := m.stablePosition(file.Decls[1].Pos(), fset)
+
+	if want := "main.go:3:1"; first != want {
+		t.Errorf("stablePosition = %q, want %q", first, want)
+	}
+	if first == second {
+		t.Errorf("two locations rendered identically (%q) — closures in one file would collide", first)
+	}
+
+	// The position RECORDED on a node is a different thing: it stays absolute,
+	// because that is what opens the file.
+	if recorded := m.positionString(file.Decls[0].Pos(), fset); !filepath.IsAbs(recorded[:strings.Index(recorded, ":")]) {
+		t.Errorf("recorded position %q is not absolute; source lookups need the real path", recorded)
+	}
+
+	// Guards.
+	if got := m.stablePosition(token.NoPos, fset); got != "" {
+		t.Errorf("invalid position = %q, want empty", got)
+	}
+	if got := m.stablePosition(file.Decls[0].Pos(), nil); got != "" {
+		t.Errorf("nil fileset = %q, want empty", got)
+	}
+	var nilMeta *Metadata
+	if got := nilMeta.stablePosition(file.Decls[0].Pos(), fset); got != "" {
+		t.Errorf("nil metadata = %q, want empty", got)
 	}
 }

--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -150,6 +150,12 @@ type Metadata struct {
 	// posCache memoizes position rendering — see positionIndex.
 	posCache map[token.Pos]int
 	posMutex sync.RWMutex
+
+	// moduleDir is the filesystem root of the analysed module. It is not part of
+	// the recorded facts — it exists so a closure's identity can be stated
+	// relative to the module rather than to this machine (see stablePosition,
+	// issue #216). Empty when unknown, which leaves paths as they are.
+	moduleDir string
 	// implementersCache memoizes ImplementersOf, which otherwise re-scans every
 	// package and type (with two sorts) on every call.
 	implementersCache map[string][]string

--- a/testdata/closure_operation_ids/go.mod
+++ b/testdata/closure_operation_ids/go.mod
@@ -1,0 +1,3 @@
+module github.com/ehabterra/apispec/testdata/closure_operation_ids
+
+go 1.22

--- a/testdata/closure_operation_ids/main.go
+++ b/testdata/closure_operation_ids/main.go
@@ -1,0 +1,37 @@
+// Fixture: a closure has no declared name, so apispec identifies it by WHERE it
+// is written — and that identity becomes the route's operationId.
+//
+// While the position carried the absolute file path, the same source produced a
+// different spec on every machine: an operationId read
+// `FuncLit:/Users/someone/checkout/main.go:31:24`, so the output could not be
+// diffed against a colleague's, reviewed in a PR, or committed. Seen on
+// photoprism, where 116 of 131 operations were named that way.
+//
+// Two closure routes, because one would not show whether the identity stays
+// unique once the path is dropped.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type Item struct {
+	ID string `json:"id"`
+}
+
+func main() {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("GET /items", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(Item{})
+	})
+
+	mux.HandleFunc("POST /items", func(w http.ResponseWriter, r *http.Request) {
+		var in Item
+		_ = json.NewDecoder(r.Body).Decode(&in)
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	_ = http.ListenAndServe(":8080", mux)
+}


### PR DESCRIPTION
Closes #216. Built on the position plumbing from #228.

## The problem

A closure has no declared name, so apispec identifies it by *where it is written*, and that identity becomes the route's operationId:

```yaml
operationId: github.com/photoprism/photoprism/internal/api.FuncLit:/Users/ehab/Documents/Work/Private/photoprism/internal/api/options.go:18:26
```

**116 of photoprism's 131 operations** were named after the checkout directory. The same source produced a different spec on every machine, so the output could not be diffed against a colleague's, reviewed in a PR, or committed.

## The fix

The identity is stated relative to the module:

| source | identity |
|---|---|
| in-module | path from the module root, forward slashes (the OS doesn't change the answer) |
| dependency | the part after `pkg/mod/` — already carries module **and version** |
| neither | left alone; a `../../..` chain's depth depends on where the module sits, so it would only *look* stable |

```yaml
operationId: github.com/photoprism/photoprism/internal/api.FuncLit:internal/api/options.go:18:26
```

**Only the identity changes.** The position recorded on each node stays absolute, because that is what opens a file — the insight source view, the diagram's file filter and the endpoint trace keep working on real paths.

## One consumer did read a path out of the identity

The insight endpoint locates a factory-returned closure by the position embedded in its key (a closure's caller edge often records no position of its own — that's *why* the key embeds one). Its scanner required a leading slash, so a relative key yielded nothing and the closure could not be located at all. It now accepts both forms and compares them on a path boundary. Its iteration is also sorted now: two closures on one line were previously separated by map order.

Verified end-to-end against the UI: `handlerFound: true`, a 3-node trace, and `handlerPos` unchanged (empty for closures before this PR too).

## Verification

- `testdata/closure_operation_ids` states the property the only way it can be stated — the same fixture generated from **two directories**, operationIds must match. **Reverting the fix fails it**; asserting expected strings would not (they'd pass on the machine that wrote them).
- photoprism: **zero** absolute paths left in any operationId.
- Drift across the fixture suite is exactly the intended change, in the 7 fixtures that register closure routes; nothing else moved.
- Metadata goldens unaffected (they carry relative filenames already).
- Full suite, `go vet`, `gofmt`, `golangci-lint` (0 issues); coverage 96.0% against the 96% floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Made anonymous function operation IDs consistent across different checkout locations.
  - Prevented operation IDs from containing absolute filesystem paths.
  - Improved handler and source-file matching when relative and absolute paths are combined.
  - Preserved accurate line and column information while normalizing source identifiers.
- **Tests**
  - Added coverage for reproducible operation IDs and relative-path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->