### PR TITLE
fix(spec): a package qualifier belongs on a name, not on a container (#259)

### DIFF
--- a/generator/testdata_nested_slice_field_test.go
+++ b/generator/testdata_nested_slice_field_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"maps"
+	"slices"
+	"strings"
+	"testing"
+
+	intspec "github.com/ehabterra/apispec/internal/spec"
+	"github.com/ehabterra/apispec/spec"
+)
+
+// TestTestdata_NestedSliceField locks in issue #259: a struct field typed
+// [][]T used to be emitted as an array whose items were a $ref to a component
+// nobody defined (the package qualifier was glued onto the inner container,
+// which then looked nameable to the $ref fast-paths). Every container level
+// must nest inline; only the named leaf may become a $ref.
+func TestTestdata_NestedSliceField(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "nested_slice_field", spec.DefaultChiConfig())
+	noDanglingRefs(t, out)
+	noUnresolvedPlaceholders(t, out)
+
+	for _, path := range []string{"/table", "/containers"} {
+		item, ok := out.Paths[path]
+		if !ok {
+			t.Fatalf("path %q missing; have %v", path, mapPathKeys(out.Paths))
+		}
+		if opFor(item, "GET") == nil {
+			t.Errorf("GET %s missing", path)
+		}
+	}
+
+	schemaBySuffix := func(suffix string) *intspec.Schema {
+		t.Helper()
+		for k, v := range out.Components.Schemas {
+			if strings.HasSuffix(k, suffix) {
+				return v
+			}
+		}
+		t.Fatalf("no component ending %q; have %v", suffix, slices.Sorted(maps.Keys(out.Components.Schemas)))
+		return nil
+	}
+
+	// arrayDepth peels array levels and returns the depth plus the schema at
+	// the bottom, so nesting can be asserted without pinning component names.
+	arrayDepth := func(s *intspec.Schema) (int, *intspec.Schema) {
+		depth := 0
+		for s != nil && s.Type == "array" {
+			depth++
+			s = s.Items
+		}
+		return depth, s
+	}
+
+	table := schemaBySuffix("_Table")
+
+	// []string: the single-level case that always worked — the regression guard
+	// for the level the fix must not change.
+	if depth, leaf := arrayDepth(table.Properties["header"]); depth != 1 || leaf == nil || leaf.Type != "string" {
+		t.Errorf("header: depth=%d leaf=%+v, want a 1-deep array of string", depth, leaf)
+	}
+
+	// [][]string: the reported shape. Both levels inline, string at the bottom,
+	// no $ref anywhere along the way.
+	if depth, leaf := arrayDepth(table.Properties["rows"]); depth != 2 || leaf == nil || leaf.Type != "string" || leaf.Ref != "" {
+		t.Errorf("rows: depth=%d leaf=%+v, want a 2-deep array of string", depth, leaf)
+	}
+
+	// [][][]int: arbitrary nesting depth, not just two levels.
+	if depth, leaf := arrayDepth(table.Properties["cube"]); depth != 3 || leaf == nil || leaf.Type != "integer" {
+		t.Errorf("cube: depth=%d leaf=%+v, want a 3-deep array of integer", depth, leaf)
+	}
+
+	// [][]Item: the named leaf — and only the named leaf — becomes a $ref, so
+	// the nesting survives instead of collapsing a level.
+	depth, leaf := arrayDepth(table.Properties["grid"])
+	if depth != 2 || leaf == nil || !strings.HasSuffix(leaf.Ref, "_Item") {
+		t.Fatalf("grid: depth=%d leaf=%+v, want a 2-deep array of $ref …_Item", depth, leaf)
+	}
+	if item := schemaBySuffix("_Item"); item.Properties["name"] == nil {
+		t.Errorf("Item component missing 'name': %+v", item)
+	}
+
+	containers := schemaBySuffix("_Containers")
+
+	// []map[string]T and map[string][]T: the neighbouring composite shapes
+	// named in the issue. The map value is the only $ref site.
+	sliceOfMaps := containers.Properties["sliceOfMaps"]
+	if sliceOfMaps == nil || sliceOfMaps.Type != "array" || sliceOfMaps.Items == nil ||
+		sliceOfMaps.Items.AdditionalProperties == nil || sliceOfMaps.Items.AdditionalProperties.Type != "string" {
+		t.Errorf("sliceOfMaps = %+v, want an array of map[string]string", sliceOfMaps)
+	}
+
+	mapOfSlices := containers.Properties["mapOfSlices"]
+	if mapOfSlices == nil || mapOfSlices.AdditionalProperties == nil {
+		t.Fatalf("mapOfSlices = %+v, want an object with additionalProperties", mapOfSlices)
+	}
+	if d, l := arrayDepth(mapOfSlices.AdditionalProperties); d != 1 || l == nil || l.Type != "string" {
+		t.Errorf("mapOfSlices value: depth=%d leaf=%+v, want a 1-deep array of string", d, l)
+	}
+
+	mapOfNested := containers.Properties["mapOfNested"]
+	if mapOfNested == nil || mapOfNested.AdditionalProperties == nil {
+		t.Fatalf("mapOfNested = %+v, want an object with additionalProperties", mapOfNested)
+	}
+	if d, l := arrayDepth(mapOfNested.AdditionalProperties); d != 2 || l == nil || l.Type != "integer" {
+		t.Errorf("mapOfNested value: depth=%d leaf=%+v, want a 2-deep array of integer", d, l)
+	}
+
+	sliceOfItems := containers.Properties["sliceOfItems"]
+	if sliceOfItems == nil || sliceOfItems.Type != "array" || sliceOfItems.Items == nil ||
+		sliceOfItems.Items.AdditionalProperties == nil ||
+		!strings.HasSuffix(sliceOfItems.Items.AdditionalProperties.Ref, "_Item") {
+		t.Errorf("sliceOfItems = %+v, want an array of map[string]$ref(…_Item)", sliceOfItems)
+	}
+}

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -1260,6 +1260,57 @@ func substituteTypeParams(fieldType string, genericTypes map[string]string) stri
 	return fieldType
 }
 
