### PR TITLE
fix(metadata): stop erasing declarations whose name reads like a test double

### DIFF
--- a/generator/testdata_mock_named_handlers_test.go
+++ b/generator/testdata_mock_named_handlers_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/spec"
+)
+
+// TestTestdata_MockNamedHandlers guards issue #279: metadata used to drop any
+// declaration — and every call made from it — whose identifier contained
+// "mock", "fake" or "stub" as a substring. Production endpoints named after
+// what they do (a fake-door A/B test, a sandbox tenant serving canned data, an
+// indicative "stub" price) came out as empty operations: a documented route
+// with `type: object` where its plainly-named twin resolved a $ref.
+//
+// Every route in the fixture returns either Widget or StubQuote, so the
+// assertion is simply that the colliding names resolve the same schema as the
+// control route — no name may change what a handler documents.
+func TestTestdata_MockNamedHandlers(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "mock_named_handlers", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+	noUnresolvedPlaceholders(t, out)
+
+	cases := []struct {
+		path, component, why string
+	}{
+		{"/health", "Widget", "control: no colliding identifier anywhere"},
+		{"/fake-door", "Widget", "colliding function name (also the calling function)"},
+		{"/sandbox/data", "Widget", "colliding receiver type on a handler method"},
+		{"/quote", "StubQuote", "colliding response type name"},
+		{"/indicative", "StubQuote", "colliding callee name in the response helper"},
+	}
+
+	for _, tc := range cases {
+		item, ok := out.Paths[tc.path]
+		if !ok {
+			t.Errorf("GET %s missing (%s); have %v", tc.path, tc.why, mapPathKeys(out.Paths))
+			continue
+		}
+		op := opFor(item, "GET")
+		if op == nil {
+			t.Errorf("GET %s has no GET operation (%s)", tc.path, tc.why)
+			continue
+		}
+		// The fixture's handlers write without an explicit status, so which
+		// status slot the body lands in is not what this test is about.
+		if !responseSchemaRefs(op.Responses, tc.component) {
+			t.Errorf("GET %s does not document %s (%s); the handler body was erased",
+				tc.path, tc.component, tc.why)
+		}
+	}
+}

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -280,11 +280,6 @@ func GenerateMetadataWithLogger(pkgs map[string]map[string]*ast.File, fileToInfo
 				}
 				recvType := getTypeName(fn.Recv.List[0].Type, info)
 
