### PR TITLE
feat(ui): offer indirect-call resolution from apispecui

### DIFF
--- a/README.md
+++ b/README.md
@@ -808,6 +808,9 @@ Turn it on when a project answers through interfaces or embedded contexts and th
 spec is missing schemas because of it — on one such project it took the output
 from 1 component to 15.
 
+In `apispecui` the same option is the **Resolve indirect calls (experimental)**
+checkbox under the analysis engine, and the choice is remembered between runs.
+
 ### Automatic wrapper detection
 
 Plenty of projects do not call the framework directly. They put their own router in front of it, and answer through their own context:

--- a/cmd/apispecui/assets/js/actions.js
+++ b/cmd/apispecui/assets/js/actions.js
@@ -251,6 +251,7 @@ function fullGenerateRequest() {
     overrides: c.overrides,
     frameworkConfig: s.frameworkConfig || undefined,
     legacyTracker: !!s.legacyTracker,
+    resolveCallGraph: !!s.resolveCallGraph,
     limits: s.limits || {},
   };
 }

--- a/cmd/apispecui/assets/js/spec.js
+++ b/cmd/apispecui/assets/js/spec.js
@@ -5,6 +5,7 @@
 // in a separate browser tab from the rail.
 import { html, useState } from "/assets/js/preact.js";
 import { useStore, setState } from "/assets/js/store.js";
