### PR TITLE
fix(spec): a house router in front of the framework documents its real routes (#221)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ testdata/param_name_resolution/param_name_resolution
 
 # a `go build` inside the response-header fixture drops its binary beside main.go
 testdata/response_header_param/response_header_param
+
+# a `go build` inside the wrapper-router fixture drops its binary beside main.go
+testdata/wrapper_router/wrapper_router

--- a/cmd/apispecui/assets/js/config.js
+++ b/cmd/apispecui/assets/js/config.js
@@ -504,6 +504,7 @@ const PATTERN_FIELDS = {
     ["pathFromArg", "Path from arg", "bool", "Read the path from the path argument."],
     ["handlerFromArg", "Handler from arg", "bool", "Resolve the handler from the handler argument."],
     ["methodFromPath", "Method from path", "bool", "The path argument may carry the verb, Go 1.22 style: mux.HandleFunc('GET /users', h). An explicit verb here wins over every other source and suppresses switch-on-r.Method splitting."],
+    ["methodFromArg", "Method from arg", "bool", "The verb travels as the argument at 'Method arg index', and may name several: a house router's Methods('GET,POST', path, h) registers both, and one operation per verb is emitted. Use this for a registrar whose entry point takes the verb as a value."],
   ],
   requestBodyPatterns: [
     ...COMMON_MATCH,

--- a/generator/testdata_wrapper_router_test.go
+++ b/generator/testdata_wrapper_router_test.go
@@ -1,0 +1,154 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	intspec "github.com/ehabterra/apispec/internal/spec"
+)
+
+// wrapperRouterConfig describes the fixture's house router the way a project
+// would: its own patterns ON TOP of chi's defaults, which stay active because the
+// project still uses chi directly elsewhere.
+//
+// Keeping chi's patterns is the whole point of the test. They also match the
+// delegate call inside the wrapper — where the path and handler are the wrapper's
+// own parameters — and that used to win, producing one junk route (`/{path}` with
+// `operationId: net/http.HandlerFunc`) and none of the real ones (issue #221).
+func wrapperRouterConfig() *intspec.APISpecConfig {
+	const recv = `^github\.com/ehabterra/apispec/testdata/wrapper_router\.\*?Router$`
+
+	cfg := intspec.DefaultChiConfig()
+	cfg.Framework.RoutePatterns = append([]intspec.RoutePattern{
+		{
+			// r.Get("/users", listUsers) — the verb is the method name.
+			CallRegex:       `^(?i)(Get|Post|Put|Delete)$`,
+			RecvTypeRegex:   recv,
+			MethodFromCall:  true,
+			PathFromArg:     true,
+			PathArgIndex:    0,
+			HandlerFromArg:  true,
+			HandlerArgIndex: 1,
+		},
+		{
+			// r.Methods("GET,POST", "/search", h) — the verb is an argument, and
+			// may name several.
+			CallRegex:       `^Methods$`,
+			RecvTypeRegex:   recv,
+			MethodFromArg:   true,
+			MethodArgIndex:  0,
+			PathFromArg:     true,
+			PathArgIndex:    1,
+			HandlerFromArg:  true,
+			HandlerArgIndex: 2,
+		},
+	}, cfg.Framework.RoutePatterns...)
+
+	// The group prefix lives in a field the wrapper applies itself, so the Group
+	// call is what states it.
+	cfg.Framework.MountPatterns = append([]intspec.MountPattern{
+		{
+			CallRegex:     `^Group$`,
+			RecvTypeRegex: recv,
+			PathFromArg:   true,
+			PathArgIndex:  0,
+			IsMount:       true,
+		},
+	}, cfg.Framework.MountPatterns...)
+
+	return cfg
+}
+
+// TestTestdata_WrapperRouter documents a project that puts its own router type in
+// front of chi — gitea's shape — and pins the three things that were wrong:
+//
+//  1. the framework's own patterns matched the DELEGATE inside the wrapper, and
+//     the inner call's unresolved parameters overwrote the outer route's path and
+//     handler;
+//  2. a verb travelling as an argument (`Methods("GET,POST", …)`) could not be
+//     configured, so such a registration fell back to the POST default;
+//  3. a handler behind a type conversion (`http.HandlerFunc(fn)`) was taken as the
+//     handler, losing its body.
+func TestTestdata_WrapperRouter(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "wrapper_router", wrapperRouterConfig())
+	noDanglingRefs(t, out)
+	noUnresolvedPlaceholders(t, out)
+
+	// No route may be named after an unresolved parameter. `/{path}` is what the
+	// delegate produced when it won: the wrapper's `pattern` parameter, rendered
+	// as a placeholder.
+	for path := range out.Paths {
+		if path == "/{path}" || path == "/string" {
+			t.Errorf("path %q comes from the wrapper's own parameters, not from a registration; have %v", path, mapPathKeys(out.Paths))
+		}
+	}
+
+	cases := []struct {
+		method, path, handler string
+	}{
+		// Registered through the wrapper's verb methods.
+		{"GET", "/users", "listUsers"},
+		{"POST", "/users", "createUser"},
+		// Inside a Group, whose prefix the wrapper holds in a field.
+		{"GET", "/api/items", "getItem"},
+		// One registration naming two verbs.
+		{"GET", "/api/items/search", "searchItems"},
+		{"POST", "/api/items/search", "searchItems"},
+		// The handler arrives behind http.HandlerFunc(...).
+		{"GET", "/api/items/count", "countItems"},
+	}
+	for _, tc := range cases {
+		op := opFor(out.Paths[tc.path], tc.method)
+		if op == nil {
+			t.Errorf("%s %s missing; have %v", tc.method, tc.path, mapPathKeys(out.Paths))
+			continue
+		}
+		if !strings.Contains(op.OperationID, tc.handler) {
+			t.Errorf("%s %s: operationId %q does not name the handler %q — the registration resolved to something else",
+				tc.method, tc.path, op.OperationID, tc.handler)
+		}
+	}
+
+	// The handler bodies come through, which is what the junk route lost: a
+	// conversion or a `[]any` names a type, and a type has no request or response.
+	if op := opFor(out.Paths["/users"], "POST"); op != nil {
+		if op.RequestBody == nil {
+			t.Error("POST /users: the handler decodes a User, so a request body is expected")
+		}
+		if _, ok := op.Responses["201"]; !ok {
+			t.Errorf("POST /users: expected the handler's 201, have %v", statusKeys(op))
+		}
+	}
+
+	// A helper handed the framework router directly must keep working: its inner
+	// call is the only registration there is, so the fix must not reject it for
+	// being inside another function.
+	if op := opFor(out.Paths["/"], "DELETE"); op == nil {
+		t.Errorf("the helper-registrar route is gone; have %v", mapPathKeys(out.Paths))
+	} else if !strings.Contains(op.OperationID, "deleteUser") {
+		t.Errorf("helper-registrar operationId = %q, want it to name deleteUser", op.OperationID)
+	}
+}
+
+// statusKeys lists an operation's documented statuses, for failure output.
+func statusKeys(op *intspec.Operation) []string {
+	out := make([]string, 0, len(op.Responses))
+	for status := range op.Responses {
+		out = append(out, status)
+	}
+	return out
+}

