### PR TITLE
feat(spec): a receiver-scoped pattern matches either receiver form (#260)

### DIFF
--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -1070,6 +1070,43 @@ type Call struct {
 
 	// New field for function signature
 	SignatureStr int `yaml:"signature_str,omitempty"`
+
+	// writtenRecvType is the receiver this call was WRITTEN against, kept when
+	// RecvType has been replaced by the concrete type a resolved call graph
+	// proves runs. Both are facts and neither subsumes the other (golden rule
+	// #7): the concrete type is what actually executes, and the written one is
+	// what a pattern scoped to an interface names.
+	//
+	// Without it, resolving is a net loss for any interface-scoped pattern.
+	// net/http's param config excludes `Header().Get(k)` reads whose receiver
+	// originates from `net/http.ResponseWriter`; resolve that receiver to the
+	// project's own writer type and the exclusion matches nothing, so a response
+	// header is documented as a request parameter (issue #260).
+	//
+	// Stored as pool index + 1 so that UNSET is 0 rather than -1, which is what
+	// keeps `omitempty` working: an unset -1 would serialise on every call in
+	// every metadata golden. Nothing sets it unless a resolved call graph is in
+	// use, so legacy runs are byte-identical. It is exported only because
+	// metadata round-trips through YAML (LoadMetadata); read and write it
+	// through WrittenRecvType / SetWrittenRecvType, which own the encoding.
+	WrittenRecv int `yaml:"written_recv,omitempty"`
+}
+
+// WrittenRecvType returns the pooled index of the receiver this call was written
+// against, or -1 when the recorded RecvType is already that receiver.
+func (c *Call) WrittenRecvType() int {
+	return c.WrittenRecv - 1
+}
+
+// SetWrittenRecvType records the receiver a call was written against, before a
+// resolved call graph replaced RecvType with the concrete type. Passing -1 (the
+// pool's "no string") clears it.
+func (c *Call) SetWrittenRecvType(idx int) {
+	if idx < 0 {
+		c.WrittenRecv = 0
+		return
+	}
+	c.WrittenRecv = idx + 1
 }
 
 // ID returns different types of identifiers based on context

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -2237,7 +2237,6 @@ func (r *ResponsePatternMatcherImpl) MatchNode(node TrackerNodeInterface) bool {
 	}
 
 	callName := r.contextProvider.GetString(edge.Callee.Name)
-	fqRecvType := fqOwner(r.contextProvider, edge.Callee.Pkg, edge.Callee.RecvType)
 
 	// Check call regex
 	if r.pattern.CallRegex != "" && !r.matchPattern(r.pattern.CallRegex, callName) {
@@ -2252,13 +2251,9 @@ func (r *ResponsePatternMatcherImpl) MatchNode(node TrackerNodeInterface) bool {
 		}
 	}
 
-	// Check receiver type
-	if r.pattern.RecvTypeRegex != "" {
-		re, err := cachedRegex(r.pattern.RecvTypeRegex)
-		if err != nil || !re.MatchString(fqRecvType) {
-			return false
-		}
-	} else if r.pattern.RecvType != "" && r.pattern.RecvType != fqRecvType {
+	// Check receiver type. Both the recorded receiver and the one the call
+	// was written against are accepted — see recvForms (issue #260).
+	if !matchesRecvType(r.contextProvider, &edge.Callee, r.pattern.RecvType, r.pattern.RecvTypeRegex) {
 		return false
 	}
 
@@ -3281,7 +3276,6 @@ func (p *ParamPatternMatcherImpl) MatchNode(node TrackerNodeInterface) bool {
 	}
 
 	callName := p.contextProvider.GetString(edge.Callee.Name)
-	fqRecvType := fqOwner(p.contextProvider, edge.Callee.Pkg, edge.Callee.RecvType)
 
 	// Check call regex
 	if p.pattern.CallRegex != "" && !p.matchPattern(p.pattern.CallRegex, callName) {
@@ -3296,13 +3290,9 @@ func (p *ParamPatternMatcherImpl) MatchNode(node TrackerNodeInterface) bool {
 		}
 	}
 
-	// Check receiver type
-	if p.pattern.RecvTypeRegex != "" {
-		re, err := cachedRegex(p.pattern.RecvTypeRegex)
-		if err != nil || !re.MatchString(fqRecvType) {
-			return false
-		}
-	} else if p.pattern.RecvType != "" && p.pattern.RecvType != fqRecvType {
+	// Check receiver type. Both the recorded receiver and the one the call
+	// was written against are accepted — see recvForms (issue #260).
+	if !matchesRecvType(p.contextProvider, &edge.Callee, p.pattern.RecvType, p.pattern.RecvTypeRegex) {
 		return false
 	}
 

--- a/internal/spec/param_origin.go
+++ b/internal/spec/param_origin.go
@@ -47,9 +47,7 @@ func receiverOriginTypes(cp ContextProvider, edge *metadata.CallGraphEdge) []str
 	// invoked on: for `c.Response().Header().Get(k)` those are `*echo.Response`
 	// (Header's receiver) and `echo.Context` (Response's receiver).
 	for parent, depth := edge.ChainParent, 0; parent != nil && depth < receiverOriginDepth; parent, depth = parent.ChainParent, depth+1 {
-		if fq := fqCalleeRecvType(cp, parent); fq != "" {
-			types = append(types, fq)
-		}
+		types = append(types, fqCalleeRecvTypes(cp, parent)...)
 	}
 
 	// A variable receiver (`wh := w.Header(); wh.Get(k)`) has no chain parent —
@@ -67,17 +65,17 @@ func receiverOriginTypes(cp ContextProvider, edge *metadata.CallGraphEdge) []str
 	return types
 }
 
-// fqCalleeRecvType renders an edge's callee receiver the way the pattern
+// fqCalleeRecvTypes renders an edge's callee receiver the way the pattern
 // matchers do (`pkg` + `.` + `RecvType`), so one regex form works for both.
-func fqCalleeRecvType(cp ContextProvider, edge *metadata.CallGraphEdge) string {
-	recvType := cp.GetString(edge.Callee.RecvType)
-	if recvType == "" {
-		return ""
-	}
-	if pkg := cp.GetString(edge.Callee.Pkg); pkg != "" {
-		return pkg + "." + recvType
-	}
-	return recvType
+//
+// It returns every form the receiver legitimately has: the recorded one and,
+// when a resolved call graph replaced it, the one the call was written against.
+// An origin exclusion is scoped to an INTERFACE — `net/http.ResponseWriter` is
+// what `w.Header()` reads as in source — and resolving that call to the concrete
+// writer the program uses would otherwise make the exclusion match nothing, so a
+// response header would be documented as a request parameter (issue #260).
+func fqCalleeRecvTypes(cp ContextProvider, edge *metadata.CallGraphEdge) []string {
+	return recvForms(cp, &edge.Callee)
 }
 
 // argOriginTypes collects the types down an expression's spine, nearest first:

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -143,7 +143,6 @@ func (r *RoutePatternMatcherImpl) MatchNode(node TrackerNodeInterface) bool {
 	}
 
 	callName := r.contextProvider.GetString(edge.Callee.Name)
-	fqRecvType := fqOwner(r.contextProvider, edge.Callee.Pkg, edge.Callee.RecvType)
 
 	// Check call regex
 	if r.pattern.CallRegex != "" && !r.matchPattern(r.pattern.CallRegex, callName) {
@@ -158,13 +157,9 @@ func (r *RoutePatternMatcherImpl) MatchNode(node TrackerNodeInterface) bool {
 		}
 	}
 
-	// Check receiver type
-	if r.pattern.RecvTypeRegex != "" {
-		re, err := cachedRegex(r.pattern.RecvTypeRegex)
-		if err != nil || !re.MatchString(fqRecvType) {
-			return false
-		}
-	} else if r.pattern.RecvType != "" && r.pattern.RecvType != fqRecvType {
+	// Check receiver type. Both the recorded receiver and the one the call
+	// was written against are accepted — see recvForms (issue #260).
+	if !matchesRecvType(r.contextProvider, &edge.Callee, r.pattern.RecvType, r.pattern.RecvTypeRegex) {
 		return false
 	}
 
@@ -466,7 +461,6 @@ func (m *MountPatternMatcherImpl) MatchNode(node TrackerNodeInterface) bool {
 	}
 
 	callName := m.contextProvider.GetString(edge.Callee.Name)
-	fqRecvType := fqOwner(m.contextProvider, edge.Callee.Pkg, edge.Callee.RecvType)
 
 	// Check call regex
 	if m.pattern.CallRegex != "" && !m.matchPattern(m.pattern.CallRegex, callName) {
@@ -481,13 +475,9 @@ func (m *MountPatternMatcherImpl) MatchNode(node TrackerNodeInterface) bool {
 		}
 	}
 
-	// Check receiver type
-	if m.pattern.RecvTypeRegex != "" {
-		re, err := cachedRegex(m.pattern.RecvTypeRegex)
-		if err != nil || !re.MatchString(fqRecvType) {
-			return false
-		}
-	} else if m.pattern.RecvType != "" && m.pattern.RecvType != fqRecvType {
+	// Check receiver type. Both the recorded receiver and the one the call
+	// was written against are accepted — see recvForms (issue #260).
+	if !matchesRecvType(m.contextProvider, &edge.Callee, m.pattern.RecvType, m.pattern.RecvTypeRegex) {
 		return false
 	}
 
@@ -617,7 +607,6 @@ func (s *SecurityPatternMatcherImpl) MatchEdge(edge *metadata.CallGraphEdge) boo
 	}
 
 	callName := s.contextProvider.GetString(edge.Callee.Name)
-	fqRecvType := fqOwner(s.contextProvider, edge.Callee.Pkg, edge.Callee.RecvType)
 
 	if s.pattern.CallRegex != "" && !s.matchPattern(s.pattern.CallRegex, callName) {
 		return false
@@ -630,12 +619,9 @@ func (s *SecurityPatternMatcherImpl) MatchEdge(edge *metadata.CallGraphEdge) boo
 		}
 	}
 
-	if s.pattern.RecvTypeRegex != "" {
-		re, err := cachedRegex(s.pattern.RecvTypeRegex)
-		if err != nil || !re.MatchString(fqRecvType) {
-			return false
-		}
-	} else if s.pattern.RecvType != "" && s.pattern.RecvType != fqRecvType {
+	// Check receiver type. Both the recorded receiver and the one the call
+	// was written against are accepted — see recvForms (issue #260).
+	if !matchesRecvType(s.contextProvider, &edge.Callee, s.pattern.RecvType, s.pattern.RecvTypeRegex) {
 		return false
 	}
 
@@ -766,7 +752,6 @@ func (r *RequestPatternMatcherImpl) MatchNode(node TrackerNodeInterface) bool {
 	}
 
 	callName := r.contextProvider.GetString(edge.Callee.Name)
-	fqRecvType := fqOwner(r.contextProvider, edge.Callee.Pkg, edge.Callee.RecvType)
 
 	// Check call regex
 	if r.pattern.CallRegex != "" && !r.matchPattern(r.pattern.CallRegex, callName) {
@@ -782,13 +767,9 @@ func (r *RequestPatternMatcherImpl) MatchNode(node TrackerNodeInterface) bool {
 
 	}
 
-	// Check receiver type
-	if r.pattern.RecvTypeRegex != "" {
-		re, err := cachedRegex(r.pattern.RecvTypeRegex)
-		if err != nil || !re.MatchString(fqRecvType) {
-			return false
-		}
-	} else if r.pattern.RecvType != "" && r.pattern.RecvType != fqRecvType {
+	// Check receiver type. Both the recorded receiver and the one the call
+	// was written against are accepted — see recvForms (issue #260).
+	if !matchesRecvType(r.contextProvider, &edge.Callee, r.pattern.RecvType, r.pattern.RecvTypeRegex) {
 		return false
 	}
 

--- a/internal/spec/recv_forms.go
+++ b/internal/spec/recv_forms.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import "github.com/ehabterra/apispec/internal/metadata"
+
+// recvForms returns every fully-qualified receiver a call may legitimately be
+// matched on: the one recorded, and — when a resolved call graph replaced it —
+// the one the call was WRITTEN against.
+//
+// Both are facts about the same call and neither subsumes the other (golden rule
+// #7). The concrete type is what actually runs, so a pattern scoped to it should
+// match; the written type is what the source says, so a pattern scoped to THAT
+// should match too. A pattern config names interfaces — `net/http.ResponseWriter`,
+// `net/http.Header`, `net/url.Values` — precisely because that is what a reader
+// of the code sees, and resolving the graph replaces exactly those names. Matching
+// only the recorded form makes every interface-scoped pattern stop matching, and
+// every interface-scoped EXCLUSION stop excluding, as the call graph gets better
+// (issue #260).
+//
+// The recorded form is always first, so a caller that wants the primary answer
+// can take forms[0]. The written form is omitted when unset or identical, which
+// is every call on a legacy run.
+func recvForms(cp ContextProvider, call *metadata.Call) []string {
+	if cp == nil || call == nil {
+		return nil
+	}
+	recorded := fqOwner(cp, call.Pkg, call.RecvType)
+	written := call.WrittenRecvType()
+	if written < 0 {
+		if recorded == "" {
+			return nil
+		}
+		return []string{recorded}
+	}
+	writtenFq := qualifyOwner(cp.GetString(call.Pkg), cp.GetString(written))
+	switch {
+	case recorded == "":
+		if writtenFq == "" {
+			return nil
+		}
+		return []string{writtenFq}
+	case writtenFq == "" || writtenFq == recorded:
+		return []string{recorded}
+	default:
+		return []string{recorded, writtenFq}
+	}
+}
+
+// matchesRecvType applies a pattern's receiver scope to a call, accepting any of
+// the call's receiver forms.
+//
+// The regex takes precedence over the exact name, matching the order every
+// pattern matcher already used. An empty pattern scopes nothing and matches.
+func matchesRecvType(cp ContextProvider, call *metadata.Call, exact, regex string) bool {
+	if regex == "" && exact == "" {
+		return true
+	}
+	forms := recvForms(cp, call)
+	if len(forms) == 0 {
+		// No receiver at all: a scoped pattern cannot match a plain function.
+		forms = []string{""}
+	}
+	if regex != "" {
+		re, err := cachedRegex(regex)
+		if err != nil {
+			return false
+		}
+		for _, form := range forms {
+			if re.MatchString(form) {
+				return true
+			}
+		}
+		return false
+	}
+	for _, form := range forms {
+		if exact == form {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/spec/recv_forms_test.go
+++ b/internal/spec/recv_forms_test.go
@@ -1,0 +1,169 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// recvFormsFixture builds a metadata Call with a recorded receiver and,
+// optionally, the receiver it was written against.
+func recvFormsFixture(t *testing.T, pkg, recorded, written string) (*metadata.Metadata, *metadata.Call) {
+	t.Helper()
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	call := &metadata.Call{
+		Meta:     meta,
+		Pkg:      meta.StringPool.Get(pkg),
+		RecvType: meta.StringPool.Get(recorded),
+	}
+	call.SetWrittenRecvType(meta.StringPool.Get(written))
+	return meta, call
+}
+
+// TestRecvFormsKeepsBothFactsAndNeitherMore pins the shape of the answer: the
+// recorded receiver first (so a caller wanting one answer takes forms[0]), the
+// written-against one only when it exists and differs.
+func TestRecvFormsKeepsBothFactsAndNeitherMore(t *testing.T) {
+	cases := []struct {
+		name                   string
+		pkg, recorded, written string
+		want                   []string
+		why                    string
+	}{
+		{
+			name: "legacy call has one form",
+			pkg:  "net/http", recorded: "*Request", written: "",
+			want: []string{"net/http.*Request"},
+			why:  "nothing sets the written receiver without a resolved call graph",
+		},
+		{
+			name: "resolved past an interface keeps both",
+			pkg:  "example.com/app", recorded: "*recorder", written: "ResponseWriter",
+			want: []string{"example.com/app.*recorder", "example.com/app.ResponseWriter"},
+			why:  "the concrete type runs and the interface is what a pattern names",
+		},
+		{
+			name: "identical written receiver is not repeated",
+			pkg:  "net/http", recorded: "Header", written: "Header",
+			want: []string{"net/http.Header"},
+			why:  "a duplicate form would make every regex test the same string twice",
+		},
+		{
+			name: "a receiverless call qualifies to its package",
+			pkg:  "net/http", recorded: "", written: "",
+			want: []string{"net/http"},
+			why:  "pre-existing fqOwner semantics: a plain function's owner IS its package, and the matchers scope on that",
+		},
+		{
+			name: "nothing to qualify at all",
+			pkg:  "", recorded: "", written: "",
+			want: nil,
+			why:  "no package and no receiver leaves no owner to match",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			meta, call := recvFormsFixture(t, tt.pkg, tt.recorded, tt.written)
+			got := recvForms(NewContextProvider(meta), call)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("recvForms = %v, want %v — %s", got, tt.want, tt.why)
+			}
+		})
+	}
+}
+
+// TestMatchesRecvTypeAcceptsEitherForm is the rule issue #260 turns on: a
+// pattern scoped to an interface must keep matching a call whose graph has been
+// resolved past that interface.
+func TestMatchesRecvTypeAcceptsEitherForm(t *testing.T) {
+	meta, call := recvFormsFixture(t, "example.com/app", "*recorder", "ResponseWriter")
+	cp := NewContextProvider(meta)
+
+	t.Run("exact match on the written interface", func(t *testing.T) {
+		if !matchesRecvType(cp, call, "example.com/app.ResponseWriter", "") {
+			t.Error("a pattern naming the interface stopped matching once the callee was resolved to the concrete type")
+		}
+	})
+	t.Run("exact match on the concrete type", func(t *testing.T) {
+		if !matchesRecvType(cp, call, "example.com/app.*recorder", "") {
+			t.Error("a pattern naming the concrete type must still match — it is what actually runs")
+		}
+	})
+	t.Run("regex match on either", func(t *testing.T) {
+		if !matchesRecvType(cp, call, "", `\.ResponseWriter$`) {
+			t.Error("a regex scoped to the interface stopped matching")
+		}
+		if !matchesRecvType(cp, call, "", `\.\*recorder$`) {
+			t.Error("a regex scoped to the concrete type stopped matching")
+		}
+	})
+	t.Run("an unrelated scope still rejects", func(t *testing.T) {
+		if matchesRecvType(cp, call, "net/url.Values", "") {
+			t.Error("accepting either form must not accept every form")
+		}
+		if matchesRecvType(cp, call, "", `^net/url\.`) {
+			t.Error("accepting either form must not accept every form")
+		}
+	})
+	t.Run("an unscoped pattern matches anything", func(t *testing.T) {
+		if !matchesRecvType(cp, call, "", "") {
+			t.Error("a pattern that scopes no receiver must not be narrowed by this")
+		}
+	})
+	t.Run("a scoped pattern rejects a receiverless call", func(t *testing.T) {
+		_, plain := recvFormsFixture(t, "example.com/app", "", "")
+		if matchesRecvType(cp, plain, "example.com/app.Router", "") {
+			t.Error("a plain function matched a receiver-scoped pattern")
+		}
+	})
+	t.Run("an invalid regex rejects rather than panics", func(t *testing.T) {
+		if matchesRecvType(cp, call, "", "([") {
+			t.Error("an unparseable regex must not match")
+		}
+	})
+}
+
+// TestWrittenRecvTypeEncodingKeepsUnsetAtZero pins the encoding that keeps every
+// existing metadata golden byte-identical: unset must be the Go zero value, so
+// `omitempty` drops the field, because the pool's "no string" is -1 and -1 would
+// serialise on every call in the project.
+func TestWrittenRecvTypeEncodingKeepsUnsetAtZero(t *testing.T) {
+	var call metadata.Call
+	if call.WrittenRecv != 0 {
+		t.Fatalf("zero Call has WrittenRecv=%d; omitempty would serialise it", call.WrittenRecv)
+	}
+	if got := call.WrittenRecvType(); got != -1 {
+		t.Errorf("unset WrittenRecvType() = %d, want -1 (the pool's no-string)", got)
+	}
+
+	// Pool index 0 is a real index and must survive the round trip — it is the
+	// case a naive `omitempty` on the raw index would silently drop.
+	call.SetWrittenRecvType(0)
+	if call.WrittenRecv != 1 {
+		t.Errorf("SetWrittenRecvType(0) stored %d, want 1", call.WrittenRecv)
+	}
+	if got := call.WrittenRecvType(); got != 0 {
+		t.Errorf("WrittenRecvType() = %d after setting index 0", got)
+	}
+
+	call.SetWrittenRecvType(-1)
+	if call.WrittenRecv != 0 || call.WrittenRecvType() != -1 {
+		t.Error("clearing with -1 did not return the field to unset")
+	}
+}


### PR DESCRIPTION
Groundwork for #260. **Inert on its own** — legacy runs are byte-identical (full suite, all metadata goldens, zero fixture drift), because nothing sets the second receiver form without a resolved call graph. The half that populates it belongs to the resolver and lands on `feature/vta-call-graph` separately.

## The problem

The pattern configs are scoped to **interface** names — `net/http.ResponseWriter`, `net/http.Header`, `net/url.Values` — because that is what a reader of the source sees. Resolving the call graph replaces exactly those names with the concrete types that run, which is the entire point of resolving.

So every pattern scoped to an interface silently stops matching, and every interface-scoped **exclusion** silently stops excluding, as the call graph gets better. Measured: a render helper doing

```go
if rw, ok := w.(http.ResponseWriter); ok {
    if rw.Header().Get("Content-Type") == "" { … }
}
```

has `rw.Header()` resolved to the project's own status-recording writer, `responseWriterOriginRegex` then matches nothing, and a **response** header is documented as a **request** parameter on four operations of a large real project.

## The change

Both receivers are facts about the same call and neither subsumes the other (golden rule #7): the concrete type is what executes, the written one is what a pattern names. So `metadata.Call` carries the receiver a call was **written against** alongside the recorded one, and receiver scoping accepts either — `RecvType`, `RecvTypeRegex` and `ExcludeRecvOriginRegex` alike.

Six duplicated receiver comparisons across `pattern_matchers.go` and `extractor.go` collapse into one `matchesRecvType`, which is also what makes the rule testable rather than repeated in six places.

## Two things worth knowing about the encoding

- The field stores **pool index + 1**, so unset is the Go zero value and `omitempty` drops it. The string pool's "no string" is `-1`, which would otherwise have serialised on every call in every metadata golden.
- It is exported only because metadata round-trips through YAML (`LoadMetadata`). Read and write it through `WrittenRecvType` / `SetWrittenRecvType`, which own the encoding.

## Coverage

`internal/spec/recv_forms_test.go`:
- the recorded form comes first and the written one appears only when it exists and differs (a duplicate would make every regex test the same string twice)
- exact and regex scoping both match either form, and an unrelated scope still rejects — accepting either form must not become accepting every form
- an unscoped pattern is not narrowed; a receiverless call still qualifies to its package, which is pre-existing `fqOwner` semantics the matchers rely on
- the +1 encoding, including pool index 0, which is the case a naive `omitempty` on the raw index would silently drop

## Verification

```
go test ./...          # clean, zero drift, no golden regenerated
go vet ./...           # clean
golangci-lint run      # 0 issues
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)