### PR TITLE
fix(spec): report the work the tree does, not only the budget it spends (#247)

### DIFF
--- a/cmd/apispecui/main.go
+++ b/cmd/apispecui/main.go
@@ -1605,7 +1605,12 @@ func buildAPISpecConfig(req *GenerateRequest, dir string) (*spec.APISpecConfig, 
 func analysisInfo(primary string, detected []string, lazy bool, ep spec.EntrypointStats, expansion spec.ExpansionStats) insight.AnalysisInfo {
 	info := insight.AnalysisInfo{Frameworks: detected, Primary: primary}
 	if expansion.Truncated {
-		info.Expansion = &insight.ExpansionInfo{NodesBuilt: expansion.NodesBuilt, Limit: expansion.Limit, Truncated: true}
+		info.Expansion = &insight.ExpansionInfo{
+			NodesBuilt:        expansion.NodesBuilt,
+			NodesMaterialized: expansion.NodesMaterialized,
+			Limit:             expansion.Limit,
+			Truncated:         true,
+		}
 	}
 	if lazy {
 		info.Engine = "lazy"

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -497,3 +497,45 @@ func contains(s, substr string) bool {
 				return false
 			}())))
 }
+
+// TestGetExpansionStatsReportsWorkNotJustBudget pins that a run can tell how much
+// the tree actually did, not only how much of its budget it spent. Reporting the
+// budgeted number alone made a run look an order of magnitude cheaper than it
+// was: a 246-route service builds 208,394 nodes across 20,198 distinct calls,
+// against a 50,000 budget that therefore never fires (issue #247).
+func TestGetExpansionStatsReportsWorkNotJustBudget(t *testing.T) {
+	cfg := DefaultEngineConfig()
+	cfg.InputDir = filepath.Join("..", "..", "testdata", "complex_chi_router")
+
+	eng := NewEngine(cfg)
+	if _, err := eng.GenerateOpenAPI(); err != nil {
+		t.Fatalf("GenerateOpenAPI: %v", err)
+	}
+
+	stats := eng.GetExpansionStats()
+	if stats.NodesBuilt == 0 {
+		t.Fatal("no calls expanded for a fixture with routes")
+	}
+	if stats.NodesMaterialized < stats.NodesBuilt {
+		t.Errorf("materialized %d nodes across %d distinct calls — one node per call is the floor",
+			stats.NodesMaterialized, stats.NodesBuilt)
+	}
+	if stats.Limit != DefaultMaxNodesPerTree {
+		t.Errorf("reported limit %d, want the default %d", stats.Limit, DefaultMaxNodesPerTree)
+	}
+	if stats.Truncated {
+		t.Errorf("a fixture truncated at the default budget (%d calls, %d nodes) — the default is meant to clear every fixture",
+			stats.NodesBuilt, stats.NodesMaterialized)
+	}
+
+	// The rest of the "what did this run do" surface, which the UI reads to
+	// explain a result and which nothing else exercises.
+	if entry := eng.GetEntrypointStats(); entry.Rooted > entry.Declared {
+		t.Errorf("rooted %d entrypoints out of %d declared", entry.Rooted, entry.Declared)
+	}
+	for _, w := range eng.GetDetectedWrappers() {
+		if w.RecvType == "" {
+			t.Error("a detected wrapper has no receiver type, so nothing could be scoped to it")
+		}
+	}
+}