--- a/internal/spec/config.go
+++ b/internal/spec/config.go
@@ -242,8 +242,20 @@ type RoutePattern struct {
 	MethodFromCall    bool `yaml:"methodFromCall,omitempty" json:"methodFromCall,omitempty"`       // Extract method from function name
 	MethodFromHandler bool `yaml:"methodFromHandler,omitempty" json:"methodFromHandler,omitempty"` // Extract method from handler function name
 	MethodFromPath    bool `yaml:"methodFromPath,omitempty" json:"methodFromPath,omitempty"`       // Extract method from a leading verb in the path arg (Go 1.22 ServeMux: "GET /users/{id}")
-	PathFromArg       bool `yaml:"pathFromArg,omitempty" json:"pathFromArg,omitempty"`             // Extract path from argument
-	HandlerFromArg    bool `yaml:"handlerFromArg,omitempty" json:"handlerFromArg,omitempty"`       // Extract handler from argument
+
+	// MethodFromArg reads the verb from the argument at MethodArgIndex, which may
+	// name SEVERAL, comma-separated: a house router's `Methods("GET,POST", path,
+	// h)` registers both, and one route per verb is emitted. Without this a
+	// registrar whose verb travels as an argument had no way to say so and fell
+	// back to the POST default (issue #221).
+	//
+	// It is worth stating explicitly even though MethodArgIndex was already read
+	// as a fallback: that read is implicit (the index defaults to 0, so it
+	// inspects the first argument of every verb-less pattern) and it accepts only
+	// a single verb.
+	MethodFromArg  bool `yaml:"methodFromArg,omitempty" json:"methodFromArg,omitempty"`
+	PathFromArg    bool `yaml:"pathFromArg,omitempty" json:"pathFromArg,omitempty"`       // Extract path from argument
+	HandlerFromArg bool `yaml:"handlerFromArg,omitempty" json:"handlerFromArg,omitempty"` // Extract handler from argument
 
 	// Method extraction configuration
 	MethodExtraction *MethodExtractionConfig `yaml:"methodExtraction,omitempty" json:"methodExtraction,omitempty"`

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -76,6 +76,13 @@ type RouteInfo struct {
 	// won't dispatch the other verbs to the handler.
 	MethodExplicit bool
 
+	// ExtraMethods carries the remaining verbs when one registration names
+	// several — a house router's `Methods("GET,POST", path, h)` (issue #221).
+	// Method holds the first; expandMultiVerbRoutes turns the rest into their own
+	// routes once the set is collected, so nothing downstream has to know that a
+	// registration can be plural.
+	ExtraMethods []string
+
 	UsedTypes map[string]*Schema
 	Metadata  *metadata.Metadata
 
@@ -303,6 +310,11 @@ func (e *Extractor) ExtractRoutes() []*RouteInfo {
 		e.traverseForRoutes(root, "", nil, nil, nil, &routes)
 	}
 	routes = dropSubsumedMountPrefixes(routes)
+
+	// One registration naming several verbs becomes one route per verb. Done
+	// before dispatch splitting so both passes see a set where a route has exactly
+	// one method (issue #221).
+	routes = expandMultiVerbRoutes(routes)
 
 	// Split handlers that dispatch on r.Method (switch/if) into one route per
 	// HTTP method, before the per-route diagnostics below run on the settled set.
@@ -1109,10 +1121,29 @@ func frameChainKey(chain []string, node TrackerNodeInterface) string {
 }
 
 func (e *Extractor) extractRouteChildren(routeNode TrackerNodeInterface, route *RouteInfo, mountTags []string, routes *[]*RouteInfo, visitedEdges map[chainStep]bool, ci *chainInterner, chainID int, respCandidates *[]responseCandidate) {
+	e.extractRouteChildrenScoped(routeNode, route, mountTags, routes, visitedEdges, ci, chainID, respCandidates, true)
+}
+
+// extractRouteChildrenScoped is extractRouteChildren with the permission to
+// COMPLETE the route from a child. It is withdrawn as soon as the walk leaves the
+// registration — once inside a function the registration called, every deeper node
+// is part of an implementation rather than of the registration, and letting one
+// fill the route replaces resolved values with that function's parameters.
+// Everything else about the walk (request, responses, parameters) continues
+// unchanged, because those DO live in the handler's body.
+func (e *Extractor) extractRouteChildrenScoped(routeNode TrackerNodeInterface, route *RouteInfo, mountTags []string, routes *[]*RouteInfo, visitedEdges map[chainStep]bool, ci *chainInterner, chainID int, respCandidates *[]responseCandidate, mayComplete bool) {
 	for _, child := range routeNode.GetChildren() {
-		// Check for route patterns in children nodes
-		if isRoute := e.executeRoutePattern(child, route); isRoute {
-			e.handleRouteNode(child, route, "", mountTags, route.DynamicParams, nil, routes)
+		// Check for route patterns in children nodes — but only where a child can
+		// legitimately COMPLETE this route (see completesSameRegistration). A
+		// registration matched deeper, inside a function this route calls, is the
+		// same registration seen one level down, and extracting it here would
+		// overwrite the outer route's method, path and handler with the inner
+		// call's still-unresolved parameters (issue #221).
+		childMayComplete := mayComplete && e.completesSameRegistration(routeNode, child)
+		if childMayComplete {
+			if isRoute := e.executeRoutePattern(child, route); isRoute {
+				e.handleRouteNode(child, route, "", mountTags, route.DynamicParams, nil, routes)
+			}
 		}
 
 		// Extract request. A route's body may be matched at several nodes
@@ -1154,11 +1185,56 @@ func (e *Extractor) extractRouteChildren(routeNode TrackerNodeInterface, route *
 		if child != nil && child.GetArgument() == nil && child.GetEdge() != nil {
 			childChainID = ci.push(chainID, child.GetEdge().Callee.ID())
 		}
-		e.extractRouteChildren(child, route, mountTags, routes, visitedEdges, ci, childChainID, respCandidates)
+		e.extractRouteChildrenScoped(child, route, mountTags, routes, visitedEdges, ci, childChainID, respCandidates, childMayComplete)
 	}
 
 	// Extract parameters from the route node itself
 	route.Params = append(route.Params, e.extractParamsFromNode(routeNode, route)...)
+}
+
+// completesSameRegistration reports whether a child node can finish the route its
+// parent started, as opposed to being a different registration further in.
+//
+// A fluent chain is one registration written across several calls —
+// `Methods("GET").Path("/users").HandlerFunc(h)` arrives with the method on the
+// first call and the path and handler on later ones, so those later calls must be
+// allowed to fill the same route.
+//
+// A house router is the opposite case. `r.Get("/users", listUsers)` is complete
+// where it is written; the `chi.Mux.Method(...)` call inside the wrapper's body is
+// the same registration re-expressed, with the path and handler now parameters. If
+// that were allowed to fill the route it would replace `/users` with `{path}` and
+// `listUsers` with whatever local variable the wrapper built — which is what a
+// project with its own router type used to get out of the box (issue #221).
+//
+// The two are told apart by where the child is written: a chain continuation is a
+// call in the SAME function as the call it continues, while a delegate is a call
+// inside the callee's body. Comparing the caller identity says which, with no
+// guess about names or shapes.
+func (e *Extractor) completesSameRegistration(parent, child TrackerNodeInterface) bool {
+	if parent == nil || child == nil {
+		return false
+	}
+	// An argument is not a registration. An argument node carries the edge of the
+	// call it belongs to, so matching route patterns on it re-extracts that same
+	// call — and the second extraction reads the argument rather than the call,
+	// which is how a route's path became the *type* of a parameter ("string") and
+	// its handler "[]any" (issue #221).
+	if child.GetArgument() != nil {
+		return false
+	}
+	parentEdge, childEdge := parent.GetEdge(), child.GetEdge()
+	if parentEdge == nil || childEdge == nil {
+		return false
+	}
+	// An explicit chain link is decisive on its own.
+	if childEdge.ChainParent != nil {
+		return true
+	}
+	// BaseID, not ID: the question is whether both calls are written in the same
+	// FUNCTION, and an instance id carries a position that would make two calls in
+	// one function look like different callers.
+	return parentEdge.Caller.BaseID() == childEdge.Caller.BaseID()
 }
 
 // matchesResponsePattern reports whether any response matcher accepts the node.

--- a/internal/spec/method_dispatch.go
+++ b/internal/spec/method_dispatch.go
@@ -150,3 +150,31 @@ func fileOfPosition(pos string) string {
 	}
 	return rest[:midColon]
 }
+
+// expandMultiVerbRoutes turns a registration that named several verbs into one
+// route per verb — a house router's `Methods("GET,POST", path, h)` registers both
+// (issue #221).
+//
+// The copy is shallow on purpose: every verb of one registration shares the same
+// handler, so it shares the handler's request, responses and parameters. What must
+// NOT be shared is the operationId, so each verb carries it as a suffix the way a
+// dispatch split does — neither verb is the primary one, and two operations
+// differing only in method would otherwise collide.
+func expandMultiVerbRoutes(routes []*RouteInfo) []*RouteInfo {
+	out := make([]*RouteInfo, 0, len(routes))
+	for _, route := range routes {
+		if len(route.ExtraMethods) == 0 {
+			out = append(out, route)
+			continue
+		}
+		methods := append([]string{route.Method}, route.ExtraMethods...)
+		for _, method := range methods {
+			nr := *route
+			nr.Method = method
+			nr.ExtraMethods = nil
+			nr.OperationIDSuffix = method
+			out = append(out, &nr)
+		}
+	}
+	return out
+}

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -224,7 +224,7 @@ func (r *RoutePatternMatcherImpl) ExtractRoute(node TrackerNodeInterface, routeI
 	// Extract handler information
 	if r.pattern.HandlerFromArg && len(edge.Args) > r.pattern.HandlerArgIndex {
 		found = true
-		handlerArg := edge.Args[r.pattern.HandlerArgIndex]
+		handlerArg := handlerArgValue(edge.Args[r.pattern.HandlerArgIndex])
 		if handlerArg.GetKind() == metadata.KindIdent || handlerArg.GetKind() == metadata.KindFuncLit {
 
 			handlerName := handlerArg.GetName()
@@ -271,6 +271,16 @@ func (r *RoutePatternMatcherImpl) extractRouteDetails(node TrackerNodeInterface,
 			var matched bool
 			routeInfo.Method, matched = r.methodFromFunctionName(handlerName, r.pattern.MethodExtraction)
 			routeInfo.MethodExplicit = matched
+			found = true
+		}
+	} else if r.pattern.MethodFromArg && len(edge.Args) > r.pattern.MethodArgIndex {
+		// The verb travels as an argument, and may name several:
+		// `Methods("GET,POST", path, h)` registers both (issue #221). The rest are
+		// carried on the route and expanded once the set is collected.
+		if methods := r.verbsFromArg(edge.Args[r.pattern.MethodArgIndex]); len(methods) > 0 {
+			routeInfo.Method = methods[0]
+			routeInfo.ExtraMethods = methods[1:]
+			routeInfo.MethodExplicit = true
 			found = true
 		}
 	} else if r.pattern.MethodArgIndex >= 0 && len(edge.Args) > r.pattern.MethodArgIndex {
@@ -334,13 +344,14 @@ func (r *RoutePatternMatcherImpl) extractRouteDetails(node TrackerNodeInterface,
 	}
 
 	if r.pattern.HandlerFromArg && len(edge.Args) > r.pattern.HandlerArgIndex {
-		routeInfo.Handler = r.contextProvider.GetArgumentInfo(edge.Args[r.pattern.HandlerArgIndex])
-		routeInfo.Function = r.contextProvider.GetArgumentInfo(edge.Args[r.pattern.HandlerArgIndex])
+		handlerArg := handlerArgValue(edge.Args[r.pattern.HandlerArgIndex])
+		routeInfo.Handler = r.contextProvider.GetArgumentInfo(handlerArg)
+		routeInfo.Function = r.contextProvider.GetArgumentInfo(handlerArg)
 
-		pkg := edge.Args[r.pattern.HandlerArgIndex].GetPkg()
+		pkg := handlerArg.GetPkg()
 		if pkg == "" {
-			if node != nil && edge != nil && edge.Args[r.pattern.HandlerArgIndex].Fun != nil {
-				pkg = edge.Args[r.pattern.HandlerArgIndex].Fun.GetPkg()
+			if node != nil && edge != nil && handlerArg.Fun != nil {
+				pkg = handlerArg.Fun.GetPkg()
 			}
 		}
 		routeInfo.Package = pkg
@@ -1245,4 +1256,64 @@ func splitNameWords(name string) []string {
 	}
 	flush()
 	return words
+}
+
+// verbsFromArg reads the HTTP verbs an argument names, in order, or nil.
+//
+// A registrar can name several in one call — gitea's `Methods("GET,POST", …)`
+// registers both — so the result is a list. Every element has to be a real verb:
+// a value that is only partly verb-like ("GET,everything") says the argument was
+// not understood, and inventing a route from half of it would be worse than
+// leaving the route with its default (golden rule #7).
+//
+// The value may be a literal or a constant this project declares
+// (`http.MethodGet` is not resolvable — that package is not analysed — and a
+// pattern relying on it keeps the older single-verb fallback path).
+func (r *RoutePatternMatcherImpl) verbsFromArg(arg *metadata.CallArgument) []string {
+	if arg == nil {
+		return nil
+	}
+	raw, ok := r.contextProvider.ConstantValue(arg)
+	if !ok || raw == "" {
+		return nil
+	}
+
+	parts := strings.Split(raw, ",")
+	methods := make([]string, 0, len(parts))
+	seen := make(map[string]bool, len(parts))
+	for _, part := range parts {
+		verb := strings.ToUpper(strings.TrimSpace(strings.Trim(part, "\"'")))
+		if verb == "" || !r.isValidHTTPMethod(verb) {
+			return nil
+		}
+		if !seen[verb] {
+			seen[verb] = true
+			methods = append(methods, verb)
+		}
+	}
+	return methods
+}
+
+// handlerArgValue returns the value a handler argument really names, looking
+// through a type conversion.
+//
+// `r.Get("/x", http.HandlerFunc(listItems))` passes a conversion, and taking it at
+// face value documented the operation as `net/http.HandlerFunc` with no body —
+// the conversion names a type, and a type has no doc comment, no request and no
+// responses. The handler is what was converted (issue #221).
+//
+// Only a conversion wrapping something that can BE a handler is peeled: an ident,
+// a selector (`pkg.Handler`, `h.ServeHTTP`) or a literal function. Anything else
+// stays as it is, since for a non-handler argument the conversion's own type is
+// usually the answer (a `[]byte(body)` request body, for instance).
+func handlerArgValue(arg *metadata.CallArgument) *metadata.CallArgument {
+	if arg == nil || arg.GetKind() != metadata.KindTypeConversion || len(arg.Args) != 1 {
+		return arg
+	}
+	switch inner := arg.Args[0]; inner.GetKind() {
+	case metadata.KindIdent, metadata.KindSelector, metadata.KindFuncLit:
+		return inner
+	default:
+		return arg
+	}
 }

--- a/internal/spec/wrapper_router_test.go
+++ b/internal/spec/wrapper_router_test.go
@@ -1,0 +1,234 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// verbArg builds the argument a registrar receives its verb in.
+func verbArg(m *metadata.Metadata, value string) *metadata.CallArgument {
+	arg := metadata.NewCallArgument(m)
+	arg.SetKind(metadata.KindLiteral)
+	arg.SetValue(`"` + value + `"`)
+	return arg
+}
+
+// TestVerbsFromArg covers the verb-carrying argument a house router registers
+// through (issue #221). A list is the interesting case — gitea's
+// `Methods("GET,POST", …)` registers both — and so is the refusal: a value that is
+// only partly verb-like means the argument was not understood, and inventing a
+// route from half of it is worse than leaving the default.
+func TestVerbsFromArg(t *testing.T) {
+	m := wireNameMeta()
+	matcher := NewRoutePatternMatcher(
+		RoutePattern{CallRegex: "^Methods$", MethodFromArg: true},
+		&APISpecConfig{}, NewContextProvider(m), nil,
+	)
+
+	tests := []struct {
+		name  string
+		value string
+		want  []string
+	}{
+		{"one verb", "GET", []string{"GET"}},
+		{"lower case", "get", []string{"GET"}},
+		{"two verbs", "GET,POST", []string{"GET", "POST"}},
+		{"spaces around the separator", "GET, POST , PUT", []string{"GET", "POST", "PUT"}},
+		{"a repeat is listed once", "GET,GET,POST", []string{"GET", "POST"}},
+		{"every verb has to be one", "GET,everything", nil},
+		{"not a verb at all", "/users", nil},
+		{"empty", "", nil},
+		{"a trailing separator names nothing", "GET,", nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := matcher.verbsFromArg(verbArg(m, tc.value))
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("verbsFromArg(%q) = %v, want %v", tc.value, got, tc.want)
+			}
+		})
+	}
+
+	if got := matcher.verbsFromArg(nil); got != nil {
+		t.Errorf("nil argument = %v, want nil", got)
+	}
+	// A value that is not statically known names no verb: a pattern relying on
+	// `http.MethodGet` (a package apispec does not analyse) keeps the older
+	// single-verb fallback instead of guessing here.
+	unknown := metadata.NewCallArgument(m)
+	unknown.SetKind(metadata.KindIdent)
+	unknown.SetName("verb")
+	if got := matcher.verbsFromArg(unknown); got != nil {
+		t.Errorf("unresolvable argument = %v, want nil", got)
+	}
+}
+
+// TestExpandMultiVerbRoutes pins what one registration naming several verbs
+// becomes: one route per verb, each with its own operationId, sharing everything
+// the handler determines.
+func TestExpandMultiVerbRoutes(t *testing.T) {
+	plain := &RouteInfo{Method: "GET", Path: "/items", Function: "listItems"}
+	multi := &RouteInfo{
+		Method:       "GET",
+		ExtraMethods: []string{"POST", "PUT"},
+		Path:         "/search",
+		Function:     "searchItems",
+		Request:      &RequestInfo{},
+	}
+
+	got := expandMultiVerbRoutes([]*RouteInfo{plain, multi})
+	if len(got) != 4 {
+		t.Fatalf("expanded to %d routes, want 4 (1 + 3)", len(got))
+	}
+	if got[0] != plain {
+		t.Error("a single-verb route should pass through untouched")
+	}
+	if got[0].OperationIDSuffix != "" {
+		t.Errorf("single-verb suffix = %q, want none", got[0].OperationIDSuffix)
+	}
+
+	seen := map[string]string{}
+	for _, r := range got[1:] {
+		seen[r.Method] = r.OperationIDSuffix
+		if r.Path != "/search" || r.Function != "searchItems" {
+			t.Errorf("%s: path/handler changed (%s %s)", r.Method, r.Path, r.Function)
+		}
+		if r.Request == nil {
+			t.Errorf("%s: the verbs of one registration share the handler's request", r.Method)
+		}
+		if len(r.ExtraMethods) != 0 {
+			t.Errorf("%s: still carries ExtraMethods %v", r.Method, r.ExtraMethods)
+		}
+	}
+	want := map[string]string{"GET": "GET", "POST": "POST", "PUT": "PUT"}
+	if !reflect.DeepEqual(seen, want) {
+		t.Errorf("methods/suffixes = %v, want %v — every verb needs its own operationId", seen, want)
+	}
+}
+
+// TestHandlerArgValue covers looking through a type conversion to the handler.
+// `http.HandlerFunc(fn)` names a type, and a type has no doc comment, no request
+// and no responses — which is what the operation lost.
+func TestHandlerArgValue(t *testing.T) {
+	m := wireNameMeta()
+	conversion := func(inner *metadata.CallArgument) *metadata.CallArgument {
+		conv := metadata.NewCallArgument(m)
+		conv.SetKind(metadata.KindTypeConversion)
+		fun := metadata.NewCallArgument(m)
+		fun.SetKind(metadata.KindSelector)
+		conv.Fun = fun
+		if inner != nil {
+			conv.Args = []*metadata.CallArgument{inner}
+		}
+		return conv
+	}
+	of := func(kind, name string) *metadata.CallArgument {
+		a := metadata.NewCallArgument(m)
+		a.SetKind(kind)
+		a.SetName(name)
+		return a
+	}
+
+	// Peeled: each of these can BE a handler.
+	for _, kind := range []string{metadata.KindIdent, metadata.KindSelector, metadata.KindFuncLit} {
+		inner := of(kind, "listItems")
+		if got := handlerArgValue(conversion(inner)); got != inner {
+			t.Errorf("conversion of a %s was not looked through", kind)
+		}
+	}
+
+	// Left alone: a conversion of something that cannot be a handler, where the
+	// conversion's own type is usually the answer (`[]byte(body)`).
+	literal := metadata.NewCallArgument(m)
+	literal.SetKind(metadata.KindLiteral)
+	literal.SetValue(`"x"`)
+	conv := conversion(literal)
+	if got := handlerArgValue(conv); got != conv {
+		t.Error("a conversion of a literal should be left as it is")
+	}
+	// A conversion with no argument, and a plain argument.
+	empty := conversion(nil)
+	if got := handlerArgValue(empty); got != empty {
+		t.Error("an argument-less conversion should be left as it is")
+	}
+	plain := of(metadata.KindIdent, "listItems")
+	if got := handlerArgValue(plain); got != plain {
+		t.Error("a plain handler argument should be returned unchanged")
+	}
+	if got := handlerArgValue(nil); got != nil {
+		t.Error("nil should stay nil")
+	}
+}
+
+// TestCompletesSameRegistration pins the rule that keeps a framework's own
+// patterns from re-matching inside a wrapper: a child may finish the route its
+// parent started only when it belongs to the same registration.
+func TestCompletesSameRegistration(t *testing.T) {
+	m := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	e := &Extractor{}
+
+	// A call written in caller, at position pos.
+	callNode := func(caller, pos string) *TrackerNode {
+		return &TrackerNode{CallGraphEdge: &metadata.CallGraphEdge{
+			Caller: metadata.Call{Name: m.StringPool.Get(caller), Pkg: m.StringPool.Get("app"), Position: m.StringPool.Get(pos), Meta: m},
+			Callee: metadata.Call{Name: m.StringPool.Get("Get"), Pkg: m.StringPool.Get("app"), Meta: m},
+		}}
+	}
+
+	route := callNode("main", "main.go:10:2")
+
+	t.Run("a call in the same function may complete it", func(t *testing.T) {
+		// A fluent chain: Methods("GET").Path("/x") — written where the route is.
+		if !e.completesSameRegistration(route, callNode("main", "main.go:10:20")) {
+			t.Error("a sibling call in the same function was rejected")
+		}
+	})
+
+	t.Run("a call inside the callee may not", func(t *testing.T) {
+		// The wrapper's delegate: chi.Mux.Method(...) inside Router.Methods.
+		if e.completesSameRegistration(route, callNode("Methods", "router.go:46:2")) {
+			t.Error("a call inside another function was allowed to overwrite the route")
+		}
+	})
+
+	t.Run("an explicit chain link decides on its own", func(t *testing.T) {
+		chained := callNode("other", "router.go:5:2")
+		chained.ChainParent = route.CallGraphEdge
+		if !e.completesSameRegistration(route, chained) {
+			t.Error("a chain continuation was rejected")
+		}
+	})
+
+	t.Run("an argument is not a registration", func(t *testing.T) {
+		arg := callNode("main", "main.go:10:2")
+		arg.CallArgument = metadata.NewCallArgument(m)
+		if e.completesSameRegistration(route, arg) {
+			t.Error("an argument node was treated as a registration — its call would be re-extracted from the argument")
+		}
+	})
+
+	t.Run("nothing to compare", func(t *testing.T) {
+		if e.completesSameRegistration(nil, route) || e.completesSameRegistration(route, nil) {
+			t.Error("a missing node was accepted")
+		}
+		if e.completesSameRegistration(route, &TrackerNode{}) {
+			t.Error("a node with no edge was accepted")
+		}
+	})
+}

--- a/testdata/wrapper_router/go.mod
+++ b/testdata/wrapper_router/go.mod
@@ -1,0 +1,12 @@
+module github.com/ehabterra/apispec/testdata/wrapper_router
+
+go 1.21
+
+require (
+	github.com/go-chi/chi/v5 v5.0.10
+	github.com/go-chi/cors v1.2.1
+	github.com/go-chi/render v1.0.3
+	github.com/google/uuid v1.4.0
+)
+
+require github.com/ajg/form v1.5.1 // indirect

--- a/testdata/wrapper_router/go.sum
+++ b/testdata/wrapper_router/go.sum
@@ -1,0 +1,10 @@
+github.com/ajg/form v1.5.1 h1:t9c7v8JUKu/XxOGBU0yjNpaMloxGEJhUkqFRq0ibGeU=
+github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
+github.com/go-chi/chi/v5 v5.0.10 h1:rLz5avzKpjqxrYwXNfmjkrYYXOyLJd37pz53UFHC6vk=
+github.com/go-chi/chi/v5 v5.0.10/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/go-chi/cors v1.2.1 h1:xEC8UT3Rlp2QuWNEr4Fs/c2EAGVKBwy/1vHx3bppil4=
+github.com/go-chi/cors v1.2.1/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vzc58=
+github.com/go-chi/render v1.0.3 h1:AsXqd2a1/INaIfUSKq3G5uA8weYx20FOsM7uSoCyyt4=
+github.com/go-chi/render v1.0.3/go.mod h1:/gr3hVkmYR0YlEy3LxCuVRFzEu9Ruok+gFqbIofjao0=
+github.com/google/uuid v1.4.0 h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4=
+github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/testdata/wrapper_router/main.go
+++ b/testdata/wrapper_router/main.go
@@ -1,0 +1,92 @@
+// Fixture: a project that wraps a router in its own type (gitea's
+// modules/web.Router around *chi.Mux) and registers everything through it.
+//
+// Three shapes that were each broken, all in one project because a real one has
+// them together:
+//
+//  1. chi's own patterns match the DELEGATE call inside the wrapper, where the
+//     path is a call and the handler is a `[]any` — so the default run documented
+//     one junk route (`/{path}` POST, `operationId: net/http.HandlerFunc`) and
+//     none of the real ones.
+//  2. The verb arrives as an ARGUMENT (`Methods("GET,POST", …)`), which no
+//     extraction hint could read.
+//  3. A handler behind a type conversion (`http.HandlerFunc(fn)`) was taken as
+//     the handler itself, losing the body.
+//
+// registerCRUD is here as the shape that must NOT break: a helper that takes the
+// router and a base path, where the inner call IS the only registration.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type User struct {
+	ID    string `json:"id"`
+	Email string `json:"email"`
+}
+
+type Item struct {
+	SKU   string `json:"sku"`
+	Count int    `json:"count"`
+}
+
+func listUsers(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode([]User{})
+}
+
+func createUser(w http.ResponseWriter, r *http.Request) {
+	var in User
+	_ = json.NewDecoder(r.Body).Decode(&in)
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(in)
+}
+
+func getItem(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode(Item{})
+}
+
+// searchItems answers both verbs of one registration.
+func searchItems(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode([]Item{})
+}
+
+// countItems is registered through a type conversion.
+func countItems(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode(Item{})
+}
+
+// deleteUser is registered by a helper that receives the chi router directly.
+func deleteUser(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// registerCRUD registers on the chi router it is handed. The path is built from a
+// parameter, so this inner call is the only registration there is — nothing
+// outside it states the path.
+func registerCRUD(m *chi.Mux, base string) {
+	m.Delete(base+"/{id}", deleteUser)
+}
+
+func main() {
+	r := NewRouter()
+
+	r.Get("/users", listUsers)
+	r.Post("/users", createUser)
+
+	// The prefix lives in a field, applied by getPattern — no sub-router exists.
+	r.Group("/api", func() {
+		r.Get("/items", getItem)
+		// One registration, two verbs.
+		r.Methods("GET,POST", "/items/search", searchItems)
+		// The handler is behind a conversion.
+		r.Get("/items/count", http.HandlerFunc(countItems))
+	})
+
+	registerCRUD(r.chiRouter, "/users")
+
+	_ = http.ListenAndServe(":8080", r.chiRouter)
+}

--- a/testdata/wrapper_router/router.go
+++ b/testdata/wrapper_router/router.go
@@ -1,0 +1,60 @@
+// A house router: the project's own type in front of chi, the shape gitea uses in
+// modules/web/router.go.
+//
+// Every verb method delegates to one shared registrar, and the group prefix lives
+// in a FIELD that getPattern applies — there is no sub-router to mount, so the
+// prefix is only knowable by following the field.
+package main
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type Router struct {
+	chiRouter      *chi.Mux
+	curGroupPrefix string
+}
+
+func NewRouter() *Router {
+	return &Router{chiRouter: chi.NewRouter()}
+}
+
+func (r *Router) getPattern(pattern string) string {
+	if pattern == "" {
+		return r.curGroupPrefix
+	}
+	return r.curGroupPrefix + pattern
+}
+
+// Methods is the one registrar every verb goes through. The verb arrives as an
+// ARGUMENT, and may name several: gitea registers "GET,POST" in one call.
+func (r *Router) Methods(methods, pattern string, h ...any) {
+	if len(h) == 0 {
+		return
+	}
+	var handlerFunc http.HandlerFunc
+	switch fn := h[len(h)-1].(type) {
+	case func(http.ResponseWriter, *http.Request):
+		handlerFunc = fn
+	case http.HandlerFunc:
+		handlerFunc = fn
+	default:
+		return
+	}
+	r.chiRouter.Method(methods, r.getPattern(pattern), handlerFunc)
+}
+
+func (r *Router) Get(pattern string, h ...any)    { r.Methods("GET", pattern, h...) }
+func (r *Router) Post(pattern string, h ...any)   { r.Methods("POST", pattern, h...) }
+func (r *Router) Put(pattern string, h ...any)    { r.Methods("PUT", pattern, h...) }
+func (r *Router) Delete(pattern string, h ...any) { r.Methods("DELETE", pattern, h...) }
+
+// Group accumulates the prefix rather than mounting a sub-router.
+func (r *Router) Group(pattern string, fn func()) {
+	prev := r.curGroupPrefix
+	r.curGroupPrefix += pattern
+	fn()
+	r.curGroupPrefix = prev
+}


### PR DESCRIPTION
Addresses all three defects in #221.

## Before

A project wrapping a router in its own type (gitea's `modules/web.Router` around `*chi.Mux`) produced **one junk route and none of the real ones**:

```yaml
/{path}:
  post:
    operationId: example.com/wrap.net/http.HandlerFunc   # a TYPE, not a handler
    responses: {default: …}                              # so: no body
```

## Defect 1 — the delegate overwrote the route it was reached through

Not double-registration, as the issue supposed: **the inner call filled the outer route's object.** A matched route's subtree is walked for the handler's request/responses/params, and any registration found in there wrote into the *same* `RouteInfo`. That is deliberate for a fluent chain (`Methods("GET").Path("/x").HandlerFunc(h)` states one registration across several calls) — but inside a wrapper the chi call is the same registration one level down, where path and handler are the wrapper's own parameters. `/users` became `{path}`; `listUsers` became a local variable.

A child may now complete a route only when it belongs to the same registration: **written in the same function**, or linked by an explicit chain parent. Two details that measurement forced:

- the permission is withdrawn for the **whole subtree** below the first child that fails — otherwise the blocked node's own children (same caller as *it*) resumed overwriting;
- an **argument node never qualifies**. An argument carries its call's edge, so matching route patterns on one re-extracts that call *from the argument* — which is how a path became the **type** of a parameter (`/string`) and a handler `[]any`.

This fixes the **default** run too, no config needed. Consequently the four dead `Caller*/Callee*Patterns` fields were *not* needed for this; they remain unread, so that part of the issue is still open.

## Defect 2 — a verb travelling as an argument

`MethodArgIndex` was in fact read, but only as an implicit fallback accepting a single verb — so `Methods("GET,POST", path, h)` fell back to the POST default and registered one route instead of two. New `methodFromArg` hint: states where the verb lives, accepts a comma-separated list, emits one route per verb each with its own operationId (the convention a `switch r.Method` split already uses). `"GET,everything"` is refused rather than half-read (golden rule #7).

## Defect 3 — a handler behind a type conversion

`http.HandlerFunc(countItems)` documented `net/http.HandlerFunc` with no body. The conversion is now looked through when it wraps something that can be a handler (ident/selector/func literal); a conversion of anything else keeps its own type, which is what a `[]byte(body)` request needs.

## Result, with chi's default patterns active

| | operationId |
|---|---|
| `GET /users`, `POST /users` | listUsers, createUser (+ request body, 201) |
| `GET /api/items` | getItem — prefix from the field-held group |
| `GET`+`POST /api/items/search` | searchItems_GET / searchItems_POST |
| `GET /api/items/count` | countItems — conversion looked through |
| `DELETE /` | deleteUser — the helper-registrar shape, still documented |

## Verification

- `testdata/wrapper_router` replicates the shape; the config in the test adds the wrapper's patterns **on top of chi's defaults**, which is the case that used to fail.
- **Mutation-checked**: reverting any one of the three fixes fails the test with the exact symptom (`/{path}` appears; `countItems` becomes `net/http.HandlerFunc`; `/api/items/search` loses its POST).
- **Zero drift** across the other 68 fixtures; full suite, `go vet`, `gofmt`, `golangci-lint` (0 issues); coverage 96.0% against the 96% floor.
- The new `methodFromArg` field was caught missing from the UI editor by the parity test from #227, and added.

## Measured on gitea

The issue notes a gitea run with wrapper patterns "still yields 0 paths". That was true with the default tracker limits; with the limits raised so the walk reaches through `routers/web.Routes()`, the same config now documents the project — and the difference this PR makes is the whole result:

| build | paths | operations | junk paths | handlers named after a TYPE |
|---|---:|---:|---:|---:|
| main | 195 | 311 | 193 (99%) | 309 (99%) |
| this PR | **862** | **1068** | 78 (9%) | 18 (2%) |

Same config, same limits (`--max-nodes 2000000 --max-children 5000 --max-recursion-depth 60`), ~4 min. On main nearly every operation is `net/http.HandlerFunc` or `[]any` at a `/{path}`-style path — the delegate overwrite. Entry is via the entrypoint gate from #220 (`Action: runWeb`), which reports `49 declared, 1 rooted`.

The 78 remaining junk paths are gitea's `Combo("/x").Get(h).Post(h)` chained API, which needs a pattern of its own — a config gap, not a defect in this change.

## Not fixed here (worth knowing)

- The default tracker limits stop the walk partway through a route tree of gitea's size (~1000 registrations behind nested group closures), which is why the numbers above need raised limits.
- `registerCRUD(m, base)` documents `DELETE /` rather than `/users/{id}`: a path built by concatenating a *parameter* with a literal isn't composed. Pre-existing, unrelated to these three, and left as-is rather than widened into this PR.
- A bare `json.NewEncoder(w).Encode(v)` with no `WriteHeader` yields `default` rather than `200`. Also pre-existing and consistent across fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for route registrations that specify multiple HTTP methods, generating a separate API operation for each method.
  - Improved detection of handlers wrapped in standard HTTP handler conversions.
  - Enhanced route parsing for wrapper and helper-based routers.

- **Bug Fixes**
  - Prevented unresolved route placeholders from appearing in generated API paths.
  - Improved operation identifiers and request/response documentation for wrapped routes.

- **Documentation**
  - Updated configuration help text for method arguments and multi-method registrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
