### PR TITLE
fix(metadata): resolve a method call through the selection go/types already computed (#249)

### DIFF
--- a/generator/testdata_cross_pkg_receiver_test.go
+++ b/generator/testdata_cross_pkg_receiver_test.go
@@ -1,0 +1,162 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/engine"
+	intspec "github.com/ehabterra/apispec/internal/spec"
+)
+
+// responseSchemaName returns the component a response names, whether directly or
+// as the element type of an array — two of these handlers return a slice.
+func responseSchemaName(content map[string]intspec.MediaType) string {
+	for _, mt := range content {
+		if mt.Schema == nil {
+			continue
+		}
+		if mt.Schema.Ref != "" {
+			return mt.Schema.Ref
+		}
+		if mt.Schema.Items != nil && mt.Schema.Items.Ref != "" {
+			return mt.Schema.Items.Ref
+		}
+	}
+	return ""
+}
+
+// TestTestdata_CrossPkgReceiver is regression coverage for the SPEC over the two
+// shapes of issue #249. It is not the change-detector for that issue: the
+// responses here resolve from the handler's return value, so they were already
+// correct while the call graph underneath was wrong — see
+// TestCrossPkgReceiverIsRecordedWithItsReceiver for the assertion that fails
+// without the fix.
+//
+//	/subjects  a method on a service held in a struct field of another package
+//	           — the control: this shape always worked
+//	/aliased   the same call through a field typed by a LOCAL ALIAS of that
+//	           service (`type curriculumAlias = curriculum.Service`), which is how
+//	           a package avoids naming another at the type level. A *types.Alias
+//	           matched no arm of the receiver type switch, so the call was
+//	           recorded as a function of the caller's package with no receiver
+//	           at all
+//	/asset     a call through a field whose type is an INLINE interface, whose
+//	           receiver was recorded as the literal string "interface" — a name
+//	           nothing can look up
+func TestTestdata_CrossPkgReceiver(t *testing.T) {
+	out := loadTestdata(t, "cross_pkg_receiver", nil)
+
+	cases := []struct {
+		path   string
+		schema string
+		why    string
+	}{
+		{
+			path:   "/subjects",
+			schema: "curriculum_Subject",
+			why:    "the control — a plain cross-package method on a struct field",
+		},
+		{
+			path:   "/aliased",
+			schema: "curriculum_Subject",
+			why:    "reached through a local alias; the response must resolve to the type the ALIASED service returns, not be lost with the receiver",
+		},
+		{
+			path:   "/asset",
+			schema: "storage_Asset",
+			why:    "reached through an inline interface; the concrete type is what the handler encodes",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.path, func(t *testing.T) {
+			item, ok := out.Paths[tt.path]
+			if !ok {
+				t.Fatalf("%s missing; have %v", tt.path, mapPathKeys(out.Paths))
+			}
+			op := opFor(item, "GET")
+			if op == nil {
+				t.Fatalf("GET %s missing", tt.path)
+			}
+			resp, ok := op.Responses["200"]
+			if !ok {
+				t.Fatalf("GET %s: no 200; have %v — %s", tt.path, keysOf(op.Responses), tt.why)
+			}
+			ref := responseSchemaName(resp.Content)
+			if !strings.Contains(ref, tt.schema) {
+				t.Errorf("GET %s: response schema %q does not name %s — %s", tt.path, ref, tt.schema, tt.why)
+			}
+		})
+	}
+}
+
+// TestCrossPkgReceiverIsRecordedWithItsReceiver is the change-detector for
+// issue #249: it asserts on the recorded call graph, which is where the defect
+// was.
+//
+// Losing the receiver is not cosmetic. It is what a pattern scopes on, so the
+// call becomes unmatchable; and because the callee was then attributed to the
+// CALLING package, the graph named a function that exists nowhere — which also
+// made the call unjoinable to a resolved call graph.
+func TestCrossPkgReceiverIsRecordedWithItsReceiver(t *testing.T) {
+	cfg := engine.DefaultEngineConfig()
+	cfg.InputDir = filepath.Join("..", "testdata", "cross_pkg_receiver")
+
+	meta, err := engine.NewEngine(cfg).GenerateMetadataOnly()
+	if err != nil {
+		t.Fatalf("GenerateMetadataOnly: %v", err)
+	}
+
+	var subjectCalls []string
+	var describeCalls []string
+	for i := range meta.CallGraph {
+		callee := meta.CallGraph[i].Callee.BaseID()
+		switch {
+		case strings.HasSuffix(callee, ".ListSubjects"):
+			subjectCalls = append(subjectCalls, callee)
+		case strings.HasSuffix(callee, ".Describe"):
+			describeCalls = append(describeCalls, callee)
+		}
+	}
+
+	// Two calls to ListSubjects: one through the concrete field, one through a
+	// local alias of the same type. Both are the same method, so both must be
+	// recorded against the type that declares it.
+	const want = "example.com/recv/internal/curriculum.Service.ListSubjects"
+	if len(subjectCalls) != 2 {
+		t.Fatalf("recorded %d ListSubjects calls, want 2: %v", len(subjectCalls), subjectCalls)
+	}
+	for _, got := range subjectCalls {
+		if got != want {
+			t.Errorf("ListSubjects recorded as %q, want %q — a local alias of another package's type must not\n"+
+				"re-home the method in the calling package, or no receiver-scoped pattern can match it", got, want)
+		}
+	}
+
+	// An unnamed interface has no name to record, so the receiver must be empty
+	// rather than the literal string "interface", which reads like a type name
+	// and is not one.
+	for _, got := range describeCalls {
+		if strings.Contains(got, ".interface.") {
+			t.Errorf("Describe recorded as %q — \"interface\" is not a type name and nothing can look it up", got)
+		}
+	}
+	if len(describeCalls) == 0 {
+		t.Error("no Describe call recorded at all; the inline-interface shape is not being covered")
+	}
+}

