### PR TITLE
feat(callgraph): join the resolved graph to metadata by call site (VTA phase 0)

### DIFF
--- a/internal/callgraph/callsites.go
+++ b/internal/callgraph/callsites.go
@@ -1,0 +1,173 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package callgraph
+
+import (
+	"go/token"
+	"slices"
+	"sort"
+	"strings"
+)
+
+// CallSite is one resolved call, identified by WHERE it is written rather than
+// by who writes it.
+//
+// The position is the join key to metadata's call graph, and it is the join key
+// on purpose. Joining by function identity does not work for the code that
+// matters most: metadata names a closure by where it appears (`FuncLit:<pos>`)
+// while SSA names it after its parent (`pkg.parent$1`), and measured over two
+// real projects those two namings overlap in exactly ZERO cases — 0 of 1,625
+// closures on a 3,000-file module. Since routes, handlers and middleware are
+// overwhelmingly written as closures, a function-keyed join is blind to the
+// interesting half of the program. A call site has one position in one FileSet,
+// so joining there sidesteps naming entirely.
+type CallSite struct {
+	// CallerID is the FunctionID of the enclosing function.
+	CallerID string
+	// CalleeID is the FunctionID of the resolved target. For an interface or
+	// promoted method this is the CONCRETE target VTA resolved, which is the
+	// whole reason to consult this graph.
+	CalleeID string
+	// Position is where the call is written, in the FileSet the packages were
+	// loaded with — the same one metadata records positions from.
+	Position token.Position
+}
+
+// CallSites returns every resolved call that has a source position, sorted so
+// the result is identical across runs (golden rule #1: anything that can reach
+// the output is ordered).
+//
+// Synthetic edges — a wrapper the compiler generates, a call from an intrinsic —
+// have no Site and are skipped: they exist in no source file, so nothing can join
+// to them.
+func (r *Resolved) CallSites() []CallSite {
+	if r == nil || r.Graph == nil {
+		return nil
+	}
+
+	var out []CallSite
+	for fn, node := range r.Graph.Nodes {
+		callerID := FunctionID(fn)
+		if callerID == "" {
+			continue
+		}
+		for _, edge := range node.Out {
+			if edge.Site == nil || edge.Callee == nil || edge.Callee.Func == nil {
+				continue
+			}
+			pos := edge.Site.Pos()
+			if !pos.IsValid() {
+				continue
+			}
+			calleeID := FunctionID(edge.Callee.Func)
+			if calleeID == "" {
+				continue
+			}
+			out = append(out, CallSite{
+				CallerID: callerID,
+				CalleeID: calleeID,
+				Position: r.Prog.Fset.Position(pos),
+			})
+		}
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Position.Filename != out[j].Position.Filename {
+			return out[i].Position.Filename < out[j].Position.Filename
+		}
+		if out[i].Position.Offset != out[j].Position.Offset {
+			return out[i].Position.Offset < out[j].Position.Offset
+		}
+		if out[i].CallerID != out[j].CallerID {
+			return out[i].CallerID < out[j].CallerID
+		}
+		return out[i].CalleeID < out[j].CalleeID
+	})
+	return out
+}
+
+// CalleesAt indexes resolved targets by SiteKey, so a metadata edge can look up
+// what the call it records really resolves to.
+//
+// A key maps to SEVERAL targets when VTA cannot narrow an interface call to one
+// implementation. Keeping all of them is the honest answer (golden rule #7) and
+// the caller decides what to do with an ambiguous site; collapsing to "the first
+// one" here would silently pick a concrete type the program may never use.
+func (r *Resolved) CalleesAt() map[string][]string {
+	sites := r.CallSites()
+	index := make(map[string][]string, len(sites))
+	for _, site := range sites {
+		key := SiteKey(site.Position.String(), site.CalleeID)
+		if key == "" {
+			continue
+		}
+		if !slices.Contains(index[key], site.CalleeID) {
+			index[key] = append(index[key], site.CalleeID)
+		}
+	}
+	return index
+}
+
+// SiteKey builds the join key shared by both graphs: the line a call is written
+// on, plus the bare name of what it calls.
+//
+// The COLUMN is deliberately dropped. The two graphs do not agree on it and never
+// will: metadata records a call at the start of the statement that contains it,
+// while SSA records each call at its own opening parenthesis. Measured on a
+// fixture, `json.NewEncoder(w).Encode(v)` is two metadata edges both at column 6
+// and two SSA sites at columns 21 and 36 — so a column-exact join matches nothing
+// at all (0 of 49 edges), while the file and line always agree.
+//
+// The bare callee name is what separates several calls written on one line, and
+// it is the right discriminator rather than the full ID precisely BECAUSE the two
+// graphs are expected to disagree about the qualified callee: an interface call
+// that metadata records as `Storage.List` is exactly the one VTA resolves to
+// `s3driver.List`, and the shared `List` is what lets the disagreement be seen
+// instead of missed.
+func SiteKey(position, calleeID string) string {
+	line := lineOf(position)
+	if line == "" {
+		return ""
+	}
+	name := BareName(calleeID)
+	if name == "" {
+		return ""
+	}
+	return line + "#" + name
+}
+
+// BareName returns the last dot-separated segment of a function ID — the method
+// or function name without its package or receiver.
+func BareName(id string) string {
+	if i := strings.LastIndexByte(id, '.'); i >= 0 {
+		return id[i+1:]
+	}
+	return id
+}
+
+// lineOf strips the trailing `:column` from a `file:line:col` position, leaving
+// `file:line`. It counts from the right so a Windows drive letter (`C:\...`),
+// which puts a colon inside the filename, survives.
+func lineOf(position string) string {
+	last := strings.LastIndexByte(position, ':')
+	if last < 0 {
+		return ""
+	}
+	if prev := strings.LastIndexByte(position[:last], ':'); prev >= 0 {
+		return position[:last]
+	}
+	// Only one colon: the position carries no column, so it is already file:line.
+	return position
+}

