### PR TITLE
perf(spec): one condensation, one reachability pass, and the measurements that keep the default off (VTA phase 3)

### DIFF
--- a/docs/TRACKER_REDESIGN.md
+++ b/docs/TRACKER_REDESIGN.md
@@ -527,6 +527,41 @@ next.
   still run over the *metadata* (syntactic) graph — switching them to the
   resolved graph (step 2's) is deferred until the resolved graph is on by
   default, since it changes which indirect calls resolve.
+- **Steps 1-3 joined up, 2026-07-29** (`internal/callgraph/callsites.go`,
+  `disagreement.go`, `internal/spec/resolved_callees.go`,
+  `internal/spec/resolved_facts.go`): the resolved graph now feeds the recorded
+  one, behind `--resolve-call-graph` (default **off**).
+
+  - **The join is on the call SITE, not on function identity.** Metadata names a
+    closure `FuncLit:<pos>` and SSA names it `pkg.parent$1`; measured overlap is
+    ZERO (0 of 1,625 closures on gitea, 0 of 103 on a 246-route service), and
+    routes/handlers/middleware are overwhelmingly closures. The key is
+    `file:line#BareName` — the column is dropped because metadata records a call
+    at the start of its statement and SSA at its own opening parenthesis, so a
+    column-exact join matched 0 of 49 edges on a fixture.
+  - **Join rates:** 85-92% on fixtures, 73.4% on a 246-route service, 84.5% on
+    gitea. What does not join is expected: metadata records calls into
+    dependencies whose bodies were never loaded, and VTA drops calls it proves
+    unreachable.
+  - **Disagreements are classified before being acted on.** Of gitea's 10,182:
+    4,492 promoted-through-embedding, 2,880 interface->concrete (72% actionable),
+    1,570 ambiguous and 1,240 unexplained (28% that must NOT be acted on — an
+    unexplained difference is a join that landed on the wrong call).
+  - **Cost:** +12% metadata stage on a 246-route service, +15% on gitea (5.6s on
+    37.6s). Whole-run on gitea at default limits: 46s -> 55s.
+  - **The default stays off, on memory.** Peak RSS on gitea goes 3.15GB -> 4.62GB
+    (+46%) for the SSA program and VTA graph. That is the gate this step set for
+    flipping the default, and it fails it. See the follow-up on releasing the SSA
+    program once the call-site index has been extracted.
+  - **What it buys, measured:** zero drift across all 71 fixtures and a 246-route
+    service (agreement with the hand-rolled compensations is what proves the
+    resolved answer), and on gitea 7,370 rewritten call sites take the spec from
+    **1 component to 15** at default limits.
+  - The condensation is now memoized on the metadata (`Metadata.CallGraphSCC`)
+    and the second copy of the bottom-up reachability pass in
+    `entrypoint_roots.go` is gone: both consumers had been building their own,
+    so every route-bearing project condensed its graph twice.
+
 - **Step 4 — IN PROGRESS 2026-07-09** (`internal/spec/lazytree.go` +
   `internal/spike/lazytree_diff_test.go`): `LazyTree`/`LazyNode` implement
   `TrackerTreeInterface`/`TrackerNodeInterface` as an on-demand unfolding.

--- a/internal/metadata/scc.go
+++ b/internal/metadata/scc.go
@@ -29,7 +29,10 @@ package metadata
 // before traversal, so identical metadata always yields identical components,
 // numbering, and DAG.
 
-import "sort"
+import (
+	"sort"
+	"sync"
+)
 
 // CallGraphSCC is the condensation of the call graph into strongly-connected
 // components.
@@ -69,6 +72,44 @@ func (s *CallGraphSCC) SameComponent(a, b string) bool {
 func (s *CallGraphSCC) InCycle(fn string) bool {
 	c, ok := s.ComponentOf[fn]
 	return ok && s.Recursive[c]
+}
+
+// sccCache memoizes one metadata's condensation. Two callers needed the same
+// answer and each built its own: the extractor's reachability summaries and the
+// tree's entrypoint gate, so every route-bearing project condensed its graph
+// twice (89ms per build over gitea's 82k edges).
+//
+// Invalidated by BuildCallGraphMaps, which is what runs whenever the graph
+// itself changes — notably after the resolved graph repoints call edges.
+type sccCache struct {
+	mu  sync.Mutex
+	scc *CallGraphSCC
+}
+
+// CallGraphSCC returns the condensation of m's call graph, building it once.
+//
+// Prefer this over BuildCallGraphSCC: the condensation is a derived fact about
+// m's own data, and rebuilding it per consumer is pure waste.
+func (m *Metadata) CallGraphSCC() *CallGraphSCC {
+	if m == nil {
+		return &CallGraphSCC{ComponentOf: map[string]int{}}
+	}
+	m.sccOnce.mu.Lock()
+	defer m.sccOnce.mu.Unlock()
+	if m.sccOnce.scc == nil {
+		m.sccOnce.scc = BuildCallGraphSCC(m)
+	}
+	return m.sccOnce.scc
+}
+
+// invalidateSCC drops the memoized condensation after the graph changes.
+func (m *Metadata) invalidateSCC() {
+	if m == nil {
+		return
+	}
+	m.sccOnce.mu.Lock()
+	m.sccOnce.scc = nil
+	m.sccOnce.mu.Unlock()
 }
 
 // BuildCallGraphSCC condenses m's call graph. It reads m.CallGraph directly

--- a/internal/metadata/scc_test.go
+++ b/internal/metadata/scc_test.go
@@ -148,3 +148,41 @@ func TestSCC_Deterministic(t *testing.T) {
 		}
 	}
 }
