### PR TITLE
feat(callgraph): classify why the two graphs disagree (VTA phase 1)

### DIFF
--- a/internal/callgraph/callsites_test.go
+++ b/internal/callgraph/callsites_test.go
@@ -14,7 +14,11 @@
 
 package callgraph
 
-import "testing"
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
 
 // TestSiteKey pins the join key both graphs have to agree on.
 func TestSiteKey(t *testing.T) {
@@ -100,5 +104,51 @@ func TestCallSitesOnNilGraph(t *testing.T) {
 	}
 	if index := (&Resolved{}).CalleesAt(); len(index) != 0 {
 		t.Errorf("CalleesAt on an unbuilt Resolved returned %d entries", len(index))
+	}
+}
+
+// TestCallSitesOverRealGraph pins the accessor against a built graph: every
+// resolved call must carry a position in a real file, the order must be stable,
+// and CalleesAt must be able to answer for a call the fixture actually makes.
+func TestCallSitesOverRealGraph(t *testing.T) {
+	r := Build(loadFixture(t, muxFixture))
+
+	sites := r.CallSites()
+	if len(sites) == 0 {
+		t.Fatal("no call sites in a fixture that plainly makes calls")
+	}
+
+	for _, site := range sites {
+		if !site.Position.IsValid() {
+			t.Errorf("site %s -> %s has no position; it could never be joined to", site.CallerID, site.CalleeID)
+			break
+		}
+		if site.CallerID == "" || site.CalleeID == "" {
+			t.Errorf("site at %s has an empty end: caller=%q callee=%q", site.Position, site.CallerID, site.CalleeID)
+			break
+		}
+	}
+
+	// Determinism: the join is built from this, and anything feeding output must
+	// be ordered (golden rule #1).
+	again := r.CallSites()
+	if !reflect.DeepEqual(sites, again) {
+		t.Error("CallSites is not deterministic across calls on the same graph")
+	}
+
+	// mux.Vars is the call this fixture exists for; it must be findable by key.
+	index := r.CalleesAt()
+	found := false
+	for key, targets := range index {
+		if strings.HasSuffix(key, "#Vars") {
+			for _, target := range targets {
+				if strings.Contains(target, "mux") {
+					found = true
+				}
+			}
+		}
+	}
+	if !found {
+		t.Errorf("no `#Vars` site resolving into gorilla/mux; %d keys indexed", len(index))
 	}
 }

