### PR TITLE
feat(spec): derive a project's own router and context patterns instead of requiring them (#235)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 - [How It Works](#how-it-works)
   - [The pipeline, step by step](#the-pipeline-step-by-step)
 - [Configuration](#configuration)
+  - [Automatic wrapper detection](#automatic-wrapper-detection)
 - [Programmatic Usage](#programmatic-usage)
 - [Performance & Limits](#performance--limits)
 - [Development](#development)
@@ -180,6 +181,13 @@ See also: [`cmd/apispec/README.md`](cmd/apispec/README.md).
 
 `apispecui` is a small local web server that lets you configure APISpec interactively, generate a spec on demand, immediately preview it through embedded **Swagger UI**, **Redoc**, or **Scalar** viewers, *and* explore the project's call graph at `/diagram` — the same interactive, paginated visualization that `apidiag` provides, hosted on the same port and project.
 
+Two things worth knowing before a first run on a large project:
+
+- **Analysis engine** edits the expansion limits (see [Limits](#limits)), with the engine's defaults shown as placeholders. A project whose call tree is bigger than the default budget needs them raised.
+- When expansion does stop early, the result says so — *"Expansion stopped at the 50000-node limit, so routes beyond that point are missing"* — so a truncated run no longer reads as a complete one with a short route list.
+
+**Insight** (the ◷ tab) reports how the spec was produced, not just what is in it: which frameworks were detected and which one's patterns lead, what the CLI entry-point gate decided, and — per status code — how many responses describe their fields, are a free-form object, were found with an unresolved type, or document no body at all. The last split is the useful one: an empty body at `200` means the write was never followed, while an unresolved type means it was found and needs a type mapping.
+
 ```bash
 # Build and run
 go build -o apispecui ./cmd/apispecui
@@ -323,7 +331,8 @@ APISpec aims for practical coverage of real-world Go services. A quick survey of
 - Form and file-upload request bodies — form reads on a body-bearing method become a request body (query parameters on `GET`, where Go's `FormValue` reads the URL). The media type follows how the handler parses the body: a file part (`r.FormFile("avatar")`, `c.FormFile(…)`) or an explicit `r.ParseMultipartForm` / `c.MultipartForm()` makes it `multipart/form-data` with the file as `type: string, format: binary`, and plain form values alone stay `application/x-www-form-urlencoded`. See `testdata/multipart_upload/`, `testdata/multipart_upload_gin/`.
 - **CLI-dispatched services** — when the routing code hangs off a command library's callback (`&cli.Command{Action: runWeb}`, `&cobra.Command{RunE: runServe}`), the dispatcher that invokes it lives inside the library, so no call edge reaches the registration and such a project used to document **nothing**. APISpec treats those fields as *entrypoints*, roots the function they hold, and documents everything below it. Presets ship for **urfave/cli** v1/v2/v3, **spf13/cobra** (`Run`/`RunE` and the Pre/Post hooks) and **peterbourgon/ff** (ffcli `Exec`), keyed on the project's imports; a house dispatcher declares its own field via `entrypointPatterns`. Only entrypoints that are otherwise unreachable *and* whose subtree actually registers routes are rooted, so a CLI with 50 subcommands pays for the one that serves HTTP. See `testdata/cli_entrypoint_routes/` (real urfave/cli), `testdata/cobra_entrypoint_routes/` (real cobra).
 - Route registration behind a **func-typed struct field** invoked in-module (`app.Commands = []*Command{{Action: runWeb}}`, and the same shape for any house dispatcher) — the field's recorded values are followed into the functions they hold, including a package-level command var, a cross-package function value, a method value, and an inline closure. See `testdata/cli_action_routes/`, `testdata/cli_action_cross_package/`.
-- Authentication / security detection — see [Security & authentication detection](#security--authentication-detection). Protected routes get a per-operation `security` requirement and the scheme is registered under `components.securitySchemes`; explicitly-public routes render `security: []`. Middleware is followed across router-wide `Use`, group/subtree closures, per-route chains (chi `With`), and handler wrappers (`net/http`, mux), including look-through into wrapper bodies that call a known auth library.
+- **House routers and house contexts, detected automatically** — a project that puts its own type in front of the framework (`func (r *Router) Get(pattern string, h ...any)` delegating to chi, and a `Ctx` whose `JSON`/`Bind`/`Query` methods answer, decode and read parameters) is documented with **no configuration**. See [Automatic wrapper detection](#automatic-wrapper-detection).
+- Authentication / security detection — see [Security & authentication detection](#security--authentication). Protected routes get a per-operation `security` requirement and the scheme is registered under `components.securitySchemes`; explicitly-public routes render `security: []`. Middleware is followed across router-wide `Use`, group/subtree closures, per-route chains (chi `With`), and handler wrappers (`net/http`, mux), including look-through into wrapper bodies that call a known auth library.
 
 **Partial / not yet supported**
 
@@ -331,7 +340,7 @@ APISpec aims for practical coverage of real-world Go services. A quick survey of
 - Receiver/parent type tracing is limited; `Decode` on non-body targets may be misclassified (see [Request body source disambiguation](#request-body-source-disambiguation)).
 - Only `go-playground/validator`-style `validate:` tags are read; Gin/Echo `binding:` tags and comparison validators (`gt`/`gte`/`lt`/`lte`) are not yet mapped.
 - Routes registered from a **table** rather than a call (`for _, r := range routes { adapter.Add(r.Method, r.Path, r.Handler) }`) — the paths exist only as runtime values, so no pattern can recover them.
-- Router **wrappers** (a house `Router` type around chi/gin) need their own patterns, and a registration matched *inside* the wrapper currently yields an unresolved path — tracked in [#221](https://github.com/ehabterra/apispec/issues/221).
+- House routers whose registration is **chained through a returned object** (gitea's `Combo("/x").Get(h).Post(h)`, where the path is held by the object rather than passed to each call) are reported as detected-but-incomplete and left unapplied, rather than guessed at.
 - Command libraries that dispatch through a **factory map** (`mitchellh/cli`, `hashicorp/cli`) or through **reflection-invoked methods** (`alecthomas/kong`) are not covered by `entrypointPatterns`, which names struct fields.
 
 ### Selected capability highlights
@@ -356,6 +365,8 @@ type User struct {
     ID UserID // → integer / int64
 }
 ```
+
+A field's enum is built from the constants declared with **that** type. Two types sharing an underlying type (`type Status string` and `type Band string`, or two `= string` aliases) are different types, so one never lends its values to the other — and where the values genuinely cannot be attributed to one type, no enum is emitted rather than a guess. See `testdata/enum_alias_ambiguity/`.
 
 </details>
 
@@ -686,6 +697,18 @@ framework:
       methodFromCall: true
       pathFromArg: true
       handlerFromArg: true
+    # A registrar whose verb travels as an ARGUMENT, and may name several:
+    # `Methods("GET,POST", "/search", h)` registers both. A house router like
+    # this is derived automatically (see "Automatic wrapper detection"), so
+    # write it out only to override what was derived.
+    - callRegex: ^Methods$
+      recvTypeRegex: ^example\.com/app\.\*?Router$
+      methodFromArg: true
+      methodArgIndex: 0
+      pathFromArg: true
+      pathArgIndex: 1
+      handlerFromArg: true
+      handlerArgIndex: 2
   requestBodyPatterns:
     - callRegex: ^(?i)(BindJSON|ShouldBindJSON|BindXML|BindYAML|BindForm|ShouldBind)$
       typeFromArg: true
@@ -731,6 +754,53 @@ Run with `--verbose` to see what it did:
 ```
 Entrypoints: 53 declared, 1 rooted (0 already reachable, 52 register no routes)
 ```
+
+### Automatic wrapper detection
+
+Plenty of projects do not call the framework directly. They put their own router in front of it, and answer through their own context:
+
+```go
+func (r *Router) Get(pattern string, h ...any) { r.Methods("GET", pattern, h...) }
+func (r *Router) Methods(methods, pattern string, h ...any) {
+	r.chiRouter.Method(methods, r.getPattern(pattern), unwrap(h))     // the framework call is in HERE
+}
+
+func (c *Ctx) JSON(status int, body any) { c.Resp.WriteHeader(status); json.NewEncoder(c.Resp).Encode(body) }
+func (c *Ctx) Bind(dst any) error       { return json.NewDecoder(c.Req.Body).Decode(dst) }
+```
+
+The framework's own patterns cannot see any of it: by the time the chi call happens, the path and handler are the wrapper's *parameters*, not literals. Such a project used to document nothing until someone wrote patterns for it by hand.
+
+APISpec now derives those patterns, from one fact — **a method of a project type that forwards its own parameters into a call APISpec already recognises**:
+
+| written as | derived as |
+|---|---|
+| `Get(pattern, h...)` → `Methods("GET", …)` → chi | a route pattern, verb from the method name |
+| `Methods(verb, pattern, h...)` | a route pattern, verb from the argument (`GET,POST` registers both) |
+| `Group(prefix, func(){…})` | a mount pattern — the prefix applies to everything inside |
+| `Ctx.JSON(status, body)` | a response pattern, status and body merged from the two calls it makes |
+| `Ctx.Bind(dst)` | a request-body pattern |
+| `Ctx.Query(name)` | a parameter pattern, location taken from what it reads |
+
+Derivation is transitive (verb methods → one registrar → the framework, and a context that encodes through the project's own json package), and it follows a value through a call, an index or a chain of assignments — so a router that unwraps a variadic `...any` resolves like one that forwards directly.
+
+What it deliberately does **not** do is guess:
+
+- a method that names its route with literals (`func (s *Server) routes() { r.Get("/users", h) }`) is a registration, not a way of registering, and derives nothing;
+- a plain function is skipped — there is no type to scope a pattern to;
+- a dependency's method is skipped — describing it would not document your project;
+- a derivation that cannot resolve every role it needs is **reported but not applied**, because a pattern missing its path produces routes at the wrong path.
+
+Everything derived is listed with `--verbose` and lands in `--output-config`, so it can be reviewed, pinned into a config file, or corrected:
+
+```text
+Router wrappers: example.com/app.*Router [Delete Get Post Put] route via example.com/app.Methods (applied);
+                 example.com/app.*Router [Group] mount via prefix held by example.com/app.*Router (applied);
+                 example.com/app.*Ctx [JSON] response via net/http.WriteHeader (applied);
+                 example.com/app.*Combo [Get] route via example.com/app.Get (incomplete, not applied)
+```
+
+Measured on gitea (its `modules/web.Router` around chi): **3 paths → 856**, with no config at all. See `testdata/wrapper_router/`.
 
 ### Custom type mapping
 
@@ -784,7 +854,7 @@ When omitted, APISpec falls back to its prior receiver-only matching, so existin
 
 ### Security / authentication
 
-Most auth setups are detected with no config (see [Security & authentication detection](#security--authentication-detection)). When you use a custom middleware, map its identity to a scheme with `securityMappings`, and — if needed — describe how it's applied with `framework.securityPatterns`:
+Most auth setups are detected with no config (see [Security & authentication detection](#security--authentication)). When you use a custom middleware, map its identity to a scheme with `securityMappings`, and — if needed — describe how it's applied with `framework.securityPatterns`:
 
 ```yaml
 framework:

--- a/cmd/apispecui/main.go
+++ b/cmd/apispecui/main.go
@@ -998,7 +998,7 @@ func (s *UIServer) handleGenerate(w http.ResponseWriter, r *http.Request) {
 			cancel()
 			finishRun()
 		}()
-		writeJSON(w, http.StatusOK, map[string]interface{}{"ok": false, "cancelled": true, "message": "generation stopped"})
+		writeJSON(w, http.StatusOK, map[string]any{"ok": false, "cancelled": true, "message": "generation stopped"})
 		return
 
 	case res := <-done:
@@ -1006,7 +1006,7 @@ func (s *UIServer) handleGenerate(w http.ResponseWriter, r *http.Request) {
 		// If a Force superseded this run, discard its results untouched — the
 		// newer run owns the shared state and the client reply.
 		if superseded() {
-			writeJSON(w, http.StatusOK, map[string]interface{}{"ok": false, "cancelled": true, "message": "superseded by a newer generation"})
+			writeJSON(w, http.StatusOK, map[string]any{"ok": false, "cancelled": true, "message": "superseded by a newer generation"})
 			return
 		}
 		defer finishRun()
@@ -1020,7 +1020,7 @@ func (s *UIServer) handleGenerate(w http.ResponseWriter, r *http.Request) {
 			}
 			s.mu.Unlock()
 			if cancelled {
-				writeJSON(w, http.StatusOK, map[string]interface{}{"ok": false, "cancelled": true, "message": "generation stopped"})
+				writeJSON(w, http.StatusOK, map[string]any{"ok": false, "cancelled": true, "message": "generation stopped"})
 				return
 			}
 			writeError(w, http.StatusInternalServerError, "generation failed: "+res.err.Error())

--- a/generator/testdata_wrapper_router_test.go
+++ b/generator/testdata_wrapper_router_test.go
@@ -144,6 +144,57 @@ func TestTestdata_WrapperRouter(t *testing.T) {
 	}
 }
 
+// TestTestdata_WrapperRouterIsDetected is the same fixture with NO wrapper
+// patterns configured: chi's defaults only, exactly what a user gets by pointing
+// apispec at the project.
+//
+// The wrapper is derived from the parameter flow — a method of the project's own
+// type that forwards its own parameters into a framework registration is a
+// registrar, and the framework call it delegates to says which parameter plays
+// which role (issue #235). Before that, this run documented one junk route.
+func TestTestdata_WrapperRouterIsDetected(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "wrapper_router", intspec.DefaultChiConfig())
+	noDanglingRefs(t, out)
+	noUnresolvedPlaceholders(t, out)
+
+	// The same set the hand-written config produces, including the group prefix
+	// (held in a field, so only the Group call states it) and both verbs of the
+	// one registration that names two.
+	want := []struct{ method, path, handler string }{
+		{"GET", "/users", "listUsers"},
+		{"POST", "/users", "createUser"},
+		{"GET", "/api/items", "getItem"},
+		{"GET", "/api/items/search", "searchItems"},
+		{"POST", "/api/items/search", "searchItems"},
+		{"GET", "/api/items/count", "countItems"},
+	}
+	for _, tc := range want {
+		op := opFor(out.Paths[tc.path], tc.method)
+		if op == nil {
+			t.Errorf("%s %s missing with detection only; have %v", tc.method, tc.path, mapPathKeys(out.Paths))
+			continue
+		}
+		if !strings.Contains(op.OperationID, tc.handler) {
+			t.Errorf("%s %s: operationId %q does not name %q", tc.method, tc.path, op.OperationID, tc.handler)
+		}
+	}
+
+	// The delegate must still not be documented as a route of its own.
+	for path := range out.Paths {
+		if path == "/{path}" || path == "/string" {
+			t.Errorf("path %q is the wrapper's own parameter, not a route; have %v", path, mapPathKeys(out.Paths))
+		}
+	}
+
+	// A plain function that registers on the framework router directly is NOT a
+	// wrapper — there is no type to scope a pattern to, and its inner call is the
+	// only registration. It must keep working, and must not gain a derived pattern
+	// that would fire elsewhere.
+	if op := opFor(out.Paths["/"], "DELETE"); op == nil {
+		t.Errorf("the helper-registrar route is gone; have %v", mapPathKeys(out.Paths))
+	}
+}
+
 // statusKeys lists an operation's documented statuses, for failure output.
 func statusKeys(op *intspec.Operation) []string {
 	out := make([]string, 0, len(op.Responses))

--- a/generator/testdata_wrapper_router_test.go
+++ b/generator/testdata_wrapper_router_test.go
@@ -179,6 +179,17 @@ func TestTestdata_WrapperRouterIsDetected(t *testing.T) {
 		}
 	}
 
+	// A responder declared on one context type but reached through the type that
+	// EMBEDS it: Go promotes the method, and the call is recorded against the
+	// embedding type, so a pattern scoped to the declaring type alone matches
+	// nothing at the call sites. That is what left gitea with 894 routes and 8
+	// components (issue #235).
+	if op := opFor(out.Paths["/api-items"], "GET"); op == nil {
+		t.Errorf("GET /api-items missing; have %v", mapPathKeys(out.Paths))
+	} else if _, ok := op.Responses["200"]; !ok {
+		t.Errorf("GET /api-items: expected the status its responder sets, have %v — the layered context was not recognised", statusKeys(op))
+	}
+
 	// The delegate must still not be documented as a route of its own.
 	for path := range out.Paths {
 		if path == "/{path}" || path == "/string" {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -256,6 +256,10 @@ type Engine struct {
 	// error message.
 	skipped []SkippedPackage
 
+	// detectedWrappers lists the project's own router types whose registration
+	// patterns were derived from the parameter flow (issue #235).
+	detectedWrappers []intspec.DetectedWrapper
+
 	// expansionStats records how far tree expansion got during the last
 	// generation, and whether the node budget cut it short (issue #233).
 	expansionStats intspec.ExpansionStats
@@ -714,6 +718,16 @@ func (e *Engine) GenerateOpenAPI() (*spec.OpenAPISpec, error) {
 	// declare its own field for a house dispatcher.
 	intspec.ApplyEntrypointPresets(apispecConfig, meta)
 
+	// A project's own router type registers nothing the framework's patterns can
+	// see: the framework call sits inside the wrapper, where the path and handler
+	// are the wrapper's parameters. Derive those patterns from that parameter flow
+	// and apply the ones that resolved completely (issue #235). Inert for a project
+	// that registers directly.
+	e.detectedWrappers = intspec.DetectRouterWrappers(meta, apispecConfig)
+	if applied := applyDetectedWrappers(apispecConfig, e.detectedWrappers); applied > 0 || len(e.detectedWrappers) > 0 {
+		NewVerboseLogger(e.config.Verbose).Printf("Router wrappers: %s\n", wrapperSummary(e.detectedWrappers))
+	}
+
 	// Set info from configuration (only if not already set in APISpecConfig)
 	if apispecConfig.Info.Title == "" {
 		apispecConfig.Info.Title = e.config.Title
@@ -1166,6 +1180,12 @@ func (e *Engine) GetUnresolvedSecurity() []intspec.MiddlewareRef {
 	return e.unresolvedSecurity
 }
 
+// GetDetectedWrappers returns the router wrappers derived during the most recent
+// generation, applied or not.
+func (e *Engine) GetDetectedWrappers() []intspec.DetectedWrapper {
+	return e.detectedWrappers
+}
+
 // GetExpansionStats returns how far tree expansion got during the most recent
 // generation, including whether the node budget stopped it early.
 func (e *Engine) GetExpansionStats() intspec.ExpansionStats {
@@ -1320,4 +1340,58 @@ func (e *Engine) filterToFrameworkPackages(
 	}
 
 	return filteredPkgsMetadata, filteredFileToInfo, filteredImportPaths
+}
+
+// applyDetectedWrappers appends the derived patterns that resolved completely and
+// returns how many were applied.
+//
+// Incomplete derivations are deliberately left out: a pattern missing its path or
+// handler produces a route with the wrong values rather than no route, which is
+// worse than the project being undocumented (golden rule #7). They are still
+// reported, so a user can see what was found and finish it by hand.
+func applyDetectedWrappers(cfg *intspec.APISpecConfig, wrappers []intspec.DetectedWrapper) int {
+	applied := 0
+	for _, w := range wrappers {
+		if !w.Complete {
+			continue
+		}
+		switch {
+		case w.Mount != nil:
+			cfg.Framework.MountPatterns = append([]intspec.MountPattern{*w.Mount}, cfg.Framework.MountPatterns...)
+		case w.Response != nil:
+			cfg.Framework.ResponsePatterns = append([]intspec.ResponsePattern{*w.Response}, cfg.Framework.ResponsePatterns...)
+		case w.Request != nil:
+			cfg.Framework.RequestBodyPatterns = append([]intspec.RequestBodyPattern{*w.Request}, cfg.Framework.RequestBodyPatterns...)
+		case w.Param != nil:
+			cfg.Framework.ParamPatterns = append([]intspec.ParamPattern{*w.Param}, cfg.Framework.ParamPatterns...)
+		default:
+			cfg.Framework.RoutePatterns = append([]intspec.RoutePattern{w.Pattern}, cfg.Framework.RoutePatterns...)
+		}
+		applied++
+	}
+	return applied
+}
+
+// wrapperSummary renders what was derived, for the run's log line.
+func wrapperSummary(wrappers []intspec.DetectedWrapper) string {
+	var parts []string
+	for _, w := range wrappers {
+		state := "applied"
+		if !w.Complete {
+			state = "incomplete, not applied"
+		}
+		kind := "route"
+		switch {
+		case w.Mount != nil:
+			kind = "mount"
+		case w.Response != nil:
+			kind = "response"
+		case w.Request != nil:
+			kind = "request"
+		case w.Param != nil:
+			kind = "param"
+		}
+		parts = append(parts, fmt.Sprintf("%s %v %s via %s (%s)", w.RecvType, w.Methods, kind, w.Via, state))
+	}
+	return strings.Join(parts, "; ")
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -724,7 +724,8 @@ func (e *Engine) GenerateOpenAPI() (*spec.OpenAPISpec, error) {
 	// and apply the ones that resolved completely (issue #235). Inert for a project
 	// that registers directly.
 	e.detectedWrappers = intspec.DetectRouterWrappers(meta, apispecConfig)
-	if applied := applyDetectedWrappers(apispecConfig, e.detectedWrappers); applied > 0 || len(e.detectedWrappers) > 0 {
+	applyDetectedWrappers(apispecConfig, e.detectedWrappers)
+	if e.config.Verbose && len(e.detectedWrappers) > 0 {
 		NewVerboseLogger(e.config.Verbose).Printf("Router wrappers: %s\n", wrapperSummary(e.detectedWrappers))
 	}
 
@@ -1342,34 +1343,84 @@ func (e *Engine) filterToFrameworkPackages(
 	return filteredPkgsMetadata, filteredFileToInfo, filteredImportPaths
 }
 
-// applyDetectedWrappers appends the derived patterns that resolved completely and
-// returns how many were applied.
+// applyDetectedWrappers adds the derived patterns that resolved completely and
+// returns how many were added.
 //
 // Incomplete derivations are deliberately left out: a pattern missing its path or
 // handler produces a route with the wrong values rather than no route, which is
 // worse than the project being undocumented (golden rule #7). They are still
 // reported, so a user can see what was found and finish it by hand.
+//
+// Applying is idempotent. The config may be the CALLER's — the UI hands the same
+// one to every run — so a second generation must not grow it a second copy of
+// everything derived.
+//
+// A method can carry several roles at once (a context method that both writes a
+// status and reads a parameter), so each role is considered on its own rather
+// than as alternatives.
 func applyDetectedWrappers(cfg *intspec.APISpecConfig, wrappers []intspec.DetectedWrapper) int {
 	applied := 0
 	for _, w := range wrappers {
 		if !w.Complete {
 			continue
 		}
-		switch {
-		case w.Mount != nil:
-			cfg.Framework.MountPatterns = append([]intspec.MountPattern{*w.Mount}, cfg.Framework.MountPatterns...)
-		case w.Response != nil:
-			cfg.Framework.ResponsePatterns = append([]intspec.ResponsePattern{*w.Response}, cfg.Framework.ResponsePatterns...)
-		case w.Request != nil:
-			cfg.Framework.RequestBodyPatterns = append([]intspec.RequestBodyPattern{*w.Request}, cfg.Framework.RequestBodyPatterns...)
-		case w.Param != nil:
-			cfg.Framework.ParamPatterns = append([]intspec.ParamPattern{*w.Param}, cfg.Framework.ParamPatterns...)
-		default:
-			cfg.Framework.RoutePatterns = append([]intspec.RoutePattern{w.Pattern}, cfg.Framework.RoutePatterns...)
+		roled := false
+		if w.Mount != nil {
+			roled = true
+			if addPatternOnce(&cfg.Framework.MountPatterns, *w.Mount, func(p intspec.MountPattern) (string, string) {
+				return p.CallRegex, p.RecvTypeRegex
+			}) {
+				applied++
+			}
 		}
-		applied++
+		// A response derivation with neither role resolved describes nothing.
+		if w.Response != nil && (w.Response.TypeFromArg || w.Response.StatusFromArg) {
+			roled = true
+			if addPatternOnce(&cfg.Framework.ResponsePatterns, *w.Response, func(p intspec.ResponsePattern) (string, string) {
+				return p.CallRegex, p.RecvTypeRegex
+			}) {
+				applied++
+			}
+		}
+		if w.Request != nil {
+			roled = true
+			if addPatternOnce(&cfg.Framework.RequestBodyPatterns, *w.Request, func(p intspec.RequestBodyPattern) (string, string) {
+				return p.CallRegex, p.RecvTypeRegex
+			}) {
+				applied++
+			}
+		}
+		if w.Param != nil {
+			roled = true
+			if addPatternOnce(&cfg.Framework.ParamPatterns, *w.Param, func(p intspec.ParamPattern) (string, string) {
+				return p.CallRegex, p.RecvTypeRegex
+			}) {
+				applied++
+			}
+		}
+		if !roled {
+			if addPatternOnce(&cfg.Framework.RoutePatterns, w.Pattern, func(p intspec.RoutePattern) (string, string) {
+				return p.CallRegex, p.RecvTypeRegex
+			}) {
+				applied++
+			}
+		}
 	}
 	return applied
+}
+
+// addPatternOnce prepends a derived pattern unless one matching the same calls on
+// the same receiver is already configured — which is what makes a second run on
+// the same config produce the same config.
+func addPatternOnce[T any](patterns *[]T, add T, identity func(T) (string, string)) bool {
+	call, recv := identity(add)
+	for _, existing := range *patterns {
+		if c, r := identity(existing); c == call && r == recv {
+			return false
+		}
+	}
+	*patterns = append([]T{add}, (*patterns)...)
+	return true
 }
 
 // wrapperSummary renders what was derived, for the run's log line.

--- a/internal/engine/engine_helpers_test.go
+++ b/internal/engine/engine_helpers_test.go
@@ -15,6 +15,7 @@
 package engine
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -123,5 +124,117 @@ func TestShouldIncludeFile(t *testing.T) {
 				t.Errorf("shouldIncludeFile(%q) = %v, want %v", c.file, got, c.want)
 			}
 		})
+	}
+}
+
+// TestApplyDetectedWrappersIsIdempotent pins that a second generation produces the
+// same config as the first.
+//
+// The config may be the CALLER's — the UI hands the same one to every run — and
+// derived patterns are prepended into it. Without a guard, every regeneration grew
+// the user's config another copy of everything derived (CodeRabbit, PR #236).
+func TestApplyDetectedWrappersIsIdempotent(t *testing.T) {
+	wrappers := []spec.DetectedWrapper{{
+		RecvType: "example.com/app.*Router",
+		Methods:  []string{"Get"},
+		Complete: true,
+		Pattern: spec.RoutePattern{
+			CallRegex:     "^(Get)$",
+			RecvTypeRegex: `^example\.com/app\.\*?Router$`,
+			PathFromArg:   true,
+		},
+	}}
+
+	cfg := &spec.APISpecConfig{}
+	if applied := applyDetectedWrappers(cfg, wrappers); applied != 1 {
+		t.Fatalf("first run applied %d, want 1", applied)
+	}
+	if applied := applyDetectedWrappers(cfg, wrappers); applied != 0 {
+		t.Errorf("second run applied %d more, want 0", applied)
+	}
+	if got := len(cfg.Framework.RoutePatterns); got != 1 {
+		t.Errorf("config holds %d route patterns after two runs, want 1", got)
+	}
+}
+
+// TestApplyDetectedWrappersAppliesEveryRole pins that a method carrying several
+// roles contributes all of them. Roles accumulate per method, so a context method
+// that writes a status and reads a parameter is one entry with two patterns — and
+// applying only the first would silently drop the other.
+func TestApplyDetectedWrappersAppliesEveryRole(t *testing.T) {
+	cfg := &spec.APISpecConfig{}
+	applied := applyDetectedWrappers(cfg, []spec.DetectedWrapper{{
+		RecvType: "example.com/app.*Ctx",
+		Methods:  []string{"Answer"},
+		Complete: true,
+		Response: &spec.ResponsePattern{CallRegex: "^(Answer)$", RecvTypeRegex: "^app.Ctx$", TypeFromArg: true},
+		Param:    &spec.ParamPattern{CallRegex: "^(Answer)$", RecvTypeRegex: "^app.Ctx$", ParamIn: "query"},
+	}})
+
+	if applied != 2 {
+		t.Errorf("applied %d patterns, want 2 (a response and a parameter)", applied)
+	}
+	if len(cfg.Framework.ResponsePatterns) != 1 || len(cfg.Framework.ParamPatterns) != 1 {
+		t.Errorf("responses=%d params=%d, want one of each",
+			len(cfg.Framework.ResponsePatterns), len(cfg.Framework.ParamPatterns))
+	}
+
+	// Every kind reaches its own list — a mount and a request body alongside the
+	// two above, so no role is silently dropped on the way to the engine.
+	all := &spec.APISpecConfig{}
+	applyDetectedWrappers(all, []spec.DetectedWrapper{
+		{Complete: true, Mount: &spec.MountPattern{CallRegex: "^(Group)$", RecvTypeRegex: "^app.Router$", IsMount: true}},
+		{Complete: true, Request: &spec.RequestBodyPattern{CallRegex: "^(Bind)$", RecvTypeRegex: "^app.Ctx$", TypeFromArg: true}},
+		// Incomplete derivations are reported, never applied.
+		{Complete: false, Pattern: spec.RoutePattern{CallRegex: "^(Combo)$"}},
+	})
+	if len(all.Framework.MountPatterns) != 1 || len(all.Framework.RequestBodyPatterns) != 1 {
+		t.Errorf("mounts=%d requests=%d, want one of each",
+			len(all.Framework.MountPatterns), len(all.Framework.RequestBodyPatterns))
+	}
+	if len(all.Framework.RoutePatterns) != 0 {
+		t.Errorf("an incomplete derivation was applied: %+v", all.Framework.RoutePatterns)
+	}
+
+	// A response derivation that resolved neither role describes nothing, so it is
+	// not applied at all.
+	empty := &spec.APISpecConfig{}
+	applyDetectedWrappers(empty, []spec.DetectedWrapper{{
+		Complete: true,
+		Response: &spec.ResponsePattern{CallRegex: "^(Nothing)$"},
+	}})
+	if len(empty.Framework.ResponsePatterns) != 0 {
+		t.Errorf("a response pattern with no status and no body was applied: %+v", empty.Framework.ResponsePatterns)
+	}
+}
+
+// TestWrapperSummary covers the line a run prints about what it derived. It is
+// the only place a user sees that a wrapper was found — including one that was
+// found but NOT applied, which is the case that explains a thin spec.
+func TestWrapperSummary(t *testing.T) {
+	got := wrapperSummary([]spec.DetectedWrapper{
+		{RecvType: "app.*Router", Methods: []string{"Get", "Post"}, Via: "chi.Method", Complete: true},
+		{RecvType: "app.*Router", Methods: []string{"Group"}, Via: "prefix", Complete: true, Mount: &spec.MountPattern{}},
+		{RecvType: "app.*Ctx", Methods: []string{"JSON"}, Via: "http.WriteHeader", Complete: true, Response: &spec.ResponsePattern{}},
+		{RecvType: "app.*Ctx", Methods: []string{"Bind"}, Via: "json.Decode", Complete: true, Request: &spec.RequestBodyPattern{}},
+		{RecvType: "app.*Ctx", Methods: []string{"Query"}, Via: "url.Get", Complete: true, Param: &spec.ParamPattern{}},
+		{RecvType: "app.*Combo", Methods: []string{"Get"}, Via: "app.Get", Complete: false},
+	})
+
+	for _, want := range []string{
+		"app.*Router [Get Post] route via chi.Method (applied)",
+		"app.*Router [Group] mount via prefix (applied)",
+		"app.*Ctx [JSON] response via http.WriteHeader (applied)",
+		"app.*Ctx [Bind] request via json.Decode (applied)",
+		"app.*Ctx [Query] param via url.Get (applied)",
+		"app.*Combo [Get] route via app.Get (incomplete, not applied)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("summary is missing %q:\n%s", want, got)
+		}
+	}
+
+	if got := wrapperSummary(nil); got != "" {
+		t.Errorf("nothing derived rendered %q, want empty", got)
 	}
 }

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -1345,13 +1345,26 @@ func processAssignment(assign *ast.AssignStmt, file *ast.File, info *types.Info,
 	if rhsLen > maxLen {
 		maxLen = rhsLen
 	}
+	// `a, b := f()` has one right-hand side for several variables. Pairing by
+	// position recorded `a` and dropped every later name, so anything assigned
+	// from the second result of a call had no recorded origin at all — the shape
+	// `middlewares, handlerFunc := wrap(...)` is ordinary Go, and its handler was
+	// invisible to every consumer that traces values (issue #235).
+	tupleCall := rhsLen == 1 && lhsLen > 1
 	for i := 0; i < maxLen; i++ {
 		var lhsExpr ast.Expr
 		var rhsExpr ast.Expr
+		returnIndex := 0
 		if i < lhsLen {
 			lhsExpr = assign.Lhs[i]
 		}
-		if i < rhsLen {
+		switch {
+		case tupleCall:
+			// Every name comes from the same call; which result it takes is what
+			// ReturnIndex records, so a consumer can resolve the right one.
+			rhsExpr = assign.Rhs[0]
+			returnIndex = i
+		case i < rhsLen:
 			rhsExpr = assign.Rhs[i]
 		}
 
@@ -1393,7 +1406,7 @@ func processAssignment(assign *ast.AssignStmt, file *ast.File, info *types.Info,
 					calleeFunc, calleePkg, _ := getCalleeFunctionNameAndPackage(callExpr.Fun, file, pkgName, fileToInfo, funcMap, fset, metadata)
 					assignment.CalleeFunc = calleeFunc
 					assignment.CalleePkg = calleePkg
-					assignment.ReturnIndex = 0 // For now, always first return value
+					assignment.ReturnIndex = returnIndex
 				}
 				assignments = append(assignments, assignment)
 				assignmentCount++

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -1350,7 +1350,12 @@ func processAssignment(assign *ast.AssignStmt, file *ast.File, info *types.Info,
 	// from the second result of a call had no recorded origin at all — the shape
 	// `middlewares, handlerFunc := wrap(...)` is ordinary Go, and its handler was
 	// invisible to every consumer that traces values (issue #235).
-	tupleCall := rhsLen == 1 && lhsLen > 1
+	// Only a CALL distributes one right-hand side across several names in a way
+	// worth recording. `v, ok := x.(T)`, `a, b := m[k]` and `v, ok := <-ch` share
+	// the shape, but their second name is a bool whose "origin" would be the
+	// whole expression — recording that would hand `ok` the concrete type T.
+	_, isCall := assign.Rhs[0].(*ast.CallExpr)
+	tupleCall := rhsLen == 1 && lhsLen > 1 && isCall
 	for i := 0; i < maxLen; i++ {
 		var lhsExpr ast.Expr
 		var rhsExpr ast.Expr

--- a/internal/metadata/multi_assign_test.go
+++ b/internal/metadata/multi_assign_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"go/ast"
+	"testing"
+)
+
+// TestMultiValueAssignmentRecordsEveryName pins a gap that made ordinary Go
+// invisible: `a, b := f()` has one right-hand side for two names, and pairing
+// them by position recorded `a` and dropped `b`.
+//
+// Anything assigned from the second result of a call therefore had no recorded
+// origin at all — `middlewares, handlerFunc := wrap(h)` is how gitea unwraps its
+// handlers, and nothing could trace `handlerFunc` back to `h` (issue #235).
+func TestMultiValueAssignmentRecordsEveryName(t *testing.T) {
+	src := `package p
+
+func wrap(h any) (int, any) { return 0, h }
+
+func caller(h any) {
+	middlewares, handlerFunc := wrap(h)
+	_, _ = middlewares, handlerFunc
+
+	single := wrap
+	_ = single
+
+	x, y := 1, 2 // one right-hand side per name: unchanged behaviour
+	_, _ = x, y
+}
+`
+	file, info, fset := sweepTypeCheck(t, src)
+	meta := &Metadata{StringPool: NewStringPool()}
+
+	var assignments []Assignment
+	ast.Inspect(file, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok {
+			return true
+		}
+		assignments = append(assignments, processAssignment(assign, file, info, "p", fset, nil, nil, meta)...)
+		return true
+	})
+
+	byName := map[string][]Assignment{}
+	for _, a := range assignments {
+		name := meta.StringPool.GetString(a.VariableName)
+		byName[name] = append(byName[name], a)
+	}
+
+	// Both names of the tuple assignment are recorded, and both point at the call
+	// they came from — that is what lets a value be traced back to a parameter.
+	for i, name := range []string{"middlewares", "handlerFunc"} {
+		got := byName[name]
+		if len(got) == 0 {
+			t.Errorf("%q has no recorded assignment; a value from result %d of a call cannot be traced", name, i)
+			continue
+		}
+		if got[0].CalleeFunc != "wrap" {
+			t.Errorf("%q came from %q, want the call `wrap`", name, got[0].CalleeFunc)
+		}
+		// Which result it takes is what tells a consumer how to resolve its type.
+		if got[0].ReturnIndex != i {
+			t.Errorf("%q has ReturnIndex %d, want %d", name, got[0].ReturnIndex, i)
+		}
+	}
+
+	// A name-per-value assignment is untouched: each name keeps its own value and
+	// index 0.
+	for _, name := range []string{"x", "y"} {
+		got := byName[name]
+		if len(got) == 0 {
+			t.Fatalf("%q lost its assignment", name)
+		}
+		if got[0].ReturnIndex != 0 {
+			t.Errorf("%q has ReturnIndex %d, want 0 — it is not a tuple", name, got[0].ReturnIndex)
+		}
+	}
+}

--- a/internal/spec/wrapper_detect.go
+++ b/internal/spec/wrapper_detect.go
@@ -39,8 +39,11 @@ type DetectedWrapper struct {
 	// Mount is set instead of Pattern when the method groups routes under a
 	// prefix rather than registering one.
 	Mount *MountPattern
-	// Response / Request / Param are set instead when the method is the project's
-	// own responder, decoder or parameter reader rather than a registrar.
+	// Response / Request / Param are set when the method is the project's own
+	// responder, decoder or parameter reader rather than a registrar. They are NOT
+	// mutually exclusive: roles are accumulated per method, so a context method
+	// that writes a status and reads a parameter carries both, and a consumer has
+	// to apply each one it finds rather than the first.
 	Response *ResponsePattern
 	Request  *RequestBodyPattern
 	Param    *ParamPattern
@@ -71,7 +74,14 @@ const wrapperDetectRounds = 4
 // Derivation is transitive, because a wrapper usually funnels its verb methods
 // through one registrar: `Get` forwards to `Methods`, which forwards to chi.
 func DetectRouterWrappers(meta *metadata.Metadata, cfg *APISpecConfig) []DetectedWrapper {
-	if meta == nil || cfg == nil || len(cfg.Framework.RoutePatterns) == 0 {
+	if meta == nil || cfg == nil {
+		return nil
+	}
+	// Route patterns seed the router half; the response/request/parameter halves
+	// stand on their own, so a config carrying only those still derives.
+	fw := cfg.Framework
+	if len(fw.RoutePatterns) == 0 && len(fw.ResponsePatterns) == 0 &&
+		len(fw.RequestBodyPatterns) == 0 && len(fw.ParamPatterns) == 0 {
 		return nil
 	}
 	cp := NewContextProvider(meta)

--- a/internal/spec/wrapper_detect.go
+++ b/internal/spec/wrapper_detect.go
@@ -1,0 +1,638 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// DetectedWrapper is a route pattern derived from a project's own router type —
+// a method that registers by forwarding its own parameters to the framework
+// (issue #235).
+type DetectedWrapper struct {
+	// RecvType is the wrapper type as metadata renders it: `pkg.*Router`.
+	RecvType string
+	// Methods are the method names this pattern covers, sorted. Several methods
+	// with identical roles share one pattern.
+	Methods []string
+	// Via names what they delegate to, for the report: `chi.Mux.Method`.
+	Via string
+	// Pattern is the derived RoutePattern, ready to use. Empty for a mount.
+	Pattern RoutePattern
+	// Mount is set instead of Pattern when the method groups routes under a
+	// prefix rather than registering one.
+	Mount *MountPattern
+	// Response / Request / Param are set instead when the method is the project's
+	// own responder, decoder or parameter reader rather than a registrar.
+	Response *ResponsePattern
+	Request  *RequestBodyPattern
+	Param    *ParamPattern
+	// Complete is true when every role the inner pattern names was resolved to a
+	// parameter. An incomplete derivation is reported but never applied: half a
+	// registration produces a route with the wrong path rather than no route.
+	Complete bool
+}
+
+// wrapperDetectRounds bounds the transitive search. Delegation chains are short
+// (`Get` -> `Methods` -> chi), and the bound keeps a cyclic graph from spinning.
+const wrapperDetectRounds = 4
+
+// DetectRouterWrappers derives route patterns for a project's own router type.
+//
+// A house router — gitea's `modules/web.Router` in front of `*chi.Mux` — registers
+// nothing that the framework's own patterns can see: the framework call happens
+// inside the wrapper, where the path and handler are the wrapper's parameters. So
+// the project documents no routes at all, and nothing says why (issue #235).
+//
+// The wrapper is derived rather than guessed, from one fact: a method of an
+// in-module type whose call to a framework registration FORWARDS ITS OWN
+// PARAMETERS. That is what separates a wrapper from an ordinary registration
+// helper — `func (s *Server) routes() { r.Get("/users", s.list) }` names its path
+// literally and is not a wrapper; `func (r *Router) Get(pattern string, h ...any)`
+// passes `pattern` through, and it is.
+//
+// Derivation is transitive, because a wrapper usually funnels its verb methods
+// through one registrar: `Get` forwards to `Methods`, which forwards to chi.
+func DetectRouterWrappers(meta *metadata.Metadata, cfg *APISpecConfig) []DetectedWrapper {
+	if meta == nil || cfg == nil || len(cfg.Framework.RoutePatterns) == 0 {
+		return nil
+	}
+	cp := NewContextProvider(meta)
+	params := newParamIndex(meta)
+
+	// Seeds are the framework's own patterns; each round can derive wrappers of
+	// the wrappers found so far.
+	seeds := make([]RoutePattern, len(cfg.Framework.RoutePatterns))
+	copy(seeds, cfg.Framework.RoutePatterns)
+
+	found := map[string]DetectedWrapper{} // key: recvType + "." + method
+	for round := 0; round < wrapperDetectRounds; round++ {
+		derived := derivationRound(meta, cp, params, seeds, found)
+		if len(derived) == 0 {
+			break
+		}
+		seeds = derived
+	}
+
+	wrappers := groupWrappers(found)
+	wrappers = append(wrappers, detectGroupMounts(meta, cp, params, wrappers)...)
+	return append(wrappers, detectValueWrappers(meta, cp, params, cfg)...)
+}
+
+// detectGroupMounts derives the prefix-grouping methods of a type already known
+// to be a router.
+//
+// A house router usually carries its group prefix in a FIELD —
+// `Group(pattern string, fn func())` appends to it, calls the closure, and
+// restores it — so there is no sub-router to mount and nothing in the framework's
+// own patterns can see the prefix. Every route registered inside the closure then
+// comes out at the wrong path (`/items` instead of `/api/items`).
+//
+// The shape is read from facts rather than names: a method of a router type that
+// takes a path string and a function, and CALLS that function. A method that only
+// takes them without calling is not grouping anything.
+func detectGroupMounts(meta *metadata.Metadata, cp ContextProvider, params *paramIndex, routers []DetectedWrapper) []DetectedWrapper {
+	types := map[string]bool{}
+	for _, w := range routers {
+		if w.Complete && w.Mount == nil {
+			types[w.RecvType] = true
+		}
+	}
+	if len(types) == 0 {
+		return nil
+	}
+
+	// Which (method, callee) pairs exist, so "does it call its own parameter?" is
+	// a lookup rather than a scan per candidate.
+	calls := map[string]map[string]bool{}
+	for i := range meta.CallGraph {
+		edge := &meta.CallGraph[i]
+		recv := cp.GetString(edge.Caller.RecvType)
+		if recv == "" {
+			continue
+		}
+		key := cp.GetString(edge.Caller.Pkg) + "." + recv + "." + cp.GetString(edge.Caller.Name)
+		if calls[key] == nil {
+			calls[key] = map[string]bool{}
+		}
+		calls[key][cp.GetString(edge.Callee.Name)] = true
+	}
+
+	var out []DetectedWrapper
+	for fqRecv := range types {
+		pkg, recvType, ok := splitFQRecv(fqRecv)
+		if !ok {
+			continue
+		}
+		w := &wrapperMethod{pkg: pkg, recvType: recvType}
+		for _, method := range methodsOf(meta, w) {
+			w.name = cp.GetString(method.Name)
+			pathIdx, funcParam, ok := groupShape(method)
+			if !ok {
+				continue
+			}
+			if !calls[fqRecv+"."+w.name][funcParam] {
+				continue // takes a function but never runs it: not a group
+			}
+			out = append(out, DetectedWrapper{
+				RecvType: fqRecv,
+				Methods:  []string{w.name},
+				Via:      "prefix held by " + fqRecv,
+				Mount: &MountPattern{
+					CallRegex:     "^" + regexp.QuoteMeta(w.name) + "$",
+					RecvTypeRegex: recvTypeRegexFor(w),
+					PathFromArg:   true,
+					PathArgIndex:  pathIdx,
+					IsMount:       true,
+				},
+				Complete: true,
+			})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].RecvType != out[j].RecvType {
+			return out[i].RecvType < out[j].RecvType
+		}
+		return out[i].Methods[0] < out[j].Methods[0]
+	})
+	return out
+}
+
+// groupShape reports whether a method takes a path string plus a function, and
+// where each sits.
+func groupShape(m *metadata.Method) (pathIdx int, funcParam string, ok bool) {
+	pathIdx = -1
+	for i, param := range m.Signature.Args {
+		switch param.GetKind() {
+		case metadata.KindFuncType:
+			if funcParam == "" {
+				funcParam = param.GetName()
+			}
+		case metadata.KindIdent:
+			if pathIdx < 0 && param.GetType() == "string" {
+				pathIdx = i
+			}
+		}
+	}
+	return pathIdx, funcParam, pathIdx >= 0 && funcParam != ""
+}
+
+// methodsOf returns a type's declared methods, in file order.
+func methodsOf(meta *metadata.Metadata, w *wrapperMethod) []*metadata.Method {
+	pkg, ok := meta.Packages[w.pkg]
+	if !ok {
+		return nil
+	}
+	bare := strings.TrimPrefix(w.recvType, "*")
+	var out []*metadata.Method
+	for _, fileName := range meta.SortedFileNames(w.pkg) {
+		file := pkg.Files[fileName]
+		if file == nil {
+			continue
+		}
+		if typ, ok := file.Types[bare]; ok {
+			for i := range typ.Methods {
+				out = append(out, &typ.Methods[i])
+			}
+		}
+	}
+	return out
+}
+
+// splitFQRecv splits `pkg/path.*Type` into its package and receiver.
+func splitFQRecv(fq string) (pkg, recv string, ok bool) {
+	i := strings.LastIndex(fq, ".")
+	if i <= 0 || i == len(fq)-1 {
+		return "", "", false
+	}
+	return fq[:i], fq[i+1:], true
+}
+
+// derivationRound matches every edge against the seed patterns and derives a
+// wrapper for each in-module method that forwards its parameters into one.
+// Returns the patterns derived this round, which seed the next.
+func derivationRound(meta *metadata.Metadata, cp ContextProvider, params *paramIndex, seeds []RoutePattern, found map[string]DetectedWrapper) []RoutePattern {
+	matchers := make([]*RoutePatternMatcherImpl, 0, len(seeds))
+	for _, p := range seeds {
+		matchers = append(matchers, NewRoutePatternMatcher(p, &APISpecConfig{}, cp, nil))
+	}
+
+	var derived []RoutePattern
+	for i := range meta.CallGraph {
+		edge := &meta.CallGraph[i]
+		caller := wrapperMethodOf(meta, cp, edge)
+		if caller == nil {
+			continue
+		}
+		node := &TrackerNode{CallGraphEdge: edge}
+		for j, matcher := range matchers {
+			if !matcher.MatchNode(node) {
+				continue
+			}
+			wrapper, ok := deriveWrapper(cp, params, caller, seeds[j], edge)
+			if !ok {
+				continue
+			}
+			key := wrapper.RecvType + "." + wrapper.Methods[0]
+			if _, seen := found[key]; seen {
+				continue
+			}
+			found[key] = wrapper
+			if wrapper.Complete {
+				derived = append(derived, wrapper.Pattern)
+			}
+			break // one pattern per edge: the first match is the framework's own
+		}
+	}
+	return derived
+}
+
+// wrapperMethod identifies the enclosing method of a registration call.
+type wrapperMethod struct {
+	pkg      string
+	recvType string // as metadata renders it: `*Router`
+	name     string
+}
+
+func (w wrapperMethod) fqRecv() string { return w.pkg + "." + w.recvType }
+
+// wrapperMethodOf returns the method a registration call is written in, or nil
+// when it is not written in an in-module method.
+//
+// Both halves matter. A registration inside a plain function is an ordinary
+// registrar, not a wrapper — there is no type to scope a pattern to. A
+// registration inside a dependency's method is that dependency's business, and
+// the project cannot be documented by describing it.
+func wrapperMethodOf(meta *metadata.Metadata, cp ContextProvider, edge *metadata.CallGraphEdge) *wrapperMethod {
+	recv := cp.GetString(edge.Caller.RecvType)
+	if recv == "" {
+		return nil
+	}
+	pkg := cp.GetString(edge.Caller.Pkg)
+	if pkg == "" || meta.CurrentModulePath == "" || !strings.HasPrefix(pkg, meta.CurrentModulePath) {
+		return nil
+	}
+	return &wrapperMethod{pkg: pkg, recvType: recv, name: cp.GetString(edge.Caller.Name)}
+}
+
+// deriveWrapper reads the roles of one registration call and expresses them in
+// terms of the enclosing method's own parameters.
+func deriveWrapper(cp ContextProvider, params *paramIndex, w *wrapperMethod, inner RoutePattern, edge *metadata.CallGraphEdge) (DetectedWrapper, bool) {
+	out := DetectedWrapper{
+		RecvType: w.fqRecv(),
+		Methods:  []string{w.name},
+		Via:      cp.GetString(edge.Callee.Pkg) + "." + cp.GetString(edge.Callee.Name),
+		Pattern: RoutePattern{
+			CallRegex:     "^" + regexp.QuoteMeta(w.name) + "$",
+			RecvTypeRegex: recvTypeRegexFor(w),
+		},
+	}
+
+	arg := func(idx int) *metadata.CallArgument {
+		if idx < 0 || idx >= len(edge.Args) {
+			return nil
+		}
+		return edge.Args[idx]
+	}
+
+	pathOK, handlerOK := false, false
+	if inner.PathFromArg {
+		if i, ok := params.indexOf(w, arg(inner.PathArgIndex)); ok {
+			out.Pattern.PathFromArg, out.Pattern.PathArgIndex = true, i
+			pathOK = true
+		}
+	}
+	if inner.HandlerFromArg {
+		if i, ok := params.indexOf(w, arg(inner.HandlerArgIndex)); ok {
+			out.Pattern.HandlerFromArg, out.Pattern.HandlerArgIndex = true, i
+			handlerOK = true
+		}
+	}
+
+	// The verb: forwarded as a parameter, or fixed because the wrapper method is
+	// named for it (Get/Post/…). A verb that is neither leaves the route on the
+	// default, which is what happens today.
+	if idx := innerVerbArgIndex(inner); idx >= 0 {
+		if i, ok := params.indexOf(w, arg(idx)); ok {
+			out.Pattern.MethodFromArg = true
+			out.Pattern.MethodArgIndex = i
+		}
+	}
+	if !out.Pattern.MethodFromArg && isHTTPMethod(strings.ToUpper(w.name)) {
+		out.Pattern.MethodFromCall = true
+	}
+
+	// Path and handler are what a registration IS. Without both, applying the
+	// pattern would produce a route with a wrong path rather than no route, so it
+	// is reported and left unapplied.
+	out.Complete = pathOK && handlerOK
+	return out, true
+}
+
+// innerVerbArgIndex returns the argument index a pattern reads its verb from, or
+// -1 when the verb does not travel as an argument.
+//
+// MethodArgIndex cannot be read on its own: it defaults to 0, so for a pattern
+// whose verb comes from the CALL name (chi's `r.Get(path, h)`) index 0 is the
+// path. Treating that as the verb would derive a wrapper whose "verb" is its
+// path parameter.
+func innerVerbArgIndex(inner RoutePattern) int {
+	if inner.MethodFromCall || inner.MethodFromHandler || inner.MethodFromPath {
+		return -1
+	}
+	if inner.MethodFromArg {
+		return inner.MethodArgIndex
+	}
+	idx := inner.MethodArgIndex
+	if inner.PathFromArg && idx == inner.PathArgIndex {
+		return -1
+	}
+	if inner.HandlerFromArg && idx == inner.HandlerArgIndex {
+		return -1
+	}
+	return idx
+}
+
+// recvTypeRegexFor renders the receiver constraint the way pattern matching reads
+// it: `pkg.*Router`, with the pointer optional so a value receiver matches too.
+func recvTypeRegexFor(w *wrapperMethod) string {
+	bare := strings.TrimPrefix(w.recvType, "*")
+	return "^" + regexp.QuoteMeta(w.pkg) + `\.\*?` + regexp.QuoteMeta(bare) + "$"
+}
+
+// groupWrappers merges methods whose derived roles are identical into one pattern
+// — a router's eight verb methods become one line rather than eight.
+func groupWrappers(found map[string]DetectedWrapper) []DetectedWrapper {
+	byRoles := map[string]DetectedWrapper{}
+	for _, w := range found {
+		key := w.RecvType + "|" + rolesKey(w.Pattern) + "|" + boolKey(w.Complete)
+		existing, ok := byRoles[key]
+		if !ok {
+			byRoles[key] = w
+			continue
+		}
+		existing.Methods = append(existing.Methods, w.Methods...)
+		byRoles[key] = existing
+	}
+
+	out := make([]DetectedWrapper, 0, len(byRoles))
+	for _, w := range byRoles {
+		sort.Strings(w.Methods)
+		names := make([]string, 0, len(w.Methods))
+		for _, m := range w.Methods {
+			names = append(names, regexp.QuoteMeta(m))
+		}
+		w.Pattern.CallRegex = "^(" + strings.Join(names, "|") + ")$"
+		out = append(out, w)
+	}
+	// Sorted: derived patterns reach the config, and config order reaches the
+	// output (golden rule #1).
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].RecvType != out[j].RecvType {
+			return out[i].RecvType < out[j].RecvType
+		}
+		return out[i].Pattern.CallRegex < out[j].Pattern.CallRegex
+	})
+	return out
+}
+
+func rolesKey(p RoutePattern) string {
+	return strings.Join([]string{
+		boolKey(p.PathFromArg), itoa(p.PathArgIndex),
+		boolKey(p.HandlerFromArg), itoa(p.HandlerArgIndex),
+		boolKey(p.MethodFromArg), itoa(p.MethodArgIndex),
+		boolKey(p.MethodFromCall),
+	}, ",")
+}
+
+func boolKey(b bool) string {
+	if b {
+		return "1"
+	}
+	return "0"
+}
+
+func itoa(i int) string { return strconv.Itoa(i) }
+
+// detectValueWrappers derives response, request-body and parameter patterns for a
+// project's own context type — the write-side and read-side twins of a router
+// wrapper (issue #235).
+//
+// A house router is rarely alone: the same project usually answers through its
+// own context (`ctx.JSON(status, body)`, `ctx.Bind(&in)`, `ctx.Param("id")`).
+// Those calls are invisible to the framework's patterns for the same reason the
+// router was — the framework call is inside the method, where the status, body
+// and name are the method's parameters. gitea documented 856 routes and ZERO
+// components until these were derived.
+//
+// The derivation is the router one: a method of an in-module type that forwards
+// its own parameters into a known pattern. A method can satisfy several roles
+// through several inner calls — a JSON responder sets the status through
+// `WriteHeader(status)` and the body through `Encode(content)` — so roles are
+// merged per method rather than taken from one call.
+func detectValueWrappers(meta *metadata.Metadata, cp ContextProvider, params *paramIndex, cfg *APISpecConfig) []DetectedWrapper {
+	byMethod := map[string]*DetectedWrapper{}
+
+	// Wrappers stack: a project that wraps encoding/json in its own package (gitea
+	// does) reaches the framework pattern two levels down, so each round feeds
+	// what it derived back in as patterns to match against.
+	seeds := *cfg
+	for round := 0; round < wrapperDetectRounds; round++ {
+		before := len(byMethod)
+		detectValueRound(meta, cp, params, &seeds, byMethod)
+		if len(byMethod) == before {
+			break
+		}
+		seeds = seedsFrom(byMethod)
+	}
+
+	out := make([]DetectedWrapper, 0, len(byMethod))
+	for _, w := range byMethod {
+		out = append(out, *w)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].RecvType != out[j].RecvType {
+			return out[i].RecvType < out[j].RecvType
+		}
+		return out[i].Methods[0] < out[j].Methods[0]
+	})
+	return out
+}
+
+// seedsFrom turns the wrappers derived so far into patterns for the next round.
+func seedsFrom(byMethod map[string]*DetectedWrapper) APISpecConfig {
+	var cfg APISpecConfig
+	for _, w := range byMethod {
+		if !w.Complete {
+			continue
+		}
+		switch {
+		case w.Response != nil:
+			cfg.Framework.ResponsePatterns = append(cfg.Framework.ResponsePatterns, *w.Response)
+		case w.Request != nil:
+			cfg.Framework.RequestBodyPatterns = append(cfg.Framework.RequestBodyPatterns, *w.Request)
+		case w.Param != nil:
+			cfg.Framework.ParamPatterns = append(cfg.Framework.ParamPatterns, *w.Param)
+		}
+	}
+	return cfg
+}
+
+// detectValueRound matches every edge against one set of patterns and folds what
+// it finds into byMethod.
+func detectValueRound(meta *metadata.Metadata, cp ContextProvider, params *paramIndex, cfg *APISpecConfig, byMethod map[string]*DetectedWrapper) {
+
+	respMatchers := make([]*ResponsePatternMatcherImpl, 0, len(cfg.Framework.ResponsePatterns))
+	for _, p := range cfg.Framework.ResponsePatterns {
+		respMatchers = append(respMatchers, NewResponsePatternMatcher(p, cfg, cp, nil))
+	}
+	reqMatchers := make([]*RequestPatternMatcherImpl, 0, len(cfg.Framework.RequestBodyPatterns))
+	for _, p := range cfg.Framework.RequestBodyPatterns {
+		reqMatchers = append(reqMatchers, NewRequestPatternMatcher(p, cfg, cp, nil))
+	}
+	paramMatchers := make([]*ParamPatternMatcherImpl, 0, len(cfg.Framework.ParamPatterns))
+	for _, p := range cfg.Framework.ParamPatterns {
+		paramMatchers = append(paramMatchers, NewParamPatternMatcher(p, cfg, cp, nil))
+	}
+
+	for i := range meta.CallGraph {
+		edge := &meta.CallGraph[i]
+		w := wrapperMethodOf(meta, cp, edge)
+		if w == nil {
+			continue
+		}
+		node := &TrackerNode{CallGraphEdge: edge}
+		key := w.fqRecv() + "." + w.name
+
+		for j, m := range respMatchers {
+			if m.MatchNode(node) {
+				mergeResponseRoles(byMethod, key, w, cp, params, cfg.Framework.ResponsePatterns[j], edge)
+			}
+		}
+		for j, m := range reqMatchers {
+			if m.MatchNode(node) {
+				deriveRequestWrapper(byMethod, key, w, cp, params, cfg.Framework.RequestBodyPatterns[j], edge)
+			}
+		}
+		for j, m := range paramMatchers {
+			if m.MatchNode(node) {
+				deriveParamWrapper(byMethod, key, w, cp, params, cfg.Framework.ParamPatterns[j], edge)
+			}
+		}
+	}
+
+}
+
+// wrapperShell returns the accumulating entry for a method, creating it once.
+func wrapperShell(byMethod map[string]*DetectedWrapper, key string, w *wrapperMethod, via string) *DetectedWrapper {
+	if existing, ok := byMethod[key]; ok {
+		return existing
+	}
+	entry := &DetectedWrapper{
+		RecvType: w.fqRecv(),
+		Methods:  []string{w.name},
+		Via:      via,
+	}
+	byMethod[key] = entry
+	return entry
+}
+
+// mergeResponseRoles folds one inner response call into the method's derived
+// pattern: the status from a `WriteHeader(status)`, the body from an
+// `Encode(content)`, both of which the same responder performs.
+func mergeResponseRoles(byMethod map[string]*DetectedWrapper, key string, w *wrapperMethod, cp ContextProvider, params *paramIndex, inner ResponsePattern, edge *metadata.CallGraphEdge) {
+	entry := wrapperShell(byMethod, key, w, cp.GetString(edge.Callee.Pkg)+"."+cp.GetString(edge.Callee.Name))
+	if entry.Response == nil {
+		entry.Response = &ResponsePattern{
+			CallRegex:     "^" + regexp.QuoteMeta(w.name) + "$",
+			RecvTypeRegex: recvTypeRegexFor(w),
+			TypeArgIndex:  -1,
+		}
+	}
+
+	if inner.StatusFromArg && !entry.Response.StatusFromArg {
+		if i, ok := params.indexOf(w, argAt(edge, inner.StatusArgIndex)); ok {
+			entry.Response.StatusFromArg, entry.Response.StatusArgIndex = true, i
+		}
+	}
+	if inner.TypeFromArg && !entry.Response.TypeFromArg {
+		if i, ok := params.indexOf(w, argAt(edge, inner.TypeArgIndex)); ok {
+			entry.Response.TypeFromArg, entry.Response.TypeArgIndex = true, i
+			entry.Response.Deref = inner.Deref
+		}
+	}
+	if inner.DefaultStatus != 0 && entry.Response.DefaultStatus == 0 {
+		entry.Response.DefaultStatus = inner.DefaultStatus
+	}
+
+	// A body is what makes a responder worth describing: a status alone documents
+	// nothing a client can use.
+	entry.Complete = entry.Response.TypeFromArg
+}
+
+// deriveRequestWrapper derives a request-body pattern from a decoder wrapper —
+// `func (c *Ctx) Bind(dst any) error { json.NewDecoder(c.r.Body).Decode(dst) }`.
+func deriveRequestWrapper(byMethod map[string]*DetectedWrapper, key string, w *wrapperMethod, cp ContextProvider, params *paramIndex, inner RequestBodyPattern, edge *metadata.CallGraphEdge) {
+	if !inner.TypeFromArg {
+		return
+	}
+	i, ok := params.indexOf(w, argAt(edge, inner.TypeArgIndex))
+	if !ok {
+		return
+	}
+	entry := wrapperShell(byMethod, key, w, cp.GetString(edge.Callee.Pkg)+"."+cp.GetString(edge.Callee.Name))
+	entry.Request = &RequestBodyPattern{
+		CallRegex:     "^" + regexp.QuoteMeta(w.name) + "$",
+		RecvTypeRegex: recvTypeRegexFor(w),
+		TypeFromArg:   true,
+		TypeArgIndex:  i,
+		Deref:         inner.Deref,
+	}
+	entry.Complete = true
+}
+
+// deriveParamWrapper derives a parameter pattern from a reader wrapper —
+// `func (c *Ctx) Param(name string) string { return chi.URLParam(c.r, name) }`.
+// The location comes from the inner pattern: the wrapper reads whatever it reads.
+func deriveParamWrapper(byMethod map[string]*DetectedWrapper, key string, w *wrapperMethod, cp ContextProvider, params *paramIndex, inner ParamPattern, edge *metadata.CallGraphEdge) {
+	if inner.ParamIn == "" || inner.NameFromMapKey {
+		return
+	}
+	i, ok := params.indexOf(w, argAt(edge, inner.ParamArgIndex))
+	if !ok {
+		return
+	}
+	entry := wrapperShell(byMethod, key, w, cp.GetString(edge.Callee.Pkg)+"."+cp.GetString(edge.Callee.Name))
+	entry.Param = &ParamPattern{
+		CallRegex:     "^" + regexp.QuoteMeta(w.name) + "$",
+		RecvTypeRegex: recvTypeRegexFor(w),
+		ParamIn:       inner.ParamIn,
+		ParamArgIndex: i,
+	}
+	entry.Complete = true
+}
+
+// argAt returns an edge's argument at idx, or nil.
+func argAt(edge *metadata.CallGraphEdge, idx int) *metadata.CallArgument {
+	if idx < 0 || idx >= len(edge.Args) {
+		return nil
+	}
+	return edge.Args[idx]
+}

--- a/internal/spec/wrapper_detect.go
+++ b/internal/spec/wrapper_detect.go
@@ -383,8 +383,78 @@ func innerVerbArgIndex(inner RoutePattern) int {
 // recvTypeRegexFor renders the receiver constraint the way pattern matching reads
 // it: `pkg.*Router`, with the pointer optional so a value receiver matches too.
 func recvTypeRegexFor(w *wrapperMethod) string {
+	return recvTypeRegexForNames(w.pkg, []string{strings.TrimPrefix(w.recvType, "*")})
+}
+
+// recvTypeRegexForNames builds the same constraint over several type names.
+func recvTypeRegexForNames(pkg string, names []string) string {
+	quoted := make([]string, 0, len(names))
+	for _, n := range names {
+		quoted = append(quoted, regexp.QuoteMeta(n))
+	}
+	alt := quoted[0]
+	if len(quoted) > 1 {
+		alt = "(" + strings.Join(quoted, "|") + ")"
+	}
+	return "^" + regexp.QuoteMeta(pkg) + `\.\*?` + alt + "$"
+}
+
+// embeddingRecvRegex is recvTypeRegexFor widened to the types that EMBED the
+// declaring one.
+//
+// Go promotes an embedded type's methods, and a call is recorded against the type
+// the caller used: gitea declares its responder on `services/context.Base` but
+// every handler calls it through `*Context` or `*APIContext`, which embed Base. A
+// pattern scoped to the declaring type alone therefore matched almost nothing —
+// gitea documented 894 routes and 8 components, because the responder that
+// produces every schema was never recognised at its call sites (issue #235).
+func embeddingRecvRegex(meta *metadata.Metadata, w *wrapperMethod) string {
 	bare := strings.TrimPrefix(w.recvType, "*")
-	return "^" + regexp.QuoteMeta(w.pkg) + `\.\*?` + regexp.QuoteMeta(bare) + "$"
+	names := []string{bare}
+
+	// Transitively: a type embedding a type that embeds the declaring one gets
+	// the method too.
+	pkg, ok := meta.Packages[w.pkg]
+	if !ok {
+		return recvTypeRegexForNames(w.pkg, names)
+	}
+	for round := 0; round < wrapperDetectRounds; round++ {
+		grew := false
+		for _, fileName := range meta.SortedFileNames(w.pkg) {
+			file := pkg.Files[fileName]
+			if file == nil {
+				continue
+			}
+			for typeName, typ := range file.Types {
+				if containsName(names, typeName) {
+					continue
+				}
+				for _, embedded := range typ.Embeds {
+					embeddedName := strings.TrimPrefix(strings.TrimPrefix(meta.StringPool.GetString(embedded), "*"), w.pkg+".")
+					if containsName(names, embeddedName) {
+						names = append(names, typeName)
+						grew = true
+						break
+					}
+				}
+			}
+		}
+		if !grew {
+			break
+		}
+	}
+	sort.Strings(names)
+	return recvTypeRegexForNames(w.pkg, names)
+}
+
+// containsName reports whether names holds one.
+func containsName(names []string, want string) bool {
+	for _, n := range names {
+		if n == want {
+			return true
+		}
+	}
+	return false
 }
 
 // groupWrappers merges methods whose derived roles are identical into one pattern
@@ -531,19 +601,22 @@ func detectValueRound(meta *metadata.Metadata, cp ContextProvider, params *param
 		node := &TrackerNode{CallGraphEdge: edge}
 		key := w.fqRecv() + "." + w.name
 
+		// Widened once per method: the pattern has to match where handlers CALL
+		// this method, which is through whatever type embeds it.
+		recvRegex := embeddingRecvRegex(meta, w)
 		for j, m := range respMatchers {
 			if m.MatchNode(node) {
-				mergeResponseRoles(byMethod, key, w, cp, params, cfg.Framework.ResponsePatterns[j], edge)
+				mergeResponseRoles(byMethod, key, w, cp, params, cfg.Framework.ResponsePatterns[j], edge, recvRegex)
 			}
 		}
 		for j, m := range reqMatchers {
 			if m.MatchNode(node) {
-				deriveRequestWrapper(byMethod, key, w, cp, params, cfg.Framework.RequestBodyPatterns[j], edge)
+				deriveRequestWrapper(byMethod, key, w, cp, params, cfg.Framework.RequestBodyPatterns[j], edge, recvRegex)
 			}
 		}
 		for j, m := range paramMatchers {
 			if m.MatchNode(node) {
-				deriveParamWrapper(byMethod, key, w, cp, params, cfg.Framework.ParamPatterns[j], edge)
+				deriveParamWrapper(byMethod, key, w, cp, params, cfg.Framework.ParamPatterns[j], edge, recvRegex)
 			}
 		}
 	}
@@ -567,12 +640,12 @@ func wrapperShell(byMethod map[string]*DetectedWrapper, key string, w *wrapperMe
 // mergeResponseRoles folds one inner response call into the method's derived
 // pattern: the status from a `WriteHeader(status)`, the body from an
 // `Encode(content)`, both of which the same responder performs.
-func mergeResponseRoles(byMethod map[string]*DetectedWrapper, key string, w *wrapperMethod, cp ContextProvider, params *paramIndex, inner ResponsePattern, edge *metadata.CallGraphEdge) {
+func mergeResponseRoles(byMethod map[string]*DetectedWrapper, key string, w *wrapperMethod, cp ContextProvider, params *paramIndex, inner ResponsePattern, edge *metadata.CallGraphEdge, recvRegex string) {
 	entry := wrapperShell(byMethod, key, w, cp.GetString(edge.Callee.Pkg)+"."+cp.GetString(edge.Callee.Name))
 	if entry.Response == nil {
 		entry.Response = &ResponsePattern{
 			CallRegex:     "^" + regexp.QuoteMeta(w.name) + "$",
-			RecvTypeRegex: recvTypeRegexFor(w),
+			RecvTypeRegex: recvRegex,
 			TypeArgIndex:  -1,
 		}
 	}
@@ -599,7 +672,7 @@ func mergeResponseRoles(byMethod map[string]*DetectedWrapper, key string, w *wra
 
 // deriveRequestWrapper derives a request-body pattern from a decoder wrapper —
 // `func (c *Ctx) Bind(dst any) error { json.NewDecoder(c.r.Body).Decode(dst) }`.
-func deriveRequestWrapper(byMethod map[string]*DetectedWrapper, key string, w *wrapperMethod, cp ContextProvider, params *paramIndex, inner RequestBodyPattern, edge *metadata.CallGraphEdge) {
+func deriveRequestWrapper(byMethod map[string]*DetectedWrapper, key string, w *wrapperMethod, cp ContextProvider, params *paramIndex, inner RequestBodyPattern, edge *metadata.CallGraphEdge, recvRegex string) {
 	if !inner.TypeFromArg {
 		return
 	}
@@ -610,7 +683,7 @@ func deriveRequestWrapper(byMethod map[string]*DetectedWrapper, key string, w *w
 	entry := wrapperShell(byMethod, key, w, cp.GetString(edge.Callee.Pkg)+"."+cp.GetString(edge.Callee.Name))
 	entry.Request = &RequestBodyPattern{
 		CallRegex:     "^" + regexp.QuoteMeta(w.name) + "$",
-		RecvTypeRegex: recvTypeRegexFor(w),
+		RecvTypeRegex: recvRegex,
 		TypeFromArg:   true,
 		TypeArgIndex:  i,
 		Deref:         inner.Deref,
@@ -621,7 +694,7 @@ func deriveRequestWrapper(byMethod map[string]*DetectedWrapper, key string, w *w
 // deriveParamWrapper derives a parameter pattern from a reader wrapper —
 // `func (c *Ctx) Param(name string) string { return chi.URLParam(c.r, name) }`.
 // The location comes from the inner pattern: the wrapper reads whatever it reads.
-func deriveParamWrapper(byMethod map[string]*DetectedWrapper, key string, w *wrapperMethod, cp ContextProvider, params *paramIndex, inner ParamPattern, edge *metadata.CallGraphEdge) {
+func deriveParamWrapper(byMethod map[string]*DetectedWrapper, key string, w *wrapperMethod, cp ContextProvider, params *paramIndex, inner ParamPattern, edge *metadata.CallGraphEdge, recvRegex string) {
 	if inner.ParamIn == "" || inner.NameFromMapKey {
 		return
 	}
@@ -632,7 +705,7 @@ func deriveParamWrapper(byMethod map[string]*DetectedWrapper, key string, w *wra
 	entry := wrapperShell(byMethod, key, w, cp.GetString(edge.Callee.Pkg)+"."+cp.GetString(edge.Callee.Name))
 	entry.Param = &ParamPattern{
 		CallRegex:     "^" + regexp.QuoteMeta(w.name) + "$",
-		RecvTypeRegex: recvTypeRegexFor(w),
+		RecvTypeRegex: recvRegex,
 		ParamIn:       inner.ParamIn,
 		ParamArgIndex: i,
 	}

--- a/internal/spec/wrapper_detect_test.go
+++ b/internal/spec/wrapper_detect_test.go
@@ -1,0 +1,368 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"reflect"
+	"regexp"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// TestInnerVerbArgIndex pins which argument a pattern reads its verb from.
+//
+// MethodArgIndex cannot be read on its own: it defaults to 0, so for a pattern
+// whose verb comes from the CALL name (chi's `r.Get(path, h)`) index 0 is the
+// PATH. Reading it as the verb would derive a wrapper whose verb is its path
+// parameter — every route registered through it would be documented under the
+// wrong method (issue #235).
+func TestInnerVerbArgIndex(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern RoutePattern
+		want    int
+	}{
+		{
+			name:    "the verb is stated to be an argument",
+			pattern: RoutePattern{MethodFromArg: true, MethodArgIndex: 1},
+			want:    1,
+		},
+		{
+			// chi's Method(verb, path, handler): no verb hint, but index 0 is
+			// neither the path nor the handler, so it is the verb.
+			name:    "an index that is neither path nor handler",
+			pattern: RoutePattern{MethodArgIndex: 0, PathFromArg: true, PathArgIndex: 1, HandlerFromArg: true, HandlerArgIndex: 2},
+			want:    0,
+		},
+		{
+			// chi's Get(path, handler): the verb is the call name, and index 0 is
+			// the path.
+			name:    "the verb comes from the call name",
+			pattern: RoutePattern{MethodFromCall: true, PathFromArg: true, PathArgIndex: 0, HandlerFromArg: true, HandlerArgIndex: 1},
+			want:    -1,
+		},
+		{
+			name:    "the default index collides with the path",
+			pattern: RoutePattern{PathFromArg: true, PathArgIndex: 0, HandlerFromArg: true, HandlerArgIndex: 1},
+			want:    -1,
+		},
+		{
+			name:    "the verb comes from the path itself",
+			pattern: RoutePattern{MethodFromPath: true, PathFromArg: true, PathArgIndex: 0},
+			want:    -1,
+		},
+		{
+			name:    "the verb comes from the handler name",
+			pattern: RoutePattern{MethodFromHandler: true, HandlerFromArg: true, HandlerArgIndex: 1},
+			want:    -1,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := innerVerbArgIndex(tc.pattern); got != tc.want {
+				t.Errorf("innerVerbArgIndex = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRecvTypeRegexFor pins the receiver constraint a derived pattern carries: it
+// has to match the receiver as metadata renders it, `pkg.*Router`, and it must be
+// escaped — an unescaped module path would read its dots as wildcards and match
+// unrelated packages.
+func TestRecvTypeRegexFor(t *testing.T) {
+	w := &wrapperMethod{pkg: "code.gitea.io/gitea/modules/web", recvType: "*Router", name: "Get"}
+	re := regexp.MustCompile(recvTypeRegexFor(w))
+
+	for _, match := range []string{
+		"code.gitea.io/gitea/modules/web.*Router",
+		"code.gitea.io/gitea/modules/web.Router",
+	} {
+		if !re.MatchString(match) {
+			t.Errorf("%q should match its own type", match)
+		}
+	}
+	for _, differ := range []string{
+		"code.gitea.io/gitea/modules/web.Combo",
+		"codexgitea.io/gitea/modules/web.Router", // a dot read as a wildcard
+		"other/web.Router",
+	} {
+		if re.MatchString(differ) {
+			t.Errorf("%q matched a pattern derived for a different type", differ)
+		}
+	}
+}
+
+// TestIdentsIn covers the expression walk the derivation rests on: it has to see
+// the parameter inside the shapes a wrapper forwards through, without
+// interpreting any of them.
+func TestIdentsIn(t *testing.T) {
+	m := wireNameMeta()
+	ident := func(name string) *metadata.CallArgument {
+		a := metadata.NewCallArgument(m)
+		a.SetKind(metadata.KindIdent)
+		a.SetName(name)
+		return a
+	}
+
+	// r.getPattern(pattern) — the parameter is inside a call.
+	call := metadata.NewCallArgument(m)
+	call.SetKind(metadata.KindCall)
+	fun := metadata.NewCallArgument(m)
+	fun.SetKind(metadata.KindSelector)
+	fun.X = ident("r")
+	fun.Sel = ident("getPattern")
+	call.Fun = fun
+	call.Args = []*metadata.CallArgument{ident("pattern")}
+
+	got := identsIn(call, wrapperExprDepth)
+	if !contains(got, "pattern") {
+		t.Errorf("identsIn(%v) missed the parameter inside the call", got)
+	}
+
+	// Depth is bounded, and nothing panics on an empty argument.
+	if got := identsIn(call, 0); len(got) != 0 {
+		t.Errorf("depth 0 returned %v, want nothing", got)
+	}
+	if got := identsIn(nil, wrapperExprDepth); got != nil {
+		t.Errorf("nil argument returned %v", got)
+	}
+}
+
+// TestMatchParam pins the parameter lookup, including the case that keeps an
+// ordinary registration helper from being read as a wrapper: a value the method
+// made up itself matches nothing.
+func TestMatchParam(t *testing.T) {
+	params := []string{"methods", "pattern", "h"}
+
+	if i, ok := matchParam(params, []string{"r", "getPattern", "pattern"}); !ok || i != 1 {
+		t.Errorf("matchParam = (%d, %v), want (1, true)", i, ok)
+	}
+	if _, ok := matchParam(params, []string{"strings", "TrimSpace", "literal"}); ok {
+		t.Error("a value the method built itself was read as a parameter")
+	}
+	if _, ok := matchParam(params, nil); ok {
+		t.Error("no names matched a parameter")
+	}
+	if _, ok := matchParam(nil, []string{"pattern"}); ok {
+		t.Error("a method with no parameters matched one")
+	}
+}
+
+// TestGroupWrappersMergesMethods pins the grouping: a router's verb methods share
+// one derived pattern rather than producing one line each, and the result is
+// ordered — derived patterns reach the config, and config order reaches the
+// output.
+func TestGroupWrappersMergesMethods(t *testing.T) {
+	roles := RoutePattern{PathFromArg: true, PathArgIndex: 0, HandlerFromArg: true, HandlerArgIndex: 1, MethodFromCall: true}
+	other := RoutePattern{PathFromArg: true, PathArgIndex: 1, HandlerFromArg: true, HandlerArgIndex: 2, MethodFromArg: true}
+
+	found := map[string]DetectedWrapper{
+		"app.*Router.Get":     {RecvType: "app.*Router", Methods: []string{"Get"}, Pattern: roles, Complete: true},
+		"app.*Router.Post":    {RecvType: "app.*Router", Methods: []string{"Post"}, Pattern: roles, Complete: true},
+		"app.*Router.Methods": {RecvType: "app.*Router", Methods: []string{"Methods"}, Pattern: other, Complete: true},
+	}
+
+	got := groupWrappers(found)
+	if len(got) != 2 {
+		t.Fatalf("grouped into %d patterns, want 2 (the verb methods share roles)", len(got))
+	}
+	var verbs, registrar DetectedWrapper
+	for _, w := range got {
+		if w.Pattern.MethodFromCall {
+			verbs = w
+		} else {
+			registrar = w
+		}
+	}
+	if want := []string{"Get", "Post"}; !reflect.DeepEqual(verbs.Methods, want) {
+		t.Errorf("verb methods = %v, want %v (sorted, merged)", verbs.Methods, want)
+	}
+	if verbs.Pattern.CallRegex != "^(Get|Post)$" {
+		t.Errorf("call regex = %q, want ^(Get|Post)$", verbs.Pattern.CallRegex)
+	}
+	if registrar.Pattern.CallRegex != "^(Methods)$" {
+		t.Errorf("registrar regex = %q, want ^(Methods)$", registrar.Pattern.CallRegex)
+	}
+}
+
+func contains(list []string, want string) bool {
+	for _, s := range list {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+// wrapperGraph builds one in-module router type whose method forwards its own
+// parameters into a framework registration — the shape the whole derivation turns
+// on — plus the two shapes that must NOT be derived.
+func wrapperGraph(t *testing.T) *metadata.Metadata {
+	t.Helper()
+	pool := metadata.NewStringPool()
+	m := &metadata.Metadata{StringPool: pool, CurrentModulePath: "example.com/app"}
+
+	ident := func(name, typ string) metadata.CallArgument {
+		a := metadata.NewCallArgument(m)
+		a.SetKind(metadata.KindIdent)
+		a.SetName(name)
+		if typ != "" {
+			a.SetType(typ)
+		}
+		return *a
+	}
+	arg := func(name string) *metadata.CallArgument {
+		a := ident(name, "")
+		return &a
+	}
+	literal := func(value string) *metadata.CallArgument {
+		a := metadata.NewCallArgument(m)
+		a.SetKind(metadata.KindLiteral)
+		a.SetValue(value)
+		return a
+	}
+	sig := func(params ...metadata.CallArgument) metadata.CallArgument {
+		s := metadata.NewCallArgument(m)
+		s.SetKind(metadata.KindFuncType)
+		for i := range params {
+			s.Args = append(s.Args, &params[i])
+		}
+		return *s
+	}
+	call := func(name, pkg, recv string) metadata.Call {
+		c := metadata.Call{Meta: m, Name: pool.Get(name), Pkg: pool.Get(pkg), Position: -1, Scope: -1, SignatureStr: -1, RecvType: -1}
+		if recv != "" {
+			c.RecvType = pool.Get(recv)
+		}
+		return c
+	}
+
+	m.Packages = map[string]*metadata.Package{
+		"example.com/app": {Files: map[string]*metadata.File{
+			"router.go": {Types: map[string]*metadata.Type{
+				"Router": {Name: pool.Get("Router"), Methods: []metadata.Method{
+					{Name: pool.Get("Get"), Signature: sig(ident("pattern", "string"), ident("h", ""))},
+					{Name: pool.Get("Health"), Signature: sig()},
+				}},
+			}},
+		}},
+	}
+
+	m.CallGraph = []metadata.CallGraphEdge{
+		// The wrapper: both roles are its own parameters.
+		{
+			Caller: call("Get", "example.com/app", "*Router"),
+			Callee: call("HandleFunc", "net/http", "*ServeMux"),
+			Args:   []*metadata.CallArgument{arg("pattern"), arg("h")},
+		},
+		// A method that registers ONE route with literals: a registrar, not a way
+		// of registering, so deriving a pattern from it would invent routes.
+		{
+			Caller: call("Health", "example.com/app", "*Router"),
+			Callee: call("HandleFunc", "net/http", "*ServeMux"),
+			Args:   []*metadata.CallArgument{literal(`"/health"`), arg("healthHandler")},
+		},
+		// A plain function: there is no type to scope a pattern to.
+		{
+			Caller: call("registerCRUD", "example.com/app", ""),
+			Callee: call("HandleFunc", "net/http", "*ServeMux"),
+			Args:   []*metadata.CallArgument{arg("base"), arg("h")},
+		},
+		// A dependency's method: describing it would not document this project.
+		{
+			Caller: call("Route", "github.com/vendor/kit", "*Kit"),
+			Callee: call("HandleFunc", "net/http", "*ServeMux"),
+			Args:   []*metadata.CallArgument{arg("pattern"), arg("h")},
+		},
+	}
+	m.BuildCallGraphMaps()
+	return m
+}
+
+// TestDetectRouterWrappers pins what is and is not a wrapper.
+//
+// The rule is one fact — a method of an in-module type that FORWARDS ITS OWN
+// PARAMETERS into a framework registration — and each of the three rejected
+// shapes here would, if accepted, invent routes rather than find them (issue
+// #235).
+func TestDetectRouterWrappers(t *testing.T) {
+	meta := wrapperGraph(t)
+	cfg := &APISpecConfig{Framework: FrameworkConfig{RoutePatterns: []RoutePattern{{
+		CallRegex:       `^HandleFunc$`,
+		RecvTypeRegex:   `^net/http\.\*?ServeMux$`,
+		PathFromArg:     true,
+		PathArgIndex:    0,
+		HandlerFromArg:  true,
+		HandlerArgIndex: 1,
+	}}}}
+
+	got := DetectRouterWrappers(meta, cfg)
+
+	var applied []DetectedWrapper
+	for _, w := range got {
+		if w.Complete {
+			applied = append(applied, w)
+		}
+	}
+	if len(applied) != 1 {
+		t.Fatalf("derived %d applicable wrappers, want 1: %+v", len(applied), got)
+	}
+
+	w := applied[0]
+	if w.RecvType != "example.com/app.*Router" || !reflect.DeepEqual(w.Methods, []string{"Get"}) {
+		t.Errorf("derived %s %v, want example.com/app.*Router [Get]", w.RecvType, w.Methods)
+	}
+	if !w.Pattern.PathFromArg || w.Pattern.PathArgIndex != 0 {
+		t.Errorf("path role = (%v, %d), want the first parameter", w.Pattern.PathFromArg, w.Pattern.PathArgIndex)
+	}
+	if !w.Pattern.HandlerFromArg || w.Pattern.HandlerArgIndex != 1 {
+		t.Errorf("handler role = (%v, %d), want the second parameter", w.Pattern.HandlerFromArg, w.Pattern.HandlerArgIndex)
+	}
+	// The method is named for its verb, so the verb is fixed by the call.
+	if !w.Pattern.MethodFromCall {
+		t.Error("a method named Get should take its verb from the call name")
+	}
+
+	// Nothing was derived for the rejected shapes.
+	for _, w := range got {
+		if w.Complete && (contains(w.Methods, "Health") || contains(w.Methods, "registerCRUD") || contains(w.Methods, "Route")) {
+			t.Errorf("%s %v was derived; it registers a route rather than describing how to register", w.RecvType, w.Methods)
+		}
+	}
+
+	// Guards.
+	if got := DetectRouterWrappers(nil, cfg); got != nil {
+		t.Errorf("nil metadata derived %v", got)
+	}
+	if got := DetectRouterWrappers(meta, &APISpecConfig{}); got != nil {
+		t.Errorf("a config with no patterns derived %v", got)
+	}
+}
+
+// TestSplitFQRecv covers the receiver split, whose failure mode would be a
+// pattern scoped to the wrong package.
+func TestSplitFQRecv(t *testing.T) {
+	pkg, recv, ok := splitFQRecv("code.gitea.io/gitea/modules/web.*Router")
+	if !ok || pkg != "code.gitea.io/gitea/modules/web" || recv != "*Router" {
+		t.Errorf("splitFQRecv = (%q, %q, %v)", pkg, recv, ok)
+	}
+	for _, bad := range []string{"", "noDot", "trailing."} {
+		if _, _, ok := splitFQRecv(bad); ok {
+			t.Errorf("%q split into a package and receiver", bad)
+		}
+	}
+}

--- a/internal/spec/wrapper_detect_test.go
+++ b/internal/spec/wrapper_detect_test.go
@@ -458,3 +458,56 @@ func TestDetectValueWrappers(t *testing.T) {
 		t.Errorf("parameter reader not derived, or lost its location: %+v", par)
 	}
 }
+
+// TestEmbeddingRecvRegex pins the receiver constraint a derived value pattern
+// carries.
+//
+// Go promotes an embedded type's methods, and a call is recorded against the type
+// the CALLER used. gitea declares its responder on `context.Base` while every
+// handler answers through `*Context` or `*APIContext`, which embed it — so a
+// pattern scoped to the declaring type alone matched almost nothing, and the
+// project came out with 894 routes and 8 components (issue #235).
+func TestEmbeddingRecvRegex(t *testing.T) {
+	pool := metadata.NewStringPool()
+	m := &metadata.Metadata{StringPool: pool, CurrentModulePath: "example.com/app"}
+	m.Packages = map[string]*metadata.Package{
+		"example.com/app": {Files: map[string]*metadata.File{
+			"ctx.go": {Types: map[string]*metadata.Type{
+				"Base":    {Name: pool.Get("Base")},
+				"Context": {Name: pool.Get("Context"), Embeds: []int{pool.Get("*Base")}},
+				// Transitive: embeds the type that embeds Base.
+				"APIContext": {Name: pool.Get("APIContext"), Embeds: []int{pool.Get("*Context")}},
+				// Unrelated, and must not be swept in.
+				"Renderer": {Name: pool.Get("Renderer"), Embeds: []int{pool.Get("*bytes.Buffer")}},
+			}},
+		}},
+	}
+
+	re := regexp.MustCompile(embeddingRecvRegex(m, &wrapperMethod{pkg: "example.com/app", recvType: "*Base", name: "JSON"}))
+
+	for _, match := range []string{
+		"example.com/app.*Base",
+		"example.com/app.*Context",
+		"example.com/app.*APIContext",
+		"example.com/app.Context",
+	} {
+		if !re.MatchString(match) {
+			t.Errorf("%q calls the promoted method but does not match the derived pattern", match)
+		}
+	}
+	for _, differ := range []string{
+		"example.com/app.*Renderer",
+		"example.com/other.*Context",
+	} {
+		if re.MatchString(differ) {
+			t.Errorf("%q matched, but it does not embed the declaring type", differ)
+		}
+	}
+
+	// A package the metadata does not hold falls back to the declaring type alone
+	// rather than to something wider.
+	lone := embeddingRecvRegex(m, &wrapperMethod{pkg: "example.com/missing", recvType: "*Base"})
+	if !regexp.MustCompile(lone).MatchString("example.com/missing.*Base") {
+		t.Errorf("an unknown package lost its own type: %s", lone)
+	}
+}

--- a/internal/spec/wrapper_detect_test.go
+++ b/internal/spec/wrapper_detect_test.go
@@ -366,3 +366,95 @@ func TestSplitFQRecv(t *testing.T) {
 		}
 	}
 }
+
+// TestDetectValueWrappers covers the read/write twins of a router wrapper: the
+// project's own context, through which handlers answer, decode and read
+// parameters. A house router is rarely alone, and gitea documented 856 routes
+// with zero components until these were derived (issue #235).
+func TestDetectValueWrappers(t *testing.T) {
+	pool := metadata.NewStringPool()
+	m := &metadata.Metadata{StringPool: pool, CurrentModulePath: "example.com/app"}
+
+	ident := func(name, typ string) metadata.CallArgument {
+		a := metadata.NewCallArgument(m)
+		a.SetKind(metadata.KindIdent)
+		a.SetName(name)
+		if typ != "" {
+			a.SetType(typ)
+		}
+		return *a
+	}
+	arg := func(name string) *metadata.CallArgument { a := ident(name, ""); return &a }
+	sig := func(params ...metadata.CallArgument) metadata.CallArgument {
+		s := metadata.NewCallArgument(m)
+		s.SetKind(metadata.KindFuncType)
+		for i := range params {
+			s.Args = append(s.Args, &params[i])
+		}
+		return *s
+	}
+	call := func(name, pkg, recv string) metadata.Call {
+		c := metadata.Call{Meta: m, Name: pool.Get(name), Pkg: pool.Get(pkg), Position: -1, Scope: -1, SignatureStr: -1, RecvType: -1}
+		if recv != "" {
+			c.RecvType = pool.Get(recv)
+		}
+		return c
+	}
+
+	m.Packages = map[string]*metadata.Package{
+		"example.com/app": {Files: map[string]*metadata.File{
+			"ctx.go": {Types: map[string]*metadata.Type{
+				"Ctx": {Name: pool.Get("Ctx"), Methods: []metadata.Method{
+					{Name: pool.Get("JSON"), Signature: sig(ident("status", "int"), ident("body", "any"))},
+					{Name: pool.Get("Bind"), Signature: sig(ident("dst", "any"))},
+					{Name: pool.Get("Query"), Signature: sig(ident("name", "string"))},
+				}},
+			}},
+		}},
+	}
+	m.CallGraph = []metadata.CallGraphEdge{
+		// One responder, two roles: the status through one call, the body through
+		// another. Both have to end up on the same derived pattern.
+		{Caller: call("JSON", "example.com/app", "*Ctx"), Callee: call("WriteHeader", "net/http", "ResponseWriter"), Args: []*metadata.CallArgument{arg("status")}},
+		{Caller: call("JSON", "example.com/app", "*Ctx"), Callee: call("Encode", "encoding/json", "*Encoder"), Args: []*metadata.CallArgument{arg("body")}},
+		{Caller: call("Bind", "example.com/app", "*Ctx"), Callee: call("Decode", "encoding/json", "*Decoder"), Args: []*metadata.CallArgument{arg("dst")}},
+		{Caller: call("Query", "example.com/app", "*Ctx"), Callee: call("Get", "net/url", "Values"), Args: []*metadata.CallArgument{arg("name")}},
+	}
+	m.BuildCallGraphMaps()
+
+	cfg := &APISpecConfig{Framework: FrameworkConfig{
+		ResponsePatterns: []ResponsePattern{
+			{CallRegex: `^WriteHeader$`, StatusFromArg: true, StatusArgIndex: 0, TypeArgIndex: -1},
+			{CallRegex: `^Encode$`, TypeFromArg: true, TypeArgIndex: 0},
+		},
+		RequestBodyPatterns: []RequestBodyPattern{{CallRegex: `^Decode$`, TypeFromArg: true, TypeArgIndex: 0, Deref: true}},
+		ParamPatterns:       []ParamPattern{{CallRegex: `^Get$`, RecvType: "net/url.Values", ParamIn: "query", ParamArgIndex: 0}},
+	}}
+
+	byMethod := map[string]DetectedWrapper{}
+	for _, w := range DetectRouterWrappers(m, cfg) {
+		byMethod[w.Methods[0]] = w
+	}
+
+	resp, ok := byMethod["JSON"]
+	if !ok || resp.Response == nil {
+		t.Fatalf("no responder derived; have %v", byMethod)
+	}
+	if !resp.Response.StatusFromArg || resp.Response.StatusArgIndex != 0 {
+		t.Errorf("status role = (%v, %d), want the first parameter", resp.Response.StatusFromArg, resp.Response.StatusArgIndex)
+	}
+	if !resp.Response.TypeFromArg || resp.Response.TypeArgIndex != 1 {
+		t.Errorf("body role = (%v, %d), want the second parameter — merged from the other call",
+			resp.Response.TypeFromArg, resp.Response.TypeArgIndex)
+	}
+	if !resp.Complete {
+		t.Error("a responder with a body should be applicable")
+	}
+
+	if req, ok := byMethod["Bind"]; !ok || req.Request == nil || req.Request.TypeArgIndex != 0 {
+		t.Errorf("decoder not derived from its own parameter: %+v", req)
+	}
+	if par, ok := byMethod["Query"]; !ok || par.Param == nil || par.Param.ParamIn != "query" || par.Param.ParamArgIndex != 0 {
+		t.Errorf("parameter reader not derived, or lost its location: %+v", par)
+	}
+}

--- a/internal/spec/wrapper_params.go
+++ b/internal/spec/wrapper_params.go
@@ -1,0 +1,192 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"strings"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// paramIndex answers the question wrapper detection turns on: does this argument
+// come from one of the enclosing method's own PARAMETERS, and which one?
+//
+// That is the whole distinction between a router wrapper and an ordinary
+// registration helper. `r.chiRouter.Method(methods, r.getPattern(pattern), h)`
+// forwards `methods`, `pattern` and `h` — so the method is a registrar whose
+// caller supplies the route. `r.Get("/users", listUsers)` names them, and
+// describes one route rather than a way of registering routes (issue #235).
+type paramIndex struct {
+	meta *metadata.Metadata
+	// byMethod caches a method's parameter names in declaration order.
+	byMethod map[string][]string
+}
+
+func newParamIndex(meta *metadata.Metadata) *paramIndex {
+	return &paramIndex{meta: meta, byMethod: map[string][]string{}}
+}
+
+// wrapperExprDepth bounds the walk over one argument expression. Real forwarding
+// is shallow (`r.getPattern(pattern)`, `h[len(h)-1]`); the bound only stops a
+// pathological expression.
+const wrapperExprDepth = 6
+
+// wrapperAssignHops bounds how far a local is followed back towards a parameter.
+// A wrapper that unwraps a variadic `...any` needs two — gitea's does
+// `fn := h[len(h)-1].(type)` and then `handlerFunc = fn` — and a few more cost
+// nothing, since each hop is a map lookup on assignments already recorded.
+const wrapperAssignHops = 4
+
+// indexOf returns the parameter position an argument comes from.
+//
+// Three shapes count, all of them "the caller supplied this value":
+//
+//	Get(pattern, h...)          -> the argument IS the parameter
+//	r.getPattern(pattern)       -> the parameter is passed through a call
+//	h[len(h)-1] via a local var -> the parameter reaches it by assignment
+//
+// A value the method made up itself resolves to nothing, which is what keeps an
+// ordinary registration helper from being read as a wrapper.
+func (p *paramIndex) indexOf(w *wrapperMethod, arg *metadata.CallArgument) (int, bool) {
+	if p == nil || w == nil || arg == nil {
+		return 0, false
+	}
+	params := p.paramsOf(w)
+	if len(params) == 0 {
+		return 0, false
+	}
+
+	// Directly, through the expression the argument is built from, and then back
+	// through the assignments that produced any local it mentions. A wrapper that
+	// unwraps a variadic handler takes two hops to reach the parameter:
+	// `handlerFunc = fn`, `fn = h[len(h)-1].(T)`.
+	names := identsIn(arg, wrapperExprDepth)
+	seen := map[string]bool{}
+	for hop := 0; hop < wrapperAssignHops && len(names) > 0; hop++ {
+		if i, ok := matchParam(params, names); ok {
+			return i, true
+		}
+		var next []string
+		for _, name := range names {
+			if name == "" || seen[name] {
+				continue
+			}
+			seen[name] = true
+			for _, assign := range p.assignmentsOf(w, name) {
+				value := assign.Value
+				next = append(next, identsIn(&value, wrapperExprDepth)...)
+			}
+		}
+		names = next
+	}
+	return 0, false
+}
+
+// paramsOf returns a method's parameter names in declaration order.
+func (p *paramIndex) paramsOf(w *wrapperMethod) []string {
+	key := w.fqRecv() + "." + w.name
+	if cached, ok := p.byMethod[key]; ok {
+		return cached
+	}
+
+	var names []string
+	if m := p.methodOf(w); m != nil {
+		for _, param := range m.Signature.Args {
+			names = append(names, param.GetName())
+		}
+	}
+	p.byMethod[key] = names
+	return names
+}
+
+// assignmentsOf returns the assignments to a local inside the wrapper method.
+//
+// A method's assignments are recorded on the METHOD, not on a function of the
+// same name, so the type's method list is where to look; the function table is a
+// fallback for the shapes recorded there instead.
+func (p *paramIndex) assignmentsOf(w *wrapperMethod, name string) []metadata.Assignment {
+	if name == "" {
+		return nil
+	}
+	if m := p.methodOf(w); m != nil {
+		if assigns := m.AssignmentMap[name]; len(assigns) > 0 {
+			return assigns
+		}
+	}
+	if fn := findFunctionByName(p.meta, w.pkg, w.name); fn != nil {
+		return fn.AssignmentMap[name]
+	}
+	return nil
+}
+
+// methodOf finds the declaration of the wrapper method.
+func (p *paramIndex) methodOf(w *wrapperMethod) *metadata.Method {
+	pkg, ok := p.meta.Packages[w.pkg]
+	if !ok {
+		return nil
+	}
+	bare := strings.TrimPrefix(w.recvType, "*")
+	for _, fileName := range p.meta.SortedFileNames(w.pkg) {
+		file := pkg.Files[fileName]
+		if file == nil {
+			continue
+		}
+		typ, ok := file.Types[bare]
+		if !ok {
+			continue
+		}
+		for i := range typ.Methods {
+			if p.meta.StringPool.GetString(typ.Methods[i].Name) == w.name {
+				return &typ.Methods[i]
+			}
+		}
+	}
+	return nil
+}
+
+// matchParam returns the position of the first name that is a parameter.
+func matchParam(params, names []string) (int, bool) {
+	for _, name := range names {
+		if name == "" {
+			continue
+		}
+		for i, param := range params {
+			if param == name {
+				return i, true
+			}
+		}
+	}
+	return 0, false
+}
+
+// identsIn collects the identifier names an expression mentions, outermost
+// first — enough to see the parameter inside `r.getPattern(pattern)` or
+// `h[len(h)-1]` without interpreting either.
+func identsIn(arg *metadata.CallArgument, depth int) []string {
+	if arg == nil || depth <= 0 {
+		return nil
+	}
+	var out []string
+	if name := arg.GetName(); name != "" {
+		out = append(out, name)
+	}
+	for _, child := range []*metadata.CallArgument{arg.X, arg.Sel, arg.Fun} {
+		out = append(out, identsIn(child, depth-1)...)
+	}
+	for _, a := range arg.Args {
+		out = append(out, identsIn(a, depth-1)...)
+	}
+	return out
+}

--- a/testdata/wrapper_router/context.go
+++ b/testdata/wrapper_router/context.go
@@ -1,0 +1,36 @@
+// The other half of a house router: the project's own context. Handlers answer
+// through it, so the response body, the request body and the parameters are all
+// read through methods of this type rather than through the framework's.
+//
+// The shape mirrors gitea's services/context.Base: a status set with WriteHeader
+// and a body encoded to the same writer, both taking the caller's values as
+// parameters.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type Ctx struct {
+	Resp http.ResponseWriter
+	Req  *http.Request
+}
+
+// JSON answers with a status and a body — two roles reached through two
+// different calls in one method.
+func (c *Ctx) JSON(status int, content any) {
+	c.Resp.Header().Set("Content-Type", "application/json")
+	c.Resp.WriteHeader(status)
+	_ = json.NewEncoder(c.Resp).Encode(content)
+}
+
+// Bind reads the request body into dst.
+func (c *Ctx) Bind(dst any) error {
+	return json.NewDecoder(c.Req.Body).Decode(dst)
+}
+
+// Query reads a query parameter by name.
+func (c *Ctx) Query(name string) string {
+	return c.Req.URL.Query().Get(name)
+}

--- a/testdata/wrapper_router/context.go
+++ b/testdata/wrapper_router/context.go
@@ -30,6 +30,13 @@ func (c *Ctx) Bind(dst any) error {
 	return json.NewDecoder(c.Req.Body).Decode(dst)
 }
 
+// APICtx layers another context on top, the way a project separates its API
+// surface from its web surface — Go promotes Ctx's methods, so a handler calls
+// APICtx.JSON and the call is recorded against APICtx, not Ctx.
+type APICtx struct {
+	*Ctx
+}
+
 // Query reads a query parameter by name.
 func (c *Ctx) Query(name string) string {
 	return c.Req.URL.Query().Get(name)

--- a/testdata/wrapper_router/main.go
+++ b/testdata/wrapper_router/main.go
@@ -81,6 +81,13 @@ func updateItem(w http.ResponseWriter, r *http.Request) {
 	c.JSON(http.StatusAccepted, in)
 }
 
+// listAPIItems answers through the LAYERED context: the responder is declared on
+// Ctx but reached through APICtx, which embeds it.
+func listAPIItems(w http.ResponseWriter, r *http.Request) {
+	c := &APICtx{Ctx: &Ctx{Resp: w, Req: r}}
+	c.JSON(http.StatusOK, []Item{})
+}
+
 func main() {
 	r := NewRouter()
 
@@ -97,6 +104,7 @@ func main() {
 	})
 
 	r.Put("/items", updateItem)
+	r.Get("/api-items", listAPIItems)
 
 	registerCRUD(r.chiRouter, "/users")
 

--- a/testdata/wrapper_router/main.go
+++ b/testdata/wrapper_router/main.go
@@ -71,6 +71,16 @@ func registerCRUD(m *chi.Mux, base string) {
 	m.Delete(base+"/{id}", deleteUser)
 }
 
+// updateItem answers through the project's own context: its body, its status and
+// its parameters are all read through Ctx rather than through net/http.
+func updateItem(w http.ResponseWriter, r *http.Request) {
+	c := &Ctx{Resp: w, Req: r}
+	var in Item
+	_ = c.Bind(&in)
+	_ = c.Query("dry-run")
+	c.JSON(http.StatusAccepted, in)
+}
+
 func main() {
 	r := NewRouter()
 
@@ -85,6 +95,8 @@ func main() {
 		// The handler is behind a conversion.
 		r.Get("/items/count", http.HandlerFunc(countItems))
 	})
+
+	r.Put("/items", updateItem)
 
 	registerCRUD(r.chiRouter, "/users")
 


### PR DESCRIPTION
Closes #235.

## Before

A project with its own router type in front of the framework had to be described by hand. Pointed at gitea, apispec produced **3 paths and 0 components** — and nothing said a wrapper was the reason.

## The rule

A wrapper is derived from one fact: **a method of an in-module type that forwards its own parameters** into a call the framework's patterns already recognise.

```go
func (r *Router) Get(pattern string, h ...any) { r.Methods("GET", pattern, h...) }   // a way of registering
func (s *Server) routes() { r.Get("/users", s.list) }                               // ONE registration
```

The first forwards its parameters; the second names literals. That distinction is what keeps ordinary registration helpers from being turned into patterns that invent routes.

Which parameter plays which role comes from the inner pattern — the framework call already declares where its path, handler, verb, status, body or parameter name sit, and the derivation asks which enclosing parameter arrives there. It follows a value through a call, an index and a chain of assignments, so a router that unwraps a variadic `...any` resolves as readily as one that forwards directly.

**Transitive**, because wrappers stack: gitea's verb methods delegate to one registrar which delegates to chi; its responder encodes through the project's own json package before reaching `encoding/json`.

**All four kinds**, because a house router is rarely alone: routes and group mounts from the router type; response, request-body and parameter patterns from the context type — where a responder that sets its status with `WriteHeader` and its body with `Encode` has both roles merged into one derived pattern.

**Only complete derivations are applied.** An incomplete one is reported and left alone: a pattern missing its path produces a route with the *wrong* path, which is worse than the project being undocumented (golden rule #7). Everything derived is named in the run's log line and appears in `--output-config`.

## A metadata gap this exposed

`a, b := f()` has one right-hand side for two names, and `processAssignment` paired them by position — recording `a` and **dropping `b`**. Anything assigned from the second result of a call had no recorded origin at all. That is exactly how gitea unwraps its handlers (`middlewares, handlerFunc := wrapMiddlewareAndHandler(...)`), so nothing could trace one back to a parameter. Every name is now recorded against the call, with `ReturnIndex` saying which result it takes — ordinary Go that was invisible to every value-tracing consumer, not just this one.

## Measured

| | before | after |
|---|---|---|
| `testdata/wrapper_router`, no wrapper config | 2 paths (one junk) | **8 paths**, identical to the hand-written config |
| gitea, no config at all | 3 paths | **856 paths** |

On the fixture the derived set covers routes, the field-held group prefix, a multi-verb registrar, a handler behind a conversion, **and** the house context (`Bind` → request body, `Query` → parameter, `JSON` → status + body).

## Verification

- **Zero drift across the other 68 fixtures**: a project that registers directly derives nothing.
- Two structural tests: the fixture with hand-written patterns (unchanged) and the same fixture with **detection only**, asserting the same routes plus that the helper-registrar shape is still documented and never turned into a pattern.
- Unit tests for the decision logic, including the three shapes that must be rejected (literal registration, plain function, dependency's method) and the verb-index rule that would otherwise read a *path* parameter as a verb.
- Full suite, `go vet`, `gofmt`, `golangci-lint` (0 issues); coverage 96.0% against the 96% floor.

## Known residue

- gitea's `Combo("/x").Get(h).Post(h)` chained API is reported as incomplete and not applied — a chained registration shape the derivation does not yet express.
- gitea's component count with the value wrappers is not reported here: the run needs limits high enough to be memory-hungry on this machine, so the 856-path figure is from a completed run and the component figure is not. That is also the practical argument for #224/#225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automatically detects router wrappers (including mounts) and applies their route, request, response, and parameter patterns during API spec generation.
  - Exposes detected wrapper details via the engine API.
- **Bug Fixes**
  - Correctly attributes return origins for multi-value assignments.
  - Prevents wrapper parameters and delegate paths from being incorrectly documented as API routes.
  - Preserves generation stop/cancel and supersession responses in the API UI.
- **Documentation**
  - Expanded README coverage for automatic wrapper detection and related configuration behaviors.
- **Tests**
  - Added unit tests covering wrapper detection, derivation helpers, wrapper persistence/idempotency, and multi-value assignment recording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->