### PR TITLE
feat(spec): point call edges at the function that actually runs (VTA phase 2)

### DIFF
--- a/cmd/apispec/main.go
+++ b/cmd/apispec/main.go
@@ -129,33 +129,35 @@ func printVersion() {
 
 // CLIConfig holds the configuration parsed from command line arguments
 type CLIConfig struct {
-	Verbose                      bool
-	InputDir                     string
-	OutputFile                   string
-	Title                        string
-	APIVersion                   string
-	Description                  string
-	TermsOfService               string
-	ContactName                  string
-	ContactURL                   string
-	ContactEmail                 string
-	LicenseName                  string
-	LicenseURL                   string
-	OpenAPIVersion               string
-	ConfigFile                   string
-	OutputConfig                 string
-	WriteMetadata                bool
-	SplitMetadata                bool
-	DiagramPath                  string
-	PaginatedDiagram             bool
-	DiagramPageSize              int
-	MaxNodesPerTree              int
-	MaxChildrenPerNode           int
-	MaxArgsPerFunction           int
-	MaxNestedArgsDepth           int
-	MaxRecursionDepth            int
-	MaxInstancesPerKey           int
-	LegacyTracker                bool
+	Verbose            bool
+	InputDir           string
+	OutputFile         string
+	Title              string
+	APIVersion         string
+	Description        string
+	TermsOfService     string
+	ContactName        string
+	ContactURL         string
+	ContactEmail       string
+	LicenseName        string
+	LicenseURL         string
+	OpenAPIVersion     string
+	ConfigFile         string
+	OutputConfig       string
+	WriteMetadata      bool
+	SplitMetadata      bool
+	DiagramPath        string
+	PaginatedDiagram   bool
+	DiagramPageSize    int
+	MaxNodesPerTree    int
+	MaxChildrenPerNode int
+	MaxArgsPerFunction int
+	MaxNestedArgsDepth int
+	MaxRecursionDepth  int
+	MaxInstancesPerKey int
+	LegacyTracker      bool
+
+	ResolveCallGraph             bool
 	ShowVersion                  bool
 	OutputFlagSet                bool
 	IncludeFiles                 []string
@@ -289,6 +291,8 @@ func parseFlags(args []string) (*CLIConfig, error) {
 		"Maximum copies of one callee within an instance scope (raise it when a group closure holds more routes than the default budget covers)")
 
 	fs.BoolVar(&config.LegacyTracker, "legacy-tracker", false, "Use the legacy (eager) tracker tree instead of the default lazy tracker")
+	fs.BoolVar(&config.ResolveCallGraph, "resolve-call-graph", false,
+		"Resolve call targets with SSA+VTA: an interface method with one implementation, and a method reached through embedding, are documented as the function that actually runs (experimental)")
 
 	// Include/exclude flags
 	fs.Var((*stringSliceFlag)(&config.IncludeFiles), "include-file", "Include files matching pattern (can be specified multiple times)")
@@ -391,6 +395,7 @@ func runGeneration(config *CLIConfig) (*spec.OpenAPISpec, *engine.Engine, error)
 		MaxRecursionDepth:            config.MaxRecursionDepth,
 		MaxInstancesPerKey:           config.MaxInstancesPerKey,
 		UseLazyTracker:               !config.LegacyTracker,
+		ResolveCallGraph:             config.ResolveCallGraph,
 		IncludeFiles:                 config.IncludeFiles,
 		IncludePackages:              config.IncludePackages,
 		IncludeFunctions:             config.IncludeFunctions,

--- a/generator/testdata_frameworks_test.go
+++ b/generator/testdata_frameworks_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ehabterra/apispec/internal/engine"
 	intspec "github.com/ehabterra/apispec/internal/spec"
 	"github.com/ehabterra/apispec/spec"
 )
@@ -331,4 +332,27 @@ func TestTestdata_MuxPathParamKeyMismatch(t *testing.T) {
 	if !strings.HasSuffix(m.Handler, "getTag") {
 		t.Errorf("mismatch handler = %q, want it to name getTag", m.Handler)
 	}
+}
+
+// loadTestdataResolved generates a fixture's spec with SSA+VTA call-target
+// resolution on, so a test can compare it against the syntactic run.
+func loadTestdataResolved(t *testing.T, name string, cfg *spec.APISpecConfig) *spec.OpenAPISpec {
+	t.Helper()
+	dir := filepath.Join("..", "testdata", name)
+
+	engineConfig := engine.DefaultEngineConfig()
+	engineConfig.InputDir = dir
+	engineConfig.ResolveCallGraph = true
+	if cfg != nil {
+		engineConfig.APISpecConfig = cfg
+	}
+
+	out, err := engine.NewEngine(engineConfig).GenerateOpenAPI()
+	if err != nil {
+		t.Fatalf("GenerateOpenAPI(%s) with the resolved call graph: %v", dir, err)
+	}
+	if out == nil || out.Paths == nil {
+		t.Fatalf("nil spec or paths for %s", name)
+	}
+	return out
 }

--- a/generator/testdata_wrapper_router_test.go
+++ b/generator/testdata_wrapper_router_test.go
@@ -214,3 +214,44 @@ func statusKeys(op *intspec.Operation) []string {
 	}
 	return out
 }
