### PR TITLE
fix: reconcile the published counts, and address the review of #250

### DIFF
--- a/README.md
+++ b/README.md
@@ -797,7 +797,7 @@ An interface with several implementations stays the interface — picking one wo
 invent a concrete type your program may never use — and a difference the analysis
 cannot explain is left exactly as recorded.
 
-```
+```console
 $ apispec --dir . --resolve-call-graph --verbose
 Resolved call graph: 5860 call sites joined, 17 rewritten (17 interface, 0 promoted), 1 left ambiguous, 10 unexplained
 ```

--- a/cmd/apispecui/assets/js/spec.js
+++ b/cmd/apispecui/assets/js/spec.js
@@ -257,11 +257,12 @@ function Onboarding({ s, onGenerate, onBrowse }) {
               <input
                 type="checkbox"
                 checked=${!!s.resolveCallGraph}
+                disabled=${s.generating}
                 onChange=${(e) => setState({ resolveCallGraph: e.target.checked })}
               />
               <span>Resolve indirect calls (experimental)</span>
               <${Info}
-                text="Builds an SSA+VTA call graph alongside the syntactic one and points each call at the function that actually runs: an interface method with exactly one implementation becomes that implementation, and a method reached through embedding is attributed to the type that declares it. An interface with several implementations is left as the interface — picking one would invent a concrete type your program may never use. Costs roughly +19% time and +46% memory on a large module, so turn it on when your handlers answer through interfaces or an embedded context type and schemas are missing."
+                text="Builds an SSA+VTA call graph alongside the syntactic one and points each call at the function that actually runs: an interface method with exactly one implementation becomes that implementation, and a method reached through embedding is attributed to the type that declares it. An interface with several implementations is left as the interface — picking one would invent a concrete type your program may never use. Cost grows with the node budget rather than being a flat percentage: on a 3,000-file project the mapping stage goes 1m30s to 2m56s at a 100k node budget, because resolution makes more of the program analysable. Turn it on when your handlers answer through interfaces or an embedded context type and schemas are missing."
               />
             </label>
           </div>

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -380,7 +380,7 @@ as independent knobs.
 
 `--verbose` reports what it changed:
 
-```
+```text
 Resolved call graph: 69230 call sites joined, 7370 rewritten (2880 interface, 4490 promoted), 1570 left ambiguous, 1230 unexplained
 ```
 

--- a/docs/TRACKER_REDESIGN.md
+++ b/docs/TRACKER_REDESIGN.md
@@ -543,10 +543,12 @@ next.
     gitea. What does not join is expected: metadata records calls into
     dependencies whose bodies were never loaded, and VTA drops calls it proves
     unreachable.
-  - **Disagreements are classified before being acted on.** Of gitea's 10,182:
-    4,492 promoted-through-embedding, 2,880 interface->concrete (72% actionable),
-    1,570 ambiguous and 1,240 unexplained (28% that must NOT be acted on — an
-    unexplained difference is a join that landed on the wrong call).
+  - **Disagreements are classified before being acted on.** Of gitea's 10,170
+    (all four counts from one `--resolve-call-graph --verbose` run, so they add
+    up): 4,490 promoted-through-embedding, 2,880 interface->concrete (72%
+    actionable), 1,570 ambiguous and 1,230 unexplained (28% that must NOT be
+    acted on — an unexplained difference is a join that landed on the wrong
+    call).
   - **Cost:** +12% metadata stage on a 246-route service, +15% on gitea (5.6s on
     37.6s). Whole-run on gitea at default limits: 46s -> 55s.
   - **The default stays off, on memory.** Peak RSS on gitea goes 3.15GB -> 4.62GB