+import { Info } from "/assets/js/components/charts.js";
 
 const VIEWS = [
   ["swagger", "Swagger UI"],
@@ -250,6 +251,19 @@ function Onboarding({ s, onGenerate, onBrowse }) {
               <option value="lazy">Lazy tracker (default)</option>
               <option value="legacy">Legacy tracker (eager)</option>
             </select>
+          </div>
+          <div class="field">
+            <label class="row" style="cursor:pointer;gap:6px">
+              <input
+                type="checkbox"
+                checked=${!!s.resolveCallGraph}
+                onChange=${(e) => setState({ resolveCallGraph: e.target.checked })}
+              />
+              <span>Resolve indirect calls (experimental)</span>
+              <${Info}
+                text="Builds an SSA+VTA call graph alongside the syntactic one and points each call at the function that actually runs: an interface method with exactly one implementation becomes that implementation, and a method reached through embedding is attributed to the type that declares it. An interface with several implementations is left as the interface — picking one would invent a concrete type your program may never use. Costs roughly +19% time and +46% memory on a large module, so turn it on when your handlers answer through interfaces or an embedded context type and schemas are missing."
+              />
+            </label>
           </div>
           <div class="field" style="margin-bottom:0">
             <label>③ Generate</label>

--- a/cmd/apispecui/assets/js/store.js
+++ b/cmd/apispecui/assets/js/store.js
@@ -12,6 +12,7 @@ const state = {
   supportedFrameworks: ["gin", "chi", "echo", "fiber", "mux", "net/http"],
   openapiVersion: "3.1.0",
   legacyTracker: false, // analysis engine: false = lazy tracker (default), true = legacy eager
+  resolveCallGraph: false, // SSA+VTA call-target resolution; costs memory, so opt-in
   // Tree-expansion limits. Empty means "use the engine default" — the server
   // fills any unset field, so the UI never has to hardcode a number that would
   // then drift from Go (issue #233).
@@ -62,7 +63,7 @@ const state = {
 
 // View prefs persisted across refreshes so a reload lands the user back where
 // they were (which tab, which spec viewer, panel layout).
-const PERSIST_KEYS = ["mode", "specView", "panelCollapsed", "legacyTracker", "limits"];
+const PERSIST_KEYS = ["mode", "specView", "panelCollapsed", "legacyTracker", "resolveCallGraph", "limits"];
 const PERSIST_LS_KEY = "apispecui.view";
 
 function loadPersistedView() {

--- a/cmd/apispecui/config_parity_test.go
+++ b/cmd/apispecui/config_parity_test.go
@@ -127,3 +127,45 @@ func jsonFieldName(f reflect.StructField) string {
 	}
 	return tag
 }
+
+// TestGenerateRequestOptionsReachTheUI is the same guard as the config editor's,
+// one level out: an analysis option the server accepts but the UI never sends is
+// invisible to a user, which is how --resolve-call-graph shipped in the first
+// place (CLI only, discoverable through --help alone).
+//
+// It checks the option is wired at both ends — the request struct declares it and
+// the browser sends it — not that it behaves correctly; that is the engine's
+// tests. Its job is to fail when the next option is added on one side only.
+func TestGenerateRequestOptionsReachTheUI(t *testing.T) {
+	actions, err := os.ReadFile("assets/js/actions.js")
+	if err != nil {
+		t.Fatalf("read actions.js: %v", err)
+	}
+	store, err := os.ReadFile("assets/js/store.js")
+	if err != nil {
+		t.Fatalf("read store.js: %v", err)
+	}
+
+	// Analysis options the UI is expected to offer, by their JSON name.
+	options := []string{"legacyTracker", "resolveCallGraph"}
+
+	typ := reflect.TypeOf(GenerateRequest{})
+	declared := map[string]bool{}
+	for i := 0; i < typ.NumField(); i++ {
+		if name := jsonFieldName(typ.Field(i)); name != "" {
+			declared[name] = true
+		}
+	}
+
+	for _, option := range options {
+		if !declared[option] {
+			t.Errorf("GenerateRequest has no %q field; the UI would send an option the server ignores", option)
+		}
+		if !strings.Contains(string(actions), option) {
+			t.Errorf("%q is never sent by the browser — the server accepts it and no user can reach it", option)
+		}
+		if !strings.Contains(string(store), option) {
+			t.Errorf("%q has no state in the store, so it cannot be toggled or remembered", option)
+		}
+	}
+}

--- a/cmd/apispecui/main.go
+++ b/cmd/apispecui/main.go
@@ -204,6 +204,14 @@ type GenerateRequest struct {
 	// tree; the default is the lazy tracker.
 	LegacyTracker bool `json:"legacyTracker"`
 
+	// ResolveCallGraph builds an SSA+VTA call graph alongside the syntactic one
+	// and repoints each call at the function that actually runs — an interface
+	// method with one implementation, and a method reached through embedding. Off
+	// by default: it costs about +19% wall clock and +46% peak memory on a large
+	// module, which is a lot to spend on a project that does not answer through
+	// interfaces or an embedded context.
+	ResolveCallGraph bool `json:"resolveCallGraph"`
+
 	// Limits bound tree expansion. Every field is optional: a zero keeps the
 	// engine default. They are here because a project can be large enough that
 	// the default budget stops expansion part-way through its routes, and the UI
@@ -921,6 +929,7 @@ func (s *UIServer) handleGenerate(w http.ResponseWriter, r *http.Request) {
 		AutoExcludeMocks:             true,
 		Verbose:                      s.cfg.Verbose,
 		UseLazyTracker:               !req.LegacyTracker,
+		ResolveCallGraph:             req.ResolveCallGraph,
 		OnPhase: func(phase string, elapsed time.Duration) {
 			// Pushed by the engine at each major phase boundary. The UI
 			// polls /api/generate/progress to surface this as the live


### PR DESCRIPTION
`--resolve-call-graph` shipped CLI-only in #242, so the one surface built for trying things out couldn't try it.

It's now a **Resolve indirect calls (experimental)** checkbox under the analysis engine, remembered between runs like the other analysis options. The tooltip states the trade rather than just the upside — what it repoints, what it deliberately leaves alone and why, and the +19% time / +46% memory cost.

Verified in the browser end to end against `testdata/wrapper_router`: ticking the box and generating produces `[engine] resolved call graph built (1195 functions) in 14ms` server-side and a spec that renders normally.

**A wiring guard comes with it.** `TestGenerateRequestOptionsReachTheUI` asserts every analysis option is declared by `GenerateRequest`, sent by the browser, and held in the store — the same shape as the config-editor parity check, one level out. That's precisely the gap that let this option ship CLI-only in the first place.

Full suite green, lint 0 issues, coverage 96.0%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)