--- a/internal/callgraph/disagreement.go
+++ b/internal/callgraph/disagreement.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package callgraph
+
+import "strings"
+
+// Disagreement classifies why the resolved graph names a different callee than
+// the syntactic one at the same call site.
+//
+// The classes are not cosmetic: each one is a decision about whether the
+// resolved answer may be trusted over the recorded one. An interface call
+// resolved to its single implementation is an improvement; the same call
+// resolved to four implementations is an ambiguity that must stay ambiguous
+// (golden rule #7), and a target in an unrelated package is a join that landed
+// on the wrong call and must not be acted on at all.
+type Disagreement int
+
+const (
+	// DisagreeUnknown is a difference none of the classes below explain. Treat it
+	// as untrustworthy: it is the shape a mis-join takes.
+	DisagreeUnknown Disagreement = iota
+
+	// DisagreeInterface: the recorded callee is a method on an interface and the
+	// resolved one is a concrete implementation. This is what the resolved graph
+	// exists for.
+	DisagreeInterface
+
+	// DisagreePromoted: the recorded callee is a method on a type that EMBEDS the
+	// type declaring it, and the resolved one names the declaring type. Go
+	// promotes the method, so both names describe the same function — gitea's
+	// `ctx.FormString` recorded on `*Context`, declared on `*Base`.
+	DisagreePromoted
+
+	// DisagreeAmbiguous: several concrete targets at one site, none of which the
+	// recorded name matches. Honest resolution keeps all of them.
+	DisagreeAmbiguous
+)
+
+// String names the class for reports and test failures.
+func (d Disagreement) String() string {
+	switch d {
+	case DisagreeInterface:
+		return "interface->concrete"
+	case DisagreePromoted:
+		return "promoted-through-embedding"
+	case DisagreeAmbiguous:
+		return "ambiguous"
+	default:
+		return "unexplained"
+	}
+}
+
+// TypeFacts is what classification needs to know about the program's types,
+// supplied by the caller so this package does not depend on the metadata layer.
+type TypeFacts struct {
+	// IsInterface reports whether a fully-qualified type name (`pkg.Name`) is
+	// declared as an interface.
+	IsInterface func(qualified string) bool
+	// Embeds reports whether the first type embeds the second, transitively.
+	Embeds func(outer, inner string) bool
+}
+
+// Classify explains a disagreement between the callee a call site was recorded
+// with and the targets the resolved graph gives for it.
+func Classify(recorded string, resolved []string, facts TypeFacts) Disagreement {
+	if len(resolved) == 0 {
+		return DisagreeUnknown
+	}
+	if len(resolved) > 1 {
+		return DisagreeAmbiguous
+	}
+
+	recordedOwner, recordedName := splitOwner(recorded)
+	resolvedOwner, resolvedName := splitOwner(resolved[0])
+	if recordedName == "" || recordedName != resolvedName {
+		// Different function entirely: the join landed on the wrong call.
+		return DisagreeUnknown
+	}
+	if recordedOwner == "" || resolvedOwner == "" {
+		return DisagreeUnknown
+	}
+
+	if facts.IsInterface != nil && facts.IsInterface(recordedOwner) {
+		return DisagreeInterface
+	}
+	if facts.Embeds != nil && facts.Embeds(recordedOwner, resolvedOwner) {
+		return DisagreePromoted
+	}
+	return DisagreeUnknown
+}
+
+// splitOwner splits a function ID into the type or package that owns it and the
+// bare function name: `pkg/sub.Type.Method` -> (`pkg/sub.Type`, `Method`).
+func splitOwner(id string) (owner, name string) {
+	i := strings.LastIndexByte(id, '.')
+	if i < 0 {
+		return "", id
+	}
+	return id[:i], id[i+1:]
+}

