### PR TITLE
feat: expansion limits are configurable from the UI, and a truncated run says so (#233)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ apispec --output openapi.yaml --skip-cgo
 | `--max-args`                | `-ma`     | Max arguments per function                             | `100`                           |
 | `--max-nested-args`         | `-md`     | Max depth for nested arguments                         | `100`                           |
 | `--max-recursion-depth`     | `-mrd`    | Max recursion depth (anti-loop)                        | `10`                            |
+| `--max-instances-per-key`   |           | Max copies of one callee within an instance scope (lazy engine) | `25`                   |
 | `--legacy-tracker`          |           | Use the legacy (eager) tracker tree instead of the default lazy tracker | `false`        |
 | `--skip-cgo`                |           | Skip CGO packages                                      | `true`                          |
 | `--include-file`            |           | Include files matching pattern (repeatable)            | `""`                            |
@@ -639,7 +640,7 @@ APISpec turns Go source into an OpenAPI document through a fixed sequence of sta
 - *Importance:* Nothing downstream touches the raw AST again — metadata is the substrate. String-pooling plus sorted iteration at every boundary make the output **deterministic** (clean release diffs and reliable golden tests), and `--write-metadata` dumps this model so a missed route can be debugged.
 
 **6. Build the tracker tree**
-- *Role:* Starting from each route-registration call site, expand the call graph down to the actual handler and the calls made inside it — through wrappers, groups, mounts, handler factories, and helper functions — bounded by engine-specific limits (see [Performance & Limits](#performance--limits)). The default **lazy** tree expands subtrees on demand and is bounded by `--max-nodes`/`--max-children`/`--max-args` plus an internal per-scope instance cap; the eager tree (`--legacy-tracker`) materializes them up front and additionally honors `--max-recursion-depth` and `--max-nested-args`.
+- *Role:* Starting from each route-registration call site, expand the call graph down to the actual handler and the calls made inside it — through wrappers, groups, mounts, handler factories, and helper functions — bounded by engine-specific limits (see [Performance & Limits](#performance--limits)). The default **lazy** tree expands subtrees on demand and is bounded by `--max-nodes`/`--max-children`/`--max-args`/`--max-instances-per-key`; the eager tree (`--legacy-tracker`) materializes them up front and additionally honors `--max-recursion-depth` and `--max-nested-args`.
 - *Purpose:* Connect a route to the concrete code that actually serves it, following real control flow rather than assuming the handler lives where the route is declared.
 - *Importance:* In real codebases the handler is rarely at the registration site — it's behind middleware, a group closure, a mounted sub-router, or a factory. This traversal is what makes detection work across those styles. The bounds are the safety brake that turns a pathological (deep or cyclic) call graph into a truncation warning instead of a hang or out-of-memory.
 
@@ -852,8 +853,19 @@ APISpec applies safeguards to prevent runaway analysis. **Not every knob applies
 | Max args / function  | 100      | `--max-args`            | both                                                                       |
 | Max nested arg depth | 100      | `--max-nested-args`     | **eager only**                                                             |
 | Max recursion depth  | 10       | `--max-recursion-depth` | **eager only**                                                             |
+| Max instances / key  | 25       | `--max-instances-per-key` | **lazy only**                                                            |
 
-Instead of the recursion-depth / nested-args caps, the lazy engine uses a fixed per-scope instance cap (≈ per handler): it keeps one copy of a shared helper per route so per-route value tracing stays accurate, but cuts the combinatorial copies a call diamond inside a single handler would otherwise create — the role the eager tree's per-ID recursion cap plays. This cap is internal (not a CLI flag); tune the lazy engine through `--max-nodes` / `--max-children` / `--max-args`.
+Instead of the recursion-depth / nested-args caps, the lazy engine bounds copies of one callee **within an instance scope**: it keeps a copy of a shared helper per route so per-route value tracing stays accurate, but cuts the combinatorial copies a call diamond inside a single handler would otherwise create — the role the eager tree's per-ID recursion cap plays.
+
+The scope is the nearest argument ancestor, which is "per handler" only when routes are registered directly. Register them inside a group closure (`r.Route("/x", func(r chi.Router) {…})`) and the *closure* becomes the scope for every route in the group, so a response helper shared across it exhausts the budget after that many routes and every later route in the group silently loses its response body. Raising `--max-instances-per-key` is the remedy until the cap is scoped per route (issue #224); it is a real trade, measured on a ~330-route service and a 107-route service:
+
+| `--max-instances-per-key` | success bodies (330-route service) | time (107-route service) |
+|---|---|---|
+| 5   | 77 / 391  | — |
+| 25 (default) | 391 / 391 | 66s |
+| 40  | 391 / 391 | 82s |
+
+Raise it when success responses are missing bodies on a project with large route groups; leave it alone otherwise, since the cost is paid by every project regardless of shape.
 
 When a limit is reached, APISpec logs a clear warning, e.g.:
 

--- a/cmd/apispec/main.go
+++ b/cmd/apispec/main.go
@@ -154,6 +154,7 @@ type CLIConfig struct {
 	MaxArgsPerFunction           int
 	MaxNestedArgsDepth           int
 	MaxRecursionDepth            int
+	MaxInstancesPerKey           int
 	LegacyTracker                bool
 	ShowVersion                  bool
 	OutputFlagSet                bool
@@ -284,6 +285,8 @@ func parseFlags(args []string) (*CLIConfig, error) {
 
 	fs.IntVar(&config.MaxRecursionDepth, "max-recursion-depth", engine.DefaultMaxRecursionDepth, "Maximum recursion depth to prevent infinite loops")
 	fs.IntVar(&config.MaxRecursionDepth, "mrd", engine.DefaultMaxRecursionDepth, "Shorthand for --max-recursion-depth")
+	fs.IntVar(&config.MaxInstancesPerKey, "max-instances-per-key", engine.DefaultMaxInstancesPerKey,
+		"Maximum copies of one callee within an instance scope (raise it when a group closure holds more routes than the default budget covers)")
 
 	fs.BoolVar(&config.LegacyTracker, "legacy-tracker", false, "Use the legacy (eager) tracker tree instead of the default lazy tracker")
 
@@ -386,6 +389,7 @@ func runGeneration(config *CLIConfig) (*spec.OpenAPISpec, *engine.Engine, error)
 		MaxArgsPerFunction:           config.MaxArgsPerFunction,
 		MaxNestedArgsDepth:           config.MaxNestedArgsDepth,
 		MaxRecursionDepth:            config.MaxRecursionDepth,
+		MaxInstancesPerKey:           config.MaxInstancesPerKey,
 		UseLazyTracker:               !config.LegacyTracker,
 		IncludeFiles:                 config.IncludeFiles,
 		IncludePackages:              config.IncludePackages,

--- a/cmd/apispecui/analysis_test.go
+++ b/cmd/apispecui/analysis_test.go
@@ -29,7 +29,7 @@ import (
 // second is true of an ordinary web service.
 func TestAnalysisInfo(t *testing.T) {
 	t.Run("no entrypoints declared", func(t *testing.T) {
-		got := analysisInfo("chi", []string{"chi"}, true, spec.EntrypointStats{})
+		got := analysisInfo("chi", []string{"chi"}, true, spec.EntrypointStats{}, spec.ExpansionStats{})
 		want := insight.AnalysisInfo{Frameworks: []string{"chi"}, Primary: "chi", Engine: "lazy"}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("analysisInfo = %+v, want %+v", got, want)
@@ -38,7 +38,7 @@ func TestAnalysisInfo(t *testing.T) {
 
 	t.Run("entrypoints declared", func(t *testing.T) {
 		got := analysisInfo("mux", []string{"mux", "gin"}, true,
-			spec.EntrypointStats{Declared: 53, Rooted: 1, AlreadyReachable: 0, NoRoutes: 52})
+			spec.EntrypointStats{Declared: 53, Rooted: 1, AlreadyReachable: 0, NoRoutes: 52}, spec.ExpansionStats{})
 		if got.Entrypoints == nil {
 			t.Fatal("entrypoints not reported")
 		}
@@ -49,7 +49,7 @@ func TestAnalysisInfo(t *testing.T) {
 	})
 
 	t.Run("the tracker engine is named", func(t *testing.T) {
-		if got := analysisInfo("chi", nil, false, spec.EntrypointStats{}); got.Engine != "eager" {
+		if got := analysisInfo("chi", nil, false, spec.EntrypointStats{}, spec.ExpansionStats{}); got.Engine != "eager" {
 			t.Errorf("engine = %q, want eager", got.Engine)
 		}
 	})
@@ -108,5 +108,67 @@ func TestBuildAPISpecConfigKeepsEverySection(t *testing.T) {
 	// count.
 	if len(fc.EntrypointPatterns) == 1 && fc.EntrypointPatterns[0].FieldRegex != "^Action$" {
 		t.Errorf("entrypoint fieldRegex = %q, want ^Action$", fc.EntrypointPatterns[0].FieldRegex)
+	}
+}
+
+// TestTrackerLimitsResolved pins the rule that lets a client say nothing about
+// limits and still get the engine's behaviour: a zero means "default", and a
+// value is passed through. Without this the UI could only ever run at the
+// defaults, which is not enough for a large project (issue #233).
+func TestTrackerLimitsResolved(t *testing.T) {
+	defaults := defaultTrackerLimits()
+
+	if got := (TrackerLimits{}).resolved(); got != defaults {
+		t.Errorf("an empty request resolved to %+v, want the defaults %+v", got, defaults)
+	}
+
+	// Every field is independent: raising one must not silently reset the rest.
+	raised := TrackerLimits{MaxNodesPerTree: 2_000_000}.resolved()
+	if raised.MaxNodesPerTree != 2_000_000 {
+		t.Errorf("max nodes = %d, want the requested 2000000", raised.MaxNodesPerTree)
+	}
+	if raised.MaxChildrenPerNode != defaults.MaxChildrenPerNode ||
+		raised.MaxRecursionDepth != defaults.MaxRecursionDepth ||
+		raised.MaxArgsPerFunction != defaults.MaxArgsPerFunction ||
+		raised.MaxNestedArgsDepth != defaults.MaxNestedArgsDepth ||
+		raised.MaxInstancesPerKey != defaults.MaxInstancesPerKey {
+		t.Errorf("raising one limit changed the others: %+v", raised)
+	}
+
+	// A negative is not a limit; it means the same as unset rather than "no
+	// bound", which would turn a typo into an unbounded walk.
+	if got := (TrackerLimits{MaxNodesPerTree: -5}).resolved(); got.MaxNodesPerTree != defaults.MaxNodesPerTree {
+		t.Errorf("negative max nodes = %d, want the default", got.MaxNodesPerTree)
+	}
+
+	all := TrackerLimits{
+		MaxNodesPerTree:    1,
+		MaxChildrenPerNode: 2,
+		MaxArgsPerFunction: 3,
+		MaxNestedArgsDepth: 4,
+		MaxRecursionDepth:  5,
+		MaxInstancesPerKey: 6,
+	}
+	if got := all.resolved(); got != all {
+		t.Errorf("fully specified limits were altered: %+v, want %+v", got, all)
+	}
+}
+
+// TestAnalysisInfoReportsTruncation covers what the Insight view is told when
+// expansion stopped early — and that it says nothing when the walk finished,
+// since an absent block is what "complete" means.
+func TestAnalysisInfoReportsTruncation(t *testing.T) {
+	finished := analysisInfo("chi", []string{"chi"}, true, spec.EntrypointStats{}, spec.ExpansionStats{NodesBuilt: 120, Limit: 50000})
+	if finished.Expansion != nil {
+		t.Errorf("a completed walk reported expansion %+v, want nothing", finished.Expansion)
+	}
+
+	cut := analysisInfo("chi", []string{"chi"}, true, spec.EntrypointStats{},
+		spec.ExpansionStats{NodesBuilt: 50000, Limit: 50000, Truncated: true})
+	if cut.Expansion == nil {
+		t.Fatal("a truncated walk reported nothing")
+	}
+	if !cut.Expansion.Truncated || cut.Expansion.Limit != 50000 || cut.Expansion.NodesBuilt != 50000 {
+		t.Errorf("expansion = %+v, want the truncation and its budget", *cut.Expansion)
 	}
 }

--- a/cmd/apispecui/assets/js/actions.js
+++ b/cmd/apispecui/assets/js/actions.js
@@ -61,6 +61,7 @@ export function applyDetect(d) {
     modulePath: d.modulePath || "",
     framework: d.detectedFramework || getState().framework,
     supportedFrameworks: d.supportedFrameworks || getState().supportedFrameworks,
+    trackerDefaults: d.trackerDefaults || getState().trackerDefaults,
     openapiVersion: d.openapiVersion || getState().openapiVersion,
     frameworkConfig: d.frameworkConfig || null,
     detected: d,
@@ -95,6 +96,8 @@ export async function detectInitial() {
 // applyStatusResult restores the last completed generation's result into the
 // store (so the spec viewer / insight / banners come back after a refresh).
 function applyStatusResult(st) {
+  // The engine's own limits, so a blank field can say what it defaults to.
+  if (st && st.trackerDefaults) setState({ trackerDefaults: st.trackerDefaults });
   const r = st && st.result;
   if (r && r.ok) {
     setState({
@@ -102,6 +105,8 @@ function applyStatusResult(st) {
       lastPaths: r.pathCount || 0,
       skipped: r.skippedPackages || [],
       unresolvedSecurity: r.unresolvedSecurity || [],
+      truncated: !!r.truncated,
+      nodeLimit: r.nodeLimit || 0,
       lastGenTick: Date.now(),
     });
   } else if (st && st.hasSpec) {
@@ -246,6 +251,7 @@ function fullGenerateRequest() {
     overrides: c.overrides,
     frameworkConfig: s.frameworkConfig || undefined,
     legacyTracker: !!s.legacyTracker,
+    limits: s.limits || {},
   };
 }
 
@@ -306,9 +312,13 @@ export async function generate(opts = {}) {
         specView: "swagger",
         skipped,
         unresolvedSecurity: res.unresolvedSecurity || [],
+        truncated: !!res.truncated,
+        nodeLimit: res.nodeLimit || 0,
         genBlocked: false,
       });
-      if (skipped.length) {
+      if (res.truncated) {
+        setStatus(`generated ${res.pathCount || 0} paths · expansion hit the ${res.nodeLimit}-node limit, so routes are missing · ${took}`, "warn");
+      } else if (skipped.length) {
         setStatus(`generated ${res.pathCount || 0} paths · ${skipped.length} package(s) skipped · ${took}`, "warn");
       } else {
         setStatus(`generated ${res.pathCount || 0} paths in ${took}`, "ok");

--- a/cmd/apispecui/assets/js/config.js
+++ b/cmd/apispecui/assets/js/config.js
@@ -352,7 +352,7 @@ export function ConfigMode() {
             ${txt("Default response status", c.defaults?.responseStatus, (e) => setDefaults({ responseStatus: parseInt(e.target.value, 10) || 0 }), "200")}
           <//>
 
-          <${Section} title="Analysis engine" help="Which tracker tree powers the analysis. The lazy tracker (default) expands the call tree on demand — it covers the same wiring styles as the legacy tree, resolves some responses/bodies the legacy tree misses, and is bounded on very dense call graphs. Choose Legacy (eager) only to compare against the previous engine's output.">
+          <${Section} title="Analysis engine" help="Which tracker tree powers the analysis, and how far it is allowed to walk. The lazy tracker (default) expands the call tree on demand — it covers the same wiring styles as the legacy tree, resolves some responses/bodies the legacy tree misses, and is bounded on very dense call graphs. Choose Legacy (eager) only to compare against the previous engine's output. The limits below bound that walk; leave them blank to use the defaults shown.">
             <div class="field">
               <label>Tracker tree</label>
               <select class="input" value=${s.legacyTracker ? "legacy" : "lazy"} onChange=${(e) => setState({ legacyTracker: e.target.value === "legacy" })}>
@@ -360,6 +360,7 @@ export function ConfigMode() {
                 <option value="legacy">Legacy (eager)</option>
               </select>
             </div>
+            <${TrackerLimits} />
           <//>
 
           <${Section} title="Include / exclude filters" help="Scope the analysis: include limits it to the listed packages/files/functions/types, exclude removes them (exclude wins). One entry per line, glob-style. Tests and mocks are auto-excluded already. Examples — exclude files: **/*_test.go ; exclude packages: github.com/me/api/internal/mocks ; include packages: github.com/me/api/handlers (narrow a huge repo to just the HTTP layer to speed up generation).">
@@ -815,5 +816,53 @@ function UnresolvedMiddleware({ c }) {
       )}
       <button class="btn sm" onClick=${() => generate()}>Re-generate with mappings</button>
     </div>
+  `;
+}
+
+// TrackerLimits edits the bounds on tree expansion.
+//
+// They matter more than they look: a project whose call tree is bigger than the
+// node budget stops expanding part-way through its routes, and the result reads as
+// a working run with a short route list. gitea documents 5 paths at the default
+// budget and 862 with it raised (issue #233). Blank means the default, which the
+// server reports rather than the UI hardcoding numbers that would drift from Go.
+function TrackerLimits() {
+  const s = useStore();
+  const limits = s.limits || {};
+  const defaults = s.trackerDefaults || {};
+  const set = (key, value) => {
+    const next = { ...limits };
+    const n = parseInt(value, 10);
+    if (!value || isNaN(n) || n <= 0) {
+      delete next[key];
+    } else {
+      next[key] = n;
+    }
+    setState({ limits: next });
+  };
+  const row = (key, label, help) => html`<div class="field">
+    <label>${label} <${Info} text=${help} /></label>
+    <input
+      class="input"
+      type="number"
+      min="1"
+      value=${limits[key] ?? ""}
+      placeholder=${defaults[key] ? `default ${defaults[key]}` : "default"}
+      onInput=${(e) => set(key, e.target.value)}
+    />
+  </div>`;
+
+  return html`
+    ${s.truncated
+      ? html`<p class="muted" style="font-size:var(--fs-sm);margin:0 0 var(--sp-2);color:var(--warn)">
+          The last run stopped at the ${s.nodeLimit}-node limit, so routes past that point are missing from the spec. Raise Max nodes and generate again.
+        </p>`
+      : ""}
+    ${row("maxNodesPerTree", "Max nodes", "Total tracker nodes the walk may build. Reaching it stops expansion, so anything not yet reached is absent from the spec — the one limit worth raising first on a large project.")}
+    ${row("maxChildrenPerNode", "Max children per node", "How many callees one node may expand. A router that registers hundreds of routes in a single function needs this above the default.")}
+    ${row("maxRecursionDepth", "Max recursion depth", "How deep a call chain may be followed through repeated frames. Deeply nested group closures need more.")}
+    ${row("maxInstancesPerKey", "Max instances per key", "How many copies of one callee are expanded within a scope (roughly per handler, but per GROUP closure in practice). A response helper shared by a group exhausts this budget after that many routes, and every later route in the group silently loses its response body — raise it for a project whose groups hold many routes.")}
+    ${row("maxArgsPerFunction", "Max args per function", "How many arguments of one call are expanded.")}
+    ${row("maxNestedArgsDepth", "Max nested arg depth", "How deep a composite argument (a struct literal holding a call holding a literal) is expanded.")}
   `;
 }

--- a/cmd/apispecui/assets/js/store.js
+++ b/cmd/apispecui/assets/js/store.js
@@ -12,6 +12,17 @@ const state = {
   supportedFrameworks: ["gin", "chi", "echo", "fiber", "mux", "net/http"],
   openapiVersion: "3.1.0",
   legacyTracker: false, // analysis engine: false = lazy tracker (default), true = legacy eager
+  // Tree-expansion limits. Empty means "use the engine default" — the server
+  // fills any unset field, so the UI never has to hardcode a number that would
+  // then drift from Go (issue #233).
+  limits: {},
+  // trackerDefaults is what the server reports those defaults to be, shown as
+  // placeholders so a user can see what they are changing.
+  trackerDefaults: {},
+  // truncated/nodeLimit record that the last run stopped at the node budget, so
+  // the routes simply end — the failure that used to look like a clean result.
+  truncated: false,
+  nodeLimit: 0,
   // Full structured config edited by Configure mode. Seeded from
   // /api/detect and sent (structured) to /api/generate.
   config: {
@@ -51,7 +62,7 @@ const state = {
 
 // View prefs persisted across refreshes so a reload lands the user back where
 // they were (which tab, which spec viewer, panel layout).
-const PERSIST_KEYS = ["mode", "specView", "panelCollapsed", "legacyTracker"];
+const PERSIST_KEYS = ["mode", "specView", "panelCollapsed", "legacyTracker", "limits"];
 const PERSIST_LS_KEY = "apispecui.view";
 
 function loadPersistedView() {

--- a/cmd/apispecui/main.go
+++ b/cmd/apispecui/main.go
@@ -139,9 +139,14 @@ type DetectResponse struct {
 	Defaults            spec.Defaults                  `json:"defaults"`
 	TypeMapping         []spec.TypeMapping             `json:"typeMapping"`
 	ExternalTypes       []spec.ExternalType            `json:"externalTypes"`
-	Overrides           []spec.Override                `json:"overrides"`
-	Include             spec.IncludeExclude            `json:"include"`
-	Exclude             spec.IncludeExclude            `json:"exclude"`
+
+	// TrackerDefaults reports the engine's expansion limits so the UI can show
+	// what a blank field means, rather than hardcoding numbers that would drift
+	// from Go (issue #233).
+	TrackerDefaults TrackerLimits       `json:"trackerDefaults"`
+	Overrides       []spec.Override     `json:"overrides"`
+	Include         spec.IncludeExclude `json:"include"`
+	Exclude         spec.IncludeExclude `json:"exclude"`
 	// Framework is the full default FrameworkConfig (route/requestBody/response/
 	// param/mount patterns) for the detected framework — pre-filled so the UI
 	// can render every pattern editor.
@@ -198,6 +203,62 @@ type GenerateRequest struct {
 	// LegacyTracker switches spec generation to the legacy (eager) tracker
 	// tree; the default is the lazy tracker.
 	LegacyTracker bool `json:"legacyTracker"`
+
+	// Limits bound tree expansion. Every field is optional: a zero keeps the
+	// engine default. They are here because a project can be large enough that
+	// the default budget stops expansion part-way through its routes, and the UI
+	// had no way to raise it — gitea documents 5 paths at the default node limit
+	// and 862 with it raised (issue #233).
+	Limits TrackerLimits `json:"limits"`
+}
+
+// TrackerLimits mirrors the engine's traversal bounds, as the UI sends them.
+// Zero means "use the engine default", so a client that knows nothing about
+// limits sends nothing and gets today's behaviour.
+type TrackerLimits struct {
+	MaxNodesPerTree    int `json:"maxNodesPerTree,omitempty"`
+	MaxChildrenPerNode int `json:"maxChildrenPerNode,omitempty"`
+	MaxArgsPerFunction int `json:"maxArgsPerFunction,omitempty"`
+	MaxNestedArgsDepth int `json:"maxNestedArgsDepth,omitempty"`
+	MaxRecursionDepth  int `json:"maxRecursionDepth,omitempty"`
+	MaxInstancesPerKey int `json:"maxInstancesPerKey,omitempty"`
+}
+
+// defaultTrackerLimits is what the engine uses when the request says nothing. The
+// UI shows these so a user can see what they are changing.
+func defaultTrackerLimits() TrackerLimits {
+	return TrackerLimits{
+		MaxNodesPerTree:    engine.DefaultMaxNodesPerTree,
+		MaxChildrenPerNode: engine.DefaultMaxChildrenPerNode,
+		MaxArgsPerFunction: engine.DefaultMaxArgsPerFunction,
+		MaxNestedArgsDepth: engine.DefaultMaxNestedArgsDepth,
+		MaxRecursionDepth:  engine.DefaultMaxRecursionDepth,
+		MaxInstancesPerKey: engine.DefaultMaxInstancesPerKey,
+	}
+}
+
+// resolved returns the limits with every unset field filled from the defaults.
+func (l TrackerLimits) resolved() TrackerLimits {
+	d := defaultTrackerLimits()
+	if l.MaxNodesPerTree <= 0 {
+		l.MaxNodesPerTree = d.MaxNodesPerTree
+	}
+	if l.MaxChildrenPerNode <= 0 {
+		l.MaxChildrenPerNode = d.MaxChildrenPerNode
+	}
+	if l.MaxArgsPerFunction <= 0 {
+		l.MaxArgsPerFunction = d.MaxArgsPerFunction
+	}
+	if l.MaxNestedArgsDepth <= 0 {
+		l.MaxNestedArgsDepth = d.MaxNestedArgsDepth
+	}
+	if l.MaxRecursionDepth <= 0 {
+		l.MaxRecursionDepth = d.MaxRecursionDepth
+	}
+	if l.MaxInstancesPerKey <= 0 {
+		l.MaxInstancesPerKey = d.MaxInstancesPerKey
+	}
+	return l
 }
 
 // GenerateResponse is the result of a successful generation.
@@ -217,6 +278,12 @@ type GenerateResponse struct {
 	// security scheme. The UI offers a picker to map each to a scheme, which is
 	// persisted into securityMappings for the next generation.
 	UnresolvedSecurity []spec.MiddlewareRef `json:"unresolvedSecurity,omitempty"`
+
+	// Truncated reports that expansion stopped at the node budget rather than
+	// because it was finished, so the spec is incomplete by an unknown amount.
+	// NodeLimit is the budget it stopped at, for the message the UI shows.
+	Truncated bool `json:"truncated,omitempty"`
+	NodeLimit int  `json:"nodeLimit,omitempty"`
 }
 
 // UIServer holds shared state across requests.
@@ -608,6 +675,7 @@ func (s *UIServer) buildDetectResponse(dir string) DetectResponse {
 	}
 
 	return DetectResponse{
+		TrackerDefaults:     defaultTrackerLimits(),
 		InputDir:            dir,
 		ModuleRoot:          root,
 		ModulePath:          modPath,
@@ -829,6 +897,7 @@ func (s *UIServer) handleGenerate(w http.ResponseWriter, r *http.Request) {
 	s.genCancel = cancel
 	s.mu.Unlock()
 
+	limits := req.Limits.resolved()
 	engCfg := &engine.EngineConfig{
 		Context:                      genCtx,
 		InputDir:                     s.currentDir(),
@@ -837,11 +906,12 @@ func (s *UIServer) handleGenerate(w http.ResponseWriter, r *http.Request) {
 		Description:                  req.Info.Description,
 		OpenAPIVersion:               req.OpenAPIVersion,
 		APISpecConfig:                apiCfg,
-		MaxNodesPerTree:              engine.DefaultMaxNodesPerTree,
-		MaxChildrenPerNode:           engine.DefaultMaxChildrenPerNode,
-		MaxArgsPerFunction:           engine.DefaultMaxArgsPerFunction,
-		MaxNestedArgsDepth:           engine.DefaultMaxNestedArgsDepth,
-		MaxRecursionDepth:            engine.DefaultMaxRecursionDepth,
+		MaxNodesPerTree:              limits.MaxNodesPerTree,
+		MaxChildrenPerNode:           limits.MaxChildrenPerNode,
+		MaxArgsPerFunction:           limits.MaxArgsPerFunction,
+		MaxNestedArgsDepth:           limits.MaxNestedArgsDepth,
+		MaxRecursionDepth:            limits.MaxRecursionDepth,
+		MaxInstancesPerKey:           limits.MaxInstancesPerKey,
 		SkipCGOPackages:              true,
 		AnalyzeFrameworkDependencies: true,
 		AutoIncludeFrameworkPackages: true,
@@ -962,12 +1032,13 @@ func (s *UIServer) handleGenerate(w http.ResponseWriter, r *http.Request) {
 			summary = summarizeMetadata(genMeta, gen.ModuleRoot())
 		}
 
+		expansion := gen.GetExpansionStats()
 		now := time.Now()
 		s.mu.Lock()
 		s.currentSpec = out
 		s.currentCfg = apiCfg
 		s.currentMeta = genMeta
-		s.currentAnalysis = analysisInfo(req.Framework, detectedFrameworks, !req.LegacyTracker, gen.GetEntrypointStats())
+		s.currentAnalysis = analysisInfo(req.Framework, detectedFrameworks, !req.LegacyTracker, gen.GetEntrypointStats(), expansion)
 		s.lastGen = now
 		s.lastErr = ""
 		s.genPhase = ""
@@ -984,6 +1055,15 @@ func (s *UIServer) handleGenerate(w http.ResponseWriter, r *http.Request) {
 		if len(skipped) > 0 {
 			msg = fmt.Sprintf("%d package(s) skipped because they failed to type-check — the spec may be incomplete. Ensure the project builds (go build ./...).", len(skipped))
 		}
+		if expansion.Truncated {
+			// The failure mode this guards against is a run that LOOKS fine: the
+			// routes simply stop, with no error anywhere (issue #233).
+			trunc := fmt.Sprintf("Expansion stopped at the %d-node limit, so routes beyond that point are missing. Raise 'Max nodes' under Analysis engine and generate again.", expansion.Limit)
+			if msg != "" {
+				msg += " "
+			}
+			msg += trunc
+		}
 		resp := GenerateResponse{
 			OK:                 true,
 			Framework:          req.Framework,
@@ -993,6 +1073,8 @@ func (s *UIServer) handleGenerate(w http.ResponseWriter, r *http.Request) {
 			Message:            msg,
 			SkippedPackages:    skipped,
 			UnresolvedSecurity: gen.GetUnresolvedSecurity(),
+			Truncated:          expansion.Truncated,
+			NodeLimit:          expansion.Limit,
 		}
 		// Retain for /api/status so a page refresh can restore this result.
 		s.mu.Lock()
@@ -1063,16 +1145,17 @@ func (s *UIServer) handleStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, map[string]interface{}{
-		"running":    running,
-		"stopping":   stopping,
-		"phase":      phase,
-		"sinceMs":    sinceMs,
-		"stoppingMs": stoppingMs,
-		"hasSpec":    hasSpec,
-		"lastGenAt":  lastGen,
-		"lastError":  lastErr,
-		"projectDir": dir,
-		"result":     result, // nil until the first successful generation
+		"running":         running,
+		"stopping":        stopping,
+		"phase":           phase,
+		"sinceMs":         sinceMs,
+		"stoppingMs":      stoppingMs,
+		"hasSpec":         hasSpec,
+		"lastGenAt":       lastGen,
+		"lastError":       lastErr,
+		"projectDir":      dir,
+		"trackerDefaults": defaultTrackerLimits(),
+		"result":          result, // nil until the first successful generation
 	})
 }
 
@@ -1515,8 +1598,11 @@ func buildAPISpecConfig(req *GenerateRequest, dir string) (*spec.APISpecConfig, 
 // analysisInfo assembles what the Insight view reports about the run itself.
 // primary is the framework whose patterns led (the request's choice, or the first
 // detected one, which buildAPISpecConfig has already filled in).
-func analysisInfo(primary string, detected []string, lazy bool, ep spec.EntrypointStats) insight.AnalysisInfo {
+func analysisInfo(primary string, detected []string, lazy bool, ep spec.EntrypointStats, expansion spec.ExpansionStats) insight.AnalysisInfo {
 	info := insight.AnalysisInfo{Frameworks: detected, Primary: primary}
+	if expansion.Truncated {
+		info.Expansion = &insight.ExpansionInfo{NodesBuilt: expansion.NodesBuilt, Limit: expansion.Limit, Truncated: true}
+	}
 	if lazy {
 		info.Engine = "lazy"
 	} else {

--- a/cmd/apispecui/main.go
+++ b/cmd/apispecui/main.go
@@ -281,7 +281,9 @@ type GenerateResponse struct {
 
 	// Truncated reports that expansion stopped at the node budget rather than
 	// because it was finished, so the spec is incomplete by an unknown amount.
-	// NodeLimit is the budget it stopped at, for the message the UI shows.
+	// NodeLimit is the budget it stopped AT, so it is set only alongside
+	// Truncated: a completed run never stopped at one, and a number there would
+	// read as a bound that was hit (CodeRabbit, PR #234).
 	Truncated bool `json:"truncated,omitempty"`
 	NodeLimit int  `json:"nodeLimit,omitempty"`
 }
@@ -1074,7 +1076,9 @@ func (s *UIServer) handleGenerate(w http.ResponseWriter, r *http.Request) {
 			SkippedPackages:    skipped,
 			UnresolvedSecurity: gen.GetUnresolvedSecurity(),
 			Truncated:          expansion.Truncated,
-			NodeLimit:          expansion.Limit,
+		}
+		if expansion.Truncated {
+			resp.NodeLimit = expansion.Limit
 		}
 		// Retain for /api/status so a page refresh can restore this result.
 		s.mu.Lock()

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -95,6 +95,9 @@ const (
 	DefaultMaxArgsPerFunction = 100
 	DefaultMaxNestedArgsDepth = 100
 	DefaultMaxRecursionDepth  = 10
+	// DefaultMaxInstancesPerKey mirrors the lazy tree's own default, so the
+	// engine reports one number rather than two that can drift.
+	DefaultMaxInstancesPerKey = intspec.DefaultMaxInstancesPerKey
 	DefaultMetadataFile       = "metadata.yaml"
 	CopyrightNotice           = "apispec - Copyright 2026 Ehab Terra"
 	LicenseNotice             = "Licensed under the Apache License 2.0. See LICENSE and NOTICE."
@@ -128,6 +131,9 @@ type EngineConfig struct {
 	MaxArgsPerFunction int
 	MaxNestedArgsDepth int
 	MaxRecursionDepth  int
+	// MaxInstancesPerKey bounds copies of one callee within an instance scope.
+	// Zero uses DefaultMaxInstancesPerKey.
+	MaxInstancesPerKey int
 
 	// Include/exclude filters
 	IncludeFiles                 []string
@@ -249,6 +255,10 @@ type Engine struct {
 	// can warn that the spec may be incomplete. Keyed by package path → first
 	// error message.
 	skipped []SkippedPackage
+
+	// expansionStats records how far tree expansion got during the last
+	// generation, and whether the node budget cut it short (issue #233).
+	expansionStats intspec.ExpansionStats
 
 	// entrypointStats records what the entrypoint gate decided during the last
 	// generation (issue #220): how many field-stored functions were found and how
@@ -752,6 +762,7 @@ func (e *Engine) GenerateOpenAPI() (*spec.OpenAPISpec, error) {
 		MaxArgsPerFunction: e.config.MaxArgsPerFunction,
 		MaxNestedArgsDepth: e.config.MaxNestedArgsDepth,
 		MaxRecursionDepth:  e.config.MaxRecursionDepth,
+		MaxInstancesPerKey: e.config.MaxInstancesPerKey,
 	}
 	if err := e.ctx().Err(); err != nil {
 		return nil, err
@@ -791,6 +802,16 @@ func (e *Engine) GenerateOpenAPI() (*spec.OpenAPISpec, error) {
 		EntrypointStats() intspec.EntrypointStats
 	}); ok {
 		e.entrypointStats = reporter.EntrypointStats()
+	}
+	if reporter, ok := tree.(interface {
+		ExpansionStats() intspec.ExpansionStats
+	}); ok {
+		e.expansionStats = reporter.ExpansionStats()
+		if e.expansionStats.Truncated {
+			// Louder than the tree's own stderr line: a truncated expansion means
+			// the spec is incomplete, which is a result, not a debug detail.
+			e.reportPhase(fmt.Sprintf("expansion truncated at the %d-node limit — the spec is incomplete", e.expansionStats.Limit), 0)
+		}
 	}
 	e.reportPhase(fmt.Sprintf("spec mapped (%d paths)", len(openAPISpec.Paths)), time.Since(tSpec))
 
@@ -1143,6 +1164,12 @@ func (e *Engine) GetMetadata() *metadata.Metadata {
 // generation that matched no SecurityMapping (deduped). Empty when none.
 func (e *Engine) GetUnresolvedSecurity() []intspec.MiddlewareRef {
 	return e.unresolvedSecurity
+}
+
+// GetExpansionStats returns how far tree expansion got during the most recent
+// generation, including whether the node budget stopped it early.
+func (e *Engine) GetExpansionStats() intspec.ExpansionStats {
+	return e.expansionStats
 }
 
 // GetEntrypointStats returns what the entrypoint gate decided during the most

--- a/internal/insight/overview.go
+++ b/internal/insight/overview.go
@@ -126,6 +126,15 @@ type EntrypointInfo struct {
 	NoRoutes         int `json:"noRoutes"`         // ...skipped: their subtree registers no route
 }
 
+// ExpansionInfo reports that tree expansion stopped at its node budget instead of
+// finishing. Everything past that point is missing from the spec, so a route count
+// read without it can be wildly wrong (issue #233).
+type ExpansionInfo struct {
+	NodesBuilt int  `json:"nodesBuilt"`
+	Limit      int  `json:"limit"`
+	Truncated  bool `json:"truncated"`
+}
+
 // AnalysisInfo describes HOW the spec was produced rather than what is in it.
 // None of it is derivable from the spec, so BuildOverview leaves it empty and the
 // caller (the UI server, which ran the analysis) fills it in.
@@ -134,6 +143,10 @@ type AnalysisInfo struct {
 	Primary     string          `json:"primary,omitempty"`    // the one whose patterns lead
 	Engine      string          `json:"engine,omitempty"`     // tracker engine used
 	Entrypoints *EntrypointInfo `json:"entrypoints,omitempty"`
+
+	// Expansion is set only when expansion was cut short — its absence means the
+	// walk finished, which is the ordinary case.
+	Expansion *ExpansionInfo `json:"expansion,omitempty"`
 }
 
 // CoverMetric is a have-of-total coverage tally.

--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -1281,6 +1281,11 @@ type TrackerLimits struct {
 	MaxArgsPerFunction int
 	MaxNestedArgsDepth int
 	MaxRecursionDepth  int
+
+	// MaxInstancesPerKey bounds copies of one callee within an instance scope —
+	// see the lazy tree's DefaultMaxInstancesPerKey for what the number trades
+	// off. Zero means that default.
+	MaxInstancesPerKey int
 }
 
 // ProcessFunctionReturnTypes processes all functions and methods in the metadata

--- a/internal/spec/entrypoint_roots.go
+++ b/internal/spec/entrypoint_roots.go
@@ -222,3 +222,17 @@ func RouteRegistrationMatcher(cfg *APISpecConfig, meta *metadata.Metadata) func(
 		return false
 	}
 }
+
+// ExpansionStats reports how far tree expansion got.
+//
+// Truncated is the fact worth surfacing: expansion stopped because it ran out of
+// node budget, not because there was nothing left to expand, so the spec is
+// incomplete by an unknown amount. On a large project that reads as a working run
+// with a suspiciously short route list — gitea documents 5 paths at the default
+// limit and 862 with the budget raised — and the only sign was a line on stderr
+// (issue #233).
+type ExpansionStats struct {
+	NodesBuilt int
+	Limit      int
+	Truncated  bool
+}

--- a/internal/spec/lazytree.go
+++ b/internal/spec/lazytree.go
@@ -62,6 +62,12 @@ type LazyTree struct {
 	// report it (the numbers otherwise live only in a --verbose line).
 	entrypointStats EntrypointStats
 
+	// truncated records that expansion stopped at the node budget rather than
+	// because there was nothing left to expand. It is the difference between a
+	// spec that is complete and one that simply ends, and it used to be visible
+	// only as a line on stderr (issue #233).
+	truncated bool
+
 	// calleeEdges memoizes, per function base key, the filtered+ordered call
 	// edges used to expand any node of that function. Computed once.
 	calleeEdges map[string][]*metadata.CallGraphEdge
@@ -109,7 +115,7 @@ type LazyTree struct {
 	nodesBuilt int
 
 	// instanceCount counts node copies per (instance scope, callee ID) —
-	// see maxInstancesPerKey. A node is (edge, parent), so a callee reached
+	// see DefaultMaxInstancesPerKey. A node is (edge, parent), so a callee reached
 	// along many paths gets many copies; business-layer diamonds make that
 	// exponential and would drain the node budget before traversal reaches
 	// later router wiring. Nested by scope to avoid a key concatenation per
@@ -161,7 +167,7 @@ type LazyTree struct {
 	seenKeys map[string]bool
 }
 
-// maxInstancesPerKey bounds node copies of the same callee WITHIN one
+// DefaultMaxInstancesPerKey bounds node copies of the same callee WITHIN one
 // instance scope (the subtree of the nearest argument-node ancestor —
 // approximately "per handler"). Scoping matters: a response helper shared by
 // every handler legitimately needs one copy per route for per-route value
@@ -195,7 +201,19 @@ type LazyTree struct {
 // would be ample everywhere and no project would pay for another's shape. Until
 // then this stays a mitigation — a group with more than ~25 routes sharing one
 // helper still starves, silently.
-const maxInstancesPerKey = 25
+const DefaultMaxInstancesPerKey = 25
+
+// instanceBudget is the cap in force for this tree: the configured value, or the
+// default. It is configurable because the right number depends on a project's
+// shape — a group closure holding 40 routes needs more than one holding 5, and
+// until the cap is scoped per route (issue #224) the only way to document such a
+// project is to raise it.
+func (t *LazyTree) instanceBudget() int {
+	if t.limits.MaxInstancesPerKey > 0 {
+		return t.limits.MaxInstancesPerKey
+	}
+	return DefaultMaxInstancesPerKey
+}
 
 // budgetExhausted reports whether the cumulative node budget is spent.
 func (t *LazyTree) budgetExhausted() bool {
@@ -513,6 +531,12 @@ func (t *LazyTree) edgesFor(baseKey string) []*metadata.CallGraphEdge {
 // the extractor asks for roots BEFORE it expands anything. Deferring left the
 // extra roots invisible — the tree had them, nobody ever saw them. The call is
 // memoized, so this only moves work that every expansion path pays anyway.
+// ExpansionStats reports how far expansion got, and whether it stopped early.
+func (t *LazyTree) ExpansionStats() ExpansionStats {
+	t.buildRelations()
+	return ExpansionStats{NodesBuilt: t.nodesBuilt, Limit: t.limits.MaxNodesPerTree, Truncated: t.truncated}
+}
+
 // EntrypointStats reports what the entrypoint gate decided during this tree's
 // build. Zero when the project declares no entrypoints.
 func (t *LazyTree) EntrypointStats() EntrypointStats {
@@ -596,7 +620,7 @@ func (n *LazyNode) GetTypeParamMap() map[string]string {
 
 // onPath reports whether key is already an ancestor of n (cycle guard: the
 // per-path state a lazy unfolding needs, in contrast to a global seen-set).
-// instanceScope identifies the counting scope for maxInstancesPerKey: the
+// instanceScope identifies the counting scope for the instance budget: the
 // key of the nearest argument-node ancestor (the handler/value subtree this
 // node belongs to), or "" at wiring level. Each scope gets its own copy
 // allowance, so shared helpers trace per route while intra-handler diamonds
@@ -661,6 +685,7 @@ func (n *LazyNode) GetChildren() []TrackerNodeInterface {
 		return n.children
 	}
 	if n.tree.budgetExhausted() {
+		n.tree.truncated = true
 		if !n.tree.budgetWarned {
 			n.tree.budgetWarned = true
 			fmt.Fprintf(os.Stderr,
@@ -688,7 +713,7 @@ func (n *LazyNode) GetChildren() []TrackerNodeInterface {
 		if n.onPath(spec.key) {
 			continue // cycle: this call is already on the current path
 		}
-		if scopeCounts[spec.key] >= maxInstancesPerKey {
+		if scopeCounts[spec.key] >= n.tree.instanceBudget() {
 			// Diamond inside this scope: stop materializing further copies.
 			// Reusing an existing instance instead would make the tree cyclic
 			// (consumers of a memoized subtree could reach themselves), so the

--- a/internal/spec/lazytree_budget_test.go
+++ b/internal/spec/lazytree_budget_test.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// TestInstanceBudget covers the configurable copy cap. It is configurable because
+// the default is a compromise: the scope is a group closure rather than a route,
+// so a group holding more routes than the budget starves every later route of its
+// response body (issue #224). Until that scoping is fixed, raising the number is
+// the only way to document such a project — which a constant does not allow.
+func TestInstanceBudget(t *testing.T) {
+	unset := &LazyTree{}
+	if got := unset.instanceBudget(); got != DefaultMaxInstancesPerKey {
+		t.Errorf("unset budget = %d, want the default %d", got, DefaultMaxInstancesPerKey)
+	}
+
+	configured := &LazyTree{limits: metadata.TrackerLimits{MaxInstancesPerKey: 200}}
+	if got := configured.instanceBudget(); got != 200 {
+		t.Errorf("configured budget = %d, want 200", got)
+	}
+
+	// A negative is not a budget; it means the same as unset rather than "no
+	// cap", so a typo cannot turn the walk loose.
+	negative := &LazyTree{limits: metadata.TrackerLimits{MaxInstancesPerKey: -1}}
+	if got := negative.instanceBudget(); got != DefaultMaxInstancesPerKey {
+		t.Errorf("negative budget = %d, want the default", got)
+	}
+}

--- a/internal/spec/lazytree_budget_test.go
+++ b/internal/spec/lazytree_budget_test.go
@@ -15,6 +15,8 @@
 package spec
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/ehabterra/apispec/internal/metadata"
@@ -41,5 +43,90 @@ func TestInstanceBudget(t *testing.T) {
 	negative := &LazyTree{limits: metadata.TrackerLimits{MaxInstancesPerKey: -1}}
 	if got := negative.instanceBudget(); got != DefaultMaxInstancesPerKey {
 		t.Errorf("negative budget = %d, want the default", got)
+	}
+}
+
+// sharedHelperGraph builds the shape the cap exists for: `main` calls
+// `step1..stepN`, each of those calls `helper`, and `helper` calls `shared` at ONE
+// call site.
+//
+// That single site is what gets copied — once per path that reaches it — so all N
+// copies share a key and count against one budget. Copies of a key, not distinct
+// call sites, is what the cap bounds: N separate calls to `shared` would be N
+// different keys and would never touch it.
+func sharedHelperGraph(callers int) *metadata.Metadata {
+	pool := metadata.NewStringPool()
+	meta := &metadata.Metadata{StringPool: pool}
+	pkg := pool.Get("example")
+
+	// Pooled fields use -1 for "unset"; 0 is a valid index, so the zero value
+	// would resolve to a real string.
+	call := func(name, position string) metadata.Call {
+		return metadata.Call{
+			Meta: meta, Name: pool.Get(name), Pkg: pkg, Position: pool.Get(position),
+			RecvType: -1, Scope: -1, SignatureStr: -1,
+		}
+	}
+
+	// One position for main across every edge: a root is minted per distinct
+	// caller instance, and several roots would each walk the whole graph again.
+	mainCall := call(metadata.MainFunc, "main.go:1:1")
+	for i := 1; i <= callers; i++ {
+		step := fmt.Sprintf("step%d", i)
+		meta.CallGraph = append(meta.CallGraph,
+			metadata.CallGraphEdge{Caller: mainCall, Callee: call(step, fmt.Sprintf("main.go:%d:2", i))},
+			metadata.CallGraphEdge{Caller: call(step, fmt.Sprintf("step.go:%d:1", i)), Callee: call("helper", fmt.Sprintf("step.go:%d:2", i))},
+		)
+	}
+	// The one site every path converges on.
+	meta.CallGraph = append(meta.CallGraph,
+		metadata.CallGraphEdge{Caller: call("helper", "helper.go:1:1"), Callee: call("shared", "helper.go:2:2")},
+	)
+	meta.BuildCallGraphMaps()
+	return meta
+}
+
+// countKey walks the whole tree and counts nodes whose key names fn.
+func countKey(nodes []TrackerNodeInterface, fn string) int {
+	n := 0
+	for _, node := range nodes {
+		if strings.Contains(node.GetKey(), "."+fn) {
+			n++
+		}
+		n += countKey(node.GetChildren(), fn)
+	}
+	return n
+}
+
+// TestInstanceBudgetCapsTraversal is the behavioural half: the configured number
+// is what the walk actually admits.
+//
+// Six functions call one shared helper. Copies of that helper are what the cap
+// counts, so a budget of three has to yield three copies and a budget above the
+// demand has to yield all six — the difference between a project whose later
+// routes keep their response bodies and one where they silently vanish (#224).
+func TestInstanceBudgetCapsTraversal(t *testing.T) {
+	const callers = 6
+
+	tests := []struct {
+		name   string
+		budget int
+		want   int
+	}{
+		{"a budget below the demand admits exactly the budget", 3, 3},
+		{"a budget above the demand admits every copy", 50, callers},
+		{"unset uses the default, which covers this demand", 0, callers},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := NewLazyTree(sharedHelperGraph(callers), metadata.TrackerLimits{
+				MaxNodesPerTree:    10000,
+				MaxChildrenPerNode: 100,
+				MaxInstancesPerKey: tc.budget,
+			})
+			if got := countKey(tree.GetRoots(), "shared"); got != tc.want {
+				t.Errorf("budget %d admitted %d copies of the shared helper, want %d", tc.budget, got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/spec/tracker.go
+++ b/internal/spec/tracker.go
@@ -266,6 +266,10 @@ type TrackerTree struct {
 	entrypointKeys     []string
 	entrypointStats    EntrypointStats
 
+	// truncated records that the node budget stopped expansion — see
+	// LazyTree.truncated (issue #233).
+	truncated bool
+
 	// logger receives traversal-time warnings (limit truncations, etc.).
 	// May be nil; callers should reach it via t.warn / t.info.
 	logger metadata.VerboseLogger
@@ -1436,6 +1440,7 @@ func NewTrackerNode(tree *TrackerTree, meta *metadata.Metadata, parentID, id str
 	// synthetic tests that drive NewTrackerNode directly — the cumulative
 	// counter needs a tree, so it is simply disabled there.
 	if tree != nil && limits.MaxNodesPerTree > 0 && tree.nodesBuilt >= limits.MaxNodesPerTree {
+		tree.truncated = true
 		// A single global key: once the cumulative cap is hit it is a tree-wide
 		// condition, so warn exactly once rather than once per truncated node.
 		tree.warnOnce("maxnodes",
@@ -1742,6 +1747,11 @@ func NewTrackerNode(tree *TrackerTree, meta *metadata.Metadata, parentID, id str
 	}
 
 	return node
+}
+
+// ExpansionStats reports how far expansion got, and whether it stopped early.
+func (t *TrackerTree) ExpansionStats() ExpansionStats {
+	return ExpansionStats{NodesBuilt: t.nodesBuilt, Limit: t.limits.MaxNodesPerTree, Truncated: t.truncated}
 }
 
 // EntrypointStats reports what the entrypoint gate decided during this tree's


### PR DESCRIPTION
Closes #233.

## The gap

The UI hardcoded the engine's traversal limits. A project whose call tree outgrows them cannot be documented from the UI at all — and nothing says why; the routes just stop.

| gitea, with house-router patterns configured | paths |
|---|---:|
| default limits | 5 |
| raised | **862** |

Five paths reads as a working run, not a truncated one.

## Limits are editable

The generate request carries them (every field optional; the server fills what it is not given, so an old client behaves exactly as before). The **Analysis engine** section edits all six, with the engine's defaults shown as placeholders — reported by the server rather than hardcoded in JavaScript, which would be a second copy free to drift from Go.

## A truncated expansion is now reported

Both trees already knew; the lazy tree counts nodes and warns on **stderr**, where the UI cannot see it. That fact now travels out through the engine (the same plumbing as entrypoint stats in #227) and appears three ways:

- an engine phase line;
- a warning on the generate result — *"Expansion stopped at the 50000-node limit, so routes beyond that point are missing. Raise 'Max nodes' under Analysis engine and generate again."*;
- the Insight analysis card.

Verified end to end in the browser: with **Max nodes = 200** the status bar reads *"generated 0 paths · expansion hit the 200-node limit, so routes are missing"* and the section shows the same in context; unset, the same project generates 333 paths with no warning.

## maxInstancesPerKey becomes a real limit

It was a constant, and it is the one whose default is a compromise: the scope is a *group closure* rather than a route, so a group holding more routes than the budget starves every later route of its response body (#224). Raising it is the only remedy until that scoping is fixed, which a constant does not allow.

Measured on a ~330-route service:

| `--max-instances-per-key` | success bodies |
|---|---|
| 5 | 77 / 391 |
| 25 (default) | 391 / 391 |

Exposed as a CLI flag (`--max-instances-per-key`), a UI field, and a README row with the trade written out — including why raising it is not free for projects that gain nothing from it.

## Verification

- Zero output drift across the fixture suite: defaults unchanged, and unset still means default on every path.
- Full suite, `go vet`, `gofmt`, `golangci-lint` (0 issues); coverage 96.0% against the 96% floor.
- New tests: limit resolution (unset/negative/partial/full), the instance budget, and what the Insight card is told when a walk is cut short versus when it finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable tracker expansion limits in the UI and CLI, including per-key instance limits.
  - Saved limit settings between sessions and displayed server-provided defaults.
  - Added expansion status reporting, including nodes built and whether generation was truncated.
  - Added clear warnings when generation stops at the node limit.

- **Documentation**
  - Updated CLI and performance guidance for tracker expansion limits and scoping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->