### PR TITLE
perf(spec): spend the node budget on routing code first (#264, part 1)

### DIFF
--- a/internal/spec/lazytree.go
+++ b/internal/spec/lazytree.go
@@ -153,6 +153,12 @@ type LazyTree struct {
 	// routeMatch gates which entrypoints earn a root: only those whose subtree
 	// can reach a route registration.
 	routeMatch func(*metadata.CallGraphEdge) bool
+	// routeReach is routeMatch's transitive closure — the functions whose
+	// expansion leads to a route registration. Used to ORDER a node's callee
+	// children so the budget is spent on routing code first (issue #264); never
+	// to drop any. Built once, on first use.
+	routeReach     map[string]bool
+	routeReachOnce bool
 	// logger reports how many entrypoints were rooted vs skipped.
 	logger metadata.VerboseLogger
 
@@ -288,6 +294,62 @@ func scopeLabel(scope string) string {
 		return "<router wiring>"
 	}
 	return scope
+}
+
+// leadsToRoute reports whether expanding a callee key can reach a route
+// registration. Unknown answers "yes": this orders work, and a wrong "no" would
+// push real routing code behind everything else.
+func (t *LazyTree) leadsToRoute(key string) bool {
+	if t.routeMatch == nil {
+		return true
+	}
+	if !t.routeReachOnce {
+		t.routeReachOnce = true
+		t.routeReach = routeReachSet(t.meta, t.routeMatch)
+	}
+	if t.routeReach == nil {
+		return true
+	}
+	return t.routeReach[metadata.StripToBase(key)]
+}
+
+// orderTowardRoutes moves the callee children that lead to a route registration
+// ahead of those that do not, leaving each group's relative order alone.
+//
+// This is the whole of issue #264 at the tree level. The node budget is one
+// allowance for the entire walk, and the extractor's traversal is depth-first:
+// whatever is expanded first spends it. On a ~900-route project that was
+// `modules/setting` and `modules/log`, and the run documented 12 paths before
+// truncating — not because routing code is expensive, but because the budget was
+// gone before the walk reached it.
+//
+// Ordering rather than pruning is the safe half of that fix. Nothing is dropped,
+// so a subtree the reach set misses — and it will miss some, since reachability
+// through data flow is undecidable in general — is merely expanded later. Pruning
+// was tried and reverted: it deleted 124 of 312 operations.
+//
+// ARGUMENT children are deliberately left in place at the front. A route group's
+// closure is an argument, not a callee, and it is the single most route-dense
+// child a node can have; reordering around it could only hurt.
+func (t *LazyTree) orderTowardRoutes(plan []childSpec, from int) {
+	if t.routeMatch == nil || from >= len(plan) {
+		return
+	}
+	seg := plan[from:]
+	leading := make([]childSpec, 0, len(seg))
+	trailing := make([]childSpec, 0, len(seg))
+	for _, spec := range seg {
+		if t.leadsToRoute(spec.key) {
+			leading = append(leading, spec)
+		} else {
+			trailing = append(trailing, spec)
+		}
+	}
+	if len(leading) == 0 || len(trailing) == 0 {
+		return // nothing to reorder; keep the slice untouched
+	}
+	copy(seg, leading)
+	copy(seg[len(leading):], trailing)
 }
 
 // budgetExhausted reports whether the cumulative node budget is spent.
@@ -934,6 +996,9 @@ func (t *LazyTree) buildPlan(n *LazyNode) []childSpec {
 	}
 
 	// Callee children: the function's own calls, then relation-derived ones.
+	// calleeStart marks where they begin, so orderTowardRoutes can reorder them
+	// without disturbing the argument children ahead of them (issue #264).
+	calleeStart := len(plan)
 	added := map[string]bool{}
 	appendCalleeOpts := func(edge *metadata.CallGraphEdge, chainParented, genericFilter bool) {
 		calleeID := strings.TrimPrefix(edge.Callee.ID(), "*")
@@ -1027,6 +1092,9 @@ func (t *LazyTree) buildPlan(n *LazyNode) []childSpec {
 	for _, edge := range t.receiverChildren[n.key] {
 		appendCallee(edge, false)
 	}
+
+	// Spend the budget on routing code first — see orderTowardRoutes.
+	t.orderTowardRoutes(plan, calleeStart)
 	return plan
 }
 

--- a/internal/spec/route_reach.go
+++ b/internal/spec/route_reach.go
@@ -1,0 +1,91 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import "github.com/ehabterra/apispec/internal/metadata"
+
+// routeReachSet returns the function base keys from which a route registration
+// is transitively reachable — the set the tree uses to decide which subtree to
+// spend its budget on first (issue #264).
+//
+// It is a backward walk from every registration site rather than the extractor's
+// bottom-up pass over the SCC condensation, for one reason: it must follow
+// FUNC LITERALS, and the call graph does not.
+//
+// A closure passed as an argument — `r.Route("/api", func(api chi.Router){ … })`,
+// which is how most real projects group routes — is not a callee of the function
+// that writes it, so no call edge leads there. Reachability that only follows
+// call edges therefore reports that the enclosing function reaches no route,
+// which is false for exactly the code that matters most. That blind spot is why
+// an earlier attempt to PRUNE by pattern reachability deleted 124 of 312
+// operations: `chi.Group` matches no route pattern and reaches none, yet every
+// route lives inside its closure.
+//
+// So two relations propagate "leads to a registration" backwards:
+//
+//   - callee -> caller, the ordinary one;
+//   - closure -> the function that lexically defines it, so a group closure's
+//     routes count for the function that writes the group.
+//
+// The result is a HINT, never a gate. Ordering by it defers work; it never drops
+// any, so a function this set misses is expanded late rather than not at all.
+func routeReachSet(meta *metadata.Metadata, match func(*metadata.CallGraphEdge) bool) map[string]bool {
+	if meta == nil || match == nil {
+		return nil
+	}
+
+	// Predecessors: for a key, the functions whose own expansion leads to it.
+	preds := make(map[string][]string, len(meta.CallGraph))
+	addPred := func(of, pred string) {
+		if of == "" || pred == "" || of == pred {
+			return
+		}
+		preds[of] = append(preds[of], pred)
+	}
+
+	reaches := make(map[string]bool)
+	var queue []string
+	mark := func(key string) {
+		if key == "" || reaches[key] {
+			return
+		}
+		reaches[key] = true
+		queue = append(queue, key)
+	}
+
+	for i := range meta.CallGraph {
+		edge := &meta.CallGraph[i]
+		caller := edge.Caller.BaseID()
+		addPred(edge.Callee.BaseID(), caller)
+		if edge.ParentFunction != nil {
+			// The closure's body is written inside its parent, so reaching a
+			// registration from the closure means the parent's subtree leads to
+			// one — even though nothing CALLS the closure.
+			addPred(caller, edge.ParentFunction.BaseID())
+		}
+		if match(edge) {
+			mark(caller)
+		}
+	}
+
+	for len(queue) > 0 {
+		key := queue[0]
+		queue = queue[1:]
+		for _, pred := range preds[key] {
+			mark(pred)
+		}
+	}
+	return reaches
+}

--- a/internal/spec/route_reach_test.go
+++ b/internal/spec/route_reach_test.go
@@ -1,0 +1,194 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// closureMeta builds a call graph in the shape that matters for #264:
+//
+//	main        -> registerAPI          (a plain call)
+//	registerAPI -> chi.Router.Route     (the group call; its closure is an ARGUMENT)
+//	FuncLit     -> chi.Router.Get       (the registration, written inside the closure)
+//	main        -> loadSettings         (a plain call that leads nowhere near a route)
+//	loadSettings-> ini.Section.Key
+//
+// The closure's edges carry ParentFunction = registerAPI, which is the only link
+// back to the function that writes the group — nothing CALLS the closure.
+func closureMeta(t *testing.T) *metadata.Metadata {
+	t.Helper()
+	m := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	call := func(pkg, recv, name string) metadata.Call {
+		return metadata.Call{
+			Meta: m, Name: m.StringPool.Get(name), Pkg: m.StringPool.Get(pkg),
+			RecvType: m.StringPool.Get(recv), Position: -1, Scope: -1, SignatureStr: -1,
+		}
+	}
+	const app = "example.com/app"
+	const chi = "github.com/go-chi/chi/v5"
+
+	registerAPI := call(app, "", "registerAPI")
+	edges := []metadata.CallGraphEdge{
+		{Caller: call(app, "", "main"), Callee: registerAPI},
+		{Caller: registerAPI, Callee: call(chi, "Router", "Route")},
+		// Written inside registerAPI's closure; reachable only via ParentFunction.
+		{
+			Caller:         call(app, "", "FuncLit:main.go:10:20"),
+			Callee:         call(chi, "Router", "Get"),
+			ParentFunction: &registerAPI,
+		},
+		{Caller: call(app, "", "main"), Callee: call(app, "", "loadSettings")},
+		{Caller: call(app, "", "loadSettings"), Callee: call("gopkg.in/ini.v1", "Section", "Key")},
+	}
+	m.CallGraph = append(m.CallGraph, edges...)
+	m.BuildCallGraphMaps()
+	return m
+}
+
+// registersRoute matches the chi verb call the fixture registers with.
+func registersRoute(m *metadata.Metadata) func(*metadata.CallGraphEdge) bool {
+	return func(edge *metadata.CallGraphEdge) bool {
+		return m.StringPool.GetString(edge.Callee.Name) == "Get"
+	}
+}
+
+// TestRouteReachSetFollowsFuncLiterals is the property the whole of #264 rests
+// on, and the one a plain call-graph walk gets wrong.
+//
+// A group closure is an ARGUMENT, not a callee, so nothing calls it. Reachability
+// that follows only call edges therefore reports that `registerAPI` reaches no
+// route — false for the single most common way real projects group routes, and
+// exactly why an earlier attempt to PRUNE by pattern reachability deleted 124 of
+// 312 operations.
+func TestRouteReachSetFollowsFuncLiterals(t *testing.T) {
+	m := closureMeta(t)
+	reach := routeReachSet(m, registersRoute(m))
+
+	const app = "example.com/app"
+	for _, key := range []string{
+		app + ".FuncLit:main.go:10:20", // registers directly
+		app + ".registerAPI",           // only via the closure it writes
+		app + ".main",                  // only via registerAPI
+	} {
+		if !reach[key] {
+			t.Errorf("%s does not lead to a route registration; a closure's routes must count for the function that writes it", key)
+		}
+	}
+
+	for _, key := range []string{
+		app + ".loadSettings",
+		"gopkg.in/ini.v1.Section.Key",
+	} {
+		if reach[key] {
+			t.Errorf("%s was marked as leading to a route; nothing below it registers one", key)
+		}
+	}
+}
+
+// TestRouteReachSetIsInertWithoutAPredicate covers the callers that supply none.
+func TestRouteReachSetIsInertWithoutAPredicate(t *testing.T) {
+	m := closureMeta(t)
+	if got := routeReachSet(m, nil); got != nil {
+		t.Errorf("routeReachSet with no predicate = %v, want nil", got)
+	}
+	if got := routeReachSet(nil, registersRoute(m)); got != nil {
+		t.Errorf("routeReachSet with no metadata = %v, want nil", got)
+	}
+}
+
+// TestOrderTowardRoutesDefersOnlyAndStably pins the two properties that make
+// ordering safe where pruning was not: nothing is removed, and equal-class
+// children keep their relative order so the output stays deterministic (golden
+// rule #1).
+func TestOrderTowardRoutesDefersOnlyAndStably(t *testing.T) {
+	m := closureMeta(t)
+	tree := &LazyTree{meta: m, routeMatch: registersRoute(m)}
+
+	const app = "example.com/app"
+	plan := []childSpec{
+		{key: "arg-child"}, // an argument child, ahead of the callee segment
+		{key: app + ".loadSettings"},
+		{key: app + ".registerAPI"},
+		{key: "gopkg.in/ini.v1.Section.Key"},
+		{key: app + ".main"},
+	}
+	before := append([]childSpec(nil), plan...)
+
+	tree.orderTowardRoutes(plan, 1)
+
+	if plan[0].key != "arg-child" {
+		t.Errorf("argument child moved to %q; a group closure is an argument and must stay ahead of the callee segment", plan[0].key)
+	}
+	wantOrder := []string{
+		"arg-child",
+		app + ".registerAPI", // leads to a route, kept in its original relative order
+		app + ".main",
+		app + ".loadSettings", // does not, deferred
+		"gopkg.in/ini.v1.Section.Key",
+	}
+	var gotOrder []string
+	for _, spec := range plan {
+		gotOrder = append(gotOrder, spec.key)
+	}
+	if !reflect.DeepEqual(gotOrder, wantOrder) {
+		t.Errorf("order = %v, want %v", gotOrder, wantOrder)
+	}
+
+	// Nothing dropped: ordering defers, it never prunes. This is the property
+	// that makes an imperfect reach set safe — a subtree it misses is expanded
+	// late rather than not at all.
+	if len(plan) != len(before) {
+		t.Fatalf("plan went from %d children to %d; ordering must not drop any", len(before), len(plan))
+	}
+	seen := map[string]int{}
+	for _, spec := range plan {
+		seen[spec.key]++
+	}
+	for _, spec := range before {
+		if seen[spec.key] != 1 {
+			t.Errorf("child %q appears %d times after ordering, want exactly once", spec.key, seen[spec.key])
+		}
+	}
+}
+
+// TestOrderTowardRoutesLeavesUniformPlansAlone keeps the common case free: when
+// every child is in the same class there is nothing to reorder, and the slice
+// must not be touched.
+func TestOrderTowardRoutesLeavesUniformPlansAlone(t *testing.T) {
+	m := closureMeta(t)
+	const app = "example.com/app"
+
+	t.Run("all lead to routes", func(t *testing.T) {
+		tree := &LazyTree{meta: m, routeMatch: registersRoute(m)}
+		plan := []childSpec{{key: app + ".registerAPI"}, {key: app + ".main"}}
+		tree.orderTowardRoutes(plan, 0)
+		if plan[0].key != app+".registerAPI" || plan[1].key != app+".main" {
+			t.Errorf("uniform plan was reordered: %v", plan)
+		}
+	})
+
+	t.Run("no predicate leaves the plan alone", func(t *testing.T) {
+		tree := &LazyTree{meta: m}
+		plan := []childSpec{{key: app + ".loadSettings"}, {key: app + ".registerAPI"}}
+		tree.orderTowardRoutes(plan, 0)
+		if plan[0].key != app+".loadSettings" {
+			t.Errorf("a tree with no route predicate reordered its plan: %v", plan)
+		}
+	})
+}


### PR DESCRIPTION
Part 1 of #264. Does **not** close it — the per-route budget is what stops truncation, and it is the deeper change; this lands first so the improvement isn't held hostage to it.

## The problem

`MaxNodesPerTree` is one allowance for the whole walk, and the extractor's route traversal is depth-first over lazily-expanded children. Whatever is expanded first spends it.

On a ~900-route project that was `modules/setting` and `modules/log`:

```
[engine] expansion truncated at the 50000-node limit — the spec is incomplete
[engine] instance cap (25) dropped 4768689 call copies — first: gopkg.in/ini.v1.Section.Key@…/modules/setting/config_provider.go:163:9 in scope <router wiring>
[engine] spec mapped (12 paths)
```

12 paths out of ~900 — not because routing code is expensive, but because the budget was gone before the walk reached it. (The `instance cap` line is the diagnostic added in #262, pointing straight at the culprit on its first real run.)

## The change

A node's **callee** children are ordered so the ones whose subtree can reach a route registration expand first.

| | baseline | + ordering |
| --- | --- | --- |
| paths | **12** | **46** |
| wall | 52.9s | 88.1s |
| peak RSS | 3.12 GB | 5.87 GB |
| still truncated | yes | yes |

Zero fixture drift across all 74 fixtures.

The cost is real and worth naming: the walk now reaches — and expands — routing code it previously never got to, so it does more work. That is the trade this buys 3.8× the routes with.

## Why it follows func literals

This is the whole difficulty, and where the previous attempt failed.

A group closure — `r.Route("/api", func(api chi.Router){…})` — is an **argument**, not a callee. Nothing *calls* it. Reachability that follows only call edges therefore reports that the enclosing function reaches no route, which is false for the single most common way real projects group routes. That blind spot is exactly why an earlier attempt to **prune** by pattern reachability deleted **124 of 312** operations: `chi.Group` matches no route pattern and, on a call-graph walk, reaches none either.

So `routeReachSet` propagates "leads to a registration" backwards over two relations: callee → caller, and **closure → the function that lexically defines it**.

## Why ordering and not pruning

Nothing is dropped, so a subtree the reach set misses is expanded *late* rather than *not at all*.

That matters because the set **will** miss some — reachability through data flow is undecidable in general. I tried the pruning form of this too (skip non-route subtrees during discovery) and it broke six fixtures: `cli_action_routes`, `cli_action_cross_package`, `functional_options`, `wrapper_router` and the func-field parity tests. Those reach their routes through **tree relations** the lazy tree builds at query time — func-field dispatch, producer/assignment links — which no call-graph reach set can see, and patching it per wiring style is the heuristic golden rule #9 forbids. Reverted.

Deferring is safe where dropping is not, and that asymmetry is the design.

**Argument children keep their place at the front.** A route group's closure is an argument and the most route-dense child a node can have; reordering around it could only hurt.

## Coverage

`internal/spec/route_reach_test.go`:
- **`TestRouteReachSetFollowsFuncLiterals`** — the change-detector. A route registered inside a closure must count for the function that writes the closure and for its callers. Verified to fail with `example.com/app.registerAPI does not lead to a route registration` when the `ParentFunction` propagation is removed.
- ordering **defers only** — every child survives, exactly once
- ordering is **stable** — equal-class children keep their relative order, so output stays deterministic (golden rule #1)
- a uniform plan and a tree with no route predicate are left untouched

## Verification

```
go test ./...          # clean, zero fixture drift
go vet ./...           # clean
golangci-lint run      # 0 issues
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Route-related code paths are now prioritized during tree expansion, helping route registrations be discovered sooner.
  - Existing traversal order is preserved where possible, while required argument processing remains unchanged.
  - Route discovery continues through nested function closures for more complete results.

- **Bug Fixes**
  - Improved behavior when route-related paths compete for limited expansion capacity.
  - Ensured prioritization reorders items without dropping any paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->