--- a/internal/insight/overview.go
+++ b/internal/insight/overview.go
@@ -130,9 +130,14 @@ type EntrypointInfo struct {
 // finishing. Everything past that point is missing from the spec, so a route count
 // read without it can be wildly wrong (issue #233).
 type ExpansionInfo struct {
-	NodesBuilt int  `json:"nodesBuilt"`
-	Limit      int  `json:"limit"`
-	Truncated  bool `json:"truncated"`
+	// NodesBuilt is the distinct calls expanded — what Limit bounds.
+	NodesBuilt int `json:"nodesBuilt"`
+	// NodesMaterialized is the tree nodes those calls actually produced, which is
+	// the work done and is typically an order of magnitude larger. Reporting only
+	// the budgeted number made a run look far cheaper than it was (issue #247).
+	NodesMaterialized int  `json:"nodesMaterialized,omitempty"`
+	Limit             int  `json:"limit"`
+	Truncated         bool `json:"truncated"`
 }
 
 // AnalysisInfo describes HOW the spec was produced rather than what is in it.

--- a/internal/spec/entrypoint_roots.go
+++ b/internal/spec/entrypoint_roots.go
@@ -232,7 +232,14 @@ func RouteRegistrationMatcher(cfg *APISpecConfig, meta *metadata.Metadata) func(
 // limit and 862 with the budget raised — and the only sign was a line on stderr
 // (issue #233).
 type ExpansionStats struct {
+	// NodesBuilt is the distinct callee keys expanded — what Limit bounds.
 	NodesBuilt int
-	Limit      int
-	Truncated  bool
+	// NodesMaterialized is the nodes actually created, which is the work the
+	// unfolding does and is typically an order of magnitude larger: a 246-route
+	// service builds 208,394 nodes across 20,198 keys. Reported rather than
+	// budgeted, because a global node budget starves route discovery — see
+	// issue #247, and #224 for the unit problem underneath.
+	NodesMaterialized int
+	Limit             int
+	Truncated         bool
 }

--- a/internal/spec/lazytree.go
+++ b/internal/spec/lazytree.go
@@ -107,12 +107,18 @@ type LazyTree struct {
 	// value that was stored (CartAPIs(...) above).
 	producerArgs map[string][]string
 
-	// nodesBuilt counts every LazyNode created. The per-path cycle guard
+	// nodesBuilt counts distinct callee keys — what MaxNodesPerTree bounds. It is
+	// NOT the number of nodes: see nodesMaterialized, and issue #247 for why the
+	// two are reported separately rather than one being made to mean the other. The per-path cycle guard
 	// bounds each path, but a dense cyclic graph still has exponentially many
 	// distinct acyclic paths — the same blow-up MaxNodesPerTree exists to
 	// stop in the eager tree. Once the budget is spent, expansion returns
 	// leaves.
 	nodesBuilt int
+
+	// nodesMaterialized counts every LazyNode created, which is the work the
+	// unfolding actually does. Reported, not budgeted (#247).
+	nodesMaterialized int
 
 	// instanceCount counts node copies per (instance scope, callee ID) —
 	// see DefaultMaxInstancesPerKey. A node is (edge, parent), so a callee reached
@@ -159,6 +165,15 @@ type LazyTree struct {
 	// CPU profile when re-run for every per-path node copy of the same
 	// argument (var, caller fn, caller pkg) -> (originVar, originPkg, originFunc).
 	traceCache map[string][3]string
+
+	// nodeSlab hands out LazyNodes in chunks instead of one heap object each.
+	// Unfolding a DAG into paths is inherently allocation-heavy — a call reached
+	// along many paths gets a node per path — and on a large project those
+	// individual allocations dominated both the allocator and the collector: 4.1GB
+	// of the 11.5GB a gitea run allocated came from this one site, with GC frames
+	// (madvise, scanObjectsSmall) taking ~60% of CPU. A slab keeps the same node
+	// lifetime and identity, and simply stops asking the allocator per node.
+	nodeSlab []LazyNode
 
 	// seenKeys backs the node budget: distinct callee IDs ever materialized,
 	// the same graph-sized unit as the eager tree's shared-node cap —
@@ -534,7 +549,12 @@ func (t *LazyTree) edgesFor(baseKey string) []*metadata.CallGraphEdge {
 // ExpansionStats reports how far expansion got, and whether it stopped early.
 func (t *LazyTree) ExpansionStats() ExpansionStats {
 	t.buildRelations()
-	return ExpansionStats{NodesBuilt: t.nodesBuilt, Limit: t.limits.MaxNodesPerTree, Truncated: t.truncated}
+	return ExpansionStats{
+		NodesBuilt:        t.nodesBuilt,
+		NodesMaterialized: t.nodesMaterialized,
+		Limit:             t.limits.MaxNodesPerTree,
+		Truncated:         t.truncated,
+	}
 }
 
 // EntrypointStats reports what the entrypoint gate decided during this tree's
@@ -705,8 +725,12 @@ func (n *LazyNode) GetChildren() []TrackerNodeInterface {
 		scopeCounts = map[string]int{}
 		n.tree.instanceCount[scope] = scopeCounts
 	}
+	plan := n.tree.planFor(n)
+	if cap(n.children) < len(plan) {
+		n.children = make([]TrackerNodeInterface, 0, len(plan))
+	}
 	childCount := 0
-	for _, spec := range n.tree.planFor(n) {
+	for _, spec := range plan {
 		if spec.arg == nil && childCount >= n.tree.limits.MaxChildrenPerNode {
 			continue
 		}
@@ -720,12 +744,11 @@ func (n *LazyNode) GetChildren() []TrackerNodeInterface {
 			// bound is a skip — the role the eager per-ID recursion cap plays.
 			continue
 		}
-		child := &LazyNode{
-			tree:   n.tree,
-			key:    spec.key,
-			parent: n,
-			edge:   spec.edge,
-		}
+		child := n.tree.newNode()
+		child.tree = n.tree
+		child.key = spec.key
+		child.parent = n
+		child.edge = spec.edge
 		if spec.arg != nil {
 			child.edge = spec.argEdge
 			child.arg = spec.arg
@@ -738,16 +761,50 @@ func (n *LazyNode) GetChildren() []TrackerNodeInterface {
 			childCount++
 		}
 		scopeCounts[spec.key]++
+		// Two different quantities, deliberately kept apart (issue #247).
+		//
+		// nodesMaterialized is the WORK: one node per path a call is reached along,
+		// which is what costs time and memory. nodesBuilt is what the budget
+		// bounds — distinct callee keys — and the two differ by more than an order
+		// of magnitude: a 246-route service builds 208,394 nodes across 20,198
+		// keys.
+		//
+		// The budget stays on keys because switching it to nodes, though truthful,
+		// starves route discovery: a global budget is spent depth-first on whatever
+		// is expanded first, and on gitea that is modules/setting and modules/log.
+		// Measured, gitea documents 900 paths at a raised KEY budget and 1 path at
+		// a node budget of fifteen million. The unit is the real problem and it is
+		// #224; what this counter can honestly do meanwhile is report the work
+		// instead of hiding it.
+		n.tree.nodesMaterialized++
 		if n.tree.seenKeys == nil {
 			n.tree.seenKeys = map[string]bool{}
 		}
 		if !n.tree.seenKeys[spec.key] {
 			n.tree.seenKeys[spec.key] = true
-			n.tree.nodesBuilt++ // budget counts globally distinct keys, like the eager shared-node cap
+			n.tree.nodesBuilt++
 		}
 		n.children = append(n.children, child)
 	}
 	return n.children
+}
+
+// nodeSlabChunk is how many nodes are carved at once. Large enough that the
+// allocation is rare, small enough that a tree which stops early has not
+// reserved much it will never use.
+const nodeSlabChunk = 4096
+
+// newNode returns a zeroed node from the current slab, carving a new one when
+// the current is spent. The returned pointer is stable: a slab is never grown in
+// place (append would copy and invalidate every pointer already handed out), it
+// is replaced.
+func (t *LazyTree) newNode() *LazyNode {
+	if len(t.nodeSlab) == 0 {
+		t.nodeSlab = make([]LazyNode, nodeSlabChunk)
+	}
+	node := &t.nodeSlab[0]
+	t.nodeSlab = t.nodeSlab[1:]
+	return node
 }
 
 // planFor returns (building on first use) the memoized expansion plan for

--- a/internal/spec/lazytree_budget_test.go
+++ b/internal/spec/lazytree_budget_test.go
@@ -130,3 +130,82 @@ func TestInstanceBudgetCapsTraversal(t *testing.T) {
 		})
 	}
 }
+
+// TestNewNodeSlabHandsOutStablePointers pins the property the slab must keep: a
+// node's address never moves. Nodes reference their parent, so a slab that grew
+// in place (append) would copy the backing array and leave every pointer already
+// handed out pointing at a stale copy.
+func TestNewNodeSlabHandsOutStablePointers(t *testing.T) {
+	tree := &LazyTree{}
+
+	// Cross a chunk boundary: the failure only appears when a second slab is
+	// carved.
+	nodes := make([]*LazyNode, 0, nodeSlabChunk+16)
+	for i := 0; i < nodeSlabChunk+16; i++ {
+		node := tree.newNode()
+		node.key = "node"
+		nodes = append(nodes, node)
+	}
+
+	seen := make(map[*LazyNode]bool, len(nodes))
+	for i, node := range nodes {
+		if seen[node] {
+			t.Fatalf("node %d reuses an address already handed out", i)
+		}
+		seen[node] = true
+		if node.key != "node" {
+			t.Fatalf("node %d was mutated after being handed out: key=%q", i, node.key)
+		}
+	}
+
+	// A freshly carved node must be zero, not whatever the previous tenant left.
+	fresh := tree.newNode()
+	if fresh.key != "" || fresh.parent != nil || fresh.edge != nil || fresh.expanded {
+		t.Errorf("a new node is not zeroed: %+v", *fresh)
+	}
+}
+
+// TestBudgetCountsKeysWhileStatsReportWork pins the distinction issue #247 is
+// about: MaxNodesPerTree bounds distinct callee KEYS, while the tree materialises
+// a node per path a call is reached along. Reporting only the budgeted number
+// made a run look an order of magnitude cheaper than it was — a 246-route service
+// builds 208,394 nodes across 20,198 keys.
+//
+// The budget deliberately stays on keys. Switching it to nodes is truthful and
+// starves route discovery: a global budget is spent depth-first on whatever
+// expands first, and gitea documents 900 paths at a raised key budget against 1
+// path at a node budget of fifteen million. The unit is the real problem (#224).
+func TestBudgetCountsKeysWhileStatsReportWork(t *testing.T) {
+	// A diamond: several callers reach one shared call site, so that site is
+	// materialised once per path while remaining a single key.
+	meta := sharedHelperGraph(6)
+	tree := NewLazyTree(meta, metadata.TrackerLimits{MaxNodesPerTree: 100000, MaxChildrenPerNode: 100})
+
+	var walk func(n TrackerNodeInterface, depth int)
+	walk = func(n TrackerNodeInterface, depth int) {
+		if n == nil || depth > 12 {
+			return
+		}
+		for _, child := range n.GetChildren() {
+			walk(child, depth+1)
+		}
+	}
+	for _, root := range tree.GetRoots() {
+		walk(root, 0)
+	}
+
+	stats := tree.ExpansionStats()
+	if stats.NodesBuilt == 0 {
+		t.Fatal("no keys expanded; the fixture builds no tree")
+	}
+	if stats.NodesMaterialized < stats.NodesBuilt {
+		t.Errorf("materialized %d nodes across %d keys — a node per key is the floor, not the ceiling",
+			stats.NodesMaterialized, stats.NodesBuilt)
+	}
+	// A diamond reaches the same callee along several paths, which is precisely
+	// the difference the two counters exist to show.
+	if stats.NodesMaterialized == stats.NodesBuilt {
+		t.Errorf("materialized == built (%d): the diamond in this fixture must produce more nodes than keys, "+
+			"or the counters are measuring the same thing and the distinction is lost", stats.NodesBuilt)
+	}
+}

--- a/internal/spec/tracker.go
+++ b/internal/spec/tracker.go
@@ -1751,7 +1751,14 @@ func NewTrackerNode(tree *TrackerTree, meta *metadata.Metadata, parentID, id str
 
 // ExpansionStats reports how far expansion got, and whether it stopped early.
 func (t *TrackerTree) ExpansionStats() ExpansionStats {
-	return ExpansionStats{NodesBuilt: t.nodesBuilt, Limit: t.limits.MaxNodesPerTree, Truncated: t.truncated}
+	// The eager tree materialises one node per distinct key, so the two counts
+	// coincide here; they diverge in the lazy tree, which unfolds per path.
+	return ExpansionStats{
+		NodesBuilt:        t.nodesBuilt,
+		NodesMaterialized: t.nodesBuilt,
+		Limit:             t.limits.MaxNodesPerTree,
+		Truncated:         t.truncated,
+	}
 }
 
 // EntrypointStats reports what the entrypoint gate decided during this tree's


### PR DESCRIPTION
Closes #247. **Targets `main`** — this has no dependency on the SSA/VTA branch.

`MaxNodesPerTree` is documented as a node budget and is not one: the counter behind it increments only for a callee key never seen before.

> A 246-route service builds **208,394 nodes across 20,198 keys**, so a 50,000 budget never fires and no truncation is ever reported.

A run can materialise an order of magnitude more work than the number in the logs — and the "limit reached, truncating" warning, which is how a run tells you the spec may be incomplete (#233), cannot fire.

## What changes

`ExpansionStats`, `insight.ExpansionInfo` and the UI now carry **both**:

- `NodesBuilt` — distinct calls expanded, what the budget bounds (**unchanged**)
- `NodesMaterialized` — the nodes those calls produced: the work

## What deliberately does not change: the budget's unit

I implemented counting nodes, measured it, and reverted it:

| gitea | result |
|---|---|
| raised **key** budget | 900 paths |
| 3,000,000-**node** budget | 1 path, truncating in `modules/setting` |
| 15,000,000-**node** budget | 1 path |

A global node budget is spent depth-first on whatever expands first — on gitea that's settings and logging, not routers — so counting the work truthfully **starves route discovery**. Re-tuning couldn't rescue it either: I measured 21,100 nodes for the largest of the 72 fixtures and 208,394 for the service above, set the default to 500,000 accordingly, and gitea still collapsed. One global budget can't tell useful expansion from useless — that's **#224**, and this PR records the evidence against it rather than pretending to fix it.

## Also: the allocation fix the profiling turned up

`LazyNode.GetChildren` allocated **4.1 GB of a large run's 11.5 GB**, one heap object per node, with the collector taking ~60% of CPU (`madvise`, `scanObjectsSmall`). Nodes now come from a slab carved in 4,096-node chunks and the children slice is sized from the expansion plan.

A node's address must never move — nodes reference their parent — so the slab is **replaced, not grown**, and `TestNewNodeSlabHandsOutStablePointers` pins that across a chunk boundary.

## Verification

- **Zero drift** across all 71 fixtures; a 246-route service byte-identical to the pre-change run.
- Full suite green, `gofmt -s` clean, `golangci-lint` 0 issues, coverage 96.0% (floor 96).
- New: `TestBudgetCountsKeysWhileStatsReportWork` (a diamond must produce more nodes than keys, or the two counters are measuring the same thing), `TestNewNodeSlabHandsOutStablePointers`, `TestGetExpansionStatsReportsWorkNotJustBudget`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)