+
+// TestCallGraphSCCIsMemoizedAndInvalidated pins the two properties the shared
+// condensation needs: consumers get the same instance instead of each building
+// their own (89ms per build over gitea's 82k edges, and it was being built
+// twice), and it stops being returned once the graph it describes has changed.
+func TestCallGraphSCCIsMemoizedAndInvalidated(t *testing.T) {
+	pool := NewStringPool()
+	meta := &Metadata{StringPool: pool}
+	meta.CallGraph = []CallGraphEdge{{
+		Caller: Call{Meta: meta, Name: pool.Get("main"), Pkg: pool.Get("app")},
+		Callee: Call{Meta: meta, Name: pool.Get("run"), Pkg: pool.Get("app")},
+	}}
+	meta.BuildCallGraphMaps()
+
+	first := meta.CallGraphSCC()
+	if first == nil || len(first.ComponentOf) == 0 {
+		t.Fatal("the condensation is empty for a graph with an edge")
+	}
+	if second := meta.CallGraphSCC(); second != first {
+		t.Error("a second consumer got its own condensation; the whole point is that they share one")
+	}
+
+	// Re-indexing the graph is exactly when the condensation stops being true —
+	// the resolved call graph repoints edges and then rebuilds the maps.
+	meta.BuildCallGraphMaps()
+	if again := meta.CallGraphSCC(); again == first {
+		t.Error("the condensation survived a graph rebuild; it would describe edges that no longer exist")
+	}
+}
+
+// TestCallGraphSCCOnNilMetadata pins that asking a nil metadata is answerable,
+// since the accessor is reached from gates that run before anything is loaded.
+func TestCallGraphSCCOnNilMetadata(t *testing.T) {
+	var meta *Metadata
+	if scc := meta.CallGraphSCC(); scc == nil || len(scc.ComponentOf) != 0 {
+		t.Error("nil metadata did not produce an empty condensation")
+	}
+}

