### PR TITLE
fix: a route's request body must come from code the route runs (#269)

### DIFF
--- a/generator/testdata_shared_body_helper_test.go
+++ b/generator/testdata_shared_body_helper_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/engine"
+)
+
+// TestTestdata_SharedBodyHelper pins the FAILURE MODE of a request body that
+// resolves through a shared generic decode helper (issue #269).
+//
+// The fixture puts several routes in one chi group closure, each handler a
+// closure returned by a factory, each decoding through one generic
+// `httpx.DecodeJSON[T]` in another package. That single `decoder.Decode(&data)`
+// is the ONLY body call site in the program: what tells the routes apart is the
+// type argument at each call, so every route's schema depends on binding that
+// argument back to its own call site. One route's response converter reads a
+// domain field that another route's handler writes — the shape that lets the
+// producer relation reach a sibling's body (see the fixture doc comment).
+//
+// On a real service four endpoints came out documented with a SIBLING route's
+// DTO — a confidently wrong schema, which is strictly worse than a missing one
+// because nothing downstream can tell it is wrong. The rule this test encodes:
+//
+//	a truncated or starved route must be documented as LESS detailed,
+//	never as DIFFERENTLY detailed.
+//
+// So a route is allowed to have no request body at all, and fails only when it
+// claims a body belonging to a different route. The caps and budgets below are
+// the levers that starve resolution; the assertion is identical under all of
+// them.
+//
+// NOTE: this fixture does NOT reproduce #269 on its own — it is green here both
+// before and after the provenance gate that fixes the defect, at every setting
+// swept below. The mechanism is known (the producer relation reaching a sibling
+// handler through a shared domain field) but a synthetic version of it has not
+// been made to fire; on the affected service it fires with shipped defaults.
+// The gate's actual evidence is that service (three endpoints corrected, no
+// request body lost, rest of the spec byte-identical) and the unit tests in
+// internal/spec/request_provenance_test.go. This file is fail-safe coverage and
+// a change-detector: passing it is NOT evidence that the defect is fixed.
+func TestTestdata_SharedBodyHelper(t *testing.T) {
+	const fixture = "shared_body_helper"
+
+	// want maps each route to the ONE DTO it may legitimately document.
+	want := map[string]string{}
+	for _, name := range []string{
+		"alpha", "bravo", "charlie", "delta", "echo", "foxtrot",
+	} {
+		want["/api/"+name] = strings.ToUpper(name[:1]) + name[1:] + "Request"
+	}
+
+	// Each pair starves resolution differently: the instance cap bounds copies
+	// of the shared helper, the node budget cuts expansion short. Both are ways
+	// a route can lose its own binding, which is when substitution was observed.
+	for _, tc := range []struct {
+		instanceCap int
+		maxNodes    int
+	}{
+		{0, 0},     // defaults
+		{1, 0},     // harshest cap: one copy of the shared helper
+		{5, 0},     // fewer copies than routes
+		{0, 20000}, // budget above what the fixture needs
+		{0, 400},   // budget that truncates most routes
+		{0, 150},   // budget that truncates nearly everything
+	} {
+		t.Run(fmt.Sprintf("cap=%d/nodes=%d", tc.instanceCap, tc.maxNodes), func(t *testing.T) {
+			cfg := engine.DefaultEngineConfig()
+			cfg.InputDir = filepath.Join("..", "testdata", fixture)
+			if tc.instanceCap > 0 {
+				cfg.MaxInstancesPerKey = tc.instanceCap
+			}
+			if tc.maxNodes > 0 {
+				cfg.MaxNodesPerTree = tc.maxNodes
+			}
+
+			out, err := engine.NewEngine(cfg).GenerateOpenAPI()
+			if err != nil {
+				t.Fatalf("GenerateOpenAPI: %v", err)
+			}
+
+			for path, wantDTO := range want {
+				item, ok := out.Paths[path]
+				if !ok {
+					continue // a starved route may not be documented at all
+				}
+				op := opFor(item, "POST")
+				if op == nil || op.RequestBody == nil {
+					continue // no body is the acceptable degradation
+				}
+				mt, ok := op.RequestBody.Content["application/json"]
+				if !ok || mt.Schema == nil || mt.Schema.Ref == "" {
+					continue
+				}
+				if !strings.HasSuffix(mt.Schema.Ref, "_"+wantDTO) {
+					t.Errorf("%s: documents %q, want the route's own %s — a starved route may lose its body, never borrow a sibling's",
+						path, mt.Schema.Ref, wantDTO)
+				}
+			}
+		})
+	}
+}

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -1121,7 +1121,7 @@ func frameChainKey(chain []string, node TrackerNodeInterface) string {
 }
 
 func (e *Extractor) extractRouteChildren(routeNode TrackerNodeInterface, route *RouteInfo, mountTags []string, routes *[]*RouteInfo, visitedEdges map[chainStep]bool, ci *chainInterner, chainID int, respCandidates *[]responseCandidate) {
-	e.extractRouteChildrenScoped(routeNode, route, mountTags, routes, visitedEdges, ci, chainID, respCandidates, true)
+	e.extractRouteChildrenScoped(routeNode, route, mountTags, routes, visitedEdges, ci, chainID, respCandidates, true, true, 0)
 }
 
 // extractRouteChildrenScoped is extractRouteChildren with the permission to