--- a/internal/metadata/analysis.go
+++ b/internal/metadata/analysis.go
@@ -210,6 +210,40 @@ func isTypeConversion(call *ast.CallExpr, info *types.Info) bool {
 }
 
 // getCalleeFunctionNameAndPackage extracts function name, package, and receiver type from a call expression
+// calleeFromSelection resolves a method call the way go/types already has:
+// info.Selections records, for every selector, which method it selects and on
+// what. Reading it answers questions the shape of the expression cannot.
+//
+// The type switches below enumerate the receiver shapes they know — Named,
+// Pointer, Interface — and anything else falls through to "a function of the
+// calling package". A local `type Alias = other.Service` is exactly that
+// anything else, so `h.field.Method()` through an alias was recorded as
+// `caller/pkg.Method` with no receiver at all: unmatchable by any pattern scoped
+// on its type, and attributed to the wrong package (issue #249).
+//
+// The method's own declared receiver is used rather than the type of the
+// expression, so an alias, an embedded field or a type argument all report the
+// type that actually declares the method.
+func calleeFromSelection(x *ast.SelectorExpr, info *types.Info) (name, pkg, recv string, ok bool) {
+	if info == nil {
+		return "", "", "", false
+	}
+	sel := info.Selections[x]
+	if sel == nil || sel.Kind() != types.MethodVal {
+		return "", "", "", false
+	}
+	fn, isFunc := sel.Obj().(*types.Func)
+	if !isFunc || fn.Pkg() == nil {
+		return "", "", "", false
+	}
+
+	recvType := sel.Recv()
+	if sig, isSig := fn.Type().(*types.Signature); isSig && sig.Recv() != nil {
+		recvType = sig.Recv().Type()
+	}
+	return fn.Name(), fn.Pkg().Path(), getReceiverTypeString(recvType), true
+}
+
 func getCalleeFunctionNameAndPackage(expr ast.Expr, file *ast.File, pkgName string, fileToInfo map[*ast.File]*types.Info, funcMap map[string]*ast.FuncDecl, fset *token.FileSet, meta *Metadata) (string, string, string) {
 	switch x := expr.(type) {
 	case *ast.Ident:
@@ -217,6 +251,11 @@ func getCalleeFunctionNameAndPackage(expr ast.Expr, file *ast.File, pkgName stri
 		return x.Name, pkgName, ""
 
 	case *ast.SelectorExpr:
+		// What go/types already resolved beats re-deriving it from the syntax.
+		if name, pkg, recv, ok := calleeFromSelection(x, fileToInfo[file]); ok {
+			return name, pkg, recv
+		}
+
 		if ident, ok := x.X.(*ast.Ident); ok {
 
 			// If not an import, try to resolve as variable/method
@@ -334,8 +373,17 @@ func getReceiverTypeString(t types.Type) string {
 	case *types.Pointer:
 		// Handle pointer types like *MyStruct
 		return "*" + getReceiverTypeString(t.Elem())
+	case *types.Alias:
+		// An alias is a second name for a type, not a type of its own. Record
+		// what it stands for, or a local `type X = other.Y` makes every call
+		// through it look like a call on a type of the calling package.
+		return getReceiverTypeString(types.Unalias(t))
 	case *types.Interface:
-		return "interface"
+		// An unnamed interface has no name to record. "interface" looks like a
+		// type name and is not one: nothing can look it up, and a pattern scoped
+		// by receiver can never match it. A NAMED interface never reaches here —
+		// it is a *types.Named whose underlying type is this (issue #249).
+		return ""
 	default:
 		return ""
 	}

--- a/internal/metadata/metadata_sweep_test.go
+++ b/internal/metadata/metadata_sweep_test.go
@@ -289,7 +289,11 @@ func TestSweepGetCalleeFunctionNameAndPackageArms(t *testing.T) {
 		return &ast.SelectorExpr{X: x, Sel: ast.NewIdent(name)}
 	}
 
-	// Ident receiver typed as a bare interface.
+	// Ident receiver typed as a bare interface. An UNNAMED interface has no name
+	// to record: "interface" reads like a type name, is not one, and cannot be
+	// looked up or matched by a receiver-scoped pattern (issue #249). A named
+	// interface never reaches this arm — it is a Named whose underlying type is
+	// the interface.
 	identX := ast.NewIdent("r")
 	ifaceType := types.NewInterfaceType(nil, nil)
 	ifaceType.Complete()
@@ -298,8 +302,8 @@ func TestSweepGetCalleeFunctionNameAndPackageArms(t *testing.T) {
 	}}
 	name, pkg, recv := getCalleeFunctionNameAndPackage(mkSel(identX, "Read"), file, "p",
 		map[*ast.File]*types.Info{file: infoVar}, nil, fset, sweepMeta())
-	if name != "Read" || pkg != "p" || recv != "interface" {
-		t.Errorf("iface var receiver: got (%q,%q,%q)", name, pkg, recv)
+	if name != "Read" || pkg != "p" || recv != "" {
+		t.Errorf("iface var receiver: got (%q,%q,%q), want (\"Read\",\"p\",\"\")", name, pkg, recv)
 	}
 
 	// Complex receiver whose type is a Named with a nil package (error).
@@ -320,8 +324,8 @@ func TestSweepGetCalleeFunctionNameAndPackageArms(t *testing.T) {
 	}}
 	name, pkg, recv = getCalleeFunctionNameAndPackage(mkSel(callX2, "Do"), file, "p",
 		map[*ast.File]*types.Info{file: infoIface}, nil, fset, sweepMeta())
-	if name != "Do" || pkg != "p" || recv != "interface" {
-		t.Errorf("iface complex receiver: got (%q,%q,%q)", name, pkg, recv)
+	if name != "Do" || pkg != "p" || recv != "" {
+		t.Errorf("iface complex receiver: got (%q,%q,%q), want (\"Do\",\"p\",\"\")", name, pkg, recv)
 	}
 
 	// Complex receiver typed as a basic type: no switch arm matches.

--- a/testdata/cross_pkg_receiver/go.mod
+++ b/testdata/cross_pkg_receiver/go.mod
@@ -1,0 +1,5 @@
+module example.com/recv
+
+go 1.24
+
+require github.com/go-chi/chi/v5 v5.2.1

--- a/testdata/cross_pkg_receiver/go.sum
+++ b/testdata/cross_pkg_receiver/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
+github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=

--- a/testdata/cross_pkg_receiver/internal/curriculum/service.go
+++ b/testdata/cross_pkg_receiver/internal/curriculum/service.go
@@ -1,0 +1,14 @@
+// Package curriculum holds a service whose methods a handler calls through a
+// struct field, from another package.
+package curriculum
+
+type Subject struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type Service struct{}
+
+func (s *Service) ListSubjects() []Subject {
+	return []Subject{}
+}

--- a/testdata/cross_pkg_receiver/internal/storage/storage.go
+++ b/testdata/cross_pkg_receiver/internal/storage/storage.go
@@ -1,0 +1,12 @@
+// Package storage is reached through an INLINE interface field, so the receiver
+// type as written has no name of its own.
+package storage
+
+type Asset struct {
+	Key string `json:"key"`
+	URL string `json:"url"`
+}
+
+type S3 struct{}
+
+func (s *S3) Describe() Asset { return Asset{} }

--- a/testdata/cross_pkg_receiver/main.go
+++ b/testdata/cross_pkg_receiver/main.go
@@ -1,0 +1,76 @@
+// Package main pins two shapes that lost their receiver in the recorded call
+// graph (issue #249):
+//
+//  1. a method on a service held in a struct FIELD of another package — the call
+//     was recorded with no receiver at all, under the CALLER's package;
+//  2. a call through a field whose declared type is an INLINE interface — the
+//     receiver was recorded as the literal string "interface";
+//  3. a call through a field typed by a LOCAL ALIAS of a type in another package
+//     — the receiver resolved in the caller's package instead of the declaring
+//     one.
+//
+// Both make a pattern scoped by recvTypeRegex unmatchable, and both are
+// invisible in a single-package fixture.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"example.com/recv/internal/curriculum"
+	"example.com/recv/internal/storage"
+	"github.com/go-chi/chi/v5"
+)
+
+// curriculumAlias is a local alias of a type declared elsewhere, the shape a
+// project uses to keep a struct from naming another package at the type level.
+type curriculumAlias = curriculum.Service
+
+type Deps struct {
+	Curriculum *curriculum.Service
+
+	// Typed by the local alias rather than by the declaring package.
+	Aliased *curriculumAlias
+
+	// Declared inline, so the field's type has no name.
+	Assets interface {
+		Describe() storage.Asset
+	}
+}
+
+func main() {
+	deps := Deps{
+		Curriculum: &curriculum.Service{},
+		Aliased:    &curriculum.Service{},
+		Assets:     &storage.S3{},
+	}
+	r := chi.NewRouter()
+	r.Get("/subjects", listSubjects(deps))
+	r.Get("/asset", describeAsset(deps))
+	r.Get("/aliased", listAliased(deps))
+	_ = http.ListenAndServe(":8080", r)
+}
+
+func listSubjects(deps Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		out := deps.Curriculum.ListSubjects()
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(out)
+	}
+}
+
+func listAliased(deps Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		out := deps.Aliased.ListSubjects()
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(out)
+	}
+}
+
+func describeAsset(deps Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		out := deps.Assets.Describe()
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(out)
+	}
+}


