### PR TITLE
docs: document --resolve-call-graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
   - [The pipeline, step by step](#the-pipeline-step-by-step)
 - [Configuration](#configuration)
   - [Scoping a pattern to where the call is made](#scoping-a-pattern-to-where-the-call-is-made)
+  - [Resolving indirect calls (experimental)](#resolving-indirect-calls-experimental)
   - [Automatic wrapper detection](#automatic-wrapper-detection)
 - [Programmatic Usage](#programmatic-usage)
 - [Performance & Limits](#performance--limits)
@@ -780,6 +781,32 @@ Run with `--verbose` to see what it did:
 ```
 Entrypoints: 53 declared, 1 rooted (0 already reachable, 52 register no routes)
 ```
+
+### Resolving indirect calls (experimental)
+
+`--resolve-call-graph` builds an SSA + VTA call graph alongside the syntactic one
+and repoints each recorded call at the function that actually runs:
+
+- an **interface method with exactly one implementation** becomes that
+  implementation, so the concrete type's patterns and schemas apply;
+- a method reached **through embedding** is attributed to the type that declares
+  it, which is how a pattern scoped there matches a call written on the embedding
+  type.
+
+An interface with several implementations stays the interface — picking one would
+invent a concrete type your program may never use — and a difference the analysis
+cannot explain is left exactly as recorded.
+
+```
+$ apispec --dir . --resolve-call-graph --verbose
+Resolved call graph: 5860 call sites joined, 17 rewritten (17 interface, 0 promoted), 1 left ambiguous, 10 unexplained
+```
+
+It is **off by default** and stays that way for now: on a 3,000-file module it
+costs about +19% wall clock and **+46% peak memory** to hold the SSA program.
+Turn it on when a project answers through interfaces or embedded contexts and the
+spec is missing schemas because of it — on one such project it took the output
+from 1 component to 15.
 
 ### Automatic wrapper detection
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -339,6 +339,39 @@ struct definitions with doc comments in `internal/spec/config.go`. The quickest
 way to author a custom pattern is to dump the effective config with
 `--output-config` and edit the relevant block.
 
+## Resolving indirect calls: `--resolve-call-graph`
+
+Not a config-file key — a CLI flag, because it changes how the program is
+analysed rather than what the spec says.
+
+APISpec's own call graph is syntactic: it records what the source writes. A call
+on an interface value is recorded against the interface, and a call on a type that
+embeds another is recorded against the embedding type. Both are true statements
+about the source and neither names the function that runs.
+
+`--resolve-call-graph` builds an SSA + VTA graph from the same package load, joins
+it to the recorded one at each call site, and repoints two kinds of call:
+
+| recorded | resolved to | why it matters |
+|---|---|---|
+| interface method with **one** implementation | that implementation | the concrete type's patterns and schemas apply |
+| method reached through embedding | the type that **declares** it | a pattern scoped to the declaring type matches |
+
+Left alone on purpose: an interface with several implementations (choosing one
+would invent a concrete type the program may never use), and any difference the
+analysis cannot explain.
+
+Cost, measured on a 3,000-file module: **+19% wall clock, +46% peak memory** —
+which is why it is off by default. Use it when a project answers through
+interfaces or an embedded context type and the spec is missing schemas as a
+result.
+
+`--verbose` reports what it changed:
+
+```
+Resolved call graph: 69230 call sites joined, 7370 rewritten (2880 interface, 4490 promoted), 1570 left ambiguous, 1230 unexplained
+```
+
 ---
 
 ## See also


### PR DESCRIPTION
The flag shipped in phase 2 (#242) with only `--help` and `TRACKER_REDESIGN.md` to find it by — not where a user looks.

Adds a README section (with a ToC entry) and a `docs/CONFIGURATION.md` section. Both state the trade honestly: what it repoints, what it deliberately leaves alone and why, and that it costs **+19% wall clock and +46% peak memory** on a 3,000-file module, which is why it is off by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)