@@ -1131,7 +1131,7 @@ func (e *Extractor) extractRouteChildren(routeNode TrackerNodeInterface, route *
 // fill the route replaces resolved values with that function's parameters.
 // Everything else about the walk (request, responses, parameters) continues
 // unchanged, because those DO live in the handler's body.
-func (e *Extractor) extractRouteChildrenScoped(routeNode TrackerNodeInterface, route *RouteInfo, mountTags []string, routes *[]*RouteInfo, visitedEdges map[chainStep]bool, ci *chainInterner, chainID int, respCandidates *[]responseCandidate, mayComplete bool) {
+func (e *Extractor) extractRouteChildrenScoped(routeNode TrackerNodeInterface, route *RouteInfo, mountTags []string, routes *[]*RouteInfo, visitedEdges map[chainStep]bool, ci *chainInterner, chainID int, respCandidates *[]responseCandidate, mayComplete, bodyScope bool, depth int) {
 	for _, child := range routeNode.GetChildren() {
 		// Check for route patterns in children nodes — but only where a child can
 		// legitimately COMPLETE this route (see completesSameRegistration). A
@@ -1151,7 +1151,11 @@ func (e *Extractor) extractRouteChildrenScoped(routeNode TrackerNodeInterface, r
 		// keep the most specific result so a concrete type isn't clobbered by
 		// a later generic `object` — which happens when one path resolves the
 		// type through a binding wrapper and another doesn't.
-		if req := e.extractRequestFromNode(child, route); req != nil {
+		// Only where the walk got here by executing the route. A body reached
+		// through a lateral relation link belongs to another route's handler,
+		// and taking it documents a confidently wrong schema (issue #269).
+		childBodyScope := bodyScope && e.followsControlFlow(routeNode, child, depth)
+		if req := e.extractRequestFromNode(child, route); req != nil && childBodyScope {
 			// Record the call site so a method-dispatch handler can attribute
 			// this request body to the right verb branch by line range.
 			if f, l, _ := calleePosition(child); req.File == "" {
@@ -1185,7 +1189,7 @@ func (e *Extractor) extractRouteChildrenScoped(routeNode TrackerNodeInterface, r
 		if child != nil && child.GetArgument() == nil && child.GetEdge() != nil {
 			childChainID = ci.push(chainID, child.GetEdge().Callee.ID())
 		}
-		e.extractRouteChildrenScoped(child, route, mountTags, routes, visitedEdges, ci, childChainID, respCandidates, childMayComplete)
+		e.extractRouteChildrenScoped(child, route, mountTags, routes, visitedEdges, ci, childChainID, respCandidates, childMayComplete, childBodyScope, depth+1)
 	}
 
 	// Extract parameters from the route node itself

--- a/internal/spec/request_provenance.go
+++ b/internal/spec/request_provenance.go
@@ -1,0 +1,137 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import "github.com/ehabterra/apispec/internal/metadata"
+
+// handlerArgDepth is the depth at which a route's handler argument sits: the
+// registration node is depth 0, its argument children depth 1.
+const handlerArgDepth = 1
+
+// Request-body provenance (issue #269).
+//
+// A route's tracker subtree is not only the code that route runs. Several
+// relations attach nodes LATERALLY — the argument-producer link answers "who
+// produced this value" with every function that writes it, the interface
+// fan-out expands every implementer — and those answers can be another route's
+// handler. Once a sibling handler's body hangs under this route, its request
+// decode is a perfectly well-formed body candidate for the wrong route, and
+// preferRequestInfo's last-wins tie-break lets it overwrite the right one.
+//
+// Observed on a real service: a route documented a SIBLING route's DTO, reached
+// through its own RESPONSE converter — the converter reads a shared domain
+// field, producer resolution walks back to the handler that writes that field,
+// and the walk arrives inside that sibling's closure. For one route the walk
+// produced 112 candidates carrying its own type and 80 carrying the sibling's,
+// and whichever came last won. Editing an unrelated statement in one handler
+// moved the wrong schema onto a third route.
+//
+// The gate: a body candidate counts only if EVERY step from the registration
+// down to it followed the program's control flow. Losing a body when the walk
+// can only reach it laterally is the honest outcome — a route documented as
+// LESS detailed, never as DIFFERENTLY detailed (golden rule #7).
+//
+// This is deliberately narrow. It gates the request body only; responses and
+// parameters keep the full subtree, since their own resolution models
+// (pairAndFillResponses' chain pairing) already discriminate differently, and
+// widening the change would be a behaviour change beyond this defect.
+
+// followsControlFlow reports whether child is reached from parent by executing
+// it: the parent called it, it is the body of what the parent called (a
+// returned closure, an interface implementer), it is a link in the same fluent
+// chain, or it is a value inside the current frame.
+//
+// A child whose caller is some unrelated function is a lateral attachment — the
+// tracker can see that code from here, but this route does not run it.
+func (e *Extractor) followsControlFlow(parent, child TrackerNodeInterface, depth int) bool {
+	if parent == nil || child == nil {
+		return true
+	}
+	// The registration's handler ARGUMENT is how every route enters its own
+	// code, so that argument's children are the handler body. Only at the
+	// registration, though: deeper down, an argument node is an ordinary value,
+	// and the producer relation hangs every writer of that value underneath it —
+	// which is the lateral jump this gate exists to stop.
+	if parent.GetArgument() != nil {
+		return depth <= handlerArgDepth
+	}
+	// Arguments belong to the frame that is already in scope.
+	if child.GetArgument() != nil {
+		return true
+	}
+
+	parentEdge, childEdge := parent.GetEdge(), child.GetEdge()
+	if parentEdge == nil || childEdge == nil {
+		return true
+	}
+	// A fluent chain is one statement written across several calls.
+	if childEdge.ChainParent != nil {
+		return true
+	}
+
+	callerBase := childEdge.Caller.BaseID()
+	// Inside the function the parent just called — the ordinary descent.
+	if callerBase == parentEdge.Callee.BaseID() {
+		return true
+	}
+	// A sibling call in the same function: chain/receiver children are listed
+	// under this node but written in the caller's own frame.
+	if callerBase == parentEdge.Caller.BaseID() {
+		return true
+	}
+
+	meta := e.metadata()
+	if meta == nil {
+		return true
+	}
+
+	// The body of what the parent called, when that body is a function literal
+	// the callee defines or returns (a handler factory's closure). This is the
+	// ParentFunctions attachment the lazy tree makes in expandKey; following it
+	// IS control flow — the closure is what the call produces.
+	calleeBase := parentEdge.Callee.BaseID()
+	for _, edge := range meta.ParentFunctions[calleeBase] {
+		if edge == childEdge {
+			return true
+		}
+	}
+	if stripped := metadata.StripToBase(parentEdge.Callee.ID()); stripped != calleeBase {
+		for _, edge := range meta.ParentFunctions[stripped] {
+			if edge == childEdge {
+				return true
+			}
+		}
+	}
+
+	// An implementer of the interface method the parent called: same method,
+	// different receiver. The fan-out is how a call on an interface value
+	// reaches the code that actually runs.
+	cp := e.contextProvider
+	if name := cp.GetString(childEdge.Caller.Name); name != "" &&
+		name == cp.GetString(parentEdge.Callee.Name) {
+		return true
+	}
+
+	return false
+}
+
+// metadata returns the metadata behind the context provider, or nil when the
+// provider is not the standard implementation (mocks in tests).
+func (e *Extractor) metadata() *metadata.Metadata {
+	if ctxImpl, ok := e.contextProvider.(*ContextProviderImpl); ok {
+		return ctxImpl.meta
+	}
+	return nil
+}

--- a/internal/spec/request_provenance_test.go
+++ b/internal/spec/request_provenance_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// provNode is a tracker node with exactly the two things followsControlFlow
+// reads: the edge the node carries, and whether it is an argument node.
+type provNode struct {
+	edge *metadata.CallGraphEdge
+	arg  *metadata.CallArgument
+}
+
+func (n *provNode) GetKey() string                                         { return "" }
+func (n *provNode) GetChildren() []TrackerNodeInterface                    { return nil }
+func (n *provNode) GetCallGraphEdge() *metadata.CallGraphEdge              { return n.edge }
+func (n *provNode) GetCallArgument() *metadata.CallArgument                { return n.arg }
+func (n *provNode) GetArgContext() string                                  { return "" }
+func (n *provNode) GetArgIndex() int                                       { return 0 }
+func (n *provNode) GetArgType() metadata.ArgumentType                      { return metadata.ArgTypeDirectCallee }
+func (n *provNode) GetArgument() *metadata.CallArgument                    { return n.arg }
+func (n *provNode) GetEdge() *metadata.CallGraphEdge                       { return n.edge }
+func (n *provNode) GetParent() TrackerNodeInterface                        { return nil }
+func (n *provNode) GetTypeParamMap() map[string]string                     { return nil }
+func (n *provNode) GetRootAssignmentMap() map[string][]metadata.Assignment { return nil }
+
+// provEdge builds an edge "callerPkg.callerName -> calleePkg.calleeName".
+func provEdge(meta *metadata.Metadata, callerPkg, callerName, calleePkg, calleeName string) *metadata.CallGraphEdge {
+	sp := meta.StringPool
+	return &metadata.CallGraphEdge{
+		Caller: metadata.Call{Meta: meta, Name: sp.Get(callerName), Pkg: sp.Get(callerPkg), RecvType: -1},
+		Callee: metadata.Call{Meta: meta, Name: sp.Get(calleeName), Pkg: sp.Get(calleePkg), RecvType: -1},
+	}
+}
+
+func provExtractor(meta *metadata.Metadata) *Extractor {
+	return &Extractor{contextProvider: NewContextProvider(meta)}
+}
+
+// TestFollowsControlFlow_ProvenanceGate pins the rule that keeps a route from
+// documenting a SIBLING route's request body (issue #269).
+//
+// A route's tracker subtree contains more than the code the route runs: the
+// argument-producer relation answers "who produced this value" with every
+// function that WRITES it, which for a shared domain field is another route's
+// handler. Once that handler hangs under this route, its own decode call is a
+// well-formed body candidate for the wrong route, and preferRequestInfo's
+// last-wins tie-break lets it overwrite the right one. On a real service that
+// documented three endpoints with a neighbour's DTO, and the winner moved when
+// an unrelated statement in a third handler changed.
+func TestFollowsControlFlow_ProvenanceGate(t *testing.T) {
+	meta := newTestMeta()
+	meta.ParentFunctions = map[string][]*metadata.CallGraphEdge{}
+	e := provExtractor(meta)
+
+	t.Run("ordinary descent into what the parent called", func(t *testing.T) {
+		parent := &provNode{edge: provEdge(meta, "app", "handler", "app", "decode")}
+		child := &provNode{edge: provEdge(meta, "app", "decode", "json", "Decode")}
+		if !e.followsControlFlow(parent, child, 4) {
+			t.Error("a call inside the function the parent called is control flow; it must be allowed")
+		}
+	})
+
+	t.Run("sibling call written in the same function", func(t *testing.T) {
+		parent := &provNode{edge: provEdge(meta, "app", "handler", "app", "first")}
+		child := &provNode{edge: provEdge(meta, "app", "handler", "app", "second")}
+		if !e.followsControlFlow(parent, child, 4) {
+			t.Error("a chain/receiver child written in the caller's own frame must be allowed")
+		}
+	})
+
+	t.Run("registration handler argument opens the handler body", func(t *testing.T) {
+		// The handler argument sits at depth 1; its children are the handler's
+		// own body, whose caller is the closure rather than the registration.
+		parent := &provNode{
+			edge: provEdge(meta, "app", "routes", "chi", "Post"),
+			arg:  metadata.NewCallArgument(meta),
+		}
+		child := &provNode{edge: provEdge(meta, "app", "FuncLit:h.go:10:9", "httpx", "DecodeJSON")}
+		if !e.followsControlFlow(parent, child, handlerArgDepth) {
+			t.Error("the registration's handler argument must open the route's own body")
+		}
+	})
+
+	t.Run("value argument deep in the body does NOT open a sibling handler", func(t *testing.T) {
+		// This is #269: a response converter passes a shared domain field,
+		// producer resolution answers with the sibling handler that writes that
+		// field, and the sibling's decode arrives as a candidate for THIS route.
+		parent := &provNode{
+			edge: provEdge(meta, "app", "ToView", "app", "estimateView"),
+			arg:  metadata.NewCallArgument(meta),
+		}
+		child := &provNode{edge: provEdge(meta, "app", "FuncLit:sibling.go:28:9", "httpx", "DecodeJSON")}
+		if e.followsControlFlow(parent, child, handlerArgDepth+3) {
+			t.Error("a sibling handler reached through a produced value is not this route's control flow")
+		}
+	})
+
+	t.Run("closure the callee returns", func(t *testing.T) {
+		// A handler factory has no direct calls; the tree reaches its returned
+		// closure through ParentFunctions, and that IS control flow.
+		parent := &provNode{edge: provEdge(meta, "app", "routes", "app", "MakeHandler")}
+		child := &provNode{edge: provEdge(meta, "app", "FuncLit:h.go:12:9", "httpx", "DecodeJSON")}
+		meta.ParentFunctions[parent.edge.Callee.BaseID()] = []*metadata.CallGraphEdge{child.edge}
+		if !e.followsControlFlow(parent, child, 3) {
+			t.Error("a factory's returned closure is what the call produces; it must be allowed")
+		}
+	})
+
+	t.Run("interface implementer of the called method", func(t *testing.T) {
+		parent := &provNode{edge: provEdge(meta, "app", "handler", "svc", "Store")}
+		child := &provNode{edge: provEdge(meta, "impl", "Store", "db", "Insert")}
+		if !e.followsControlFlow(parent, child, 3) {
+			t.Error("an implementer of the interface method the parent called must be allowed")
+		}
+	})
+
+	t.Run("missing edges are never blocked", func(t *testing.T) {
+		if !e.followsControlFlow(&provNode{}, &provNode{}, 3) {
+			t.Error("a node with no edge carries no evidence of a lateral jump; it must not be blocked")
+		}
+		if !e.followsControlFlow(nil, nil, 0) {
+			t.Error("nil nodes must not be blocked")
+		}
+	})
+}

--- a/testdata/shared_body_helper/go.mod
+++ b/testdata/shared_body_helper/go.mod
@@ -1,0 +1,5 @@
+module example.com/sharedbodyhelper
+
+go 1.21
+
+require github.com/go-chi/chi/v5 v5.0.10

--- a/testdata/shared_body_helper/go.sum
+++ b/testdata/shared_body_helper/go.sum
@@ -1,0 +1,10 @@
+github.com/ajg/form v1.5.1 h1:t9c7v8JUKu/XxOGBU0yjNpaMloxGEJhUkqFRq0ibGeU=
+github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
+github.com/go-chi/chi/v5 v5.0.10 h1:rLz5avzKpjqxrYwXNfmjkrYYXOyLJd37pz53UFHC6vk=
+github.com/go-chi/chi/v5 v5.0.10/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/go-chi/cors v1.2.1 h1:xEC8UT3Rlp2QuWNEr4Fs/c2EAGVKBwy/1vHx3bppil4=
+github.com/go-chi/cors v1.2.1/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vzc58=
+github.com/go-chi/render v1.0.3 h1:AsXqd2a1/INaIfUSKq3G5uA8weYx20FOsM7uSoCyyt4=
+github.com/go-chi/render v1.0.3/go.mod h1:/gr3hVkmYR0YlEy3LxCuVRFzEu9Ruok+gFqbIofjao0=
+github.com/google/uuid v1.4.0 h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4=
+github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/testdata/shared_body_helper/internal/api/api.go
+++ b/testdata/shared_body_helper/internal/api/api.go
@@ -1,0 +1,117 @@
+// Package api holds the handlers and the shared domain/response mapping.
+package api
+
+import (
+	"net/http"
+
+	"example.com/sharedbodyhelper/internal/common"
+	"example.com/sharedbodyhelper/internal/dtos"
+	"example.com/sharedbodyhelper/internal/httpx"
+)
+
+// Cart is the one domain type every route works on.
+type Cart struct {
+	ID       string
+	Estimate dtos.Estimate
+}
+
+// View is the response shape.
+type View struct {
+	ID       string        `json:"id"`
+	Estimate dtos.Estimate `json:"estimate"`
+}
+
+type Service struct{}
+
+func (s *Service) Load(id string) *Cart { return &Cart{ID: id} }
+
+// applyEstimate WRITES Cart.Estimate from a request DTO. It is what makes the
+// producer of `cart.Estimate` a SIBLING route's handler.
+func applyEstimate(c *Cart, req *dtos.BravoRequest) {
+	c.Estimate = dtos.Estimate{Minutes: len(req.Bravo)}
+}
+
+// estimateView READS Cart.Estimate. Passing the field as an argument is what
+// makes the tracker resolve "who produced this value" — and answer with the
+// handler that wrote it, dragging that route's whole body in behind it.
+func estimateView(e dtos.Estimate) dtos.Estimate { return e }
+
+// ToView is the shared response converter every handler calls.
+func ToView(c *Cart) View {
+	v := View{ID: c.ID}
+	v.Estimate = estimateView(c.Estimate)
+	return v
+}
+
+func PostAlpha(svc *Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		req, err := httpx.DecodeJSON[dtos.AlphaRequest](r)
+		if err != nil {
+			common.RespondWithError(w, http.StatusBadRequest)
+			return
+		}
+		cart := svc.Load(req.CartID)
+		common.RespondWithSuccess(w, "true", ToView(cart), http.StatusOK)
+	}
+}
+
+func PostBravo(svc *Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		req, err := httpx.DecodeJSON[dtos.BravoRequest](r)
+		if err != nil {
+			common.RespondWithError(w, http.StatusBadRequest)
+			return
+		}
+		cart := svc.Load(req.CartID)
+		applyEstimate(cart, &req)
+		common.RespondWithSuccess(w, "true", ToView(cart), http.StatusOK)
+	}
+}
+
+func PostCharlie(svc *Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		req, err := httpx.DecodeJSON[dtos.CharlieRequest](r)
+		if err != nil {
+			common.RespondWithError(w, http.StatusBadRequest)
+			return
+		}
+		cart := svc.Load(req.CartID)
+		common.RespondWithSuccess(w, "true", ToView(cart), http.StatusOK)
+	}
+}
+
+func PostDelta(svc *Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		req, err := httpx.DecodeJSON[dtos.DeltaRequest](r)
+		if err != nil {
+			common.RespondWithError(w, http.StatusBadRequest)
+			return
+		}
+		cart := svc.Load(req.CartID)
+		common.RespondWithSuccess(w, "true", ToView(cart), http.StatusOK)
+	}
+}
+
+func PostEcho(svc *Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		req, err := httpx.DecodeJSON[dtos.EchoRequest](r)
+		if err != nil {
+			common.RespondWithError(w, http.StatusBadRequest)
+			return
+		}
+		cart := svc.Load(req.CartID)
+		common.RespondWithSuccess(w, "true", ToView(cart), http.StatusOK)
+	}
+}
+
+func PostFoxtrot(svc *Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		req, err := httpx.DecodeJSON[dtos.FoxtrotRequest](r)
+		if err != nil {
+			common.RespondWithError(w, http.StatusBadRequest)
+			return
+		}
+		cart := svc.Load(req.CartID)
+		common.RespondWithSuccess(w, "true", ToView(cart), http.StatusOK)
+	}
+}

--- a/testdata/shared_body_helper/internal/common/common.go
+++ b/testdata/shared_body_helper/internal/common/common.go
@@ -1,0 +1,16 @@
+// Package common holds the house responder every handler funnels through.
+package common
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func RespondWithSuccess(w http.ResponseWriter, msg string, data any, code int) {
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(data)
+}
+
+func RespondWithError(w http.ResponseWriter, code int) {
+	w.WriteHeader(code)
+}

--- a/testdata/shared_body_helper/internal/dtos/dtos.go
+++ b/testdata/shared_body_helper/internal/dtos/dtos.go
@@ -1,0 +1,40 @@
+// Package dtos holds one request type per route, so a route documenting another
+// route's type is visible.
+package dtos
+
+type AlphaRequest struct {
+	CartID string `json:"cart_id"`
+	Alpha  string `json:"alpha"`
+}
+
+type BravoRequest struct {
+	CartID string `json:"cart_id"`
+	Bravo  string `json:"bravo"`
+}
+
+type CharlieRequest struct {
+	CartID  string `json:"cart_id"`
+	Charlie string `json:"charlie"`
+}
+
+type DeltaRequest struct {
+	CartID string `json:"cart_id"`
+	Delta  string `json:"delta"`
+}
+
+type EchoRequest struct {
+	CartID string `json:"cart_id"`
+	Echo   string `json:"echo"`
+}
+
+type FoxtrotRequest struct {
+	CartID  string `json:"cart_id"`
+	Foxtrot string `json:"foxtrot"`
+}
+
+// Estimate is the shared field type at the centre of the defect: one route
+// WRITES it from its own request DTO, another route READS it in its response
+// converter.
+type Estimate struct {
+	Minutes int `json:"minutes"`
+}

--- a/testdata/shared_body_helper/internal/httpx/httpx.go
+++ b/testdata/shared_body_helper/internal/httpx/httpx.go
@@ -1,0 +1,18 @@
+// Package httpx holds the one shared decode helper. It is GENERIC: the
+// decoder.Decode(&data) inside it is a SINGLE call site shared by every route,
+// and only the type argument tells one route's body from another's.
+package httpx
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func DecodeJSON[TData any](r *http.Request) (TData, error) {
+	var data TData
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&data); err != nil {
+		return data, err
+	}
+	return data, nil
+}

--- a/testdata/shared_body_helper/main.go
+++ b/testdata/shared_body_helper/main.go
@@ -1,0 +1,41 @@
+// Fixture: routes whose request bodies all decode through ONE generic helper,
+// where one route's response converter READS a domain field that ANOTHER
+// route's handler WRITES (issue #269).
+//
+// That field is the whole point. Resolving "who produced cart.Estimate" answers
+// with the sibling handler that writes it, so the tracker hangs that handler's
+// entire closure — including its own DecodeJSON instantiation — underneath this
+// route's response converter. The sibling's body is then a well-formed request
+// body candidate for the WRONG route, and last-wins lets it overwrite the right
+// one. On a real service that documented four endpoints with a neighbour's DTO.
+//
+// The other ingredients are needed to reach that point at all: the decode helper
+// is generic (one call site for every route, told apart only by its type
+// argument), it lives in another package (a selector callee, golden rule #10),
+// and each handler is a closure returned by a factory.
+//
+// The rule under test: a truncated or starved route must be documented as LESS
+// detailed, never as DIFFERENTLY detailed. Every assertion allows "no request
+// body" and fails only on a body belonging to another route.
+package main
+
+import (
+	"net/http"
+
+	"example.com/sharedbodyhelper/internal/api"
+	"github.com/go-chi/chi/v5"
+)
+
+func main() {
+	svc := &api.Service{}
+	r := chi.NewRouter()
+	r.Route("/api", func(g chi.Router) {
+		g.Post("/alpha", api.PostAlpha(svc))
+		g.Post("/bravo", api.PostBravo(svc))
+		g.Post("/charlie", api.PostCharlie(svc))
+		g.Post("/delta", api.PostDelta(svc))
+		g.Post("/echo", api.PostEcho(svc))
+		g.Post("/foxtrot", api.PostFoxtrot(svc))
+	})
+	_ = http.ListenAndServe(":8080", r)
+}


### PR DESCRIPTION
Fixes #269.

## What was wrong

A route's tracker subtree is not only that route's code. Several relations attach nodes **laterally** — the argument-producer link answers *"who produced this value"* with every function that WRITES it; the interface fan-out expands every implementer. For a shared domain field, that answer is another route's handler.

Once a sibling handler hangs under this route, its own decode call is a well-formed request-body candidate — for the wrong route. `preferRequestInfo` returns `next` when both candidates are concrete, so last-wins lets it overwrite the correct one.

The path, from the instrumented walk:

```
registration → handler closure → its own RESPONSE converter
    → shared helper (reads a shared domain field)
    → SIBLING handler's closure → DecodeJSON{TData = the sibling's DTO}
```

## Two things this is NOT — both cost real time to rule out

- **Not a type-resolution bug.** `GetTypeParamMap` walks the node's own ancestor path and every foreign candidate reported a perfectly consistent map. Nothing is corrupted; the node just belongs to another route.
- **Not truncation.** The issue's own correcting comment says a starved route substitutes a neighbour's DTO. It reproduces at **default limits** on `main` today, and expanding more does not fix it. Raising `--max-instances-per-key` is not even monotonic: 25 → 3 endpoints wrong, 100 → 1 wrong, 400 → a previously-correct route breaks and a third DTO appears.

I'll post the correction to #269 separately; its current description would send the next reader after truncation.

## The fix

A body candidate counts only if **every step from the registration followed the program's control flow**: the parent called it, it is the body of what the parent called (a factory's returned closure via `ParentFunctions`, an interface implementer), it is a fluent-chain link, or it is a value in the current frame.