--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -151,6 +151,9 @@ type Metadata struct {
 	posCache map[token.Pos]int
 	posMutex sync.RWMutex
 
+	// sccOnce memoizes the call graph's SCC condensation; see CallGraphSCC.
+	sccOnce sccCache
+
 	// moduleDir is the filesystem root of the analysed module. It is not part of
 	// the recorded facts — it exists so a closure's identity can be stated
 	// relative to the module rather than to this machine (see stablePosition,
@@ -242,6 +245,10 @@ type calleeNamePkg struct {
 
 // BuildCallGraphMaps builds the various lookup maps
 func (m *Metadata) BuildCallGraphMaps() {
+	// The condensation is derived from the very edges about to be re-indexed, so
+	// a rebuild here is exactly when it stops being true.
+	m.invalidateSCC()
+
 	m.Callers = make(map[string][]*CallGraphEdge)
 	m.Callees = make(map[string][]*CallGraphEdge)
 	m.Args = make(map[string][]*CallGraphEdge)

--- a/internal/spec/entrypoint_roots.go
+++ b/internal/spec/entrypoint_roots.go
@@ -117,37 +117,10 @@ func functionsReachableFromMains(meta *metadata.Metadata) map[string]bool {
 }
 
 // reachesMatch returns the set of function base keys from which an edge matching
-// match is transitively reachable — the tree-side twin of Extractor.reachSet,
-// same one-pass-over-the-condensation shape, without needing an extractor.
+// match is transitively reachable — the same one-pass-over-the-condensation the
+// extractor's summaries use, over the condensation memoized on the metadata.
 func reachesMatch(meta *metadata.Metadata, match func(*metadata.CallGraphEdge) bool) map[string]bool {
-	scc := metadata.BuildCallGraphSCC(meta)
-	compReaches := make([]bool, len(scc.Components))
-	for c, comp := range scc.Components {
-		reached := false
-		for _, member := range comp {
-			for _, edge := range meta.Callers[member] {
-				if match(edge) {
-					reached = true
-					break
-				}
-				if calleeComp, ok := scc.ComponentOf[edge.Callee.BaseID()]; ok && calleeComp != c && compReaches[calleeComp] {
-					reached = true
-					break
-				}
-			}
-			if reached {
-				break
-			}
-		}
-		compReaches[c] = reached
-	}
-	set := make(map[string]bool)
-	for id, c := range scc.ComponentOf {
-		if compReaches[c] {
-			set[id] = true
-		}
-	}
-	return set
+	return reachSetOver(meta, meta.CallGraphSCC(), match)
 }
 
 // RouteRegistrationMatcher builds the predicate for gate 2 from the effective

--- a/internal/spec/reachability.go
+++ b/internal/spec/reachability.go
@@ -34,11 +34,12 @@ import (
 	"github.com/ehabterra/apispec/internal/metadata"
 )
 
-// callGraphSCC lazily builds (and caches) the SCC condensation of the
-// metadata call graph.
+// callGraphSCC returns the condensation of the metadata call graph, memoized on
+// the metadata itself so the tree's entrypoint gate and these summaries share
+// one (issue: it used to be built once per consumer).
 func (e *Extractor) callGraphSCC(meta *metadata.Metadata) *metadata.CallGraphSCC {
 	if e.scc == nil {
-		e.scc = metadata.BuildCallGraphSCC(meta)
+		e.scc = meta.CallGraphSCC()
 	}
 	return e.scc
 }
@@ -55,7 +56,19 @@ func (e *Extractor) reachSet(meta *metadata.Metadata, cacheKey string, match fun
 		return cached
 	}
 
-	scc := e.callGraphSCC(meta)
+	set := reachSetOver(meta, e.callGraphSCC(meta), match)
+	if e.reachSets == nil {
+		e.reachSets = make(map[string]map[string]bool)
+	}
+	e.reachSets[cacheKey] = set
+	return set
+}
+
+// reachSetOver is the bottom-up pass itself: one sweep over the condensation,
+// callees-first, so a component is decided once and every caller of it reads a
+// final answer. Shared by the extractor's cached summaries and by the tree's
+// entrypoint gate, which used to carry a second copy of this loop.
+func reachSetOver(meta *metadata.Metadata, scc *metadata.CallGraphSCC, match func(*metadata.CallGraphEdge) bool) map[string]bool {
 	compReaches := make([]bool, len(scc.Components))
 	for c, comp := range scc.Components {
 		reached := false
@@ -84,10 +97,6 @@ func (e *Extractor) reachSet(meta *metadata.Metadata, cacheKey string, match fun
 			set[id] = true
 		}
 	}
-	if e.reachSets == nil {
-		e.reachSets = make(map[string]map[string]bool)
-	}
-	e.reachSets[cacheKey] = set
 	return set
 }
 


### PR DESCRIPTION
Phase 3 of the SSA+VTA migration. **Targets `feature/vta-call-graph`.**

## The dedup

Two consumers needed the same fact and each computed it: the extractor's reachability summaries and the tree's entrypoint gate both condensed the call graph, so **every route-bearing project ran Tarjan twice** (89 ms per build over gitea's 82k edges) — and `entrypoint_roots.reachesMatch` carried a second copy of the bottom-up pass itself, line for line.

The condensation is now memoized on the metadata that owns it (`Metadata.CallGraphSCC`) and invalidated by `BuildCallGraphMaps` — precisely when the edges it describes change, including after the resolved graph repoints them. Both callers share `reachSetOver`.

## The switch needed no work

Phase 3's other half was "switch the summaries onto the resolved graph". Phase 2 repoints the recorded edges **in place** before the maps are rebuilt, so the summaries already read resolved callees. Nothing to do.

## The default does not flip, and the gate is why

Gitea at default limits:

| | off | on |
|---|---|---|
| wall clock | 46 s | 55 s (+19%) |
| **peak RSS** | **3.15 GB** | **4.62 GB (+46%)** |

The time is affordable. The memory is not: 1.5 GB extra to hold the SSA program and the VTA graph, on a project where large runs already strain the machine. I set that gate before measuring it, and it fails, so the flag stays opt-in.

Follow-up worth filing: the run only needs `CalleesAt()`, yet `Engine` holds the whole `ssa.Program` for the rest of the run. Whether releasing it after indexing lowers *peak* (versus only sustained) RSS depends on where the peak actually falls — needs measuring, not assuming.

## What the flag buys, measured

- **Zero drift** across all 71 fixtures and a 246-route service — agreement with the hand-rolled compensations is what proves the resolved answer.
- On **gitea**, 7,370 rewritten call sites (2,880 interface, 4,490 promoted) take the spec from **1 component to 15** at default limits. First improvement on a real project rather than parity.

## Verification

Full suite green, drift-free against the pre-phase snapshots, `golangci-lint` 0 issues, coverage 96.0%. `TestCallGraphSCCIsMemoizedAndInvalidated` pins both properties of the shared condensation. `docs/TRACKER_REDESIGN.md` records the join design, rates, class breakdown, costs and the memory gate under Progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)