-				// Skip mock/fake/stub methods
-				if isMockName(recvType) || isMockName(fn.Name.Name) {
-					continue
-				}
-
 				// Extract type parameter names for generics
 				typeParams := []string{}
 				if fn.Type != nil && fn.Type.TypeParams != nil {
@@ -615,14 +610,6 @@ func collectConstants(file *ast.File, info *types.Info, pkgName string, fset *to
 	return constMap
 }
 
-// isMockName checks if a name contains mock-related patterns
-func isMockName(name string) bool {
-	lower := strings.ToLower(name)
-	return strings.Contains(lower, "mock") || strings.Contains(lower, "fake") ||
-		strings.Contains(lower, "stub") || strings.HasPrefix(lower, "mock") ||
-		strings.HasSuffix(lower, "mock") || strings.Contains(lower, "mocked")
-}
-
 // processTypes processes all type declarations in a file
 func processTypes(file *ast.File, info *types.Info, pkgName string, fset *token.FileSet, f *File, allTypeMethods map[string][]Method, allTypes map[string]*Type, metadata *Metadata) {
 	for _, decl := range file.Decls {
@@ -650,10 +637,6 @@ func processTypes(file *ast.File, info *types.Info, pkgName string, fset *token.
 // only added if its name isn't already taken by a package-level type in this
 // file, so a real package type is never shadowed by a function-local one.
 func processTypeSpec(tspec *ast.TypeSpec, info *types.Info, pkgName string, fset *token.FileSet, f *File, allTypeMethods map[string][]Method, allTypes map[string]*Type, metadata *Metadata, local bool) {
-	// Skip mock/fake/stub types
-	if isMockName(tspec.Name.Name) {
-		return
-	}
 	if local {
 		if _, exists := f.Types[tspec.Name.Name]; exists {
 			return
@@ -1139,11 +1122,6 @@ func processFunctions(file *ast.File, info *types.Info, pkgName string, fset *to
 			continue
 		}
 
-		// Skip mock/fake/stub functions
-		if isMockName(fn.Name.Name) {
-			continue
-		}
-
 		comments := getComments(fn)
 
 		// Extract type parameter names for generics
@@ -1602,11 +1580,6 @@ func processCallExpression(call *ast.CallExpr, file *ast.File, pkgs map[string]m
 
 	callerFunc, callerParts, callerSignatureStr := getEnclosingFunctionName(file, call.Pos(), info, fset, metadata)
 	calleeFunc, calleePkg, calleeParts := getCalleeFunctionNameAndPackage(call.Fun, file, pkgName, fileToInfo, funcMap, fset, metadata)
-
-	// Skip mock calls
-	if isMockName(calleeFunc) || isMockName(calleePkg) || isMockName(callerFunc) {
-		return
-	}
 
 	var calleeSignatureStr string
 	calleeType := getTypeWithGenerics(call.Fun, info)

--- a/internal/metadata/metadata_sweep_test.go
+++ b/internal/metadata/metadata_sweep_test.go
@@ -755,7 +755,11 @@ func TestSweepGenerateMetadataModulePathInference(t *testing.T) {
 	}
 }
 
-func TestSweepGenerateMetadataSkipsMockReceivers(t *testing.T) {
+// A receiver whose name merely reads like a test double is still a fact:
+// metadata records every declaration, and excluding test scaffolding is the
+// engine's file-level job (--auto-exclude-tests/-mocks), not a substring test
+// on identifiers (issue #279).
+func TestSweepGenerateMetadataRecordsMockNamedReceivers(t *testing.T) {
 	src := "package p\n\ntype MockSvc struct{}\n\nfunc (m MockSvc) Do() {}\n\ntype Svc struct{}\n\nfunc (s Svc) Run() {}\n"
 	file, info, fset := sweepTypeCheck(t, src)
 	md := GenerateMetadata(
@@ -768,15 +772,15 @@ func TestSweepGenerateMetadataSkipsMockReceivers(t *testing.T) {
 	if pkg == nil {
 		t.Fatal("package p missing")
 	}
-	var sawSvcRun, sawMock bool
+	var sawSvcRun, sawMockDo bool
 	for _, f := range pkg.Files {
-		for name, typ := range f.Types {
-			if strings.Contains(strings.ToLower(name), "mock") {
-				sawMock = true
-			}
+		for _, typ := range f.Types {
 			for _, meth := range typ.Methods {
-				if md.StringPool.GetString(meth.Name) == "Run" {
+				switch md.StringPool.GetString(meth.Name) {
+				case "Run":
 					sawSvcRun = true
+				case "Do":
+					sawMockDo = true
 				}
 			}
 		}
@@ -784,8 +788,8 @@ func TestSweepGenerateMetadataSkipsMockReceivers(t *testing.T) {
 	if !sawSvcRun {
 		t.Error("Svc.Run not recorded")
 	}
-	if sawMock {
-		t.Error("mock type should have been skipped")
+	if !sawMockDo {
+		t.Error("MockSvc.Do not recorded: a name is not grounds for dropping a declaration")
 	}
 }
 
@@ -809,14 +813,15 @@ func TestSweepCollectConstantsNonValueSpec(t *testing.T) {
 	}
 }
 
-func TestSweepProcessTypeSpecSkips(t *testing.T) {
+// A function-local type must not shadow a package-level type of the same name
+// already recorded for the file.
+func TestSweepProcessTypeSpecSkipsLocalShadow(t *testing.T) {
 	m := sweepMeta()
 	f := &File{Types: map[string]*Type{"User": {}}}
 
-	processTypeSpec(&ast.TypeSpec{Name: ast.NewIdent("MockUser")}, nil, "p", nil, f, nil, nil, m, false)
 	processTypeSpec(&ast.TypeSpec{Name: ast.NewIdent("User")}, nil, "p", nil, f, nil, nil, m, true)
 	if len(f.Types) != 1 {
-		t.Errorf("both specs should be skipped, got %d types", len(f.Types))
+		t.Errorf("local spec should be skipped, got %d types", len(f.Types))
 	}
 }
 
@@ -905,13 +910,15 @@ func TestSweepProcessStructFieldsEmbedded(t *testing.T) {
 	}
 }
 
-func TestSweepProcessFunctionsMockAndConstDecl(t *testing.T) {
+func TestSweepProcessFunctionsMockNamedAndConstDecl(t *testing.T) {
 	m := sweepMeta()
 	file, fset := sweepParseFile(t, "package p\n\nfunc MockThing() {}\n\nfunc realFn() { const c = 1 }\n")
 	f := &File{Functions: map[string]*Function{}}
 	processFunctions(file, nil, "p", fset, f, nil, nil, m)
-	if _, ok := f.Functions["MockThing"]; ok {
-		t.Error("mock function should be skipped")
+	// A "Mock"-prefixed name is recorded like any other (issue #279): the name
+	// says nothing about whether the function is part of the served API.
+	if _, ok := f.Functions["MockThing"]; !ok {
+		t.Error("MockThing should be recorded")
 	}
 	if _, ok := f.Functions["realFn"]; !ok {
 		t.Error("realFn should be recorded")
@@ -979,9 +986,12 @@ func TestSweepGetTypeWithGenericsParen(t *testing.T) {
 	}
 }
 
-func TestSweepProcessCallExpressionSkipsMock(t *testing.T) {
+// A call to a "Mock"-named callee is an edge like any other. Dropping it used
+// to erase the entire body of the calling function from the call graph, which
+// is what emptied real handlers named after what they do (issue #279).
+func TestSweepProcessCallExpressionRecordsMockNamedCallee(t *testing.T) {
 	m := sweepMeta()
-	file, fset := sweepParseFile(t, "package p\n\nfunc h() { MockDo() }\n")
+	file, info, fset := sweepTypeCheck(t, "package p\n\nfunc MockDo() {}\n\nfunc h() { MockDo() }\n")
 	var call *ast.CallExpr
 	ast.Inspect(file, func(n ast.Node) bool {
 		if c, ok := n.(*ast.CallExpr); ok {
@@ -992,9 +1002,11 @@ func TestSweepProcessCallExpressionSkipsMock(t *testing.T) {
 	if call == nil {
 		t.Fatal("call not found")
 	}
-	processCallExpression(call, file, nil, "p", nil, map[*ast.File]*types.Info{}, nil, fset, m, nil, nil, nil)
-	if len(m.CallGraph) != 0 {
-		t.Errorf("mock callee must not create edges, got %d", len(m.CallGraph))
+	processCallExpression(call, file, nil, "p", nil,
+		map[*ast.File]*types.Info{file: info}, nil, fset, m, info,
+		map[string]*CallGraphEdge{}, map[string]*CallArgument{})
+	if len(m.CallGraph) != 1 {
+		t.Errorf("expected 1 edge for the MockDo call, got %d", len(m.CallGraph))
 	}
 }
 

--- a/testdata/mock_named_handlers/go.mod
+++ b/testdata/mock_named_handlers/go.mod
@@ -1,0 +1,3 @@
+module mock_named_handlers
+
+go 1.24

--- a/testdata/mock_named_handlers/main.go
+++ b/testdata/mock_named_handlers/main.go
@@ -1,0 +1,79 @@
+// Package main exercises production declarations whose *names* collide with
+// test-double vocabulary ("mock", "fake", "stub"). Metadata used to drop any
+// such declaration — and every call made from it — by substring-matching the
+// identifier, which erased the bodies of perfectly ordinary endpoints (a
+// fake-door A/B test, a sandbox tenant serving canned data). Each handler here
+// has a plainly-named twin: the two must document the same schema.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// Widget is the control DTO — nothing in its name collides.
+type Widget struct {
+	ID string `json:"id"`
+}
+
+// StubQuote is a real DTO: an indicative ("stub") price quote shown before the
+// pricing engine runs. Its name collides with the "stub" substring.
+type StubQuote struct {
+	Price int `json:"price"`
+}
+
+// MockDataService serves canned data to the sandbox tenant — a shipped feature,
+// not a test double. Its receiver name collides with "mock".
+type MockDataService struct{}
+
+// Serve is a handler method whose receiver name collides: the method was
+// dropped from the type's method table, and the type from the Types map.
+// This route's own schema survived that (the encode call is attributed to
+// Serve, which does not collide), so it stands as coverage for the method
+// filter rather than as a reproduction of it.
+func (s *MockDataService) Serve(w http.ResponseWriter, r *http.Request) {
+	json.NewEncoder(w).Encode(Widget{})
+}
+
+// healthHandler is the control: a plainly-named handler encoding Widget.
+func healthHandler(w http.ResponseWriter, r *http.Request) {
+	json.NewEncoder(w).Encode(Widget{})
+}
+
+// fakeDoorHandler backs a fake-door A/B test. Its function name collides, which
+// also made it a colliding *caller*, so the encode call below was dropped too.
+func fakeDoorHandler(w http.ResponseWriter, r *http.Request) {
+	json.NewEncoder(w).Encode(Widget{})
+}
+
+// quoteHandler is plainly named but returns a colliding *type*. The type
+// filter dropped StubQuote from the Types table; the schema happened to
+// survive because it is rebuilt from the composite literal at the use site.
+// Kept as coverage for the declaration filter all the same.
+func quoteHandler(w http.ResponseWriter, r *http.Request) {
+	json.NewEncoder(w).Encode(StubQuote{})
+}
+
+// writeStubQuote is a colliding *callee*: a plainly-named handler calling it
+// used to lose the edge, and with it the response body.
+func writeStubQuote(w http.ResponseWriter) {
+	json.NewEncoder(w).Encode(StubQuote{})
+}
+
+// indicativeHandler is plainly named and reaches its body through the colliding
+// helper above.
+func indicativeHandler(w http.ResponseWriter, r *http.Request) {
+	writeStubQuote(w)
+}
+
+func main() {
+	svc := &MockDataService{}
+
+	http.HandleFunc("GET /health", healthHandler)
+	http.HandleFunc("GET /fake-door", fakeDoorHandler)
+	http.HandleFunc("GET /quote", quoteHandler)
+	http.HandleFunc("GET /indicative", indicativeHandler)
+	http.HandleFunc("GET /sandbox/data", svc.Serve)
+
+	http.ListenAndServe(":8080", nil)
+}


### PR DESCRIPTION
Fixes #279.

`metadata` dropped every method, type, function and call-graph edge whose **identifier** contained `mock`, `fake` or `stub` as a case-insensitive substring. The call-edge test looked at the *caller* name too, so a matching function lost its entire body from the call graph.

Production endpoints are routinely named after what they do. On the new fixture, before this change:

| route | handler | documented |
|---|---|---|
| `/health` | `healthHandler` | `$ref: Widget` ✅ |
| `/fake-door` | `fakeDoorHandler` | `type: object`, "no response found" ❌ |
| `/indicative` | reaches its body via `writeStubQuote` | `type: object` ❌ |

All three encode the same DTO. The route survived (its registration edge is `main` → `HandleFunc`), so the failure presented as a documented route with an empty body — indistinguishable from a type the mapper could not resolve.

### Why deletion rather than a better filter

- **Golden rule #4.** Metadata records facts; deciding a declaration is uninteresting is policy, and policy belongs in the spec layer.
- **Golden rule #9.** A name is not evidence. The filter both missed real test doubles (`recorder`, `spy`, `noop`) and claimed real API code.
- **The policy already exists one layer up**, where a user can turn it off: `--auto-exclude-tests` / `--auto-exclude-mocks` match *file* names (`*_test.go`, `*mock.go`, `*fakes.go`). The identifier filter was unconditional and reachable by no flag.

### Changes

- Deletes `isMockName` and its four call sites in `internal/metadata/metadata.go`.
- Adds `testdata/mock_named_handlers` — each colliding shape (function name, receiver type, response type, callee name) paired with a plainly-named twin returning the same DTO — and `TestTestdata_MockNamedHandlers`, which asserts both document the same `$ref`.
- Rewrites the three sweep tests that pinned the old behaviour. Two of them called into the parser with nil type info and only survived because the filter returned early, so they are rebuilt on `sweepTypeCheck`.

No golden or fixture output moves: no existing fixture had a colliding identifier, which is why this went unnoticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved processing of declarations and call relationships when names contain terms such as “mock,” “fake,” or “stub.”
  * Ensured generated routes and schemas remain available for handlers with these names.
* **Tests**
  * Added regression coverage for named handlers and route collisions.
  * Expanded metadata validation to confirm matching declarations and call relationships are retained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->