--- a/internal/callgraph/callsites.go
+++ b/internal/callgraph/callsites.go
@@ -105,6 +105,15 @@ func (r *Resolved) CallSites() []CallSite {
 // implementation. Keeping all of them is the honest answer (golden rule #7) and
 // the caller decides what to do with an ambiguous site; collapsing to "the first
 // one" here would silently pick a concrete type the program may never use.
+//
+// Because the key is per LINE, two distinct calls to the same bare name written
+// on one line — `a.Read(); b.Read()` — share a key and pool their targets, so a
+// call that VTA resolved unambiguously can be reported as ambiguous. That errs in
+// the safe direction: the caller leaves an ambiguous site exactly as recorded, so
+// the cost is a rewrite not made, never a wrong one. It cannot be fixed by
+// keeping the column, which is the one thing the two graphs never agree on (see
+// SiteKey); distinguishing those calls would need the caller to match on
+// something else about the site, such as its receiver.
 func (r *Resolved) CalleesAt() map[string][]string {
 	sites := r.CallSites()
 	index := make(map[string][]string, len(sites))

--- a/internal/callgraph/disagreement_test.go
+++ b/internal/callgraph/disagreement_test.go
@@ -16,9 +16,10 @@ package callgraph
 
 import "testing"
 
-// TestClassify pins which disagreements may be acted on. Measured over gitea,
-// the four classes cover 10,182 real disagreements: 2,880 interface calls,
-// 4,492 promoted methods, 1,570 ambiguous sites and 1,240 unexplained.
+// TestClassify pins which disagreements may be acted on. Measured over gitea in
+// a single run, the four classes cover 10,170 real disagreements: 2,880
+// interface calls, 4,490 promoted methods, 1,570 ambiguous sites and 1,230
+// unexplained.
 func TestClassify(t *testing.T) {
 	facts := TypeFacts{
 		IsInterface: func(q string) bool { return q == "app.Storage" },

--- a/internal/spec/resolved_callees.go
+++ b/internal/spec/resolved_callees.go
@@ -50,14 +50,14 @@ func (s ResolvedCalleeStats) Line() string {
 //     patterns and schemas apply (2,880 sites on gitea);
 //   - a method reached through embedding, rewritten to the type that declares it,
 //     which is how a pattern scoped to the declaring type matches a call written
-//     on the embedding one (4,492 sites on gitea — the shape #236 had to emulate
+//     on the embedding one (4,490 sites on gitea — the shape #236 had to emulate
 //     by widening receiver regexes by hand).
 //
 // Two are deliberately NOT acted on. An interface with several implementations
 // stays as the interface, because choosing one would invent a concrete type the
 // program may never use (golden rule #7). A difference no relation explains is a
 // join that landed on the wrong call, and acting on it would corrupt the graph
-// (1,240 sites on gitea — 12%, far too many to wave through).
+// (1,230 sites on gitea — 12%, far too many to wave through).
 //
 // The edge's arguments, assignments and chain links are untouched: the resolved
 // graph is the authority on WHICH function a site calls, and metadata remains the


### PR DESCRIPTION
All four CodeRabbit findings on #250 were valid.

**1. The counts didn't add up — and the reason mattered.** The doc cited 4,492 promoted + 2,880 interface as "10,182 disagreements", while the run that actually applied them reported `7,370 rewritten (2,880 interface, 4,490 promoted)`. Two different measurements presented as one number. Everything now cites a **single** `--resolve-call-graph --verbose` run on gitea, so the classes add up: 2,880 + 4,490 + 1,570 + 1,230 = **10,170**. Fixed in `TRACKER_REDESIGN.md`, `resolved_callees.go` and `disagreement_test.go`.

**2. Same-line ambiguity.** `CalleesAt` keys per line, so `a.Read(); b.Read()` pools targets and a call VTA resolved unambiguously can be *reported* as ambiguous. It errs in the safe direction — an ambiguous site is left exactly as recorded, so the cost is a rewrite not made, never a wrong one — and it can't be fixed by keeping the column, which is the one thing the two graphs never agree on. Now documented at the merge rather than left for the next reader.

**3. Panel checkbox stayed operable mid-generation** while the header toggle didn't. Same `disabled` state now. Its tooltip also still carried the flat "+19%" claim this branch corrected everywhere else.

**4. Console fences** carry a language.

Full suite green, lint 0 issues, coverage 96.0%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)