--- a/internal/callgraph/callsites_test.go
+++ b/internal/callgraph/callsites_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package callgraph
+
+import "testing"
+
+// TestSiteKey pins the join key both graphs have to agree on.
+func TestSiteKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		position string
+		calleeID string
+		want     string
+		why      string
+	}{
+		{
+			name:     "column is dropped",
+			position: "/src/app/context.go:25:21",
+			calleeID: "encoding/json.NewEncoder",
+			want:     "/src/app/context.go:25#NewEncoder",
+			why:      "the two graphs never agree on the column — metadata records the statement start, SSA the opening parenthesis",
+		},
+		{
+			name:     "a differently-qualified callee keys the same",
+			position: "/src/app/media.go:40:9",
+			calleeID: "example.com/app/storage.s3driver.List",
+			want:     "/src/app/media.go:40#List",
+			why:      "an interface call metadata records as Storage.List must reach the concrete target VTA resolved, or the disagreement is invisible",
+		},
+		{
+			name:     "a Windows drive letter is not mistaken for a column",
+			position: `C:\src\app\main.go:12:3`,
+			calleeID: "net/http.ListenAndServe",
+			want:     `C:\src\app\main.go:12#ListenAndServe`,
+			why:      "the colon after the drive letter is inside the filename",
+		},
+		{
+			name:     "a position with no column is already a line",
+			position: "/src/app/main.go:12",
+			calleeID: "pkg.Fn",
+			want:     "/src/app/main.go:12#Fn",
+		},
+		{
+			name:     "no position, no key",
+			position: "",
+			calleeID: "pkg.Fn",
+			want:     "",
+			why:      "a call that is nowhere cannot be joined to",
+		},
+		{
+			name:     "no callee, no key",
+			position: "/src/app/main.go:12:3",
+			calleeID: "",
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SiteKey(tt.position, tt.calleeID); got != tt.want {
+				t.Errorf("SiteKey(%q, %q) = %q, want %q — %s", tt.position, tt.calleeID, got, tt.want, tt.why)
+			}
+		})
+	}
+}
+
+// TestBareName covers the discriminator that separates several calls written on
+// one line.
+func TestBareName(t *testing.T) {
+	for id, want := range map[string]string{
+		"encoding/json.Encoder.Encode": "Encode",
+		"example.com/app.Handler":      "Handler",
+		"Encode":                       "Encode",
+		"":                             "",
+	} {
+		if got := BareName(id); got != want {
+			t.Errorf("BareName(%q) = %q, want %q", id, got, want)
+		}
+	}
+}
+
+// TestCallSitesOnNilGraph pins that the accessor is safe before a build has run —
+// it is reachable whenever the resolved graph is off.
+func TestCallSitesOnNilGraph(t *testing.T) {
+	var r *Resolved
+	if sites := r.CallSites(); sites != nil {
+		t.Errorf("CallSites on a nil Resolved returned %d sites", len(sites))
+	}
+	if index := (&Resolved{}).CalleesAt(); len(index) != 0 {
+		t.Errorf("CalleesAt on an unbuilt Resolved returned %d entries", len(index))
+	}
+}

