### PR TITLE
fix(spec): a group must not open a per-route budget scope — main is currently dropping routes

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -795,7 +795,8 @@ func (e *Engine) GenerateOpenAPI() (*spec.OpenAPISpec, error) {
 		tree = intspec.NewLazyTree(meta, limits,
 			intspec.WithHandlerInterfaceMethods(apispecConfig.Framework.HandlerInterfaceMethods),
 			intspec.WithEntrypoints(apispecConfig.Framework.EntrypointPatterns,
-				intspec.RouteRegistrationMatcher(apispecConfig, meta), NewVerboseLogger(e.config.Verbose)))
+				intspec.RouteRegistrationMatcher(apispecConfig, meta), NewVerboseLogger(e.config.Verbose)),
+			intspec.WithTerminalRouteMatcher(intspec.TerminalRouteMatcher(apispecConfig, meta)))
 		e.reportPhase("tracker tree ready (lazy)", time.Since(tTree))
 	} else {
 		tree = intspec.NewTrackerTree(meta, limits, NewVerboseLogger(e.config.Verbose),

--- a/internal/spec/entrypoint_roots.go
+++ b/internal/spec/entrypoint_roots.go
@@ -166,6 +166,29 @@ func reachesMatch(meta *metadata.Metadata, match func(*metadata.CallGraphEdge) b
 // pattern's receiver instead. What it will not do is invent a root for a
 // subcommand that calls `cache.Get`.
 func RouteRegistrationMatcher(cfg *APISpecConfig, meta *metadata.Metadata) func(*metadata.CallGraphEdge) bool {
+	// Mounts count too: a subcommand whose only routing act is mounting a
+	// sub-router still leads to routes.
+	return registrationMatcher(cfg, meta, true)
+}
+
+// TerminalRouteMatcher matches only the calls that register ONE route — a verb
+// call — and not the mount or group calls that contain many.
+//
+// The distinction exists because the two questions are different. "Does this
+// subtree lead to a route?" must say yes for `r.Route("/api", …)`, or the whole
+// group is written off. "Is this node the route whose detail I am budgeting?"
+// must say NO for it, or every route inside the group shares one allowance and
+// the ones past it are never discovered.
+//
+// Measured: scoping the per-route budget on the mount-inclusive predicate took a
+// 246-route chi service down to 32 paths, the budget for a whole `Mux.Route`
+// group being spent inside its first few routes. That is the #224 mistake in a
+// new place — a limit applied to a group where it was meant to apply to a route.
+func TerminalRouteMatcher(cfg *APISpecConfig, meta *metadata.Metadata) func(*metadata.CallGraphEdge) bool {
+	return registrationMatcher(cfg, meta, false)
+}
+
+func registrationMatcher(cfg *APISpecConfig, meta *metadata.Metadata, includeMounts bool) func(*metadata.CallGraphEdge) bool {
 	if cfg == nil || meta == nil {
 		return func(*metadata.CallGraphEdge) bool { return false }
 	}
@@ -176,11 +199,11 @@ func RouteRegistrationMatcher(cfg *APISpecConfig, meta *metadata.Metadata) func(
 			gates = append(gates, gate{p.CallRegex, p.RecvTypeRegex, p.RecvType})
 		}
 	}
-	// Mounts count too: a subcommand whose only routing act is mounting a
-	// sub-router still leads to routes.
-	for _, p := range cfg.Framework.MountPatterns {
-		if p.CallRegex != "" {
-			gates = append(gates, gate{p.CallRegex, p.RecvTypeRegex, p.RecvType})
+	if includeMounts {
+		for _, p := range cfg.Framework.MountPatterns {
+			if p.CallRegex != "" {
+				gates = append(gates, gate{p.CallRegex, p.RecvTypeRegex, p.RecvType})
+			}
 		}
 	}
 	if len(gates) == 0 {

--- a/internal/spec/lazytree.go
+++ b/internal/spec/lazytree.go
@@ -153,6 +153,11 @@ type LazyTree struct {
 	// routeMatch gates which entrypoints earn a root: only those whose subtree
 	// can reach a route registration.
 	routeMatch func(*metadata.CallGraphEdge) bool
+	// terminalRouteMatch matches only the calls that register ONE route. It is
+	// what opens a budget scope; routeMatch (which also matches mounts and
+	// groups) must not, or every route inside a group shares one allowance —
+	// see TerminalRouteMatcher.
+	terminalRouteMatch func(*metadata.CallGraphEdge) bool
 	// routeReach is routeMatch's transitive closure — the functions whose
 	// expansion leads to a route registration. Used to ORDER a node's callee
 	// children so the budget is spent on routing code first (issue #264); never
@@ -167,6 +172,10 @@ type LazyTree struct {
 	routeScopeNodes []int
 	// routeScopeKeys names the registration each id stands for, for reporting.
 	routeScopeKeys []string
+	// routeScopeCut marks scopes already counted as truncated, so the report
+	// counts ROUTES rather than blocked expansion attempts — a truncated scope is
+	// re-entered many times as the walk unwinds, which read as "58 of 6".
+	routeScopeCut []bool
 	// routeTruncations counts route subtrees cut short by their own budget, and
 	// routeFirstTruncated names the first. Unlike the whole-walk truncation this
 	// is LOCAL — the rest of the routes are unaffected — so it is reported
@@ -399,7 +408,7 @@ func (t *LazyTree) scopeOf(n *LazyNode) int {
 	if n == nil {
 		return 0
 	}
-	if n.routeScope != 0 || t.routeMatch == nil || n.edge == nil || !t.routeMatch(n.edge) {
+	if n.routeScope != 0 || t.terminalRouteMatch == nil || n.edge == nil || !t.terminalRouteMatch(n.edge) {
 		return n.routeScope
 	}
 	// First registration on this path: open a scope for it.
@@ -432,6 +441,13 @@ func (t *LazyTree) routeBudgetExhausted(scope int) bool {
 // warns once. The route's own key is named: unlike the whole-walk truncation,
 // this says exactly which endpoint is under-documented.
 func (t *LazyTree) noteRouteTruncation(scope int) {
+	for len(t.routeScopeCut) <= scope {
+		t.routeScopeCut = append(t.routeScopeCut, false)
+	}
+	if t.routeScopeCut[scope] {
+		return // already counted: one route, however often its subtree is re-entered
+	}
+	t.routeScopeCut[scope] = true
 	t.routeTruncations++
 	key := ""
 	if scope < len(t.routeScopeKeys) {
@@ -680,6 +696,14 @@ func WithEntrypoints(patterns []EntrypointPattern, routeMatch func(*metadata.Cal
 		t.routeMatch = routeMatch
 		t.logger = logger
 	}
+}
+
+// WithTerminalRouteMatcher supplies the predicate that decides which node opens a
+// per-route budget scope: a single route registration, never a mount or group
+// (issue #264). Without it no scope is opened and expansion is bounded only by
+// MaxNodesPerTree, as it was before.
+func WithTerminalRouteMatcher(match func(*metadata.CallGraphEdge) bool) LazyTreeOption {
+	return func(t *LazyTree) { t.terminalRouteMatch = match }
 }
 
 // addEntrypointRoots appends a root per qualifying entrypoint. Called from

--- a/internal/spec/route_reach_test.go
+++ b/internal/spec/route_reach_test.go
@@ -202,7 +202,7 @@ func TestOrderTowardRoutesLeavesUniformPlansAlone(t *testing.T) {
 // documented in less detail.
 func TestRouteBudgetIsPerRegistrationNotGlobal(t *testing.T) {
 	m := closureMeta(t)
-	tree := &LazyTree{meta: m, routeMatch: registersRoute(m)}
+	tree := &LazyTree{meta: m, routeMatch: registersRoute(m), terminalRouteMatch: registersRoute(m)}
 
 	// A node that is not a registration stays in the wiring scope.
 	wiring := &LazyNode{tree: tree, key: "example.com/app.main"}
@@ -241,20 +241,66 @@ func TestRouteBudgetIsPerRegistrationNotGlobal(t *testing.T) {
 // cannot tell you which endpoint is under-documented.
 func TestRouteTruncationNamesTheRoute(t *testing.T) {
 	m := closureMeta(t)
-	tree := &LazyTree{meta: m, routeMatch: registersRoute(m)}
+	tree := &LazyTree{meta: m, routeMatch: registersRoute(m), terminalRouteMatch: registersRoute(m)}
 	regEdge := &m.CallGraph[2]
 	scope := tree.scopeOf(&LazyNode{tree: tree, key: "GET /things", edge: regEdge})
 
 	tree.noteRouteTruncation(scope)
-	tree.noteRouteTruncation(scope)
 
-	if tree.routeTruncations != 2 {
-		t.Errorf("counted %d route truncations, want 2", tree.routeTruncations)
+	if tree.routeTruncations != 1 {
+		t.Errorf("counted %d route truncations, want 1", tree.routeTruncations)
 	}
 	if tree.routeFirstTruncated != "GET /things" {
 		t.Errorf("first truncated route = %q, want the registration's key", tree.routeFirstTruncated)
 	}
 	if !tree.routeWarned {
 		t.Error("a truncated route produced no warning")
+	}
+}
+
+// TestGroupCallDoesNotOpenARouteScope is the regression guard for the worst bug
+// this work produced, caught on a real 246-route chi service.
+//
+// The reach predicate deliberately matches mounts and groups too — "does this
+// subtree lead to a route?" must say yes for `r.Route("/api", …)`, or the whole
+// group is written off. Using that same predicate to open a BUDGET scope means
+// every route inside the group shares one allowance, and the routes past the
+// first few are never discovered at all: 246 paths became 32.
+//
+// So scoping uses a terminal-route predicate, and a group must not open a scope.
+func TestGroupCallDoesNotOpenARouteScope(t *testing.T) {
+	m := closureMeta(t)
+	// routeMatch matches the group call as well (it is the reach predicate);
+	// terminalRouteMatch matches only the verb call.
+	groupOrRoute := func(edge *metadata.CallGraphEdge) bool {
+		name := m.StringPool.GetString(edge.Callee.Name)
+		return name == "Get" || name == "Route"
+	}
+	tree := &LazyTree{meta: m, routeMatch: groupOrRoute, terminalRouteMatch: registersRoute(m)}
+
+	groupEdge := &m.CallGraph[1] // chi.Router.Route — a group
+	if got := tree.scopeOf(&LazyNode{tree: tree, key: "group", edge: groupEdge}); got != 0 {
+		t.Errorf("a group call opened budget scope %d; every route inside it would then share one allowance (#264)", got)
+	}
+
+	routeEdge := &m.CallGraph[2] // chi.Router.Get — one route
+	if got := tree.scopeOf(&LazyNode{tree: tree, key: "route", edge: routeEdge}); got == 0 {
+		t.Error("a terminal route registration did not open its own budget scope")
+	}
+}
+
+// TestRouteTruncationCountsRoutesNotAttempts pins that the report counts routes.
+// A truncated subtree is re-entered many times as the walk unwinds, which once
+// read as "truncated 58 of 6 route subtrees".
+func TestRouteTruncationCountsRoutesNotAttempts(t *testing.T) {
+	m := closureMeta(t)
+	tree := &LazyTree{meta: m, routeMatch: registersRoute(m), terminalRouteMatch: registersRoute(m)}
+	scope := tree.scopeOf(&LazyNode{tree: tree, key: "GET /things", edge: &m.CallGraph[2]})
+
+	for i := 0; i < 20; i++ {
+		tree.noteRouteTruncation(scope)
+	}
+	if tree.routeTruncations != 1 {
+		t.Errorf("counted %d truncations for one route re-entered 20 times, want 1", tree.routeTruncations)
 	}
 }


### PR DESCRIPTION
**Urgent.** `main` currently loses most routes on any project that groups them with `chi.Route` / `Mount`. #266 was merged at `fce6cd1`, which is *before* this fix commit, so the defect is live on `main`.

| | paths | components |
| --- | --- | --- |
| v0.5.4 | 334 | 216 |
| **`main` today** | **35** | **24** |
| this PR | 334 | 203 |

A second project: 246 paths on v0.5.4, **32** on `main`, 246 with this PR.

## Cause

The per-route budget opened its scope using `RouteRegistrationMatcher`, which deliberately matches mounts and groups as well as routes — *"does this subtree lead to a route?"* has to say yes for `r.Route("/api", …)`, or the whole group is written off.

Reusing that predicate to open a **budget scope** meant every route inside one group shared a single 20,000-node allowance. It was spent inside the first few routes and the rest were never discovered. The diagnostic said so plainly:

```
per-route limit (20000) truncated 69 of 6 route subtrees
  (first at github.com/go-chi/chi/v5.Mux.Route@…/router.go:259:2)
```

`Mux.Route` — a group, not a route. This is the #224 mistake in a new place: a limit meant for a route, applied to a group.

## Fix

Two questions, two predicates. `RouteRegistrationMatcher` keeps mounts, for reachability and the entrypoint gate. A new `TerminalRouteMatcher` matches only a single route registration, and only that opens a scope.

`TestGroupCallDoesNotOpenARouteScope` is the regression guard.

Also fixes the report, which read `truncated 69 of 6 route subtrees`: a truncated subtree is re-entered many times as the walk unwinds, so the count has to be per scope, not per blocked attempt.

## Revised numbers for #264 overall

The ~900-route project moves 12 → **181** (not the 210 reported on #266 — part of that was itself an artefact of scoping on mounts). The 246-route and 334-route projects are unchanged from v0.5.4 on paths.

## Why the fixture suite did not catch it

All 74 fixtures passed while three real projects lost 85–90% of their paths: the fixtures are too small for any budget to fire. That gap is real and I am adding a fixture with enough routes in one group to exhaust a low `--max-nodes-per-route`, asserted at a cap where the unfixed code starves. Filed as a follow-up rather than held here, because `main` is broken now.

## Verification

```
go test ./...          # clean, zero fixture drift
go vet ./...           # clean
golangci-lint run      # 0 issues
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected route matching so grouped or mounted routes are distinguished from individual route registrations.
  * Improved route budget tracking to apply independently to each registered route.
  * Fixed route truncation counts so repeated processing of the same route is counted only once.
  * Improved identification of the first route affected by truncation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->