--- a/internal/callgraph/disagreement_test.go
+++ b/internal/callgraph/disagreement_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package callgraph
+
+import "testing"
+
+// TestClassify pins which disagreements may be acted on. Measured over gitea,
+// the four classes cover 10,182 real disagreements: 2,880 interface calls,
+// 4,492 promoted methods, 1,570 ambiguous sites and 1,240 unexplained.
+func TestClassify(t *testing.T) {
+	facts := TypeFacts{
+		IsInterface: func(q string) bool { return q == "app.Storage" },
+		Embeds: func(outer, inner string) bool {
+			return outer == "app.Context" && inner == "app.Base"
+		},
+	}
+
+	tests := []struct {
+		name     string
+		recorded string
+		resolved []string
+		want     Disagreement
+		why      string
+	}{
+		{
+			name:     "interface method resolved to its implementation",
+			recorded: "app.Storage.List",
+			resolved: []string{"app.s3driver.List"},
+			want:     DisagreeInterface,
+			why:      "the recorded owner is an interface — this is what the resolved graph is for",
+		},
+		{
+			name:     "promoted method resolved to the declaring type",
+			recorded: "app.Context.FormString",
+			resolved: []string{"app.Base.FormString"},
+			want:     DisagreePromoted,
+			why:      "Context embeds Base, so Go promotes the method and both names describe one function",
+		},
+		{
+			name:     "several implementations stay ambiguous",
+			recorded: "app.Storage.List",
+			resolved: []string{"app.s3driver.List", "app.localDriver.List"},
+			want:     DisagreeAmbiguous,
+			why:      "picking one would invent a concrete type the program may never use (golden rule #7)",
+		},
+		{
+			name:     "a different function entirely is a mis-join",
+			recorded: "app.Storage.List",
+			resolved: []string{"app.s3driver.Save"},
+			want:     DisagreeUnknown,
+			why:      "the names differ, so the join landed on the wrong call and must not be acted on",
+		},
+		{
+			name:     "unrelated owner with the same method name",
+			recorded: "app.Widget.Close",
+			resolved: []string{"other.File.Close"},
+			want:     DisagreeUnknown,
+			why:      "neither an interface nor an embedding relation explains it",
+		},
+		{
+			name:     "no resolved target",
+			recorded: "app.Storage.List",
+			resolved: nil,
+			want:     DisagreeUnknown,
+		},
+		{
+			name:     "package-level function has no owner type",
+			recorded: "app.Helper",
+			resolved: []string{"other.Helper"},
+			want:     DisagreeUnknown,
+			why:      "a package is not a type; no interface or embedding relation can hold",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Classify(tt.recorded, tt.resolved, facts); got != tt.want {
+				t.Errorf("Classify(%q, %v) = %v, want %v — %s", tt.recorded, tt.resolved, got, tt.want, tt.why)
+			}
+		})
+	}
+}
+
+// TestClassifyWithoutFacts pins that a caller supplying no type facts gets no
+// confident answers rather than wrong ones.
+func TestClassifyWithoutFacts(t *testing.T) {
+	if got := Classify("app.Storage.List", []string{"app.s3driver.List"}, TypeFacts{}); got != DisagreeUnknown {
+		t.Errorf("Classify with no facts = %v, want %v", got, DisagreeUnknown)
+	}
+}
+
+func TestDisagreementString(t *testing.T) {
+	for class, want := range map[Disagreement]string{
+		DisagreeInterface: "interface->concrete",
+		DisagreePromoted:  "promoted-through-embedding",
+		DisagreeAmbiguous: "ambiguous",
+		DisagreeUnknown:   "unexplained",
+		Disagreement(99):  "unexplained",
+	} {
+		if got := class.String(); got != want {
+			t.Errorf("Disagreement(%d).String() = %q, want %q", class, got, want)
+		}
+	}
+}
+
+func TestSplitOwner(t *testing.T) {
+	for id, want := range map[string][2]string{
+		"pkg/sub.Type.Method": {"pkg/sub.Type", "Method"},
+		"pkg.Func":            {"pkg", "Func"},
+		"Bare":                {"", "Bare"},
+		"":                    {"", ""},
+	} {
+		owner, name := splitOwner(id)
+		if owner != want[0] || name != want[1] {
+			t.Errorf("splitOwner(%q) = (%q, %q), want (%q, %q)", id, owner, name, want[0], want[1])
+		}
+	}
+}

--- a/internal/spec/resolved_facts.go
+++ b/internal/spec/resolved_facts.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"strings"
+
+	"github.com/ehabterra/apispec/internal/callgraph"
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// TypeFactsFor answers the two questions that decide whether a resolved callee
+// may be trusted over the recorded one, from the facts metadata already holds.
+//
+// It lives in the spec layer rather than in metadata or callgraph because it
+// joins the two, and neither should learn about the other (golden rule #4:
+// metadata records facts, the layer above decides what they mean).
+func TypeFactsFor(meta *metadata.Metadata) callgraph.TypeFacts {
+	if meta == nil {
+		return callgraph.TypeFacts{}
+	}
+	interfaceKind := meta.StringPool.Get("interface")
+
+	// Both answers are memoized: a large project asks about the same handful of
+	// context and interface types at thousands of call sites.
+	isInterface := map[string]bool{}
+	embeds := map[string]map[string]bool{}
+
+	lookup := func(qualified string) *metadata.Type {
+		pkg, name := splitQualified(qualified)
+		if pkg == "" || name == "" {
+			return nil
+		}
+		p, ok := meta.Packages[pkg]
+		if !ok {
+			return nil
+		}
+		for _, fileName := range meta.SortedFileNames(pkg) {
+			file := p.Files[fileName]
+			if file == nil {
+				continue
+			}
+			if typ, ok := file.Types[name]; ok {
+				return typ
+			}
+		}
+		return nil
+	}
+
+	return callgraph.TypeFacts{
+		IsInterface: func(qualified string) bool {
+			if known, ok := isInterface[qualified]; ok {
+				return known
+			}
+			typ := lookup(qualified)
+			answer := typ != nil && typ.Kind == interfaceKind
+			isInterface[qualified] = answer
+			return answer
+		},
+		Embeds: func(outer, inner string) bool {
+			if known, ok := embeds[outer]; ok {
+				return known[inner]
+			}
+			// Walk the embedding chain once per outer type: a type embedding a type
+			// that embeds the target gets its methods too.
+			reachable := map[string]bool{}
+			pkg, _ := splitQualified(outer)
+			queue := []string{outer}
+			for len(queue) > 0 {
+				current := queue[0]
+				queue = queue[1:]
+				typ := lookup(current)
+				if typ == nil {
+					continue
+				}
+				for _, embedded := range typ.Embeds {
+					name := strings.TrimPrefix(meta.StringPool.GetString(embedded), "*")
+					if name == "" {
+						continue
+					}
+					qualified := name
+					if !strings.Contains(name, ".") && pkg != "" {
+						qualified = pkg + "." + name
+					}
+					if reachable[qualified] {
+						continue
+					}
+					reachable[qualified] = true
+					queue = append(queue, qualified)
+				}
+			}
+			embeds[outer] = reachable
+			return reachable[inner]
+		},
+	}
+}
+
+// splitQualified splits `pkg/path.Name` into its package and bare type name. The
+// split is at the LAST dot, because an import path contains dots of its own
+// (`github.com/x/y.Type`).
+func splitQualified(qualified string) (pkg, name string) {
+	i := strings.LastIndexByte(qualified, '.')
+	if i < 0 {
+		return "", ""
+	}
+	return qualified[:i], qualified[i+1:]
+}