+
+// TestTestdata_WrapperRouterResolvedCallGraph pins that resolving call targets
+// with SSA+VTA does not disturb a spec the syntactic graph already gets right.
+//
+// The fixture's `APICtx.JSON` is a promoted method: it is written on the type
+// that EMBEDS the one declaring it, so the resolved graph rewrites the call to
+// the declaring type. That is the same fact #236 encodes by widening derived
+// receiver patterns over Type.Embeds, so with both in play the output must be
+// identical — the migration's safety property, checked here on the one fixture
+// where a rewrite actually fires.
+func TestTestdata_WrapperRouterResolvedCallGraph(t *testing.T) {
+	plain := loadTestdataWithFixtureConfig(t, "wrapper_router", wrapperRouterConfig())
+	resolved := loadTestdataResolved(t, "wrapper_router", wrapperRouterConfig())
+
+	if len(resolved.Paths) != len(plain.Paths) {
+		t.Fatalf("resolved run documents %d paths, plain run %d: %v vs %v",
+			len(resolved.Paths), len(plain.Paths), mapPathKeys(resolved.Paths), mapPathKeys(plain.Paths))
+	}
+	for path, item := range plain.Paths {
+		other, ok := resolved.Paths[path]
+		if !ok {
+			t.Errorf("%s disappeared when call targets were resolved", path)
+			continue
+		}
+		for _, method := range []string{"GET", "POST", "PUT", "DELETE"} {
+			op, resolvedOp := opFor(item, method), opFor(other, method)
+			if (op == nil) != (resolvedOp == nil) {
+				t.Errorf("%s %s: present=%v with the syntactic graph, present=%v with the resolved one",
+					method, path, op != nil, resolvedOp != nil)
+				continue
+			}
+			if op == nil {
+				continue
+			}
+			if len(op.Responses) != len(resolvedOp.Responses) {
+				t.Errorf("%s %s: responses %v -> %v when call targets were resolved",
+					method, path, statusKeys(op), statusKeys(resolvedOp))
+			}
+		}
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -282,12 +282,22 @@ type Engine struct {
 	// resolvedGraph is the SSA+VTA resolved call graph, built during
 	// GenerateMetadataOnly when config.ResolveCallGraph is set.
 	resolvedGraph *callgraph.Resolved
+
+	// resolvedCallees records what the resolved graph changed about the recorded
+	// call graph, for --verbose and for tests.
+	resolvedCallees intspec.ResolvedCalleeStats
 }
 
 // GetResolvedCallGraph returns the resolved call graph from the last
 // generation, or nil when config.ResolveCallGraph was off.
 func (e *Engine) GetResolvedCallGraph() *callgraph.Resolved {
 	return e.resolvedGraph
+}
+
+// GetResolvedCalleeStats reports what the resolved graph changed about the
+// recorded call graph on the last run.
+func (e *Engine) GetResolvedCalleeStats() intspec.ResolvedCalleeStats {
+	return e.resolvedCallees
 }
 
 // SkippedPackage is a package excluded from analysis due to compile/type
@@ -516,6 +526,12 @@ func (e *Engine) GenerateMetadataOnlyWithLogger(logger *VerboseLogger) (*metadat
 		tResolved := time.Now()
 		e.resolvedGraph = callgraph.Build(filteredPkgs)
 		e.reportPhase(fmt.Sprintf("resolved call graph built (%d functions)", len(e.resolvedGraph.Graph.Nodes)), time.Since(tResolved))
+
+		// Point the recorded calls at the functions that actually run. Metadata
+		// stays the authority on the call sites and their arguments; the resolved
+		// graph is the authority on which callee a site reaches.
+		e.resolvedCallees = intspec.ApplyResolvedCallees(meta, e.resolvedGraph, logger)
+		meta.BuildCallGraphMaps()
 		if err := e.ctx().Err(); err != nil {
 			return nil, err
 		}

--- a/internal/engine/engine_resolvedgraph_test.go
+++ b/internal/engine/engine_resolvedgraph_test.go
@@ -81,3 +81,38 @@ func TestResolveCallGraph_Wiring(t *testing.T) {
 		t.Error("resolved graph built despite ResolveCallGraph=false")
 	}
 }
+
+// TestResolvedCalleeStatsAreReported pins that a run says what the resolved
+// graph changed. A migration that silently documents a different program than
+// the one before it is exactly the failure mode this reporting exists to prevent
+// (docs/TRACKER_REDESIGN.md §8.4, bounded != silent).
+func TestResolvedCalleeStatsAreReported(t *testing.T) {
+	cfg := DefaultEngineConfig()
+	cfg.InputDir = filepath.Join("..", "..", "testdata", "wrapper_router")
+	cfg.ResolveCallGraph = true
+
+	eng := NewEngine(cfg)
+	if _, err := eng.GenerateOpenAPI(); err != nil {
+		t.Fatalf("GenerateOpenAPI: %v", err)
+	}
+
+	stats := eng.GetResolvedCalleeStats()
+	if stats.Joined == 0 {
+		t.Fatal("no call sites joined; the resolved graph reached nothing and every later phase would be a no-op")
+	}
+	// The fixture layers a context over another so a promoted method exists to
+	// resolve — the gitea shape, 4,492 sites there.
+	if stats.Promoted == 0 {
+		t.Errorf("no promoted method resolved in a fixture written to contain one (joined %d)", stats.Joined)
+	}
+
+	off := DefaultEngineConfig()
+	off.InputDir = cfg.InputDir
+	offEngine := NewEngine(off)
+	if _, err := offEngine.GenerateOpenAPI(); err != nil {
+		t.Fatalf("GenerateOpenAPI without the resolved graph: %v", err)
+	}
+	if stats := offEngine.GetResolvedCalleeStats(); stats.Joined != 0 {
+		t.Errorf("the resolved graph is off by default but reported %d joined sites", stats.Joined)
+	}
+}

--- a/internal/spec/resolved_callees.go
+++ b/internal/spec/resolved_callees.go
@@ -1,0 +1,188 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ehabterra/apispec/internal/callgraph"
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// ResolvedCalleeStats reports what the resolved graph changed, so a run can say
+// it out loud rather than silently documenting a different program.
+type ResolvedCalleeStats struct {
+	Joined      int // metadata edges the resolved graph also has a call at
+	Interface   int // …rewritten to the single implementation of an interface method
+	Promoted    int // …rewritten to the type that declares a promoted method
+	Ambiguous   int // …left alone: several implementations
+	Unexplained int // …left alone: no relation explains the difference
+}
+
+// Line renders the stats for --verbose.
+func (s ResolvedCalleeStats) Line() string {
+	return fmt.Sprintf("Resolved call graph: %d call sites joined, %d rewritten (%d interface, %d promoted), %d left ambiguous, %d unexplained",
+		s.Joined, s.Interface+s.Promoted, s.Interface, s.Promoted, s.Ambiguous, s.Unexplained)
+}
+
+// ApplyResolvedCallees points metadata's call edges at the callee the resolved
+// graph proves they reach.
+//
+// This is the step where SSA+VTA starts to matter. Metadata records what the
+// source says — `store.List(...)` is a call on whatever `store` is declared as —
+// while VTA knows which function actually runs. Two differences are worth acting
+// on, and both were counted before they were trusted (docs/TRACKER_REDESIGN.md):
+//
+//   - an interface method with exactly ONE implementation, so the concrete type's
+//     patterns and schemas apply (2,880 sites on gitea);
+//   - a method reached through embedding, rewritten to the type that declares it,
+//     which is how a pattern scoped to the declaring type matches a call written
+//     on the embedding one (4,492 sites on gitea — the shape #236 had to emulate
+//     by widening receiver regexes by hand).
+//
+// Two are deliberately NOT acted on. An interface with several implementations
+// stays as the interface, because choosing one would invent a concrete type the
+// program may never use (golden rule #7). A difference no relation explains is a
+// join that landed on the wrong call, and acting on it would corrupt the graph
+// (1,240 sites on gitea — 12%, far too many to wave through).
+//
+// The edge's arguments, assignments and chain links are untouched: the resolved
+// graph is the authority on WHICH function a site calls, and metadata remains the
+// authority on the call itself.
+func ApplyResolvedCallees(meta *metadata.Metadata, resolved *callgraph.Resolved, logger metadata.VerboseLogger) ResolvedCalleeStats {
+	var stats ResolvedCalleeStats
+	if meta == nil || resolved == nil {
+		return stats
+	}
+
+	byPosition := resolved.CalleesAt()
+	if len(byPosition) == 0 {
+		return stats
+	}
+
+	stats = applyResolvedCallees(meta, byPosition)
+	if logger != nil {
+		logger.Printf("%s\n", stats.Line())
+	}
+	return stats
+}
+
+// applyResolvedCallees is ApplyResolvedCallees over an already-built index, which
+// is the seam the classification rules are tested through: every class needs a
+// call site shaped a particular way, and building an SSA program per case would
+// test x/tools rather than these rules.
+func applyResolvedCallees(meta *metadata.Metadata, byPosition map[string][]string) ResolvedCalleeStats {
+	var stats ResolvedCalleeStats
+	facts := TypeFactsFor(meta)
+
+	for i := range meta.CallGraph {
+		edge := &meta.CallGraph[i]
+		position := meta.StringPool.GetString(edge.Position)
+		if position == "" {
+			continue
+		}
+		recorded := edge.Callee.BaseID()
+		targets, ok := byPosition[callgraph.SiteKey(position, recorded)]
+		if !ok {
+			continue
+		}
+		stats.Joined++
+
+		if containsTarget(targets, recorded) {
+			continue // the graphs agree; nothing to do
+		}
+
+		switch callgraph.Classify(recorded, targets, facts) {
+		case callgraph.DisagreeInterface:
+			if rewriteCallee(meta, &edge.Callee, targets[0]) {
+				stats.Interface++
+			}
+		case callgraph.DisagreePromoted:
+			if rewriteCallee(meta, &edge.Callee, targets[0]) {
+				stats.Promoted++
+			}
+		case callgraph.DisagreeAmbiguous:
+			stats.Ambiguous++
+		default:
+			stats.Unexplained++
+		}
+	}
+
+	return stats
+}
+
+// rewriteCallee repoints a call at the resolved target, keeping everything about
+// the call site that is not the callee's identity.
+//
+// A fresh Call is built rather than the fields patched in place because Call
+// memoizes its own identifiers: mutating Pkg or RecvType behind a populated
+// baseIDCache would leave the edge answering with its old identity forever.
+func rewriteCallee(meta *metadata.Metadata, callee *metadata.Call, target string) bool {
+	pkg, recvType, name := splitTarget(target)
+	if pkg == "" || name == "" {
+		return false
+	}
+
+	replacement := metadata.Call{
+		Meta:         meta,
+		Edge:         callee.Edge,
+		Name:         meta.StringPool.Get(name),
+		Pkg:          meta.StringPool.Get(pkg),
+		Position:     callee.Position,
+		Scope:        callee.Scope,
+		SignatureStr: callee.SignatureStr,
+	}
+	if recvType != "" {
+		replacement.RecvType = meta.StringPool.Get(recvType)
+	}
+	*callee = replacement
+	return true
+}
+
+// splitTarget takes a resolved function ID apart into the pieces a Call records.
+//
+// `pkg/path.Type.Method` is a method and `pkg/path.Func` is a plain function. The
+// two are told apart by the case of the segment before the name: a receiver type
+// is exported or not, but it is a TYPE, and the import path element before it is
+// lower-case by convention. That heuristic is not needed here — the resolved ID
+// is built by FunctionID, which emits exactly these two shapes — so the split is
+// simply "three dot-separated tails means a method".
+func splitTarget(target string) (pkg, recvType, name string) {
+	lastDot := strings.LastIndexByte(target, '.')
+	if lastDot < 0 {
+		return "", "", ""
+	}
+	name = target[lastDot+1:]
+	head := target[:lastDot]
+
+	// A method's head ends in `.Type`, where Type has no slash after the last dot.
+	if prevDot := strings.LastIndexByte(head, '.'); prevDot >= 0 {
+		candidate := head[prevDot+1:]
+		if candidate != "" && !strings.Contains(candidate, "/") {
+			return head[:prevDot], candidate, name
+		}
+	}
+	return head, "", name
+}
+
+func containsTarget(targets []string, want string) bool {
+	for _, target := range targets {
+		if target == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/spec/resolved_callees_test.go
+++ b/internal/spec/resolved_callees_test.go
@@ -1,0 +1,167 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+func TestSplitTarget(t *testing.T) {
+	tests := []struct {
+		target string
+		pkg    string
+		recv   string
+		name   string
+	}{
+		{"github.com/x/y.Type.Method", "github.com/x/y", "Type", "Method"},
+		{"github.com/x/y.Func", "github.com/x/y", "", "Func"},
+		{"app.Type.Method", "app", "Type", "Method"},
+		{"app.Func", "app", "", "Func"},
+		{"Bare", "", "", ""},
+		{"", "", "", ""},
+	}
+	for _, tt := range tests {
+		pkg, recv, name := splitTarget(tt.target)
+		if pkg != tt.pkg || recv != tt.recv || name != tt.name {
+			t.Errorf("splitTarget(%q) = (%q, %q, %q), want (%q, %q, %q)",
+				tt.target, pkg, recv, name, tt.pkg, tt.recv, tt.name)
+		}
+	}
+}
+
+// TestRewriteCalleeDropsTheMemoizedIdentity is the trap this code exists around:
+// Call memoizes its own BaseID, so patching Pkg or RecvType in place would leave
+// the edge answering with the identity it had before.
+func TestRewriteCalleeDropsTheMemoizedIdentity(t *testing.T) {
+	pool := metadata.NewStringPool()
+	meta := &metadata.Metadata{StringPool: pool}
+
+	callee := metadata.Call{
+		Meta:     meta,
+		Name:     pool.Get("List"),
+		Pkg:      pool.Get("example.com/app"),
+		RecvType: pool.Get("Storage"),
+	}
+	if before := callee.BaseID(); before != "example.com/app.Storage.List" {
+		t.Fatalf("BaseID before = %q", before)
+	}
+
+	if !rewriteCallee(meta, &callee, "example.com/app.s3driver.List") {
+		t.Fatal("rewriteCallee refused a well-formed target")
+	}
+	if got := callee.BaseID(); got != "example.com/app.s3driver.List" {
+		t.Errorf("BaseID after rewrite = %q, want the resolved target — a stale memo would return the old identity forever", got)
+	}
+
+	// A target that is not a function ID must be refused rather than half-applied.
+	if rewriteCallee(meta, &callee, "nodots") {
+		t.Error("rewriteCallee accepted a target with no package")
+	}
+}
+
+// TestApplyResolvedCalleesIsSafeWithoutAGraph pins that the step is a no-op when
+// the resolved graph is off, which is its default.
+func TestApplyResolvedCalleesIsSafeWithoutAGraph(t *testing.T) {
+	pool := metadata.NewStringPool()
+	meta := &metadata.Metadata{StringPool: pool}
+	if stats := ApplyResolvedCallees(meta, nil, nil); stats.Joined != 0 {
+		t.Errorf("a nil resolved graph joined %d sites", stats.Joined)
+	}
+	if stats := ApplyResolvedCallees(nil, nil, nil); stats.Joined != 0 {
+		t.Errorf("nil metadata joined %d sites", stats.Joined)
+	}
+}
+
+func TestResolvedCalleeStatsLine(t *testing.T) {
+	line := ResolvedCalleeStats{Joined: 69493, Interface: 2880, Promoted: 4492, Ambiguous: 1570, Unexplained: 1240}.Line()
+	for _, want := range []string{"69493", "7372", "2880", "4492", "1570", "1240"} {
+		if !strings.Contains(line, want) {
+			t.Errorf("stats line %q does not report %s", line, want)
+		}
+	}
+}
+
+// TestApplyResolvedCalleesClassRules covers the decision this migration turns
+// on: which disagreements are acted on and which are left exactly as recorded.
+func TestApplyResolvedCalleesClassRules(t *testing.T) {
+	pool := metadata.NewStringPool()
+	meta := &metadata.Metadata{StringPool: pool}
+	meta.Packages = map[string]*metadata.Package{
+		"app": {Files: map[string]*metadata.File{
+			"types.go": {Types: map[string]*metadata.Type{
+				"Storage": {Name: pool.Get("Storage"), Kind: pool.Get("interface")},
+				"Base":    {Name: pool.Get("Base"), Kind: pool.Get("struct")},
+				"Context": {Name: pool.Get("Context"), Kind: pool.Get("struct"), Embeds: []int{pool.Get("*Base")}},
+				"Widget":  {Name: pool.Get("Widget"), Kind: pool.Get("struct")},
+			}},
+		}},
+	}
+
+	edge := func(position, pkg, recv, name string) metadata.CallGraphEdge {
+		return metadata.CallGraphEdge{
+			Position: pool.Get(position),
+			Caller:   metadata.Call{Meta: meta, Name: pool.Get("caller"), Pkg: pool.Get("app")},
+			Callee: metadata.Call{
+				Meta: meta, Name: pool.Get(name), Pkg: pool.Get(pkg), RecvType: pool.Get(recv),
+			},
+		}
+	}
+
+	meta.CallGraph = []metadata.CallGraphEdge{
+		edge("f.go:1:1", "app", "Storage", "List"), // one implementation -> rewritten
+		edge("f.go:2:1", "app", "Context", "Form"), // promoted           -> rewritten
+		edge("f.go:3:1", "app", "Storage", "Save"), // several impls      -> left alone
+		edge("f.go:4:1", "app", "Widget", "Close"), // unexplained        -> left alone
+		edge("f.go:5:1", "app", "Base", "Write"),   // agreement          -> untouched
+		edge("f.go:6:1", "app", "Widget", "Draw"),  // no resolved site   -> untouched
+	}
+
+	byPosition := map[string][]string{
+		"f.go:1#List":  {"app.s3driver.List"},
+		"f.go:2#Form":  {"app.Base.Form"},
+		"f.go:3#Save":  {"app.s3driver.Save", "app.localDriver.Save"},
+		"f.go:4#Close": {"other.File.Close"},
+		"f.go:5#Write": {"app.Base.Write"},
+	}
+
+	stats := applyResolvedCallees(meta, byPosition)
+
+	if stats.Joined != 5 {
+		t.Errorf("joined %d sites, want 5 (the sixth has no resolved call)", stats.Joined)
+	}
+	if stats.Interface != 1 || stats.Promoted != 1 {
+		t.Errorf("rewrote %d interface / %d promoted, want 1 / 1", stats.Interface, stats.Promoted)
+	}
+	if stats.Ambiguous != 1 || stats.Unexplained != 1 {
+		t.Errorf("left %d ambiguous / %d unexplained, want 1 / 1", stats.Ambiguous, stats.Unexplained)
+	}
+
+	want := []string{
+		"app.s3driver.List", // resolved to the single implementation
+		"app.Base.Form",     // resolved to the type declaring the promoted method
+		"app.Storage.Save",  // ambiguous: stays the interface
+		"app.Widget.Close",  // unexplained: stays exactly as recorded
+		"app.Base.Write",    // agreement
+		"app.Widget.Draw",   // never joined
+	}
+	for i, expected := range want {
+		if got := meta.CallGraph[i].Callee.BaseID(); got != expected {
+			t.Errorf("edge %d callee = %q, want %q", i, got, expected)
+		}
+	}
+}


### PR DESCRIPTION
Phase 2 of the SSA+VTA migration. **Targets `feature/vta-call-graph`.** Behind `--resolve-call-graph`, off by default.

Phase 1 classified the 10,182 gitea call sites where the resolved graph names a different callee. This acts on the two classes that are safe to act on.

## What is rewritten

| class | rewrite | gitea sites |
|---|---|---|
| `interface->concrete` | an interface method with exactly **one** implementation becomes that implementation, so the concrete type's patterns and schemas apply | 2,880 |
| `promoted-through-embedding` | a call written on a type that *embeds* the declaring one is rewritten to the declaring type, which is how a pattern scoped there matches | 4,492 |

## What is deliberately left alone

- **Ambiguous** (1,570 on gitea): an interface with several implementations stays the interface. Choosing one would invent a concrete type the program may never use — golden rule #7.
- **Unexplained** (1,240, **12%**): a difference no relation explains is a join that landed on the wrong call. Far too many to wave through.

Only the callee's *identity* changes. Arguments, assignments and chain links are untouched — the resolved graph is the authority on **which** function a site calls; metadata remains the authority on the call itself.

## Measured

**Zero drift** across all 71 fixtures and across a real 246-route service with resolution **on**, while the rewrite demonstrably fires on both:

```
wrapper_router  Resolved call graph: 42 joined, 1 rewritten (0 interface, 1 promoted), 0 ambiguous, 0 unexplained
246-route svc   Resolved call graph: 5860 joined, 17 rewritten (17 interface, 0 promoted), 1 ambiguous, 10 unexplained
```

Identical output is exactly the result to want here. The hand-rolled compensations already cover these cases, so **agreeing with them is what proves the resolved answer is right** before anything is removed in phase 4. If the output had changed, that would mean one of the two is wrong and I would not know which.

## Reporting

A run says what it changed rather than silently documenting a different program (TRACKER_REDESIGN §8.4, *bounded ≠ silent*): `Resolved call graph: N joined, M rewritten (…), K left ambiguous, U unexplained`, plus `Engine.GetResolvedCalleeStats()`.

## Note on the rewrite mechanism

`Call` memoizes its own `BaseID`, so patching `Pkg`/`RecvType` in place would leave the edge answering with its old identity forever. A fresh `Call` is built instead; `TestRewriteCalleeDropsTheMemoizedIdentity` pins that.

## Verification

- `TestApplyResolvedCalleesClassRules` covers all five outcomes (rewrite ×2, leave ×2, agree) plus a site with no resolved call.
- `TestTestdata_WrapperRouterResolvedCallGraph` compares the resolved and syntactic runs on the one fixture where a rewrite fires.
- `TestResolvedCalleeStatsAreReported` pins that the stats are produced, and that they are zero when the flag is off.
- Full suite green, `gofmt -s` clean, `golangci-lint` 0 issues, coverage 96.0% (floor 96).

🤖 Generated with [Claude Code](https://claude.com/claude-code)