+// qualifyFieldType attaches the declaring package to an unqualified field
+// type. A package qualifier belongs on a *name*, so it has to be pushed all
+// the way down to the named leaf, through every container constructor. The
+// regex this replaces peeled at most one "[]" and glued the package onto
+// whatever remained, so a nested container came out as "[]pkg.[][]string" — a
+// container wearing a package qualifier. Nothing downstream can model that:
+// it parses as a named type whose name happens to contain brackets, so the
+// $ref fast-paths treat it as a nameable component and emit a reference to a
+// component no one ever defines (issue #259). Types that already carry a
+// qualifier, primitives, and anonymous struct literals (nameless, and their
+// bodies aren't a type the model can rebuild) keep their previous handling.
+func qualifyFieldType(fieldType, pkgName string) string {
+	if fieldType == "" || pkgName == "" {
+		return fieldType
+	}
+	if isAnonStructLiteral(fieldType) {
+		// Legacy shape: the anon-struct paths document (and ignore) a package
+		// path glued on the front, so keep producing exactly that.
+		if strings.Contains(fieldType, ".") {
+			return fieldType
+		}
+		return pkgName + "." + fieldType
+	}
+
+	ref := typemodel.Parse(fieldType)
+	leaf := namedLeaf(ref)
+	if leaf == nil || leaf.Name == "" || leaf.Pkg != "" || metadata.IsPrimitiveType(leaf.Name) {
+		return fieldType
+	}
+	leaf.Pkg = pkgName
+
+	return ref.String()
+}
+
+// namedLeaf descends through every container constructor — including a map's
+// value, which TypeRef.Core deliberately does not unwrap (a map's element is
+// not "the" core type) — and returns the named type at the bottom, or nil when
+// there isn't one.
+func namedLeaf(t *typemodel.TypeRef) *typemodel.TypeRef {
+	for t != nil {
+		switch t.Kind {
+		case typemodel.KindPointer, typemodel.KindSlice, typemodel.KindArray,
+			typemodel.KindChan, typemodel.KindMap:
+			t = t.Elem
+		default:
+			return t
+		}
+	}
+	return nil
+}
+
 // generateStructSchema generates a schema for a struct type
 func generateStructSchema(usedTypes map[string]*Schema, key string, typ *metadata.Type, meta *metadata.Metadata, cfg *APISpecConfig, visitedTypes map[string]bool) (*Schema, map[string]*Schema) {
 	schemas := map[string]*Schema{}
@@ -1359,12 +1410,8 @@ func generateStructSchema(usedTypes map[string]*Schema, key string, typ *metadat
 		} else {
 			isPrimitive := metadata.IsPrimitiveType(fieldType)
 
-			if !isPrimitive && !strings.Contains(fieldType, ".") {
-				re := mustCachedRegex(`((\[\])?\*?)(.+)$`)
-				matches := re.FindStringSubmatch(fieldType)
-				if len(matches) >= 4 {
-					fieldType = matches[1] + pkgName + "." + matches[3]
-				}
+			if !isPrimitive {
+				fieldType = qualifyFieldType(fieldType, pkgName)
 			}
 
 			derivedFieldType := strings.TrimPrefix(fieldType, "*")

--- a/internal/spec/nested_container_field_test.go
+++ b/internal/spec/nested_container_field_test.go
@@ -1,0 +1,158 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// TestQualifyFieldType covers the package-qualification of a field type
+// (issue #259): the qualifier belongs on the named leaf, so it must be pushed
+// through every container constructor rather than glued in front of whatever
+// follows the first one.
+func TestQualifyFieldType(t *testing.T) {
+	const pkg = "example.com/repro"
+
+	for _, tc := range []struct {
+		name  string
+		field string
+		want  string
+	}{
+		{"named", "Item", pkg + ".Item"},
+		{"pointer", "*Item", "*" + pkg + ".Item"},
+		{"slice", "[]Item", "[]" + pkg + ".Item"},
+		{"slice of pointer", "[]*Item", "[]*" + pkg + ".Item"},
+		// The reported shapes: every level is peeled, so the qualifier lands on
+		// the leaf instead of producing "[]example.com/repro.[]Item".
+		{"nested slice", "[][]Item", "[][]" + pkg + ".Item"},
+		{"triple slice", "[][][]Item", "[][][]" + pkg + ".Item"},
+		{"fixed array", "[3]Item", "[3]" + pkg + ".Item"},
+		{"map value", "map[string]Item", "map[string]" + pkg + ".Item"},
+		{"map of slices", "map[string][]Item", "map[string][]" + pkg + ".Item"},
+		{"slice of maps", "[]map[string]Item", "[]map[string]" + pkg + ".Item"},
+		{"generic base only", "Page[Item]", pkg + ".Page[Item]"},
+		// A container of primitives has no name to qualify — it must be left
+		// alone so it stays inline all the way down.
+		{"nested slice of primitives", "[][]string", "[][]string"},
+		{"map of nested primitive slices", "map[string][][]int", "map[string][][]int"},
+		// Already-qualified leaves and empty input are untouched.
+		{"already qualified", "[][]other.Item", "[][]other.Item"},
+		{"stdlib qualified", "map[string]time.Duration", "map[string]time.Duration"},
+		{"empty", "", ""},
+		// A container with nothing at the bottom has no name to qualify.
+		{"degenerate container", "[]", "[]"},
+		// Anonymous struct literals keep the legacy glued-on prefix form the
+		// anon-struct paths document (and ignore).
+		{"anon struct", "struct{Name string}", pkg + ".struct{Name string}"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := qualifyFieldType(tc.field, pkg); got != tc.want {
+				t.Errorf("qualifyFieldType(%q) = %q, want %q", tc.field, got, tc.want)
+			}
+		})
+	}
+
+	if got := qualifyFieldType("Item", ""); got != "Item" {
+		t.Errorf("qualifyFieldType with no package = %q, want it unchanged", got)
+	}
+}
+
+// TestGenerateStructSchema_NestedContainerFields is the layer-level guard for
+// issue #259: nested containers nest inline, and only the named leaf becomes a
+// $ref. Before the fix the inner container was handed to the $ref fast-path
+// and the reference dangled.
+func TestGenerateStructSchema_NestedContainerFields(t *testing.T) {
+	pool := metadata.NewStringPool()
+	item := &metadata.Type{
+		Name: pool.Get("Item"),
+		Pkg:  pool.Get("main"),
+		Kind: pool.Get("struct"),
+		Fields: []metadata.Field{
+			{Name: pool.Get("Name"), Type: pool.Get("string")},
+		},
+	}
+	table := &metadata.Type{
+		Name: pool.Get("Table"),
+		Pkg:  pool.Get("main"),
+		Kind: pool.Get("struct"),
+		Fields: []metadata.Field{
+			{Name: pool.Get("Header"), Type: pool.Get("[]string")},
+			{Name: pool.Get("Rows"), Type: pool.Get("[][]string")},
+			{Name: pool.Get("Cube"), Type: pool.Get("[][][]int")},
+			{Name: pool.Get("Grid"), Type: pool.Get("[][]Item")},
+			{Name: pool.Get("Buckets"), Type: pool.Get("map[string][][]int")},
+		},
+	}
+	meta := &metadata.Metadata{
+		StringPool: pool,
+		Packages: map[string]*metadata.Package{
+			"main": {Files: map[string]*metadata.File{
+				"main.go": {Types: map[string]*metadata.Type{"Item": item, "Table": table}},
+			}},
+		},
+	}
+
+	schema, schemas := generateStructSchema(map[string]*Schema{}, "main.Table", table, meta, DefaultAPISpecConfig(), map[string]bool{})
+	if schema == nil {
+		t.Fatal("expected a schema for main.Table")
+	}
+
+	// depthAndLeaf peels array levels so nesting is asserted without pinning
+	// component names.
+	depthAndLeaf := func(s *Schema) (int, *Schema) {
+		depth := 0
+		for s != nil && s.Type == "array" {
+			depth++
+			s = s.Items
+		}
+		return depth, s
+	}
+
+	if d, leaf := depthAndLeaf(schema.Properties["Header"]); d != 1 || leaf == nil || leaf.Type != "string" {
+		t.Errorf("Header: depth=%d leaf=%+v, want a 1-deep array of string", d, leaf)
+	}
+	if d, leaf := depthAndLeaf(schema.Properties["Rows"]); d != 2 || leaf == nil || leaf.Type != "string" || leaf.Ref != "" {
+		t.Errorf("Rows: depth=%d leaf=%+v, want a 2-deep array of string", d, leaf)
+	}
+	if d, leaf := depthAndLeaf(schema.Properties["Cube"]); d != 3 || leaf == nil || leaf.Type != "integer" {
+		t.Errorf("Cube: depth=%d leaf=%+v, want a 3-deep array of integer", d, leaf)
+	}
+
+	d, leaf := depthAndLeaf(schema.Properties["Grid"])
+	if d != 2 || leaf == nil || leaf.Ref != "#/components/schemas/main_Item" {
+		t.Fatalf("Grid: depth=%d leaf=%+v, want a 2-deep array of $ref main_Item", d, leaf)
+	}
+	if schemas["main.Item"] == nil {
+		t.Errorf("the referenced component main.Item was never registered; have %v", schemaKeys(schemas))
+	}
+
+	buckets := schema.Properties["Buckets"]
+	if buckets == nil || buckets.AdditionalProperties == nil {
+		t.Fatalf("Buckets = %+v, want an object with additionalProperties", buckets)
+	}
+	if d, leaf := depthAndLeaf(buckets.AdditionalProperties); d != 2 || leaf == nil || leaf.Type != "integer" {
+		t.Errorf("Buckets value: depth=%d leaf=%+v, want a 2-deep array of integer", d, leaf)
+	}
+
+	// Nothing anonymous may end up as a component: a container has no name, so
+	// a component keyed on one is exactly the dangling-$ref bug.
+	for key := range schemas {
+		if !canAddRefSchemaForType(key) {
+			t.Errorf("container/unnameable type %q registered as a component", key)
+		}
+	}
+}

--- a/testdata/nested_slice_field/go.mod
+++ b/testdata/nested_slice_field/go.mod
@@ -1,0 +1,5 @@
+module github.com/ehabterra/apispec/testdata/nested_slice_field
+
+go 1.24.3
+
+require github.com/go-chi/chi/v5 v5.2.2

--- a/testdata/nested_slice_field/go.sum
+++ b/testdata/nested_slice_field/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=
+github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=

--- a/testdata/nested_slice_field/main.go
+++ b/testdata/nested_slice_field/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// Item is a named struct used as the element of a nested slice, so the
+// innermost items must be a $ref to a real component.
+type Item struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// Table reproduces issue #259: the single-level []string is emitted correctly
+// while the nested [][]string used to emit a $ref to a component that was
+// never defined.
+type Table struct {
+	Header []string   `json:"header"`
+	Rows   [][]string `json:"rows"`
+	Cube   [][][]int  `json:"cube"`
+	Grid   [][]Item   `json:"grid"`
+}
+
+// Containers covers the neighbouring composite shapes named in the issue:
+// a slice of maps and a map of slices, both with anonymous element types.
+type Containers struct {
+	SliceOfMaps  []map[string]string `json:"sliceOfMaps"`
+	MapOfSlices  map[string][]string `json:"mapOfSlices"`
+	MapOfNested  map[string][][]int  `json:"mapOfNested"`
+	SliceOfItems []map[string]Item   `json:"sliceOfItems"`
+}
+
+func getTable(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode(Table{})
+}
+
+func getContainers(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode(Containers{})
+}
+
+func main() {
+	r := chi.NewRouter()
+	r.Get("/table", getTable)
+	r.Get("/containers", getContainers)
+	_ = http.ListenAndServe(":8080", r)
+}


### PR DESCRIPTION
Fixes #259.

## Root cause

`generateStructSchema` qualifies an unqualified field type with the declaring package. It did that with a regex — `((\[\])?\*?)(.+)$` — that peeled **at most one** `[]` and glued the package onto whatever remained. For a nested container that produces a malformed type string: `[][]string` became `[]pkg.[]string`, i.e. a *container wearing a package qualifier*.

Nothing downstream can model that string. It parses as a named type whose name happens to contain brackets, so the guards that keep containers out of the `$ref` fast-paths (`canAddRefSchemaForType`, which looks for a leading `[]` or a `map[`) no longer recognise it, and the inner container gets promoted to a component name. The reference is written, the component is never emitted — golden rule #4 in reverse: an inline (non-`$ref`) type reached a `$ref` fast-path, and the ref dangled.

The same glue caused three sibling defects the issue suspected:

| field | before | after |
|---|---|---|
| `Rows [][]string` | `items: $ref pkg__string` (undefined) | `array → array → string` |
| `Cube [][][]int` | `items: $ref pkg___int` (undefined) | `array → array → array → integer` |
| `Grid [][]Item` | `items: $ref pkg__Item` — one level lost, and the component was Item's *object* schema | `array → array → $ref …_Item` |
| `MapOfNested map[string][][]int` | `additionalProperties: $ref pkg____int` (undefined) | `object → array → array → integer` |

## The fix

`internal/spec/mapper.go`: the qualifier is now applied structurally, via `typemodel`, not by regex. `qualifyFieldType` parses the field type and pushes the package down to the **named leaf**, through every container constructor (`namedLeaf` descends pointer/slice/array/chan **and map value** — `TypeRef.Core` deliberately stops at a map). So:

- `[][]Item` → `[][]pkg.Item`, `map[string][]Item` → `map[string]pkg.Item`, `[]map[string]Item` → `[]map[string]pkg.Item`
- an all-primitive container (`[][]string`, `map[string][][]int`) has no name to qualify and is left alone, so it stays inline at every level
- already-qualified leaves, primitives, and generics behave exactly as before; anonymous struct literals keep the legacy glued-on prefix form that the anon-struct paths document and ignore.

Only the named leaf can become a `$ref`; every container level nests inline.

## Coverage

- **Fixture** `testdata/nested_slice_field/` (chi): the exact shape from the issue (`[]string` + `[][]string` on one struct) plus `[][][]int`, `[][]Item` (must nest to `items.items.$ref` at a *defined* component), `[]map[string]T`, `map[string][]T`, `map[string][][]int`.
- **Structural test** `generator/testdata_nested_slice_field_test.go` — reuses the existing `noDanglingRefs` / `noUnresolvedPlaceholders` helpers and asserts array depth plus the leaf at the bottom, without pinning component names. Verified as a change-detector: it fails on `main` with three dangling `$ref`s and depth 1 for `rows`/`cube`/`grid`.
- **Unit tests** `internal/spec/nested_container_field_test.go` — a table over `qualifyFieldType` (named, pointer, slice, nested slice, triple slice, fixed array, map value, map of slices, slice of maps, generic, primitive containers, already-qualified, anon struct, degenerate) and a `generateStructSchema` test that additionally asserts no unnameable key is ever registered as a component.

## Drift

None. Full `go test ./... -count=1` passes unchanged — no metadata golden regenerated, no other fixture's spec changed. `gofmt`, `go vet` and `golangci-lint run` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated API schemas for nested slices, arrays, maps, pointers, and channels.
  * Preserved correct array nesting and ensured type references point only to named leaf types.
  * Prevented invalid or dangling schema references and missing component definitions.
* **Tests**
  * Added coverage for nested container structures, API paths, generated schemas, and component references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->