--- a/internal/spec/resolved_facts_test.go
+++ b/internal/spec/resolved_facts_test.go
@@ -1,0 +1,132 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// TestTypeFactsFor covers the two questions that decide whether a resolved
+// callee may be trusted over the recorded one.
+func TestTypeFactsFor(t *testing.T) {
+	pool := metadata.NewStringPool()
+	meta := &metadata.Metadata{StringPool: pool}
+	meta.Packages = map[string]*metadata.Package{
+		"example.com/app": {Files: map[string]*metadata.File{
+			"types.go": {Types: map[string]*metadata.Type{
+				"Storage": {Name: pool.Get("Storage"), Kind: pool.Get("interface")},
+				"Base":    {Name: pool.Get("Base"), Kind: pool.Get("struct")},
+				"Context": {Name: pool.Get("Context"), Kind: pool.Get("struct"), Embeds: []int{pool.Get("*Base")}},
+				// Transitive: embeds the type that embeds Base.
+				"APIContext": {Name: pool.Get("APIContext"), Kind: pool.Get("struct"), Embeds: []int{pool.Get("*Context")}},
+				"Widget":     {Name: pool.Get("Widget"), Kind: pool.Get("struct")},
+			}},
+		}},
+	}
+
+	facts := TypeFactsFor(meta)
+
+	if !facts.IsInterface("example.com/app.Storage") {
+		t.Error("Storage is declared as an interface and was not reported as one")
+	}
+	if facts.IsInterface("example.com/app.Base") {
+		t.Error("Base is a struct and was reported as an interface")
+	}
+	if facts.IsInterface("example.com/missing.Thing") {
+		t.Error("a type in a package metadata does not hold was reported as an interface")
+	}
+	// Memoized answers must not differ from first ones.
+	if !facts.IsInterface("example.com/app.Storage") {
+		t.Error("the memoized answer contradicts the first")
+	}
+
+	if !facts.Embeds("example.com/app.Context", "example.com/app.Base") {
+		t.Error("Context embeds Base and the promotion was not seen")
+	}
+	if !facts.Embeds("example.com/app.APIContext", "example.com/app.Base") {
+		t.Error("APIContext embeds Base transitively — gitea's shape, 4,492 call sites")
+	}
+	if facts.Embeds("example.com/app.Widget", "example.com/app.Base") {
+		t.Error("Widget embeds nothing and was reported as embedding Base")
+	}
+	if facts.Embeds("example.com/app.Base", "example.com/app.Context") {
+		t.Error("embedding is directional; Base does not embed Context")
+	}
+	if !facts.Embeds("example.com/app.APIContext", "example.com/app.Base") {
+		t.Error("the memoized answer contradicts the first")
+	}
+}
+
+// TestTypeFactsForNilMetadata pins that the facts are safe when the resolved
+// graph is off and nothing has been loaded.
+func TestTypeFactsForNilMetadata(t *testing.T) {
+	facts := TypeFactsFor(nil)
+	if facts.IsInterface != nil || facts.Embeds != nil {
+		t.Error("nil metadata produced non-nil fact functions; a caller would ask them and get invented answers")
+	}
+}
+
+func TestSplitQualified(t *testing.T) {
+	for input, want := range map[string][2]string{
+		"github.com/x/y.Type": {"github.com/x/y", "Type"},
+		"app.Type":            {"app", "Type"},
+		"Type":                {"", ""},
+		"":                    {"", ""},
+	} {
+		pkg, name := splitQualified(input)
+		if pkg != want[0] || name != want[1] {
+			t.Errorf("splitQualified(%q) = (%q, %q), want (%q, %q)", input, pkg, name, want[0], want[1])
+		}
+	}
+}
+
+// TestTypeFactsForUnknownAndQualifiedEmbeds covers the two shapes the embedding
+// walk has to survive on a real project: a type in a package metadata never
+// loaded, and an embedded name that already carries its own package.
+func TestTypeFactsForUnknownAndQualifiedEmbeds(t *testing.T) {
+	pool := metadata.NewStringPool()
+	meta := &metadata.Metadata{StringPool: pool}
+	meta.Packages = map[string]*metadata.Package{
+		"example.com/app": {Files: map[string]*metadata.File{
+			"types.go": {Types: map[string]*metadata.Type{
+				// Embeds a type from another package, already qualified.
+				"Handler": {Name: pool.Get("Handler"), Embeds: []int{pool.Get("*other.io/pkg.Base")}},
+				// An empty embed entry must not become a bogus qualified name.
+				"Empty": {Name: pool.Get("Empty"), Embeds: []int{pool.Get("")}},
+			}},
+			"nil.go": nil,
+		}},
+	}
+
+	facts := TypeFactsFor(meta)
+
+	if !facts.Embeds("example.com/app.Handler", "other.io/pkg.Base") {
+		t.Error("a cross-package embed was not seen; the name already carries its package and must not be re-qualified")
+	}
+	if facts.Embeds("example.com/app.Handler", "example.com/app.Base") {
+		t.Error("a cross-package embed was re-qualified into the embedding type's own package")
+	}
+	if facts.Embeds("example.com/app.Empty", "example.com/app.Base") {
+		t.Error("an empty embed entry produced a match")
+	}
+	if facts.Embeds("example.com/missing.Thing", "example.com/app.Base") {
+		t.Error("a type in an unloaded package reported an embedding relation")
+	}
+	if facts.IsInterface("NoDotHere") {
+		t.Error("an unqualified name was looked up as though it had a package")
+	}
+}