--- a/internal/metadata/scc.go
+++ b/internal/metadata/scc.go
@@ -110,6 +110,20 @@ func BuildCallGraphSCC(m *Metadata) *CallGraphSCC {
 	return condenseSCC(nodes, adj)
 }
 
+// CondenseGraph condenses an arbitrary directed graph given as a node list and
+// adjacency map, so a caller can condense a graph this package does not own —
+// the SSA/VTA-resolved call graph being the one that matters (docs/
+// TRACKER_REDESIGN.md step 2). The algorithm never needed anything from
+// Metadata; only BuildCallGraphSCC did.
+//
+// nodes and each adjacency list must be sorted, and adjacency must not name a
+// node outside nodes: both are guaranteed by BuildCallGraphSCC and are the
+// caller's job otherwise, because the component numbering is derived from that
+// order and determinism depends on it.
+func CondenseGraph(nodes []string, adj map[string][]string) *CallGraphSCC {
+	return condenseSCC(nodes, adj)
+}
+
 // condenseSCC runs Tarjan's algorithm (iterative, so pathological call-chain
 // depth cannot overflow the goroutine stack) over a pre-sorted node list and
 // pre-sorted adjacency, then builds the condensed DAG. Tarjan finalizes a

--- a/internal/spike/vta_join_test.go
+++ b/internal/spike/vta_join_test.go
@@ -1,0 +1,169 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spike
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/callgraph"
+	"github.com/ehabterra/apispec/internal/engine"
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// joinReport is what the two graphs agree and disagree about, per project.
+type joinReport struct {
+	metaEdges int // metadata edges carrying a position
+	joined    int // …whose position VTA also has a call at
+	agreed    int // …where VTA names the callee metadata named
+	resolved  int // …where VTA names a DIFFERENT callee (the interesting ones)
+}
+
+// TestVTACallSiteJoin measures the join the whole SSA/VTA migration rests on:
+// can a metadata call edge find the same call in the resolved graph?
+//
+// It joins on POSITION rather than on function identity, because identity does
+// not join for the code that matters — metadata names a closure `FuncLit:<pos>`
+// and SSA names it `pkg.parent$1`, an overlap of zero on every project measured,
+// while routes and handlers are overwhelmingly closures.
+//
+// The floor is deliberately modest. Two things legitimately fail to join and
+// neither is a defect: metadata records calls into dependencies whose bodies were
+// never loaded (so SSA has no call site for them), and VTA drops calls it proves
+// unreachable. What the floor guards is the opposite failure — a systematic
+// mismatch, where the two sides render positions differently or point at
+// different tokens of the same call, which would make every later phase silently
+// join nothing.
+func TestVTACallSiteJoin(t *testing.T) {
+	dirs := []string{
+		filepath.Join("..", "..", "testdata", "complex_chi_router"),
+		filepath.Join("..", "..", "testdata", "wrapper_router"),
+		filepath.Join("..", "..", "testdata", "cli_entrypoint_routes"),
+	}
+	if env := os.Getenv("APISPEC_JOIN_DIRS"); env != "" {
+		dirs = strings.Split(env, string(os.PathListSeparator))
+	}
+
+	for _, dir := range dirs {
+		t.Run(filepath.Base(dir), func(t *testing.T) {
+			report := joinAt(t, dir)
+			if report.metaEdges == 0 {
+				t.Fatalf("no positioned metadata edges in %s — the join cannot be measured", dir)
+			}
+			rate := 100 * float64(report.joined) / float64(report.metaEdges)
+			t.Logf("%s: %d positioned metadata edges, %d joined (%.1f%%) — %d agree, %d resolved differently",
+				filepath.Base(dir), report.metaEdges, report.joined, rate, report.agreed, report.resolved)
+
+			if rate < 25 {
+				t.Errorf("only %.1f%% of positioned edges joined; a systematic position mismatch would look exactly like this", rate)
+			}
+			// Whatever joins must overwhelmingly agree: a join that lands on the
+			// wrong call would show up as disagreement everywhere, not just at the
+			// interface calls VTA is supposed to resolve better.
+			if report.joined > 0 {
+				agree := 100 * float64(report.agreed) / float64(report.joined)
+				if agree < 50 {
+					t.Errorf("only %.1f%% of joined sites name the same callee — the join is landing on the wrong calls", agree)
+				}
+			}
+		})
+	}
+}
+
+// joinAt loads one project both ways and joins their call graphs on position.
+func joinAt(t *testing.T, dir string) joinReport {
+	t.Helper()
+
+	eng := engine.NewEngine(&engine.EngineConfig{InputDir: dir, ResolveCallGraph: true})
+	meta, err := eng.GenerateMetadataOnly()
+	if err != nil {
+		t.Fatalf("metadata for %s: %v", dir, err)
+	}
+	resolved := eng.GetResolvedCallGraph()
+	if resolved == nil {
+		t.Fatalf("no resolved graph for %s despite ResolveCallGraph", dir)
+	}
+
+	byPosition := resolved.CalleesAt()
+
+	var report joinReport
+	for i := range meta.CallGraph {
+		edge := &meta.CallGraph[i]
+		position := meta.StringPool.GetString(edge.Position)
+		if position == "" {
+			continue
+		}
+		report.metaEdges++
+
+		targets, ok := byPosition[callgraph.SiteKey(position, edge.Callee.BaseID())]
+		if !ok {
+			continue
+		}
+		report.joined++
+
+		if containsID(targets, edge.Callee.BaseID()) {
+			report.agreed++
+		} else {
+			report.resolved++
+		}
+	}
+	return report
+}
+
+func containsID(targets []string, want string) bool {
+	for _, target := range targets {
+		if target == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestCondenseGraphIsGraphAgnostic pins that the condensation can be run over a
+// graph metadata does not own — the resolved call graph is the one that matters,
+// and the algorithm never needed anything from Metadata.
+func TestCondenseGraphIsGraphAgnostic(t *testing.T) {
+	// a -> b -> c -> b (a recursion cluster), and a -> d standing alone.
+	nodes := []string{"a", "b", "c", "d"}
+	adj := map[string][]string{
+		"a": {"b", "d"},
+		"b": {"c"},
+		"c": {"b"},
+	}
+
+	scc := metadata.CondenseGraph(nodes, adj)
+
+	if !scc.SameComponent("b", "c") {
+		t.Error("b and c call each other and were not condensed into one component")
+	}
+	if scc.SameComponent("a", "b") {
+		t.Error("a calls b but is not called back; they are not one component")
+	}
+	if !scc.InCycle("b") {
+		t.Error("b is in a recursion cluster and was not flagged")
+	}
+	if scc.InCycle("d") {
+		t.Error("d calls nothing and was flagged as recursive")
+	}
+
+	// Callees before callers: whatever component holds a must come after the one
+	// holding b, since that ordering is what summaries will depend on.
+	if scc.ComponentOf["a"] <= scc.ComponentOf["b"] {
+		t.Errorf("components are not in callees-first order: a=%d b=%d",
+			scc.ComponentOf["a"], scc.ComponentOf["b"])
+	}
+}


### PR DESCRIPTION
Phase 0 of replacing the syntactic call graph with SSA+VTA. **Targets `feature/vta-call-graph`, not `main`.**

No behaviour change: the resolved graph is still off by default and still feeds nothing. What lands is the join everything later depends on, plus the measurement that says whether the migration is viable.

## The join is on the call site, not on function identity

Identity does not join for the code that matters. Metadata names a closure `FuncLit:<pos>`; SSA names it `pkg.parent$1`. Measured overlap: **0 of 1,625** closures on gitea, **0 of 103** on a 246-route service. Routes, handlers and middleware are overwhelmingly closures, so a function-keyed join is blind to exactly the half of the program this migration is for.

A call site has one position in one FileSet, so joining there sidesteps naming entirely.

## The key drops the column, and the first measurement forced that

Metadata records a call at the start of its statement; SSA records each call at its own opening parenthesis:

```
META  context.go:25:6   -> encoding/json.NewEncoder
META  context.go:25:6   -> encoding/json.Encoder.Encode
VTA   context.go:25:21  -> encoding/json.NewEncoder
VTA   context.go:25:36  -> encoding/json.Encoder.Encode
```

A column-exact join matched **0 of 49** edges. File and line always agree, and the bare callee name separates several calls written on one line — the *bare* name rather than the qualified one precisely because the graphs are meant to disagree about qualification: the interface call metadata records as `Storage.List` is the one VTA resolves to `s3driver.List`, and the shared `List` is what makes that disagreement visible instead of missed.

## Measured

| project | positioned edges | joined | agree | **VTA names a different callee** |
|---|---|---|---|---|
| complex_chi_router | 164 | 91.5% | 150 | 0 |
| wrapper_router | 49 | 85.7% | 41 | 1 |
| cli_entrypoint_routes | 15 | 86.7% | 13 | 0 |
| 246-route chi service | 7,979 | 73.4% | 5,832 | 28 |
| gitea | 82,263 | **84.5%** | 59,311 | **10,182** |

What does not join is expected rather than broken: metadata records calls into dependencies whose bodies were never loaded, and VTA drops calls it proves unreachable.

**The last column is the payload of the migration** — 10,182 gitea call sites where the syntactic graph points at the wrong function, dominated by interface dispatch and promoted methods through embedding (`ViewProject -> services/context.Base.FormString`, the case #236 had to fix by widening receiver regexes over `Type.Embeds`).

## Also

`metadata.CondenseGraph` exports the existing Tarjan condensation for a graph this package does not own, so the resolved graph can be condensed too — the algorithm never needed anything from `Metadata`, only `BuildCallGraphSCC` did. Keeping Tarjan over Kosaraju: one pass, already iterative and deterministic.

## Verification

- `TestVTACallSiteJoin` measures the join over three fixtures on every CI run and takes `APISPEC_JOIN_DIRS` for real projects. Its floor guards the failure mode this PR already hit once — a systematic position mismatch that silently joins nothing.
- `TestSiteKey` / `TestBareName` / `TestCallSitesOnNilGraph` cover the key, including a Windows drive letter whose colon is inside the filename.
- Full suite green, `gofmt -s` clean, `golangci-lint` 0 issues, coverage 96.0% (floor 96).

🤖 Generated with [Claude Code](https://claude.com/claude-code)