### PR TITLE
feat(spec): the declared caller/callee pattern filters actually filter (#238)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 - [How It Works](#how-it-works)
   - [The pipeline, step by step](#the-pipeline-step-by-step)
 - [Configuration](#configuration)
+  - [Scoping a pattern to where the call is made](#scoping-a-pattern-to-where-the-call-is-made)
   - [Automatic wrapper detection](#automatic-wrapper-detection)
 - [Programmatic Usage](#programmatic-usage)
 - [Performance & Limits](#performance--limits)
@@ -726,6 +727,31 @@ framework:
     - callRegex: ^GetHeader$
       paramIn: header
 ```
+
+### Scoping a pattern to where the call is made
+
+Every pattern type also accepts `callerPkgPatterns`, `callerRecvTypePatterns`,
+`calleePkgPatterns` and `calleeRecvTypePatterns` — lists of regexes narrowing a
+pattern by *where a call is made*, not only by what is called. Two packages can
+register routes with the identical call, and that is the only fact separating
+them:
+
+```yaml
+framework:
+  routePatterns:
+    - callRegex: ^(?i)(Get|Post|Put|Delete)$
+      recvTypeRegex: ^github\.com/go-chi/chi(/v\d)?\.\*?(Router|Mux)$
+      methodFromCall: true
+      pathFromArg: true
+      handlerFromArg: true
+      handlerArgIndex: 1
+      callerPkgPatterns:
+        - /internal/api$      # operator endpoints stay out of the spec
+```
+
+Any entry in a list admits the call, an empty list constrains nothing, and all
+four are include filters. See
+[`docs/CONFIGURATION.md`](docs/CONFIGURATION.md#scoping-a-pattern-to-where-the-call-is-made).
 
 ### Entrypoints (CLI-dispatched services)
 

--- a/cmd/apispecui/assets/js/config.js
+++ b/cmd/apispecui/assets/js/config.js
@@ -602,9 +602,7 @@ function fieldEditor(p, f, set) {
     // Stored as a list, edited one entry per line — an empty box means "no
     // constraint", which is why blank lines are dropped rather than kept.
     return html`<div class="field">
-      ${lbl}<textarea class="input" style="min-height:54px" onInput=${(e) => set(toLines(e.target.value))}>
-${lines(val)}</textarea
-      >
+      ${lbl}<textarea class="input" style="min-height:54px" value=${lines(val)} onInput=${(e) => set(toLines(e.target.value))}></textarea>
     </div>`;
   }
   if (type.startsWith("select:")) {

--- a/cmd/apispecui/assets/js/config.js
+++ b/cmd/apispecui/assets/js/config.js
@@ -494,6 +494,16 @@ const COMMON_MATCH = [
   ["functionNameRegex", "Function name regex", "text", "Optional — match by the ENCLOSING function's name instead of the call (e.g. only routes registered inside RegisterRoutes)."],
 ];
 
+// Where a call is MADE, as opposed to what is called. One regex per line; any
+// one of them admits the call, an empty box constrains nothing, and all four are
+// include filters (there is no 'everything except').
+const SCOPE_FILTERS = [
+  ["callerPkgPatterns", "Caller package filters", "lines", "Only match calls made from these packages. Two packages can register routes with the identical call, and this is the only fact that separates them — e.g. .*/internal/api$ documents the public surface and leaves operator endpoints out of the spec."],
+  ["callerRecvTypePatterns", "Caller type filters", "lines", "Only match calls made from a method on one of these types, fully qualified — e.g. ^example\\.com/app\\.\\*Server$. A plain function is addressed by its package, the same convention the receiver type regex uses."],
+  ["calleePkgPatterns", "Callee package filters", "lines", "Only match calls INTO these packages, e.g. ^github\\.com/go-chi/chi. The list form of scoping by receiver, for when several unrelated packages should be admitted."],
+  ["calleeRecvTypePatterns", "Callee type filters", "lines", "Only match calls on one of these owner types, fully qualified — the list form of 'Receiver type regex' above, so several owners can be admitted without one alternation."],
+];
+
 const PATTERN_FIELDS = {
   routePatterns: [
     ...COMMON_MATCH,
@@ -506,6 +516,7 @@ const PATTERN_FIELDS = {
     ["handlerFromArg", "Handler from arg", "bool", "Resolve the handler from the handler argument."],
     ["methodFromPath", "Method from path", "bool", "The path argument may carry the verb, Go 1.22 style: mux.HandleFunc('GET /users', h). An explicit verb here wins over every other source and suppresses switch-on-r.Method splitting."],
     ["methodFromArg", "Method from arg", "bool", "The verb travels as the argument at 'Method arg index', and may name several: a house router's Methods('GET,POST', path, h) registers both, and one operation per verb is emitted. Use this for a registrar whose entry point takes the verb as a value."],
+    ...SCOPE_FILTERS,
   ],
   requestBodyPatterns: [
     ...COMMON_MATCH,
@@ -517,6 +528,7 @@ const PATTERN_FIELDS = {
     ["bodyFromReceiver", "Body from receiver", "bool", "The body comes from the call RECEIVER, not an argument — e.g. a json.Decoder bound to r.Body: dec.Decode(&req)."],
     ["bodySourceArgIndex", "Body source arg index", "int", "Index of the argument carrying the request-body source (the io.Reader/request), used with Require request source."],
     ["allowForGetMethods", "Allow for GET/HEAD", "bool", "Permit a request body on GET/HEAD routes (off by default, since those rarely carry one)."],
+    ...SCOPE_FILTERS,
   ],
   responsePatterns: [
     ...COMMON_MATCH,
@@ -529,6 +541,7 @@ const PATTERN_FIELDS = {
     ["defaultContentType", "Default content-type", "text", "Content-type for this pattern when not otherwise known. e.g. text/plain; charset=utf-8 for a c.String writer."],
     ["requireResponseDestination", "Require response destination", "bool", "Only classify as a response when the value being written traces to the response writer — keeps json.NewEncoder(&buf).Encode(v) or an encode to a file from being read as the response body. Pair with Response context below."],
     ["destFromReceiver", "Destination from receiver", "bool", "Resolve that destination from the call RECEIVER's factory argument — the x in json.NewEncoder(x).Encode(v)."],
+    ...SCOPE_FILTERS,
   ],
   paramPatterns: [
     ...COMMON_MATCH,
@@ -539,6 +552,7 @@ const PATTERN_FIELDS = {
     ["deref", "Dereference pointer", "bool", "Strip a leading * from the resolved type."],
     ["nameFromMapKey", "Name from map key", "bool", "The name is a KEY used to index this call's map result, not an argument — the gorilla/mux idiom vars := mux.Vars(r); vars['id']. Only keys that also appear as {placeholders} in the route path are emitted."],
     ["excludeRecvOriginRegex", "Exclude receiver origin", "text", "Drop the match when the receiver came FROM a type matching this regex. net/http.Header is the header map of the request AND the response, so a read is only a request parameter by provenance: w.Header().Get(k) and c.Response().Header().Get(k) read headers the server SENDS. An origin that cannot be resolved keeps the parameter."],
+    ...SCOPE_FILTERS,
   ],
   mountPatterns: [
     ...COMMON_MATCH,
@@ -548,6 +562,7 @@ const PATTERN_FIELDS = {
     ["routerFromArg", "Router from arg", "bool", "Follow the sub-router argument so its routes are attached under the prefix."],
     ["isMount", "Is mount", "bool", "Treat this call as a router mount/group (e.g. Chi Mount/Route, Gin Group)."],
     ["routerArgTypeRegex", "Router arg type regex", "text", "Only treat the router argument as a mounted ROUTER when its type matches. mux.Handle('/api', x) mounts a sub-router when x is a *chi.Mux but serves one handler when x is an http.Handler; without this every handler registration looks like a mount and its routes are emitted under every prefix."],
+    ...SCOPE_FILTERS,
   ],
   securityPatterns: [
     ...COMMON_MATCH,
@@ -557,6 +572,7 @@ const PATTERN_FIELDS = {
     ["middlewareExcludeLast", "Exclude last arg", "bool", "With variadic: skip the final argument because it is the handler, not middleware — gin/fiber per-route middleware."],
     ["middlewareFromRecv", "Middleware from receiver", "bool", "The middleware value is the call's receiver rather than an argument (rare)."],
     ["handlerArgIndex", "Handler arg index", "int", "Index of the guarded/wrapped handler argument, for scope route/wrapper."],
+    ...SCOPE_FILTERS,
   ],
   entrypointPatterns: [
     ["fieldRegex", "Field regex", "text", "Regex matching the struct FIELD the entrypoint function is assigned to. e.g. ^(Action|Run|RunE|Exec)$ — cobra's Run/RunE, urfave/cli's Action, ffcli's Exec."],
@@ -580,6 +596,15 @@ function fieldEditor(p, f, set) {
   if (type === "int") {
     return html`<div class="field">
       ${lbl}<input class="input" type="number" value=${val ?? ""} onInput=${(e) => set(e.target.value === "" ? 0 : parseInt(e.target.value, 10) || 0)} />
+    </div>`;
+  }
+  if (type === "lines") {
+    // Stored as a list, edited one entry per line — an empty box means "no
+    // constraint", which is why blank lines are dropped rather than kept.
+    return html`<div class="field">
+      ${lbl}<textarea class="input" style="min-height:54px" onInput=${(e) => set(toLines(e.target.value))}>
+${lines(val)}</textarea
+      >
     </div>`;
   }
   if (type.startsWith("select:")) {

--- a/cmd/apispecui/config_parity_test.go
+++ b/cmd/apispecui/config_parity_test.go
@@ -50,13 +50,6 @@ func TestConfigEditorCoversEveryField(t *testing.T) {
 		// Nested objects — see the doc comment.
 		"methodExtraction": "nested MethodExtractionConfig; defaults live in Go",
 		"bodyTransforms":   "nested BodyTransform list; edited in YAML mode",
-		// Declared on every pattern but read by nothing — no matcher consults them
-		// (issue #221). Offering them would advertise filtering that does not
-		// happen; they become editable when they become real.
-		"callerPkgPatterns":      "never read by any matcher (issue #221)",
-		"callerRecvTypePatterns": "never read by any matcher (issue #221)",
-		"calleePkgPatterns":      "never read by any matcher (issue #221)",
-		"calleeRecvTypePatterns": "never read by any matcher (issue #221)",
 	}
 
 	// Every config struct whose fields the structured editor is expected to reach.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -296,6 +296,43 @@ Sub-keys of `framework`:
 | `requestContext` | Which receivers/accessors mark a "request body" source. |
 | `responseContext` | Which types are the response *writer*, for response patterns gated on write destination (`requireResponseDestination`). Parameter reads state their own exclusion per pattern (`excludeRecvOriginRegex`). |
 
+### Scoping a pattern to where the call is made
+
+Every pattern above also accepts four filters, shared by all six pattern types:
+
+| Field | Matches against |
+|-------|-----------------|
+| `callerPkgPatterns` | the package of the function containing the call |
+| `callerRecvTypePatterns` | the type whose method contains the call |
+| `calleePkgPatterns` | the package being called into |
+| `calleeRecvTypePatterns` | the owner type of the call (the list form of `recvTypeRegex`) |
+
+Each is a list of regexes; **any** entry admits the call, all four are ANDed with
+each other, and an empty list constrains nothing. A function with no receiver is
+addressed by its package, the same convention `recvTypeRegex` uses.
+
+The caller side answers a question nothing else can: two packages may register
+routes with the *identical* call, and only where the call is made separates them.
+
+```yaml
+framework:
+  routePatterns:
+    - callRegex: ^(?i)(Get|Post|Put|Delete)$
+      recvTypeRegex: ^github\.com/go-chi/chi(/v\d)?\.\*?(Router|Mux)$
+      methodFromCall: true
+      pathFromArg: true
+      handlerFromArg: true
+      handlerArgIndex: 1
+      # Document the public surface; the operator endpoints registered the same
+      # way from internal/debugroutes stay out of the spec.
+      callerPkgPatterns:
+        - /internal/api$
+```
+
+These are **include** filters — there is no "everything except", because Go's
+regexp engine has no negative lookahead. A pattern that must avoid one caller is
+written by naming the callers it wants.
+
 Because these patterns are numerous and framework-specific, the authoritative
 reference is the in-repo default configs (`internal/spec/config_*.go`) and the
 struct definitions with doc comments in `internal/spec/config.go`. The quickest

--- a/generator/testdata_pattern_caller_scope_test.go
+++ b/generator/testdata_pattern_caller_scope_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"testing"
+
+	intspec "github.com/ehabterra/apispec/internal/spec"
+)
+
+// callerScopedConfig admits chi registrations only from the fixture's api
+// package. Nothing about the CALL distinguishes the two packages — both make the
+// same `r.Get(...)` on the same chi router — so the caller's package is the only
+// fact that can.
+func callerScopedConfig() *intspec.APISpecConfig {
+	cfg := intspec.DefaultChiConfig()
+	for i := range cfg.Framework.RoutePatterns {
+		cfg.Framework.RoutePatterns[i].CallerPkgPatterns = []string{`/internal/api$`}
+	}
+	return cfg
+}
+
+// TestTestdata_PatternCallerScope covers the four caller/callee filter fields,
+// which every pattern type has declared since the config was written and which no
+// matcher read: a user set `callerPkgPatterns`, got no filtering, no warning and
+// no error, and had no way to tell (issue #238).
+//
+// The fixture registers routes from two packages through the same router, so the
+// filter is the only thing that can separate them. Both directions are asserted
+// against the SAME fixture — first that the unfiltered config documents
+// everything, then that the filtered one drops exactly the operator routes —
+// because an assertion that something is absent proves nothing on its own: the
+// route has to be there to begin with.
+func TestTestdata_PatternCallerScope(t *testing.T) {
+	// The two runs differ in ONE field, so whatever the second one drops was
+	// dropped by the filter and by nothing else.
+	unfiltered := loadTestdata(t, "pattern_caller_scope", intspec.DefaultChiConfig())
+
+	for _, path := range []string{"/users", "/debug/stats"} {
+		if _, ok := unfiltered.Paths[path]; !ok {
+			t.Fatalf("%s missing WITHOUT any filter; have %v — the fixture cannot prove a filter dropped it",
+				path, mapPathKeys(unfiltered.Paths))
+		}
+	}
+
+	filtered := loadTestdata(t, "pattern_caller_scope", callerScopedConfig())
+
+	if _, ok := filtered.Paths["/debug/stats"]; ok {
+		t.Errorf("/debug/stats is still documented; callerPkgPatterns admitted only /internal/api, so a call made from debugroutes must not match")
+	}
+
+	// The filter must narrow, not break: the admitted package keeps everything it
+	// had, bodies included.
+	users, ok := filtered.Paths["/users"]
+	if !ok {
+		t.Fatalf("/users missing under the filter; have %v — the caller filter rejected the package it names", mapPathKeys(filtered.Paths))
+	}
+	get, post := opFor(users, "GET"), opFor(users, "POST")
+	if get == nil || post == nil {
+		t.Fatalf("/users: want GET and POST, got get=%v post=%v", get != nil, post != nil)
+	}
+	if _, hasOK := get.Responses["200"]; !hasOK {
+		t.Errorf("GET /users: 200 missing — have %v", keysOf(get.Responses))
+	}
+	if post.RequestBody == nil {
+		t.Error("POST /users: requestBody missing — the filter must not disturb extraction of the routes it admits")
+	}
+}

--- a/internal/spec/call_scope.go
+++ b/internal/spec/call_scope.go
@@ -1,0 +1,139 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import "github.com/ehabterra/apispec/internal/metadata"
+
+// callScope is the caller/callee filter set every pattern type declares, and
+// which nothing used to read: four lists of regexes narrowing a pattern by where
+// a call is MADE, not only by what is called (issue #238).
+//
+// The callee side overlaps with RecvTypeRegex on purpose — it is the list form of
+// the same question, so several unrelated owners can be admitted without writing
+// one alternation. The caller side is the capability that had no other
+// expression: `callRegex: ^Get$` scoped to callers in `.../internal/api` documents
+// the routes that package registers and leaves an identical registration
+// elsewhere alone.
+//
+// Semantics, uniform across all four:
+//
+//   - An empty list is no constraint.
+//   - A non-empty list admits the call when ANY of its regexes matches, so the
+//     lists are alternatives rather than a conjunction.
+//   - They are include filters. There is no way to say "everything except", and
+//     RE2 has no negative lookahead, so a pattern that must avoid one caller is
+//     expressed by admitting the ones it wants.
+//   - Regexes are unanchored, like every other regex in the config; anchor with
+//     ^…$ when a prefix match would be wrong.
+type callScope struct {
+	callerPkg      []string
+	callerRecvType []string
+	calleePkg      []string
+	calleeRecvType []string
+}
+
+// empty reports whether the scope constrains nothing, which is the overwhelmingly
+// common case — every built-in framework config leaves all four unset.
+func (s callScope) empty() bool {
+	return len(s.callerPkg) == 0 && len(s.callerRecvType) == 0 &&
+		len(s.calleePkg) == 0 && len(s.calleeRecvType) == 0
+}
+
+// matchCallScope reports whether an edge satisfies a pattern's caller/callee
+// filters.
+//
+// A pattern that declares a filter cannot be satisfied by a node with no edge:
+// there is no call to ask where it was made, and admitting it would make the
+// filter mean "sometimes".
+func (b *BasePatternMatcher) matchCallScope(edge *metadata.CallGraphEdge, s callScope) bool {
+	if s.empty() {
+		return true
+	}
+	if edge == nil {
+		return false
+	}
+	cp := b.contextProvider
+	return matchesAny(s.callerPkg, cp.GetString(edge.Caller.Pkg)) &&
+		matchesAny(s.callerRecvType, fqOwner(cp, edge.Caller.Pkg, edge.Caller.RecvType)) &&
+		matchesAny(s.calleePkg, cp.GetString(edge.Callee.Pkg)) &&
+		matchesAny(s.calleeRecvType, fqOwner(cp, edge.Callee.Pkg, edge.Callee.RecvType))
+}
+
+// matchesAny reports whether value matches at least one of the patterns, and
+// reports true for an empty list (no constraint).
+//
+// A pattern that fails to compile matches nothing rather than everything: a typo
+// should narrow a filter to nothing visible, not silently widen it.
+func matchesAny(patterns []string, value string) bool {
+	if len(patterns) == 0 {
+		return true
+	}
+	for _, pattern := range patterns {
+		if pattern == "" {
+			continue
+		}
+		if re, err := cachedRegex(pattern); err == nil && re.MatchString(value) {
+			return true
+		}
+	}
+	return false
+}
+
+// fqOwner renders what a function belongs to, the way RecvTypeRegex has always
+// been matched: `pkg.*Type` for a method, and the package path alone for a plain
+// function, so a package-level responder (`render.JSON`) is addressable by the
+// same field as a method on a router.
+func fqOwner(cp ContextProvider, pkgIdx, recvTypeIdx int) string {
+	pkg := cp.GetString(pkgIdx)
+	recvType := cp.GetString(recvTypeIdx)
+	switch {
+	case pkg != "" && recvType != "":
+		return pkg + "." + recvType
+	case recvType != "":
+		return recvType
+	default:
+		return pkg
+	}
+}
+
+// scope returns the caller/callee filters declared on a route pattern.
+func (p *RoutePattern) scope() callScope {
+	return callScope{p.CallerPkgPatterns, p.CallerRecvTypePatterns, p.CalleePkgPatterns, p.CalleeRecvTypePatterns}
+}
+
+// scope returns the caller/callee filters declared on a request-body pattern.
+func (p *RequestBodyPattern) scope() callScope {
+	return callScope{p.CallerPkgPatterns, p.CallerRecvTypePatterns, p.CalleePkgPatterns, p.CalleeRecvTypePatterns}
+}
+
+// scope returns the caller/callee filters declared on a response pattern.
+func (p *ResponsePattern) scope() callScope {
+	return callScope{p.CallerPkgPatterns, p.CallerRecvTypePatterns, p.CalleePkgPatterns, p.CalleeRecvTypePatterns}
+}
+
+// scope returns the caller/callee filters declared on a parameter pattern.
+func (p *ParamPattern) scope() callScope {
+	return callScope{p.CallerPkgPatterns, p.CallerRecvTypePatterns, p.CalleePkgPatterns, p.CalleeRecvTypePatterns}
+}
+
+// scope returns the caller/callee filters declared on a mount pattern.
+func (p *MountPattern) scope() callScope {
+	return callScope{p.CallerPkgPatterns, p.CallerRecvTypePatterns, p.CalleePkgPatterns, p.CalleeRecvTypePatterns}
+}
+
+// scope returns the caller/callee filters declared on a security pattern.
+func (p *SecurityPattern) scope() callScope {
+	return callScope{p.CallerPkgPatterns, p.CallerRecvTypePatterns, p.CalleePkgPatterns, p.CalleeRecvTypePatterns}
+}

--- a/internal/spec/call_scope.go
+++ b/internal/spec/call_scope.go
@@ -96,8 +96,12 @@ func matchesAny(patterns []string, value string) bool {
 // function, so a package-level responder (`render.JSON`) is addressable by the
 // same field as a method on a router.
 func fqOwner(cp ContextProvider, pkgIdx, recvTypeIdx int) string {
-	pkg := cp.GetString(pkgIdx)
-	recvType := cp.GetString(recvTypeIdx)
+	return qualifyOwner(cp.GetString(pkgIdx), cp.GetString(recvTypeIdx))
+}
+
+// qualifyOwner is fqOwner over already-resolved strings, for the callers that
+// read the string pool directly.
+func qualifyOwner(pkg, recvType string) string {
 	switch {
 	case pkg != "" && recvType != "":
 		return pkg + "." + recvType

--- a/internal/spec/call_scope_test.go
+++ b/internal/spec/call_scope_test.go
@@ -1,0 +1,200 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// scopeEdge builds a call from a method on api.Registrar in package
+// example.com/app/internal/api to a method on chi.Router.
+func scopeEdge(meta *metadata.Metadata, callerPkg, callerRecv string) *metadata.CallGraphEdge {
+	return &metadata.CallGraphEdge{
+		Caller:   sweepCall(meta, "Register", callerPkg, callerRecv, ""),
+		Callee:   sweepCall(meta, "Get", "github.com/go-chi/chi/v5", "*Mux", ""),
+		Position: meta.StringPool.Get(""),
+	}
+}
+
+// TestMatchCallScope covers the four caller/callee filters, which every pattern
+// type declared and no matcher read — a user set one and got no filtering, no
+// warning and no way to tell (issue #238).
+func TestMatchCallScope(t *testing.T) {
+	meta := exSweepMeta()
+	base := NewBasePatternMatcher(&APISpecConfig{}, NewContextProvider(meta), nil)
+	edge := scopeEdge(meta, "example.com/app/internal/api", "*Registrar")
+
+	tests := []struct {
+		name  string
+		scope callScope
+		want  bool
+		why   string
+	}{
+		{
+			name:  "no filters admit everything",
+			scope: callScope{},
+			want:  true,
+			why:   "an unset filter must not narrow anything — every built-in config leaves all four empty",
+		},
+		{
+			name:  "caller package admitted",
+			scope: callScope{callerPkg: []string{`/internal/api$`}},
+			want:  true,
+		},
+		{
+			name:  "caller package rejected",
+			scope: callScope{callerPkg: []string{`/internal/debugroutes$`}},
+			want:  false,
+			why:   "the same call made from another package is what these filters exist to separate",
+		},
+		{
+			name:  "caller receiver type admitted",
+			scope: callScope{callerRecvType: []string{`^example\.com/app/internal/api\.\*Registrar$`}},
+			want:  true,
+		},
+		{
+			name:  "caller receiver type rejected",
+			scope: callScope{callerRecvType: []string{`\.\*Router$`}},
+			want:  false,
+		},
+		{
+			name:  "callee package admitted",
+			scope: callScope{calleePkg: []string{`^github\.com/go-chi/chi`}},
+			want:  true,
+		},
+		{
+			name:  "callee package rejected",
+			scope: callScope{calleePkg: []string{`^github\.com/gin-gonic/gin$`}},
+			want:  false,
+		},
+		{
+			name:  "callee receiver type admitted",
+			scope: callScope{calleeRecvType: []string{`^github\.com/go-chi/chi/v5\.\*Mux$`}},
+			want:  true,
+		},
+		{
+			name:  "callee receiver type rejected",
+			scope: callScope{calleeRecvType: []string{`\.\*Engine$`}},
+			want:  false,
+		},
+		{
+			name:  "alternatives are ORed",
+			scope: callScope{callerPkg: []string{`/nowhere$`, `/internal/api$`}},
+			want:  true,
+			why:   "a list is a set of alternatives; requiring all of them would make two entries unsatisfiable",
+		},
+		{
+			name:  "lists are ANDed across the four fields",
+			scope: callScope{callerPkg: []string{`/internal/api$`}, calleePkg: []string{`gin`}},
+			want:  false,
+			why:   "each field that IS set must hold, or a caller filter could be undone by a callee filter",
+		},
+		{
+			name:  "an uncompilable regex matches nothing",
+			scope: callScope{callerPkg: []string{`([`}},
+			want:  false,
+			why:   "a typo must narrow a filter to nothing visible rather than silently widen it to everything",
+		},
+		{
+			name:  "an empty string in a list is not a wildcard",
+			scope: callScope{callerPkg: []string{""}},
+			want:  false,
+			why:   "an empty entry is a mistake; treating it as a match would admit everything the list means to exclude",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := base.matchCallScope(edge, tt.scope); got != tt.want {
+				t.Errorf("matchCallScope() = %v, want %v — %s", got, tt.want, tt.why)
+			}
+		})
+	}
+
+	t.Run("a filtered pattern cannot be satisfied without a call", func(t *testing.T) {
+		if base.matchCallScope(nil, callScope{callerPkg: []string{`.*`}}) {
+			t.Error("a node with no edge matched a caller filter; there is no call to ask where it was made")
+		}
+		if !base.matchCallScope(nil, callScope{}) {
+			t.Error("a node with no edge was rejected by an EMPTY scope, which constrains nothing")
+		}
+	})
+
+	t.Run("a receiver-less function is addressed by its package", func(t *testing.T) {
+		// Same convention as recvTypeRegex, which is why chi's render patterns can
+		// scope a package-level responder at all.
+		plain := &metadata.CallGraphEdge{
+			Caller:   sweepCall(meta, "Register", "example.com/app/routes", "", ""),
+			Callee:   sweepCall(meta, "JSON", "github.com/go-chi/render", "", ""),
+			Position: meta.StringPool.Get(""),
+		}
+		if !base.matchCallScope(plain, callScope{calleeRecvType: []string{`^github\.com/go-chi/render$`}}) {
+			t.Error("a package-level function did not match its package as an owner")
+		}
+		if !base.matchCallScope(plain, callScope{callerRecvType: []string{`^example\.com/app/routes$`}}) {
+			t.Error("a plain caller function did not match its package as an owner")
+		}
+	})
+}
+
+// TestCallScopeIsAppliedByEveryMatcher pins the wiring rather than the rule: the
+// filters are declared on six pattern types, and one matcher left unwired is
+// exactly the silent no-op this issue is about.
+func TestCallScopeIsAppliedByEveryMatcher(t *testing.T) {
+	meta := exSweepMeta()
+	cp := NewContextProvider(meta)
+	cfg := &APISpecConfig{}
+	edge := scopeEdge(meta, "example.com/app/internal/api", "*Registrar")
+	node := sweepNode(edge)
+
+	// Matches the caller, so each matcher must accept; then a filter naming a
+	// different package, so each must reject.
+	const admits, rejects = `/internal/api$`, `/internal/debugroutes$`
+
+	matchers := map[string]func(filter string) bool{
+		"route": func(f string) bool {
+			return NewRoutePatternMatcher(RoutePattern{CallerPkgPatterns: []string{f}}, cfg, cp, nil).MatchNode(node)
+		},
+		"requestBody": func(f string) bool {
+			return NewRequestPatternMatcher(RequestBodyPattern{CallerPkgPatterns: []string{f}}, cfg, cp, nil).MatchNode(node)
+		},
+		"response": func(f string) bool {
+			return NewResponsePatternMatcher(ResponsePattern{CallerPkgPatterns: []string{f}}, cfg, cp, nil).MatchNode(node)
+		},
+		"param": func(f string) bool {
+			return NewParamPatternMatcher(ParamPattern{CallerPkgPatterns: []string{f}}, cfg, cp, nil).MatchNode(node)
+		},
+		"mount": func(f string) bool {
+			// IsMount is what a mount pattern returns when everything else passes.
+			return NewMountPatternMatcher(MountPattern{CallerPkgPatterns: []string{f}, IsMount: true}, cfg, cp, nil).MatchNode(node)
+		},
+		"security": func(f string) bool {
+			return NewSecurityPatternMatcher(SecurityPattern{CallerPkgPatterns: []string{f}}, cfg, cp, nil).MatchNode(node)
+		},
+	}
+
+	for kind, match := range matchers {
+		t.Run(kind, func(t *testing.T) {
+			if !match(admits) {
+				t.Errorf("%sPatterns: the filter names the caller's own package and still did not match", kind)
+			}
+			if match(rejects) {
+				t.Errorf("%sPatterns: callerPkgPatterns is not read — the filter names another package and the call matched anyway", kind)
+			}
+		})
+	}
+}

--- a/internal/spec/config.go
+++ b/internal/spec/config.go
@@ -260,7 +260,9 @@ type RoutePattern struct {
 	// Method extraction configuration
 	MethodExtraction *MethodExtractionConfig `yaml:"methodExtraction,omitempty" json:"methodExtraction,omitempty"`
 
-	// Package/type filtering
+	// Package/type filtering: narrow this pattern by where the call is MADE and
+	// what it is made on. Each list is a set of alternatives, an empty list is no
+	// constraint, and they are include filters. See callScope (call_scope.go).
 	CallerPkgPatterns      []string `yaml:"callerPkgPatterns,omitempty" json:"callerPkgPatterns,omitempty"`
 	CallerRecvTypePatterns []string `yaml:"callerRecvTypePatterns,omitempty" json:"callerRecvTypePatterns,omitempty"`
 	CalleePkgPatterns      []string `yaml:"calleePkgPatterns,omitempty" json:"calleePkgPatterns,omitempty"`
@@ -296,7 +298,9 @@ type RequestBodyPattern struct {
 	// Context-aware validation
 	AllowForGetMethods bool `yaml:"allowForGetMethods,omitempty" json:"allowForGetMethods,omitempty"` // Allow this pattern for GET/HEAD methods
 
-	// Package/type filtering
+	// Package/type filtering: narrow this pattern by where the call is MADE and
+	// what it is made on. Each list is a set of alternatives, an empty list is no
+	// constraint, and they are include filters. See callScope (call_scope.go).
 	CallerPkgPatterns      []string `yaml:"callerPkgPatterns,omitempty" json:"callerPkgPatterns,omitempty"`
 	CallerRecvTypePatterns []string `yaml:"callerRecvTypePatterns,omitempty" json:"callerRecvTypePatterns,omitempty"`
 	CalleePkgPatterns      []string `yaml:"calleePkgPatterns,omitempty" json:"calleePkgPatterns,omitempty"`
@@ -336,7 +340,9 @@ type ResponsePattern struct {
 	// NewEncoder's first argument x. Mirrors RequestBodyPattern.BodyFromReceiver.
 	DestFromReceiver bool `yaml:"destFromReceiver,omitempty" json:"destFromReceiver,omitempty"`
 
-	// Package/type filtering
+	// Package/type filtering: narrow this pattern by where the call is MADE and
+	// what it is made on. Each list is a set of alternatives, an empty list is no
+	// constraint, and they are include filters. See callScope (call_scope.go).
 	CallerPkgPatterns      []string `yaml:"callerPkgPatterns,omitempty" json:"callerPkgPatterns,omitempty"`
 	CallerRecvTypePatterns []string `yaml:"callerRecvTypePatterns,omitempty" json:"callerRecvTypePatterns,omitempty"`
 	CalleePkgPatterns      []string `yaml:"calleePkgPatterns,omitempty" json:"calleePkgPatterns,omitempty"`
@@ -390,7 +396,9 @@ type ParamPattern struct {
 	// (golden rule #7 — only a proven response origin drops it).
 	ExcludeRecvOriginRegex string `yaml:"excludeRecvOriginRegex,omitempty" json:"excludeRecvOriginRegex,omitempty"`
 
-	// Package/type filtering
+	// Package/type filtering: narrow this pattern by where the call is MADE and
+	// what it is made on. Each list is a set of alternatives, an empty list is no
+	// constraint, and they are include filters. See callScope (call_scope.go).
 	CallerPkgPatterns      []string `yaml:"callerPkgPatterns,omitempty" json:"callerPkgPatterns,omitempty"`
 	CallerRecvTypePatterns []string `yaml:"callerRecvTypePatterns,omitempty" json:"callerRecvTypePatterns,omitempty"`
 	CalleePkgPatterns      []string `yaml:"calleePkgPatterns,omitempty" json:"calleePkgPatterns,omitempty"`
@@ -423,7 +431,9 @@ type MountPattern struct {
 	// Empty means the pattern does not discriminate on the argument type.
 	RouterArgTypeRegex string `yaml:"routerArgTypeRegex,omitempty" json:"routerArgTypeRegex,omitempty"`
 
-	// Package/type filtering
+	// Package/type filtering: narrow this pattern by where the call is MADE and
+	// what it is made on. Each list is a set of alternatives, an empty list is no
+	// constraint, and they are include filters. See callScope (call_scope.go).
 	CallerPkgPatterns      []string `yaml:"callerPkgPatterns,omitempty" json:"callerPkgPatterns,omitempty"`
 	CallerRecvTypePatterns []string `yaml:"callerRecvTypePatterns,omitempty" json:"callerRecvTypePatterns,omitempty"`
 	CalleePkgPatterns      []string `yaml:"calleePkgPatterns,omitempty" json:"calleePkgPatterns,omitempty"`
@@ -488,7 +498,9 @@ type SecurityPattern struct {
 	MiddlewareFromRecv    bool `yaml:"middlewareFromRecv,omitempty" json:"middlewareFromRecv,omitempty"`       // the middleware value is the receiver (rare)
 	HandlerArgIndex       int  `yaml:"handlerArgIndex,omitempty" json:"handlerArgIndex,omitempty"`             // wrapped/guarded handler arg (scope=wrapper/route)
 
-	// Package/type filtering.
+	// Package/type filtering: narrow this pattern by where the call is MADE and
+	// what it is made on. Each list is a set of alternatives, an empty list is no
+	// constraint, and they are include filters. See callScope (call_scope.go).
 	CallerPkgPatterns      []string `yaml:"callerPkgPatterns,omitempty" json:"callerPkgPatterns,omitempty"`
 	CallerRecvTypePatterns []string `yaml:"callerRecvTypePatterns,omitempty" json:"callerRecvTypePatterns,omitempty"`
 	CalleePkgPatterns      []string `yaml:"calleePkgPatterns,omitempty" json:"calleePkgPatterns,omitempty"`

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -2236,6 +2236,13 @@ func (r *ResponsePatternMatcherImpl) MatchNode(node TrackerNodeInterface) bool {
 	}
 
 	edge := node.GetEdge()
+
+	// Where the call is MADE can be as decisive as what is called: an identical
+	// registration in another package may not belong in this spec (issue #238).
+	if !r.matchCallScope(edge, r.pattern.scope()) {
+		return false
+	}
+
 	callName := r.contextProvider.GetString(edge.Callee.Name)
 	recvType := r.contextProvider.GetString(edge.Callee.RecvType)
 	recvPkg := r.contextProvider.GetString(edge.Callee.Pkg)
@@ -3282,6 +3289,13 @@ func (p *ParamPatternMatcherImpl) MatchNode(node TrackerNodeInterface) bool {
 	}
 
 	edge := node.GetEdge()
+
+	// Where the call is MADE can be as decisive as what is called: an identical
+	// registration in another package may not belong in this spec (issue #238).
+	if !p.matchCallScope(edge, p.pattern.scope()) {
+		return false
+	}
+
 	callName := p.contextProvider.GetString(edge.Callee.Name)
 	recvType := p.contextProvider.GetString(edge.Callee.RecvType)
 	recvPkg := p.contextProvider.GetString(edge.Callee.Pkg)

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -2097,14 +2097,7 @@ func (e *Extractor) handlerReachesAccessor(route *RouteInfo, pattern ParamPatter
 // regex), mirroring ParamPatternMatcherImpl.MatchNode.
 func edgeMatchesAccessor(meta *metadata.Metadata, edge *metadata.CallGraphEdge, pattern ParamPattern) bool {
 	callName := getString(meta, edge.Callee.Name)
-	recvType := getString(meta, edge.Callee.RecvType)
-	recvPkg := getString(meta, edge.Callee.Pkg)
-	fq := recvPkg
-	if fq != "" && recvType != "" {
-		fq += "." + recvType
-	} else if recvType != "" {
-		fq = recvType
-	}
+	fq := qualifyOwner(getString(meta, edge.Callee.Pkg), getString(meta, edge.Callee.RecvType))
 	if pattern.CallRegex != "" {
 		if re, err := cachedRegex(pattern.CallRegex); err != nil || !re.MatchString(callName) {
 			return false
@@ -2244,16 +2237,7 @@ func (r *ResponsePatternMatcherImpl) MatchNode(node TrackerNodeInterface) bool {
 	}
 
 	callName := r.contextProvider.GetString(edge.Callee.Name)
-	recvType := r.contextProvider.GetString(edge.Callee.RecvType)
-	recvPkg := r.contextProvider.GetString(edge.Callee.Pkg)
-
-	// Build fully qualified receiver type
-	fqRecvType := recvPkg
-	if fqRecvType != "" && recvType != "" {
-		fqRecvType += "." + recvType
-	} else if recvType != "" {
-		fqRecvType = recvType
-	}
+	fqRecvType := fqOwner(r.contextProvider, edge.Callee.Pkg, edge.Callee.RecvType)
 
 	// Check call regex
 	if r.pattern.CallRegex != "" && !r.matchPattern(r.pattern.CallRegex, callName) {
@@ -3297,16 +3281,7 @@ func (p *ParamPatternMatcherImpl) MatchNode(node TrackerNodeInterface) bool {
 	}
 
 	callName := p.contextProvider.GetString(edge.Callee.Name)
-	recvType := p.contextProvider.GetString(edge.Callee.RecvType)
-	recvPkg := p.contextProvider.GetString(edge.Callee.Pkg)
-
-	// Build fully qualified receiver type
-	fqRecvType := recvPkg
-	if fqRecvType != "" && recvType != "" {
-		fqRecvType += "." + recvType
-	} else if recvType != "" {
-		fqRecvType = recvType
-	}
+	fqRecvType := fqOwner(p.contextProvider, edge.Callee.Pkg, edge.Callee.RecvType)
 
 	// Check call regex
 	if p.pattern.CallRegex != "" && !p.matchPattern(p.pattern.CallRegex, callName) {

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -143,16 +143,7 @@ func (r *RoutePatternMatcherImpl) MatchNode(node TrackerNodeInterface) bool {
 	}
 
 	callName := r.contextProvider.GetString(edge.Callee.Name)
-	recvType := r.contextProvider.GetString(edge.Callee.RecvType)
-	recvPkg := r.contextProvider.GetString(edge.Callee.Pkg)
-
-	// Build fully qualified receiver type
-	fqRecvType := recvPkg
-	if fqRecvType != "" && recvType != "" {
-		fqRecvType += "." + recvType
-	} else if recvType != "" {
-		fqRecvType = recvType
-	}
+	fqRecvType := fqOwner(r.contextProvider, edge.Callee.Pkg, edge.Callee.RecvType)
 
 	// Check call regex
 	if r.pattern.CallRegex != "" && !r.matchPattern(r.pattern.CallRegex, callName) {
@@ -475,16 +466,7 @@ func (m *MountPatternMatcherImpl) MatchNode(node TrackerNodeInterface) bool {
 	}
 
 	callName := m.contextProvider.GetString(edge.Callee.Name)
-	recvType := m.contextProvider.GetString(edge.Callee.RecvType)
-	recvPkg := m.contextProvider.GetString(edge.Callee.Pkg)
-
-	// Build fully qualified receiver type
-	fqRecvType := recvPkg
-	if fqRecvType != "" && recvType != "" {
-		fqRecvType += "." + recvType
-	} else if recvType != "" {
-		fqRecvType = recvType
-	}
+	fqRecvType := fqOwner(m.contextProvider, edge.Callee.Pkg, edge.Callee.RecvType)
 
 	// Check call regex
 	if m.pattern.CallRegex != "" && !m.matchPattern(m.pattern.CallRegex, callName) {
@@ -635,16 +617,7 @@ func (s *SecurityPatternMatcherImpl) MatchEdge(edge *metadata.CallGraphEdge) boo
 	}
 
 	callName := s.contextProvider.GetString(edge.Callee.Name)
-	recvType := s.contextProvider.GetString(edge.Callee.RecvType)
-	recvPkg := s.contextProvider.GetString(edge.Callee.Pkg)
-
-	// Build fully qualified receiver type
-	fqRecvType := recvPkg
-	if fqRecvType != "" && recvType != "" {
-		fqRecvType += "." + recvType
-	} else if recvType != "" {
-		fqRecvType = recvType
-	}
+	fqRecvType := fqOwner(s.contextProvider, edge.Callee.Pkg, edge.Callee.RecvType)
 
 	if s.pattern.CallRegex != "" && !s.matchPattern(s.pattern.CallRegex, callName) {
 		return false
@@ -793,16 +766,7 @@ func (r *RequestPatternMatcherImpl) MatchNode(node TrackerNodeInterface) bool {
 	}
 
 	callName := r.contextProvider.GetString(edge.Callee.Name)
-	recvType := r.contextProvider.GetString(edge.Callee.RecvType)
-	recvPkg := r.contextProvider.GetString(edge.Callee.Pkg)
-
-	// Build fully qualified receiver type
-	fqRecvType := recvPkg
-	if fqRecvType != "" && recvType != "" {
-		fqRecvType += "." + recvType
-	} else if recvType != "" {
-		fqRecvType = recvType
-	}
+	fqRecvType := fqOwner(r.contextProvider, edge.Callee.Pkg, edge.Callee.RecvType)
 
 	// Check call regex
 	if r.pattern.CallRegex != "" && !r.matchPattern(r.pattern.CallRegex, callName) {

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -135,6 +135,13 @@ func (r *RoutePatternMatcherImpl) MatchNode(node TrackerNodeInterface) bool {
 	}
 
 	edge := node.GetEdge()
+
+	// Where the call is MADE can be as decisive as what is called: an identical
+	// registration in another package may not belong in this spec (issue #238).
+	if !r.matchCallScope(edge, r.pattern.scope()) {
+		return false
+	}
+
 	callName := r.contextProvider.GetString(edge.Callee.Name)
 	recvType := r.contextProvider.GetString(edge.Callee.RecvType)
 	recvPkg := r.contextProvider.GetString(edge.Callee.Pkg)
@@ -460,6 +467,13 @@ func (m *MountPatternMatcherImpl) MatchNode(node TrackerNodeInterface) bool {
 	}
 
 	edge := node.GetEdge()
+
+	// Where the call is MADE can be as decisive as what is called: an identical
+	// registration in another package may not belong in this spec (issue #238).
+	if !m.matchCallScope(edge, m.pattern.scope()) {
+		return false
+	}
+
 	callName := m.contextProvider.GetString(edge.Callee.Name)
 	recvType := m.contextProvider.GetString(edge.Callee.RecvType)
 	recvPkg := m.contextProvider.GetString(edge.Callee.Pkg)
@@ -614,6 +628,12 @@ func (s *SecurityPatternMatcherImpl) MatchEdge(edge *metadata.CallGraphEdge) boo
 		return false
 	}
 
+	// Where the call is MADE can be as decisive as what is called: an identical
+	// registration in another package may not belong in this spec (issue #238).
+	if !s.matchCallScope(edge, s.pattern.scope()) {
+		return false
+	}
+
 	callName := s.contextProvider.GetString(edge.Callee.Name)
 	recvType := s.contextProvider.GetString(edge.Callee.RecvType)
 	recvPkg := s.contextProvider.GetString(edge.Callee.Pkg)
@@ -765,6 +785,13 @@ func (r *RequestPatternMatcherImpl) MatchNode(node TrackerNodeInterface) bool {
 	}
 
 	edge := node.GetEdge()
+
+	// Where the call is MADE can be as decisive as what is called: an identical
+	// registration in another package may not belong in this spec (issue #238).
+	if !r.matchCallScope(edge, r.pattern.scope()) {
+		return false
+	}
+
 	callName := r.contextProvider.GetString(edge.Callee.Name)
 	recvType := r.contextProvider.GetString(edge.Callee.RecvType)
 	recvPkg := r.contextProvider.GetString(edge.Callee.Pkg)

--- a/testdata/pattern_caller_scope/go.mod
+++ b/testdata/pattern_caller_scope/go.mod
@@ -1,0 +1,5 @@
+module example.com/callerscope
+
+go 1.24
+
+require github.com/go-chi/chi/v5 v5.2.1

--- a/testdata/pattern_caller_scope/go.sum
+++ b/testdata/pattern_caller_scope/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
+github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=

--- a/testdata/pattern_caller_scope/internal/api/api.go
+++ b/testdata/pattern_caller_scope/internal/api/api.go
@@ -1,0 +1,31 @@
+// Package api is the public surface: these routes belong in the spec.
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type User struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func Register(r chi.Router) {
+	r.Get("/users", listUsers)
+	r.Post("/users", createUser)
+}
+
+func listUsers(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode([]User{})
+}
+
+func createUser(w http.ResponseWriter, r *http.Request) {
+	var in User
+	_ = json.NewDecoder(r.Body).Decode(&in)
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(in)
+}

--- a/testdata/pattern_caller_scope/internal/debugroutes/debug.go
+++ b/testdata/pattern_caller_scope/internal/debugroutes/debug.go
@@ -1,0 +1,23 @@
+// Package debugroutes registers operator endpoints the same way api does. They
+// are real routes — they are simply not part of the documented API.
+package debugroutes
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type Stats struct {
+	Goroutines int `json:"goroutines"`
+}
+
+func Register(r chi.Router) {
+	r.Get("/debug/stats", dumpStats)
+}
+
+func dumpStats(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(Stats{})
+}

--- a/testdata/pattern_caller_scope/main.go
+++ b/testdata/pattern_caller_scope/main.go
@@ -1,0 +1,22 @@
+// Package main registers routes from two packages through the same router.
+//
+// Both packages make the SAME chi calls, so nothing about the call itself
+// separates them — only the package the call is made FROM. A spec that should
+// describe the public API and not the operator endpoints needs to say so with
+// callerPkgPatterns; without it, both sets are documented (issue #238).
+package main
+
+import (
+	"net/http"
+
+	"example.com/callerscope/internal/api"
+	"example.com/callerscope/internal/debugroutes"
+	"github.com/go-chi/chi/v5"
+)
+
+func main() {
+	r := chi.NewRouter()
+	api.Register(r)
+	debugroutes.Register(r)
+	_ = http.ListenAndServe(":8080", r)
+}


### PR DESCRIPTION
Closes #238.

Every pattern type has declared `callerPkgPatterns`, `callerRecvTypePatterns`, `calleePkgPatterns` and `calleeRecvTypePatterns` since the config was written, documented as "Package/type filtering". **No code read them.** A user set one, got no filtering, no warning and no error, and had no way to tell.

Direction 1 of the two the issue listed: implement them, rather than delete them.

## Semantics

All six matchers (route, request body, response, parameter, mount, security) now apply them:

- each list is a set of **alternatives** — any entry admits the call;
- the four fields are **ANDed** with each other, so a callee filter cannot undo a caller filter;
- an empty list constrains nothing (every built-in framework config leaves all four unset — zero output drift across all 71 fixtures);
- a regex that fails to compile matches **nothing** rather than everything: a typo should narrow a filter to nothing visible, not silently widen it;
- a receiver-less function is addressed by its package, the same convention `recvTypeRegex` already uses.

The callee side overlaps with `recvTypeRegex` on purpose — it is the list form of the same question, for admitting several unrelated owners without one alternation. The **caller** side is the capability that had no other expression.

## Why the fixture looks like that

`testdata/pattern_caller_scope` registers routes from two packages through the same chi router, with the identical calls. Nothing about the call separates them; only where it is made does.

Both directions are asserted against that one fixture — first that the unfiltered config documents everything, then that adding the filter drops exactly the operator routes. An assertion that something is absent proves nothing on its own, and the two runs differ in one field, so whatever the second drops was dropped by the filter. Verified the test fails without the implementation.

```yaml
routePatterns:
  - callRegex: ^(?i)(Get|Post|Put|Delete)$
    recvTypeRegex: ^github\.com/go-chi/chi(/v\d)?\.\*?(Router|Mux)$
    callerPkgPatterns: [/internal/api$]   # operator endpoints stay out of the spec
```

## One thing worth stating

They are **include** filters. RE2 has no negative lookahead, so there is no "everything except"; a pattern that must avoid one caller names the ones it wants. That is why #221 could not have been solved this way and took the outermost-registration rule instead — this PR does not reopen that.

## Also

- The UI offers all four on every pattern that declares them, one regex per line, and `config_parity_test.go` no longer needs its exemption. Verified in the browser end to end: typing `/internal/api$` into one route pattern's caller filter takes the fixture from 2 paths to 1, dropping `/debug/stats` and keeping `/users` with its bodies.
- Documented in `docs/CONFIGURATION.md` (new subsection with the field table) and summarised in the README.

## Verification

- New: `TestMatchCallScope` (13 cases incl. OR/AND semantics, uncompilable regex, empty entry, no-edge, receiver-less owner), `TestCallScopeIsAppliedByEveryMatcher` (one matcher left unwired is exactly this issue's failure mode), `TestTestdata_PatternCallerScope`.
- Full suite green; **zero drift** across all 71 fixtures A/B against `main`; `golangci-lint` 0 issues; `go vet` clean; coverage 96.0% (floor 96%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added caller and callee scope filters for framework detection patterns.
  * Filters can target caller or callee packages and receiver types using regex lists.
  * Updated the configuration editor to support multi-line scope filter entries.
* **Documentation**
  * Added configuration guidance, matching behavior details, and YAML examples for scoped patterns.
* **Bug Fixes**
  * Framework matches now respect configured call-site scope constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->