--- a/internal/spike/vta_join_test.go
+++ b/internal/spike/vta_join_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ehabterra/apispec/internal/callgraph"
 	"github.com/ehabterra/apispec/internal/engine"
 	"github.com/ehabterra/apispec/internal/metadata"
+	"github.com/ehabterra/apispec/internal/spec"
 )
 
 // joinReport is what the two graphs agree and disagree about, per project.
@@ -31,6 +32,12 @@ type joinReport struct {
 	joined    int // …whose position VTA also has a call at
 	agreed    int // …where VTA names the callee metadata named
 	resolved  int // …where VTA names a DIFFERENT callee (the interesting ones)
+
+	// classes counts why the disagreements disagree — the spec for what phase 2
+	// is allowed to act on.
+	classes map[callgraph.Disagreement]int
+	// examples keeps one sample per class, for the report.
+	examples map[callgraph.Disagreement]string
 }
 
 // TestVTACallSiteJoin measures the join the whole SSA/VTA migration rests on:
@@ -68,6 +75,15 @@ func TestVTACallSiteJoin(t *testing.T) {
 			t.Logf("%s: %d positioned metadata edges, %d joined (%.1f%%) — %d agree, %d resolved differently",
 				filepath.Base(dir), report.metaEdges, report.joined, rate, report.agreed, report.resolved)
 
+			for _, class := range []callgraph.Disagreement{
+				callgraph.DisagreeInterface, callgraph.DisagreePromoted,
+				callgraph.DisagreeAmbiguous, callgraph.DisagreeUnknown,
+			} {
+				if n := report.classes[class]; n > 0 {
+					t.Logf("  %-26s %5d   e.g. %s", class, n, report.examples[class])
+				}
+			}
+
 			if rate < 25 {
 				t.Errorf("only %.1f%% of positioned edges joined; a systematic position mismatch would look exactly like this", rate)
 			}
@@ -99,8 +115,12 @@ func joinAt(t *testing.T, dir string) joinReport {
 	}
 
 	byPosition := resolved.CalleesAt()
+	facts := spec.TypeFactsFor(meta)
 
-	var report joinReport
+	report := joinReport{
+		classes:  map[callgraph.Disagreement]int{},
+		examples: map[callgraph.Disagreement]string{},
+	}
 	for i := range meta.CallGraph {
 		edge := &meta.CallGraph[i]
 		position := meta.StringPool.GetString(edge.Position)
@@ -117,8 +137,13 @@ func joinAt(t *testing.T, dir string) joinReport {
 
 		if containsID(targets, edge.Callee.BaseID()) {
 			report.agreed++
-		} else {
-			report.resolved++
+			continue
+		}
+		report.resolved++
+		class := callgraph.Classify(edge.Callee.BaseID(), targets, facts)
+		report.classes[class]++
+		if _, seen := report.examples[class]; !seen {
+			report.examples[class] = edge.Callee.BaseID() + "  ->  " + strings.Join(targets, ", ")
 		}
 	}
 	return report


### PR DESCRIPTION
Phase 1 of the SSA+VTA migration. **Targets `feature/vta-call-graph`.** Still no behaviour change — nothing consumes the resolved graph yet.

Phase 0 established that the resolved graph names a different callee at 10,182 gitea call sites. A count is not a licence to act on them: some are the improvement this migration exists for, and some are what a mis-join looks like. This PR classifies them, and the classification is the spec for phase 2.

## The four classes

| class | meaning | act on it? |
|---|---|---|
| `interface->concrete` | an interface method resolved to its single implementation | **yes** |
| `promoted-through-embedding` | the recorded owner *embeds* the type declaring the method, so Go promotes it and both names describe one function | **yes** |
| `ambiguous` | several implementations at one site | **no** — keep all of them (golden rule #7) |
| `unexplained` | neither relation holds; the join landed on the wrong call | **no** |

## Measured

Over gitea's 10,182 disagreements:

| class | count | share |
|---|---|---|
| promoted-through-embedding | **4,492** | 44% |
| interface->concrete | **2,880** | 28% |
| ambiguous | 1,570 | 15% |
| unexplained | 1,240 | 12% |

**72% safely actionable, 28% not** — the distinction phase 2 needed and could not have guessed. On the 246-route service: 17 interface, 1 ambiguous, 10 unexplained.

Real examples the report surfaced:

```
interface->concrete   setting.ConfigProvider.Sections -> setting.iniConfigProvider.Sections
promoted              git.LFSMetaObject.RelativePath  -> lfs.Pointer.RelativePath
ambiguous             storage.ObjectStorage.IterateObjects -> {Azure,Local,Minio,...}Storage.IterateObjects
```

## The fixture case is the point

`wrapper_router`'s single disagreement classifies as **promoted-through-embedding**: `APICtx.JSON -> Ctx.JSON`. That is the gitea shape #236 had to fix by widening derived receiver patterns over `Type.Embeds` by hand. The resolved graph identifies it natively — which is the argument for phase 4.

## Layering

`callgraph.Classify` needs to know which types are interfaces and which embed which. Rather than let the graph package reach into metadata, it declares a `TypeFacts` the caller supplies, and `spec.TypeFactsFor` answers it from metadata — the join lives in the layer above both (golden rule #4).

## Verification

Full suite green, `golangci-lint` 0 issues, coverage 96.0% (floor 96) after covering the new branches. The classifier runs over three fixtures on every CI run via `TestVTACallSiteJoin` and takes `APISPEC_JOIN_DIRS` for real projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)