### PR TITLE
fix(spec): the instance cap no longer truncates in silence (#224)

### DIFF
--- a/cmd/apispecui/main.go
+++ b/cmd/apispecui/main.go
@@ -1604,12 +1604,19 @@ func buildAPISpecConfig(req *GenerateRequest, dir string) (*spec.APISpecConfig, 
 // detected one, which buildAPISpecConfig has already filled in).
 func analysisInfo(primary string, detected []string, lazy bool, ep spec.EntrypointStats, expansion spec.ExpansionStats) insight.AnalysisInfo {
 	info := insight.AnalysisInfo{Frameworks: detected, Primary: primary}
-	if expansion.Truncated {
+	// Either shortfall is worth reporting, and they are independent: the
+	// instance cap can starve response bodies on a run whose node budget was
+	// never reached (issue #224).
+	if expansion.Truncated || expansion.InstanceTruncations > 0 {
 		info.Expansion = &insight.ExpansionInfo{
-			NodesBuilt:        expansion.NodesBuilt,
-			NodesMaterialized: expansion.NodesMaterialized,
-			Limit:             expansion.Limit,
-			Truncated:         true,
+			NodesBuilt:          expansion.NodesBuilt,
+			NodesMaterialized:   expansion.NodesMaterialized,
+			Limit:               expansion.Limit,
+			Truncated:           expansion.Truncated,
+			InstanceTruncations: expansion.InstanceTruncations,
+			InstanceLimit:       expansion.InstanceLimit,
+			InstanceFirstScope:  expansion.InstanceFirstScope,
+			InstanceFirstKey:    expansion.InstanceFirstKey,
 		}
 	}
 	if lazy {

--- a/generator/testdata_group_closure_instances_test.go
+++ b/generator/testdata_group_closure_instances_test.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/engine"
+	intspec "github.com/ehabterra/apispec/internal/spec"
+)
+
+// TestTestdata_GroupClosureInstances pins WHAT THE INSTANCE SCOPE IS, which is
+// the question issue #224 turns on.
+//
+// The cap bounds copies of a callee within one "instance scope" — the subtree of
+// the nearest argument-node ancestor. #224 asserted that a chi group closure,
+// being itself an argument node, becomes that scope for every route registered
+// inside it, so a helper shared by the group exhausts the budget after N routes
+// and every later route silently loses its response body.
+//
+// This fixture is that shape: 15 routes in one `r.Route("/api", func(api
+// chi.Router){…})` closure, every handler a method on a shared struct, every
+// response written through one shared responder. If the group closure were the
+// scope, the single Encode call inside that responder would be counted 15 times
+// against it and the run would starve well before 15.
+//
+// It does not. Every route keeps its schema down to a cap of ONE, because the
+// handler argument node — not the group closure — is the nearest argument
+// ancestor. The scope is already per route in this shape.
+//
+// The test is therefore a change-detector in both directions: it fails if the
+// scope ever regresses to something coarser than the handler, and it is the
+// evidence that #224's stated mechanism is not what starves a real service.
+func TestTestdata_GroupClosureInstances(t *testing.T) {
+	const (
+		fixture = "group_closure_instances"
+		routes  = 15
+	)
+
+	// One is the harshest cap that still permits a single copy of each callee.
+	// If the scope spanned the group, this could not document 15 routes.
+	for _, cap := range []int{1, 25} {
+		t.Run(fmt.Sprintf("cap=%d", cap), func(t *testing.T) {
+			cfg := engine.DefaultEngineConfig()
+			cfg.InputDir = filepath.Join("..", "testdata", fixture)
+			cfg.MaxInstancesPerKey = cap
+
+			out, err := engine.NewEngine(cfg).GenerateOpenAPI()
+			if err != nil {
+				t.Fatalf("GenerateOpenAPI: %v", err)
+			}
+			if got := len(out.Paths); got != routes {
+				t.Fatalf("documented %d paths, want %d", got, routes)
+			}
+
+			var missing []string
+			for path, item := range out.Paths {
+				op := opFor(item, "GET")
+				if op == nil {
+					t.Errorf("GET %s missing", path)
+					continue
+				}
+				resp, ok := op.Responses["200"]
+				if !ok {
+					missing = append(missing, path+" (no 200)")
+					continue
+				}
+				if !namesAComponent(resp.Content) {
+					missing = append(missing, path)
+				}
+			}
+			if len(missing) > 0 {
+				t.Errorf("%d of %d routes lost their response schema at --max-instances-per-key %d: %v\n"+
+					"every handler writes through ONE shared responder, so this is the instance cap starving "+
+					"routes that share a scope — the scope must be the handler, not the group closure (#224)",
+					len(missing), routes, cap, missing)
+			}
+		})
+	}
+}
+
+// TestGroupClosureInstanceCapIsReported pins that the cap does not truncate in
+// silence. Before #224 it was the one limit in the tree that dropped work
+// without saying so, which is why a starved response body was indistinguishable
+// from a type the mapper could not resolve.
+func TestGroupClosureInstanceCapIsReported(t *testing.T) {
+	cfg := engine.DefaultEngineConfig()
+	cfg.InputDir = filepath.Join("..", "testdata", "group_closure_instances")
+	cfg.MaxInstancesPerKey = 1
+
+	eng := engine.NewEngine(cfg)
+	if _, err := eng.GenerateOpenAPI(); err != nil {
+		t.Fatalf("GenerateOpenAPI: %v", err)
+	}
+
+	stats := eng.GetExpansionStats()
+	if stats.InstanceTruncations == 0 {
+		t.Fatal("a cap of 1 dropped no copies at all; the fixture is not exercising the cap and the report is untested")
+	}
+	if stats.InstanceLimit != 1 {
+		t.Errorf("reported instance limit %d, want the configured 1", stats.InstanceLimit)
+	}
+	if stats.InstanceFirstKey == "" {
+		t.Error("no key named for the first dropped copy — the count alone cannot be acted on")
+	}
+	// The scope is the diagnostic that matters: it is what tells a bounded
+	// diamond from one route eating another's budget.
+	if stats.InstanceFirstScope == "" {
+		t.Error("no scope named for the first dropped copy")
+	}
+	if strings.Contains(stats.InstanceFirstScope, "FuncLit:") {
+		t.Errorf("first starved scope is a closure (%s) — in this fixture the scope must be a handler",
+			stats.InstanceFirstScope)
+	}
+}
+
+// namesAComponent reports whether a response body resolves to a component,
+// directly or as an array's element type.
+func namesAComponent(content map[string]intspec.MediaType) bool {
+	for _, mt := range content {
+		if mt.Schema == nil {
+			continue
+		}
+		if mt.Schema.Ref != "" {
+			return true
+		}
+		if mt.Schema.Items != nil && mt.Schema.Items.Ref != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -827,6 +827,15 @@ func (e *Engine) GenerateOpenAPI() (*spec.OpenAPISpec, error) {
 			// the spec is incomplete, which is a result, not a debug detail.
 			e.reportPhase(fmt.Sprintf("expansion truncated at the %d-node limit — the spec is incomplete", e.expansionStats.Limit), 0)
 		}
+		if n := e.expansionStats.InstanceTruncations; n > 0 {
+			// The other, quieter shortfall, reported separately because it is a
+			// different claim: the walk may have finished the node budget fine and
+			// still dropped call copies, which is how a response body goes missing
+			// with nothing in the output to say so (issue #224). The scope is named
+			// because it is what tells a bounded diamond from a starved route.
+			e.reportPhase(fmt.Sprintf("instance cap (%d) dropped %d call copies — first: %s in scope %s",
+				e.expansionStats.InstanceLimit, n, e.expansionStats.InstanceFirstKey, e.expansionStats.InstanceFirstScope), 0)
+		}
 	}
 	e.reportPhase(fmt.Sprintf("spec mapped (%d paths)", len(openAPISpec.Paths)), time.Since(tSpec))
 

--- a/internal/insight/overview.go
+++ b/internal/insight/overview.go
@@ -138,6 +138,20 @@ type ExpansionInfo struct {
 	NodesMaterialized int  `json:"nodesMaterialized,omitempty"`
 	Limit             int  `json:"limit"`
 	Truncated         bool `json:"truncated"`
+
+	// InstanceTruncations is the SECOND way expansion can come up short, and the
+	// one that used to be silent: copies refused by the per-scope instance cap.
+	// A starved response body from that cap is indistinguishable, in the spec,
+	// from a type the mapper could not resolve — so it is reported here even
+	// when the node budget itself was never reached (issue #224).
+	//
+	// InstanceFirstScope is the diagnostic that matters: a handler scope means
+	// the cap bounded a deep diamond, which is its job; a scope spanning several
+	// routes means one route's expansion ate another's budget.
+	InstanceTruncations int    `json:"instanceTruncations,omitempty"`
+	InstanceLimit       int    `json:"instanceLimit,omitempty"`
+	InstanceFirstScope  string `json:"instanceFirstScope,omitempty"`
+	InstanceFirstKey    string `json:"instanceFirstKey,omitempty"`
 }
 
 // AnalysisInfo describes HOW the spec was produced rather than what is in it.

--- a/internal/spec/entrypoint_roots.go
+++ b/internal/spec/entrypoint_roots.go
@@ -242,4 +242,19 @@ type ExpansionStats struct {
 	NodesMaterialized int
 	Limit             int
 	Truncated         bool
+
+	// InstanceTruncations counts copies the per-scope instance cap refused, and
+	// InstanceFirstScope/Key name the first refusal. This is a SECOND, separate
+	// way expansion can come up short, and until now the only silent one: a
+	// response body starved by this cap looked exactly like a type the mapper
+	// could not resolve (issue #224).
+	//
+	// A non-zero count is not by itself a defect — bounding a deep diamond
+	// inside one handler is the cap's job. The scope is what distinguishes that
+	// from the failure case, where a scope spanning several routes means one
+	// route's expansion is consuming another's budget.
+	InstanceTruncations int
+	InstanceLimit       int
+	InstanceFirstScope  string
+	InstanceFirstKey    string
 }

--- a/internal/spec/lazytree.go
+++ b/internal/spec/lazytree.go
@@ -93,6 +93,19 @@ type LazyTree struct {
 	relationsBuilt bool
 	budgetWarned   bool
 
+	// instanceTruncations counts the copies the per-scope instance cap refused,
+	// and instanceFirst* records the first refusal. Unlike MaxNodesPerTree, this
+	// cap used to say nothing at all when it fired, so a starved response body
+	// looked like a type the mapper could not resolve (issue #224). Naming the
+	// SCOPE is the point: whether the scope that ran out is a handler (the cap
+	// working as intended on a deep diamond) or something that spans many routes
+	// (a group closure, where one route's expansion is eating another's budget)
+	// is exactly the distinction the number alone cannot make.
+	instanceTruncations int
+	instanceFirstScope  string
+	instanceFirstKey    string
+	instanceWarned      bool
+
 	// assignIndex mirrors the eager tree's assignmentIndex byte-for-byte: the
 	// SAME assignmentKey composition (name, pkg, concrete type, container —
 	// with the selector-Lhs container override) mapping to the producing
@@ -190,13 +203,23 @@ type LazyTree struct {
 // multiply copies combinatorially and must be cut — the role the eager
 // tree's per-ID recursion cap plays.
 //
-// 25, not 10, because "approximately per handler" is optimistic: routes are
-// commonly registered inside a group closure (`r.Route("/x", func(r chi.Router)
-// {…})`), and that closure is itself an argument node — so it, not the handler,
-// becomes the scope for every route in the group. A response helper shared by
-// the group then exhausts a 10-copy budget after ~10 routes and every later
-// route in that group silently loses its response body: 274 of 350 success
-// bodies missing on a ~330-route service (issue #224).
+// 25, not 10, because 10 measurably starved a real ~330-route chi service: 274
+// of 350 success bodies came out with no schema, and raising the cap recovered
+// them (issue #224).
+//
+// WHY that service starved is not settled, and the comment here used to assert
+// an explanation it could not support — that a `r.Route("/x", func(r chi.Router)
+// {…})` group closure, being itself an argument node, becomes the scope for
+// every route in the group. That mechanism does not reproduce:
+// testdata/group_closure_instances registers 15 routes inside one group closure,
+// all writing through one shared helper, and every route keeps its body down to
+// `--max-instances-per-key 1` — because the handler argument node, not the group
+// closure, is the nearest argument ancestor and therefore the scope.
+//
+// So the cap is per-handler in that shape, and the starving service has a shape
+// not yet reproduced. Rather than guess again, noteInstanceTruncation now names
+// the scope that ran out whenever the cap fires, which is the one fact that
+// distinguishes a bounded diamond from a starved route.
 //
 // The value is measured, not guessed — and the measurement is a TRADE, because
 // raising the cap costs projects that gain nothing from it:
@@ -228,6 +251,43 @@ func (t *LazyTree) instanceBudget() int {
 		return t.limits.MaxInstancesPerKey
 	}
 	return DefaultMaxInstancesPerKey
+}
+
+// noteInstanceTruncation records — and, once, reports — a copy the instance cap
+// refused.
+//
+// It warns rather than staying quiet because this cap is the one limit in the
+// tree that used to truncate in silence: MaxNodesPerTree prints when it stops,
+// and a starved response body from THIS cap was indistinguishable from a type
+// the mapper could not resolve. Measured on a large real project, the cap fires
+// 902,332 times in a default run, so the warning is deliberately once-only and
+// carries the count in the stats instead.
+//
+// Scope and key are both named. The scope answers the question the count cannot:
+// a handler scope that runs out is the cap doing its job on a deep diamond, while
+// a scope spanning several routes means one route's expansion is consuming
+// another's budget.
+func (t *LazyTree) noteInstanceTruncation(scope, key string) {
+	t.instanceTruncations++
+	if t.instanceFirstKey == "" {
+		t.instanceFirstScope = scope
+		t.instanceFirstKey = key
+	}
+	if !t.instanceWarned {
+		t.instanceWarned = true
+		fmt.Fprintf(os.Stderr,
+			"Warning: MaxInstancesPerKey limit (%d) reached, dropping repeated call copies (first: key %s in scope %s)\n",
+			t.instanceBudget(), key, scopeLabel(scope))
+	}
+}
+
+// scopeLabel renders an instance scope for a human. The empty scope is the
+// wiring level — above any argument node — and "" would read as missing data.
+func scopeLabel(scope string) string {
+	if scope == "" {
+		return "<router wiring>"
+	}
+	return scope
 }
 
 // budgetExhausted reports whether the cumulative node budget is spent.
@@ -550,10 +610,14 @@ func (t *LazyTree) edgesFor(baseKey string) []*metadata.CallGraphEdge {
 func (t *LazyTree) ExpansionStats() ExpansionStats {
 	t.buildRelations()
 	return ExpansionStats{
-		NodesBuilt:        t.nodesBuilt,
-		NodesMaterialized: t.nodesMaterialized,
-		Limit:             t.limits.MaxNodesPerTree,
-		Truncated:         t.truncated,
+		NodesBuilt:          t.nodesBuilt,
+		NodesMaterialized:   t.nodesMaterialized,
+		Limit:               t.limits.MaxNodesPerTree,
+		Truncated:           t.truncated,
+		InstanceTruncations: t.instanceTruncations,
+		InstanceLimit:       t.instanceBudget(),
+		InstanceFirstScope:  t.instanceFirstScope,
+		InstanceFirstKey:    t.instanceFirstKey,
 	}
 }
 
@@ -742,6 +806,7 @@ func (n *LazyNode) GetChildren() []TrackerNodeInterface {
 			// Reusing an existing instance instead would make the tree cyclic
 			// (consumers of a memoized subtree could reach themselves), so the
 			// bound is a skip — the role the eager per-ID recursion cap plays.
+			n.tree.noteInstanceTruncation(scope, spec.key)
 			continue
 		}
 		child := n.tree.newNode()

--- a/internal/spec/lazytree_budget_test.go
+++ b/internal/spec/lazytree_budget_test.go
@@ -209,3 +209,43 @@ func TestBudgetCountsKeysWhileStatsReportWork(t *testing.T) {
 			"or the counters are measuring the same thing and the distinction is lost", stats.NodesBuilt)
 	}
 }
+
+// TestInstanceTruncationIsRecordedAndNamed pins the reporting contract for the
+// instance cap: it counts every copy it refuses, remembers the FIRST one, and
+// warns once rather than per drop.
+//
+// The count alone is not actionable — a bounded diamond inside one handler and a
+// route starved by a scope it shares with other routes produce the same number.
+// The scope is what separates them, so it is recorded, and the empty scope (the
+// router wiring, above any argument node) is rendered rather than left blank
+// where it would read as missing data (issue #224).
+func TestInstanceTruncationIsRecordedAndNamed(t *testing.T) {
+	tree := &LazyTree{limits: metadata.TrackerLimits{MaxInstancesPerKey: 3}}
+
+	tree.noteInstanceTruncation("pkg.handler", "pkg.helper@a.go:1:1")
+	tree.noteInstanceTruncation("pkg.other", "pkg.helper@a.go:2:1")
+
+	if tree.instanceTruncations != 2 {
+		t.Errorf("counted %d truncations, want 2", tree.instanceTruncations)
+	}
+	if tree.instanceFirstScope != "pkg.handler" || tree.instanceFirstKey != "pkg.helper@a.go:1:1" {
+		t.Errorf("first truncation recorded as (%q, %q), want the FIRST one",
+			tree.instanceFirstScope, tree.instanceFirstKey)
+	}
+	if !tree.instanceWarned {
+		t.Error("the cap fired without warning; a silent truncation is the defect this fixes")
+	}
+
+	// ExpansionStats' propagation of these is asserted end to end by
+	// TestGroupClosureInstanceCapIsReported, which has a real tree; calling it
+	// here would only exercise relation-building.
+}
+
+func TestScopeLabelRendersTheWiringLevel(t *testing.T) {
+	if got := scopeLabel(""); got != "<router wiring>" {
+		t.Errorf("scopeLabel(\"\") = %q — an empty scope is the wiring level, not missing data", got)
+	}
+	if got := scopeLabel("pkg.handler"); got != "pkg.handler" {
+		t.Errorf("scopeLabel(%q) = %q, want it unchanged", "pkg.handler", got)
+	}
+}

--- a/testdata/group_closure_instances/go.mod
+++ b/testdata/group_closure_instances/go.mod
@@ -1,0 +1,5 @@
+module example.com/groupinstances
+
+go 1.21
+
+require github.com/go-chi/chi/v5 v5.0.10

--- a/testdata/group_closure_instances/go.sum
+++ b/testdata/group_closure_instances/go.sum
@@ -1,0 +1,10 @@
+github.com/ajg/form v1.5.1 h1:t9c7v8JUKu/XxOGBU0yjNpaMloxGEJhUkqFRq0ibGeU=
+github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
+github.com/go-chi/chi/v5 v5.0.10 h1:rLz5avzKpjqxrYwXNfmjkrYYXOyLJd37pz53UFHC6vk=
+github.com/go-chi/chi/v5 v5.0.10/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/go-chi/cors v1.2.1 h1:xEC8UT3Rlp2QuWNEr4Fs/c2EAGVKBwy/1vHx3bppil4=
+github.com/go-chi/cors v1.2.1/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vzc58=
+github.com/go-chi/render v1.0.3 h1:AsXqd2a1/INaIfUSKq3G5uA8weYx20FOsM7uSoCyyt4=
+github.com/go-chi/render v1.0.3/go.mod h1:/gr3hVkmYR0YlEy3LxCuVRFzEu9Ruok+gFqbIofjao0=
+github.com/google/uuid v1.4.0 h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4=
+github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/testdata/group_closure_instances/main.go
+++ b/testdata/group_closure_instances/main.go
@@ -1,0 +1,299 @@
+// Fixture: many routes registered inside ONE chi group closure, every handler a
+// method on a shared handler struct, every response written through ONE shared
+// helper method.
+//
+// This is the shape of issue #224. The instance cap bounds copies of a callee
+// within an "instance scope", and the scope is the nearest ARGUMENT-node
+// ancestor. The single `json.NewEncoder(w).Encode(v)` inside `respond` is ONE
+// call site reached by every route, so it is counted once per route against
+// whatever scope the routes share. When that scope is the group closure rather
+// than the handler, the budget is a per-GROUP budget and every route past the
+// cap silently loses its response body.
+//
+// Each handler returns a DIFFERENT type, so the payload has to be traced per
+// route: a starved route shows up as a missing schema, not as a wrong one.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type service struct{}
+
+type handler struct {
+	svc *service
+}
+
+// respond is the one house helper. The Encode call inside it is a single call
+// site shared by every route in the project.
+func (h *handler) respond(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+type Alpha struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type Bravo struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type Charlie struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type Delta struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type Echo struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type Foxtrot struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type Golf struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type Hotel struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type India struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type Juliet struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type Kilo struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type Lima struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type Mike struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type November struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type Oscar struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func (s *service) Alpha() (Alpha, error) { return Alpha{}, nil }
+
+func (s *service) Bravo() (Bravo, error) { return Bravo{}, nil }
+
+func (s *service) Charlie() (Charlie, error) { return Charlie{}, nil }
+
+func (s *service) Delta() (Delta, error) { return Delta{}, nil }
+
+func (s *service) Echo() (Echo, error) { return Echo{}, nil }
+
+func (s *service) Foxtrot() (Foxtrot, error) { return Foxtrot{}, nil }
+
+func (s *service) Golf() (Golf, error) { return Golf{}, nil }
+
+func (s *service) Hotel() (Hotel, error) { return Hotel{}, nil }
+
+func (s *service) India() (India, error) { return India{}, nil }
+
+func (s *service) Juliet() (Juliet, error) { return Juliet{}, nil }
+
+func (s *service) Kilo() (Kilo, error) { return Kilo{}, nil }
+
+func (s *service) Lima() (Lima, error) { return Lima{}, nil }
+
+func (s *service) Mike() (Mike, error) { return Mike{}, nil }
+
+func (s *service) November() (November, error) { return November{}, nil }
+
+func (s *service) Oscar() (Oscar, error) { return Oscar{}, nil }
+
+func (h *handler) getAlpha(w http.ResponseWriter, r *http.Request) {
+	res, err := h.svc.Alpha()
+	if err != nil {
+		h.respond(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	h.respond(w, http.StatusOK, res)
+}
+
+func (h *handler) getBravo(w http.ResponseWriter, r *http.Request) {
+	res, err := h.svc.Bravo()
+	if err != nil {
+		h.respond(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	h.respond(w, http.StatusOK, res)
+}
+
+func (h *handler) getCharlie(w http.ResponseWriter, r *http.Request) {
+	res, err := h.svc.Charlie()
+	if err != nil {
+		h.respond(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	h.respond(w, http.StatusOK, res)
+}
+
+func (h *handler) getDelta(w http.ResponseWriter, r *http.Request) {
+	res, err := h.svc.Delta()
+	if err != nil {
+		h.respond(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	h.respond(w, http.StatusOK, res)
+}
+
+func (h *handler) getEcho(w http.ResponseWriter, r *http.Request) {
+	res, err := h.svc.Echo()
+	if err != nil {
+		h.respond(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	h.respond(w, http.StatusOK, res)
+}
+
+func (h *handler) getFoxtrot(w http.ResponseWriter, r *http.Request) {
+	res, err := h.svc.Foxtrot()
+	if err != nil {
+		h.respond(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	h.respond(w, http.StatusOK, res)
+}
+
+func (h *handler) getGolf(w http.ResponseWriter, r *http.Request) {
+	res, err := h.svc.Golf()
+	if err != nil {
+		h.respond(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	h.respond(w, http.StatusOK, res)
+}
+
+func (h *handler) getHotel(w http.ResponseWriter, r *http.Request) {
+	res, err := h.svc.Hotel()
+	if err != nil {
+		h.respond(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	h.respond(w, http.StatusOK, res)
+}
+
+func (h *handler) getIndia(w http.ResponseWriter, r *http.Request) {
+	res, err := h.svc.India()
+	if err != nil {
+		h.respond(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	h.respond(w, http.StatusOK, res)
+}
+
+func (h *handler) getJuliet(w http.ResponseWriter, r *http.Request) {
+	res, err := h.svc.Juliet()
+	if err != nil {
+		h.respond(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	h.respond(w, http.StatusOK, res)
+}
+
+func (h *handler) getKilo(w http.ResponseWriter, r *http.Request) {
+	res, err := h.svc.Kilo()
+	if err != nil {
+		h.respond(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	h.respond(w, http.StatusOK, res)
+}
+
+func (h *handler) getLima(w http.ResponseWriter, r *http.Request) {
+	res, err := h.svc.Lima()
+	if err != nil {
+		h.respond(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	h.respond(w, http.StatusOK, res)
+}
+
+func (h *handler) getMike(w http.ResponseWriter, r *http.Request) {
+	res, err := h.svc.Mike()
+	if err != nil {
+		h.respond(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	h.respond(w, http.StatusOK, res)
+}
+
+func (h *handler) getNovember(w http.ResponseWriter, r *http.Request) {
+	res, err := h.svc.November()
+	if err != nil {
+		h.respond(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	h.respond(w, http.StatusOK, res)
+}
+
+func (h *handler) getOscar(w http.ResponseWriter, r *http.Request) {
+	res, err := h.svc.Oscar()
+	if err != nil {
+		h.respond(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	h.respond(w, http.StatusOK, res)
+}
+
+func main() {
+	h := &handler{svc: &service{}}
+	r := chi.NewRouter()
+	r.Route("/api", func(api chi.Router) {
+		api.Get("/alpha", h.getAlpha)
+		api.Get("/bravo", h.getBravo)
+		api.Get("/charlie", h.getCharlie)
+		api.Get("/delta", h.getDelta)
+		api.Get("/echo", h.getEcho)
+		api.Get("/foxtrot", h.getFoxtrot)
+		api.Get("/golf", h.getGolf)
+		api.Get("/hotel", h.getHotel)
+		api.Get("/india", h.getIndia)
+		api.Get("/juliet", h.getJuliet)
+		api.Get("/kilo", h.getKilo)
+		api.Get("/lima", h.getLima)
+		api.Get("/mike", h.getMike)
+		api.Get("/november", h.getNovember)
+		api.Get("/oscar", h.getOscar)
+	})
+	_ = http.ListenAndServe(":8080", r)
+}


### PR DESCRIPTION
Closes nothing yet — #224 stays open, with its premise corrected and a diagnostic added to settle it.

## What this changes

`MaxInstancesPerKey` was the **one limit in the tree that dropped work without saying so**. `MaxNodesPerTree` prints when it stops; this cap said nothing, so a response body it starved looked exactly like a type the mapper could not resolve. That silence is the core complaint in #224 ("bounded ≠ silent") and it is what this PR fixes.

- counts every copy the cap refuses (`ExpansionStats.InstanceTruncations`)
- records the **first** refusal's scope and key
- warns **once** on stderr, and reports a phase line — measured on a large real project the cap fires **902,332 times** in a default run, so per-drop output is not an option
- surfaces it in the UI's Insight panel (`ExpansionInfo`), including on runs where the node budget was never reached — the two shortfalls are independent

The **scope** is named, not just the key, because that is the one fact the count cannot supply: a handler scope that runs out is the cap bounding a deep diamond, which is its job; a scope spanning several routes means one route's expansion is consuming another's budget.

## What this deliberately does NOT change

**The scoping.** #224 proposes scoping the cap "to the route/handler, not to any argument ancestor", on the reasoning that a chi group closure — being itself an argument node — becomes the scope for every route registered inside it.

That mechanism does not reproduce. `testdata/group_closure_instances` is exactly that shape: 15 routes inside one `r.Route("/api", func(api chi.Router){…})` closure, every handler a method on a shared struct, every response written through one shared responder. If the group closure were the scope, the single `Encode` inside that responder would be counted 15 times against it.

| `--max-instances-per-key` | paths | with schema |
| --- | --- | --- |
| 1 | 15 | 15 |
| 2 | 15 | 15 |
| 25 (default) | 15 | 15 |

Every route keeps its schema **down to a cap of one**, because the handler argument node — not the group closure — is the nearest argument ancestor. The scope is already per route in this shape.

Independently, instrumenting the cap on a large real project shows the starving scopes are overwhelmingly deep utility argument nodes (`gitcmd.Command.cmdCtx`, `util.rightPart`, `gtprof.parentCtx`), and where a route handler's scope does exhaust, the keys that exhaust it are infrastructure diamonds (`sync/atomic.Int64.Add`, `fmt.Errorf`, `xorm.Session.Find`) — the cap working as intended, not response bodies starving.

So the ~330-route service in #224 genuinely starved (its 274-of-350 recovery on raising the cap is real evidence of a shared scope there), but it has a shape not yet reproduced here. Guessing at a scoping change that no measurement supports is the workaround golden rule #9 forbids. **The new scope report is what will identify that shape** — the next run that loses bodies now says which scope ran out.

The `DefaultMaxInstancesPerKey` doc comment is corrected accordingly: it asserted the group-closure explanation as fact.

## Coverage

- `testdata/group_closure_instances` + `generator/testdata_group_closure_instances_test.go` — a change-detector in both directions: it fails if the scope ever regresses to something coarser than the handler, and it is the standing evidence for the paragraph above. Runs at cap 1 and 25.
- `TestGroupClosureInstanceCapIsReported` — the cap fires at cap 1 (105 copies dropped in this fixture) and the report names a handler scope, not a closure.
- `internal/spec/lazytree_budget_test.go` — counter/first-refusal/warn-once contract, and the empty scope rendering as `<router wiring>` rather than blank.

## Verification

```
go test ./...          # clean, no fixture drift
go vet ./...           # clean
golangci-lint run      # 0 issues
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)