### PR TITLE
docs+ui: the cost of resolving indirect calls scales with the node budget, and say so

### DIFF
--- a/README.md
+++ b/README.md
@@ -802,11 +802,27 @@ $ apispec --dir . --resolve-call-graph --verbose
 Resolved call graph: 5860 call sites joined, 17 rewritten (17 interface, 0 promoted), 1 left ambiguous, 10 unexplained
 ```
 
-It is **off by default** and stays that way for now: on a 3,000-file module it
-costs about +19% wall clock and **+46% peak memory** to hold the SSA program.
-Turn it on when a project answers through interfaces or embedded contexts and the
-spec is missing schemas because of it — on one such project it took the output
-from 1 component to 15.
+It is **off by default**, and the cost is not a flat percentage — it grows with
+your node budget:
+
+| gitea, `--max-nodes` | mapping stage | components |
+|---|---|---|
+| 50,000 (default), off | 10s | 1 |
+| 50,000 (default), on | 11s | 15 |
+| 100,000, off | 1m30s | 41 |
+| 100,000, on | **2m56s** | **87** |
+
+Building the SSA graph is a small part of that (about 6s on gitea); the rest is
+that **resolution makes more of your program analysable**. A call the syntactic
+graph left pointing at an interface now points at a real function body, so there
+is more to expand. That is the feature working, and it is why the extra time
+buys schemas — at the 100k budget above, 340 of 389 operations gained response or
+request detail.
+
+Plan for roughly **double the mapping stage** on a large project, plus **+46%
+peak memory** for the SSA program. If you already raise `--max-nodes` to reach
+all your routes, try resolution at a *lower* budget first rather than on top of
+your highest one: it changes what the budget is spent on.
 
 In `apispecui` the same option is the **◉ Resolve** toggle in the header, beside
 the analysis-engine selector — and a matching checkbox in the generate panel. The

--- a/cmd/apispecui/assets/css/components.css
+++ b/cmd/apispecui/assets/css/components.css
@@ -1600,3 +1600,13 @@ h3 + .info {
   color: var(--accent);
   border-color: var(--accent);
 }
+
+/* Shown when indirect-call resolution is combined with a raised node budget:
+   the two compete for the same time, and the combination is what turns a
+   generation into a multi-minute run with no obvious cause. */
+.topbar .resolve-warn {
+  font-size: var(--fs-sm);
+  color: var(--warn, #d9a441);
+  white-space: nowrap;
+  cursor: help;
+}

--- a/cmd/apispecui/assets/js/app.js
+++ b/cmd/apispecui/assets/js/app.js
@@ -98,6 +98,13 @@ function TopBar({ s }) {
       >
         ${s.resolveCallGraph ? "◉" : "○"} Resolve
       </button>
+      ${s.resolveCallGraph && (s.limits?.maxNodesPerTree || 0) > 50000
+        ? html`<span
+            class="resolve-warn"
+            title="Resolution and a raised node budget compete for the same time. Resolution makes more of the program analysable, so the mapping stage roughly doubles at a raised budget — on a 3,000-file project, 1m30s becomes 2m56s at 100k nodes. Expect minutes, not seconds."
+            >⚠ slow combo</span
+          >`
+        : ""}
       <button class="btn" disabled=${s.generating || !s.project} onClick=${generate}>
         ${s.generating
           ? html`Generating…${s.genPhase ? html` ${s.genPhase}` : ""}${s.genElapsed ? html` <span class="gen-elapsed">${fmtDur(s.genElapsed)}</span>` : ""}`

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -361,10 +361,22 @@ Left alone on purpose: an interface with several implementations (choosing one
 would invent a concrete type the program may never use), and any difference the
 analysis cannot explain.
 
-Cost, measured on a 3,000-file module: **+19% wall clock, +46% peak memory** —
-which is why it is off by default. Use it when a project answers through
-interfaces or an embedded context type and the spec is missing schemas as a
-result.
+Cost is **not** a flat percentage: it scales with how much the tracker is allowed
+to expand, because resolution makes more of the program analysable. Measured on a
+3,000-file module:
+
+| `--max-nodes` | mapping stage off | mapping stage on | components off / on |
+|---|---|---|---|
+| 50,000 (default) | 10s | 11s | 1 / 15 |
+| 100,000 | 1m30s | 2m56s | 41 / 87 |
+
+Building SSA and running VTA is ~6s of that; the rest is the extra program that
+becomes reachable once calls point at real function bodies. Peak memory is +46%
+for the SSA program itself.
+
+So: expect roughly **double the mapping stage** on a large project, and treat a
+raised `--max-nodes` and this flag as competing for the same budget rather than
+as independent knobs.
 
 `--verbose` reports what it changed:
 


### PR DESCRIPTION
I documented "+19% wall clock" from a default-limit run and shipped it. **That number is wrong for the case that matters.** Turning the option on over a raised node budget — exactly what a large project needs to reach all its routes — produced a run killed after 12 minutes.

## Measured on gitea

| `--max-nodes` | mapping off | mapping on | components off / on |
|---|---|---|---|
| 50,000 (default) | 10s | 11s | 1 / 15 |
| 100,000 | 1m30s | **2m56s** | 41 / **87** |
| 300,000 | 4m04s | — | — |

The SSA build is ~6s of that. The rest is the feature working: 7,370 rewritten call sites point at real function bodies where the syntactic graph pointed at an interface or at a type that merely embeds the declaring one, so there is more program to expand. And it isn't wasted — at the 100k budget, **340 of 389 operations** gained response or request detail.

## What changes here

- **README and config reference** replace the flat percentage with the table and the shape: expect roughly double the mapping stage on a large project, and treat a raised budget and this flag as competing for the same time rather than independent knobs.
- **apispecui warns** (`⚠ slow combo`) when resolution is on *and* the node budget is raised above the default — the pairing that turns a generation into a multi-minute run with nothing on screen explaining why. Verified in the browser: it appears with `maxNodesPerTree: 300000` + resolve on, and is absent at default limits with resolve on.

## Not fixed here

The underlying defect is **#253**: every call site is resolved up front, including the vast majority no pattern will ever consult. That is what makes the cost proportional to the program rather than to the spec. This PR makes the current behaviour honest and visible; #253 makes it cheap.

Full suite green, lint 0 issues, coverage 96.0%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)