### PR TITLE
feat(ui): put the resolve toggle in the header, beside the engine selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -808,8 +808,10 @@ Turn it on when a project answers through interfaces or embedded contexts and th
 spec is missing schemas because of it — on one such project it took the output
 from 1 component to 15.
 
-In `apispecui` the same option is the **Resolve indirect calls (experimental)**
-checkbox under the analysis engine, and the choice is remembered between runs.
+In `apispecui` the same option is the **◉ Resolve** toggle in the header, beside
+the analysis-engine selector — and a matching checkbox in the generate panel. The
+header is where it stays reachable after a generation, so a spec can be produced
+both ways and compared. The choice is remembered between runs.
 
 ### Automatic wrapper detection
 

--- a/cmd/apispecui/assets/css/components.css
+++ b/cmd/apispecui/assets/css/components.css
@@ -1585,3 +1585,18 @@ h3 + .info {
 .disp-row:first-child {
   border-top: 0;
 }
+
+/* Indirect-call resolution toggle in the top bar. It sits next to the engine
+   selector because it is the same kind of choice — how the next generation
+   analyses the project — and it has to be reachable AFTER a generation, which
+   the start panel is not. */
+.topbar .resolve-toggle {
+  padding: 3px 8px;
+  font-size: var(--fs-sm);
+  height: auto;
+  white-space: nowrap;
+}
+.topbar .resolve-toggle.active {
+  color: var(--accent);
+  border-color: var(--accent);
+}

--- a/cmd/apispecui/assets/js/app.js
+++ b/cmd/apispecui/assets/js/app.js
@@ -89,6 +89,15 @@ function TopBar({ s }) {
         <option value="lazy">⚡ Lazy</option>
         <option value="legacy">Legacy</option>
       </select>
+      <button
+        class="btn ghost sm resolve-toggle ${s.resolveCallGraph ? "active" : ""}"
+        title="Resolve indirect calls (experimental). Builds an SSA+VTA call graph alongside the syntactic one and points each call at the function that actually runs: an interface method with exactly one implementation becomes that implementation, and a method reached through embedding is attributed to the type that declares it. An interface with several implementations is left alone — picking one would invent a concrete type your program may never use. Costs roughly +19% time and +46% memory on a large module."
+        disabled=${s.generating}
+        aria-pressed=${s.resolveCallGraph ? "true" : "false"}
+        onClick=${() => setState({ resolveCallGraph: !s.resolveCallGraph })}
+      >
+        ${s.resolveCallGraph ? "◉" : "○"} Resolve
+      </button>
       <button class="btn" disabled=${s.generating || !s.project} onClick=${generate}>
         ${s.generating
           ? html`Generating…${s.genPhase ? html` ${s.genPhase}` : ""}${s.genElapsed ? html` <span class="gen-elapsed">${fmtDur(s.genElapsed)}</span>` : ""}`


### PR DESCRIPTION
The checkbox from #251 was only in the generate panel, which disappears once a spec exists — so the option could be set *before* the first generation and not after it. That's backwards for what is essentially a comparison switch: the point is to generate both ways and look at the difference.

It's now also a header toggle (**○/◉ Resolve**) next to the analysis-engine selector — the same kind of choice, reachable at any time. Both controls share one piece of state.

## Verified from the browser, one server, one fixture

| run | header | server log |
|---|---|---|
| 1 | ○ Resolve | **no** resolved call graph built at all |
| 2 | ◉ Resolve | `resolved call graph built (1195 functions)` + `42 call sites joined, 1 rewritten (0 interface, 1 promoted), 0 left ambiguous, 0 unexplained` |

The negative half matters as much as the positive — it's what shows the toggle is being *read*, rather than the graph being built regardless. My verification in #251 had neither the negative control nor the rewrite stats, so it did not actually establish that the option worked end to end. This does.

Full suite green, lint 0 issues, coverage 96.0%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)