The registration's handler **argument** opens the handler body — but only at depth 1. That detail *is* the fix: exempting every argument node changes nothing, because the producer relation attaches at an argument node deep inside the body, which is exactly the lateral jump.

Losing a body the walk can only reach laterally is the honest outcome — a route documented as LESS detailed, never as DIFFERENTLY detailed (golden rule #7).

Deliberately narrow: **request bodies only**. Responses and parameters still see the whole subtree; their resolution models discriminate differently and widening this would be a behaviour change beyond this defect.

## Verification

Measured on the affected service (~68 routes, reproduces at shipped defaults):

| | result |
| --- | --- |
| the three wrong endpoints | all corrected |
| request bodies | 53 before → 53 after — **none lost** |
| rest of the spec | byte-identical (`del(.requestBody)` diff empty) |
| under truncation | `--max-nodes` 2000 / 10000 / 50000 — zero wrong |
| 4 other local projects | request bodies byte-identical |

Full suite, `go vet`, `gofmt`, `golangci-lint` clean.

## Tests

`internal/spec/request_provenance_test.go` — unit tests at the layer that changed: ordinary descent, same-frame sibling, handler argument at depth 1, **the #269 case** (a deep value argument must not open a sibling handler), factory closure, interface implementer, missing-edge safety.

`testdata/shared_body_helper` + structural test — several routes through one generic decode helper, asserting the failure mode under six cap/budget combinations: a route may have no body, and fails only if it claims another route's.

## One limitation, stated plainly

**The fixture does not reproduce #269.** It is green both before and after this change. The mechanism is understood, but a synthetic version of it has not been made to fire — four escalating fixture shapes (plain helper → group closure → cross-package → generic + factory closures + shared helpers, 6 to 34 routes, every cap) all degraded safely. The test doc says this explicitly so a passing run is never mistaken for proof the defect is fixed. The evidence for this fix is the service measurements above plus the unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request-body detection for routes that share decoding helpers.
  * Prevented unrelated sibling route schemas from being reported as a route’s request body.
  * Preserved accurate results across complex handler flows, interfaces, closures, and constrained analysis configurations.

* **Tests**
  * Added comprehensive regression coverage for request-body provenance and control-flow scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->