### PR DESCRIPTION
Closes #249.

Two shapes lost the callee's receiver. Both were found on a real project, and neither is visible in a single-package fixture.

| shape | recorded before | recorded after |
|---|---|---|
| field typed by a local alias (`type A = other.Service`) | `example.com/recv.ListSubjects` — **no receiver, caller's package** | `…/curriculum.Service.ListSubjects` |
| field typed by an inline `interface{…}` | `example.com/recv.interface.Describe` | `example.com/recv.Describe` |
| plain cross-package field (control) | correct | correct |

A `*types.Alias` matched no arm of the receiver type switch, so the call fell through to "a function of the calling package" — naming a function that exists nowhere. `"interface"` reads like a type name and is not one.

Both matter because **the receiver is what a pattern scopes on**, and a callee attributed to the wrong package can't be joined to a resolved call graph either.

## The fix

Stop enumerating receiver shapes; ask go/types what it already computed. `info.Selections` records, for every selector, which method it selects and on what. The method's **own declared receiver** is used rather than the type of the expression, so an alias, an embedded field or a type argument all report the type that actually declares the method.

## One thing worth stating plainly

**The spec for this fixture was already correct before the fix** — responses resolve from the handler's return value, not from the receiver. So the structural test passes either way; I verified that rather than assuming it. It is regression coverage, not proof. The change-detector (`TestCrossPkgReceiverIsRecordedWithItsReceiver`) asserts on the recorded call graph, where the defect actually was, and fails without the fix:

```text
ListSubjects recorded as "example.com/recv.ListSubjects",
        want "example.com/recv/internal/curriculum.Service.ListSubjects"
```

## Verification

Full suite green, **zero drift** across all 71 existing fixtures, no metadata golden changed, `gofmt -s` clean, `golangci-lint` 0 issues, coverage 96.0%. Two sweep-test expectations that pinned the literal `"interface"` were updated with the reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)