### PR TITLE
chore(spec): delete inferMethodFromContext, the unreachable mux-specific verb guess

### DIFF
--- a/internal/spec/config.go
+++ b/internal/spec/config.go
@@ -221,8 +221,7 @@ type MethodExtractionConfig struct {
 	CaseSensitive bool `yaml:"caseSensitive,omitempty" json:"caseSensitive,omitempty"` // Case sensitive matching
 
 	// Fallback behavior
-	DefaultMethod    string `yaml:"defaultMethod,omitempty" json:"defaultMethod,omitempty"`       // Default method when none found
-	InferFromContext bool   `yaml:"inferFromContext,omitempty" json:"inferFromContext,omitempty"` // Try to infer from call context
+	DefaultMethod string `yaml:"defaultMethod,omitempty" json:"defaultMethod,omitempty"` // Default method when none found
 }
 
 // RoutePattern defines how to extract route information

--- a/internal/spec/config_mux.go
+++ b/internal/spec/config_mux.go
@@ -30,11 +30,10 @@ func DefaultMethodExtractionConfig() *MethodExtractionConfig {
 			{Patterns: []string{"options"}, Method: "OPTIONS", Priority: 10},
 			{Patterns: []string{"head"}, Method: "HEAD", Priority: 10},
 		},
-		UsePrefix:        true,
-		UseContains:      true,
-		CaseSensitive:    false,
-		DefaultMethod:    "GET",
-		InferFromContext: true,
+		UsePrefix:     true,
+		UseContains:   true,
+		CaseSensitive: false,
+		DefaultMethod: "GET",
 	}
 }
 

--- a/internal/spec/coverage_improvement_test.go
+++ b/internal/spec/coverage_improvement_test.go
@@ -110,27 +110,6 @@ func TestIsValidHTTPMethod(t *testing.T) {
 	}
 }
 
-func TestInferMethodFromContext(t *testing.T) {
-	matcher := &RoutePatternMatcherImpl{
-		pattern: RoutePattern{
-			MethodExtraction: &MethodExtractionConfig{
-				InferFromContext: true,
-			},
-		},
-	}
-
-	// Test with nil node - this might cause a panic, so we use defer recover
-	defer func() {
-		if r := recover(); r != nil {
-			// Expected behavior for nil node
-			t.Logf("Recovered from panic: %v", r)
-		}
-	}()
-
-	result := matcher.inferMethodFromContext(nil, nil)
-	_ = result // Use result to avoid unused variable warning
-}
-
 func TestGetCachedRegex(t *testing.T) {
 	// Test with empty pattern
 	regex, err := cachedRegex("")

--- a/internal/spec/extractor_sweep_test.go
+++ b/internal/spec/extractor_sweep_test.go
@@ -286,24 +286,6 @@ func TestSweepExtractRouteDetails(t *testing.T) {
 		}
 	})
 
-	t.Run("unresolvable method infers from context", func(t *testing.T) {
-		meta := exSweepMeta()
-		cp := NewContextProvider(meta)
-		m := NewRoutePatternMatcher(RoutePattern{
-			MethodArgIndex: 0, MethodExtraction: DefaultMethodExtractionConfig(),
-		}, cfg, cp)
-		arg := sweepIdent(meta, "someVerb")
-		arg.SetValue("someVerb")
-		edge := sweepEdge(meta, "listThings", "app", "Handle", "app", "", "", arg)
-		route := NewRouteInfo()
-		if !m.extractRouteDetails(sweepNode(edge), route) {
-			t.Fatal("expected details to be found")
-		}
-		if route.Method != "GET" {
-			t.Errorf("Method = %q, want GET inferred from caller name", route.Method)
-		}
-	})
-
 	t.Run("dynamic path arg records a placeholder param", func(t *testing.T) {
 		meta := exSweepMeta()
 		cp := NewContextProvider(meta)
@@ -323,63 +305,35 @@ func TestSweepExtractRouteDetails(t *testing.T) {
 	})
 }
 
-func TestSweepInferMethodFromContext(t *testing.T) {
-	cfg := &APISpecConfig{}
+// TestSweepMethodFromFunctionNameWordBoundary pins golden rule #8's
+// word-boundary requirement: a mapping pattern only ever matches a whole
+// camelCase word, so the "get" inside "widget" must not claim the route. The
+// old substring matcher returned GET for every one of these.
+func TestSweepMethodFromFunctionNameWordBoundary(t *testing.T) {
+	b := NewBasePatternMatcher(&APISpecConfig{}, NewContextProvider(exSweepMeta()))
+	cfg := DefaultMethodExtractionConfig()
 
-	t.Run("sibling Methods call resolved via argument info", func(t *testing.T) {
-		meta := exSweepMeta()
-		pool := meta.StringPool
-		meta.Packages = map[string]*metadata.Package{
-			"net/http": {Files: map[string]*metadata.File{
-				"h.go": {Variables: map[string]*metadata.Variable{
-					"MethodPut": {Tok: pool.Get("const"), Value: pool.Get(`"PUT"`)},
-				}},
-			}},
+	cases := []struct {
+		name, want string
+		matched    bool
+	}{
+		// Leading word wins (UsePrefix).
+		{"deleteWidget", "DELETE", true},
+		{"updateWidget", "PUT", true},
+		// Non-leading whole word still matches (UseContains).
+		{"handleWidgetDelete", "DELETE", true},
+		// No whole word maps: the DefaultMethod is a fallback, not evidence, so
+		// the route stays open to r.Method dispatch splitting.
+		{"widget", "GET", false},
+		{"budgetReport", "GET", false},
+	}
+	for _, tc := range cases {
+		got, matched := b.methodFromFunctionName(tc.name, cfg)
+		if got != tc.want || matched != tc.matched {
+			t.Errorf("methodFromFunctionName(%q) = (%q,%v), want (%q,%v)",
+				tc.name, got, matched, tc.want, tc.matched)
 		}
-		cp := NewContextProvider(meta)
-		m := NewRoutePatternMatcher(RoutePattern{MethodExtraction: DefaultMethodExtractionConfig()}, cfg, cp)
-
-		methodArg := sweepIdent(meta, "MethodPut")
-		methodArg.SetPkg("net/http")
-		methodArg.SetValue("http.MethodPut")
-		siblingEdge := sweepEdge(meta, "main", "app", "Methods", "mux", "", "", methodArg)
-
-		parent := &TrackerNode{}
-		self := &TrackerNode{Parent: parent}
-		sibling := &TrackerNode{CallGraphEdge: siblingEdge, Parent: parent}
-		parent.Children = []*TrackerNode{self, sibling}
-
-		edge := sweepEdge(meta, "main", "app", "HandleFunc", "mux", "", "")
-		if got := m.inferMethodFromContext(self, edge); got != "PUT" {
-			t.Errorf("inferMethodFromContext() = %q, want PUT", got)
-		}
-	})
-
-	t.Run("caller name yields the method", func(t *testing.T) {
-		meta := exSweepMeta()
-		cp := NewContextProvider(meta)
-		m := NewRoutePatternMatcher(RoutePattern{MethodExtraction: DefaultMethodExtractionConfig()}, cfg, cp)
-		// "deleteWidget" pins the word-boundary fix: the old substring
-		// matcher spotted "get" inside "widget" and returned GET.
-		edge := sweepEdge(meta, "deleteWidget", "app", "HandleFunc", "mux", "", "")
-		if got := m.inferMethodFromContext(&TrackerNode{}, edge); got != "DELETE" {
-			t.Errorf("inferMethodFromContext() = %q, want DELETE", got)
-		}
-	})
-
-	t.Run("handler argument yields the method when caller maps to POST", func(t *testing.T) {
-		meta := exSweepMeta()
-		cp := NewContextProvider(meta)
-		m := NewRoutePatternMatcher(RoutePattern{MethodExtraction: DefaultMethodExtractionConfig()}, cfg, cp)
-		// "updateWidget" pins the word-boundary fix on the handler-arg path:
-		// the old substring matcher resolved "widget" to GET before the
-		// "update" prefix could map to PUT.
-		edge := sweepEdge(meta, "createThing", "app", "HandleFunc", "mux", "", "",
-			sweepLit(meta, `"/x"`), sweepIdent(meta, "updateWidget"))
-		if got := m.inferMethodFromContext(&TrackerNode{}, edge); got != "PUT" {
-			t.Errorf("inferMethodFromContext() = %q, want PUT from handler arg", got)
-		}
-	})
+	}
 }
 
 func TestSweepMountMatcherMatchNode(t *testing.T) {

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -588,13 +588,6 @@ func (r *RoutePatternMatcherImpl) extractRouteDetails(node TrackerNodeInterface,
 				}
 			}
 		}
-
-		// If we still don't have a method, try to infer from context (if enabled)
-		if routeInfo.Method == "" && r.pattern.MethodExtraction != nil && r.pattern.MethodExtraction.InferFromContext {
-			routeInfo.Method = r.inferMethodFromContext(node, edge)
-			routeInfo.MethodExplicit = true
-			found = true
-		}
 	}
 
 	if r.pattern.PathFromArg && len(edge.Args) > r.pattern.PathArgIndex {
@@ -650,69 +643,6 @@ func (r *RoutePatternMatcherImpl) isValidHTTPMethod(method string) bool {
 		}
 	}
 	return false
-}
-
-// inferMethodFromContext attempts to infer HTTP method from context
-func (r *RoutePatternMatcherImpl) inferMethodFromContext(node TrackerNodeInterface, edge *metadata.CallGraphEdge) string {
-	// Check if context inference is enabled
-	if r.pattern.MethodExtraction == nil || !r.pattern.MethodExtraction.InferFromContext {
-		return ""
-	}
-
-	// Try to find method from chained calls (like Mux .Methods("GET"))
-	if node != nil {
-		// Look for parent or sibling nodes that might contain method info
-		parent := node.GetParent()
-		if parent != nil {
-			// Check if parent has method information
-			for _, child := range parent.GetChildren() {
-				if child != node && child.GetEdge() != nil {
-					childEdge := child.GetEdge()
-					callName := r.contextProvider.GetString(childEdge.Callee.Name)
-
-					// Look for Methods call
-					if callName == "Methods" && len(childEdge.Args) > 0 {
-						methodArg := childEdge.Args[0]
-						methodValue := strings.Trim(methodArg.GetValue(), "\"'")
-						if r.isValidHTTPMethod(methodValue) {
-							return strings.ToUpper(methodValue)
-						}
-
-						// Try argument info as well
-						argInfo := r.contextProvider.GetArgumentInfo(methodArg)
-						cleanArgInfo := strings.Trim(argInfo, "\"'")
-						if r.isValidHTTPMethod(cleanArgInfo) {
-							return strings.ToUpper(cleanArgInfo)
-						}
-					}
-				}
-			}
-		}
-	}
-
-	// Try to infer from handler function name using pattern's method extraction config
-	handlerName := r.contextProvider.GetString(edge.Caller.Name)
-	if handlerName != "" {
-		method := r.extractMethodFromFunctionNameWithConfig(handlerName, r.pattern.MethodExtraction)
-		if method != "" && method != "POST" { // Don't use POST as default
-			return method
-		}
-	}
-
-	// Also try the handler from the arguments if available
-	if len(edge.Args) > 1 {
-		handlerArg := edge.Args[1] // Typically the handler is the second argument
-		argInfo := r.contextProvider.GetArgumentInfo(handlerArg)
-		if argInfo != "" {
-			method := r.extractMethodFromFunctionNameWithConfig(argInfo, r.pattern.MethodExtraction)
-			if method != "" && method != "POST" {
-				return method
-			}
-		}
-	}
-
-	// Default fallback
-	return "GET"
 }
 
 // MountPatternMatcherImpl implements MountPatternMatcher

--- a/internal/spec/pipeline_helpers_test.go
+++ b/internal/spec/pipeline_helpers_test.go
@@ -228,65 +228,6 @@ func TestIsValidHTTPMethodAndGetPattern(t *testing.T) {
 	}
 }
 
-// buildMethodsSibling builds a parent node with a route node and a sibling
-// `.Methods(<value>)` call node, the tree shape mux chained registration
-// produces, so inferMethodFromContext's sibling scan can be exercised.
-func buildMethodsSibling(meta *metadata.Metadata, methodValue string) (routeNode TrackerNodeInterface) {
-	sp := meta.StringPool
-
-	methodArg := metadata.NewCallArgument(meta)
-	methodArg.SetKind(metadata.KindLiteral)
-	methodArg.SetValue(methodValue)
-
-	methodsEdge := &metadata.CallGraphEdge{
-		Caller: metadata.Call{Meta: meta, Name: sp.Get("main"), Pkg: sp.Get("main")},
-		Callee: metadata.Call{Meta: meta, Name: sp.Get("Methods"), Pkg: sp.Get("mux")},
-		Args:   []*metadata.CallArgument{methodArg},
-	}
-
-	parent := &TrackerNode{key: "parent"}
-	route := &TrackerNode{key: "route"}
-	methods := &TrackerNode{key: "methods", CallGraphEdge: methodsEdge}
-	parent.Children = []*TrackerNode{route, methods}
-	route.Parent = parent
-	methods.Parent = parent
-	return route
-}
-
-func TestInferMethodFromContext_Siblings(t *testing.T) {
-	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
-	cp := NewContextProvider(meta)
-	cfg := &APISpecConfig{}
-	sp := meta.StringPool
-
-	routeEdge := &metadata.CallGraphEdge{
-		Caller: metadata.Call{Meta: meta, Name: sp.Get("main"), Pkg: sp.Get("main")},
-		Callee: metadata.Call{Meta: meta, Name: sp.Get("HandleFunc"), Pkg: sp.Get("mux")},
-	}
-
-	disabled := NewRoutePatternMatcher(RoutePattern{CallRegex: "HandleFunc"}, cfg, cp)
-	if got := disabled.inferMethodFromContext(buildMethodsSibling(meta, `"GET"`), routeEdge); got != "" {
-		t.Errorf("disabled inference = %q, want empty", got)
-	}
-
-	enabled := NewRoutePatternMatcher(RoutePattern{
-		CallRegex:        "HandleFunc",
-		MethodExtraction: &MethodExtractionConfig{InferFromContext: true},
-	}, cfg, cp)
-
-	if got := enabled.inferMethodFromContext(buildMethodsSibling(meta, `"delete"`), routeEdge); got != "DELETE" {
-		t.Errorf("sibling Methods(delete) = %q, want DELETE", got)
-	}
-	// An invalid sibling method falls through the scan to the GET default.
-	if got := enabled.inferMethodFromContext(buildMethodsSibling(meta, `"NOTAMETHOD"`), routeEdge); got != "GET" {
-		t.Errorf("invalid sibling method = %q, want GET default", got)
-	}
-	// No parent at all: straight to the fallback chain.
-	if got := enabled.inferMethodFromContext(&TrackerNode{key: "orphan"}, routeEdge); got != "GET" {
-		t.Errorf("orphan node = %q, want GET default", got)
-	}
-}
-
 // TestFindTargetNodeAndRouterAssignment covers the mount router-assignment
 // path: BFS lookup of the assignment's node, then traversal of its children.
 func TestFindTargetNodeAndRouterAssignment(t *testing.T) {


### PR DESCRIPTION
Fixes #281.

`inferMethodFromContext` was the one place in the extractor that hardcoded a specific framework's API into framework-agnostic code — and it could not run.

### The four defects

```go
// pattern_matchers.go — gorilla/mux's .Methods() by name, in the shared route matcher
if callName == "Methods" && len(childEdge.Args) > 0 { ... }
// magic index instead of r.pattern.HandlerArgIndex
handlerArg := edge.Args[1] // Typically the handler is the second argument
// a verb value standing in for "no evidence"
if method != "" && method != "POST" { ... }
// a guess returned as an answer
return "GET"
```

…and the caller stamped `MethodExplicit = true` on that guess — the flag that suppresses `switch r.Method` dispatch splitting.

### Why it was unreachable

The call sits behind `routeInfo.Method == ""`. `ExtractRoute` — the only entry point — seeds `Method: http.MethodPost` **before** calling `extractRouteDetails`, on both construction paths (a fresh `NewRouteInfo`, or an outer route completed by a child registration). `RouteInfo.Method` is never assigned back to `""` anywhere in the package. So the guard cannot be true in production.

Confirmed empirically before deleting — instrumenting both branches:

```
### testdata/mux              23 × outer branch entered,  0 × inference called
### testdata/mux_path_params  12 × outer branch entered,  0 × inference called
### testdata/auth_mux_subrouter 3 × outer branch entered, 0 × inference called
```

The only way to reach it was to call the unexported helper directly with an un-seeded `RouteInfo` — which is what one sweep subtest did (`"unresolvable method infers from context"`), constructing a state the production caller cannot produce.

### Coverage that was worth keeping

Three of the deleted subtests were guarding golden rule #8 — `"get"` must not match inside `"widget"`. That behaviour is real, but it lives in `methodFromFunctionName`, not here. Rather than lose the guard it is re-pointed at `methodFromFunctionName` directly and extended to pin the matched-vs-`DefaultMethod` distinction that keeps a verb-less registration open to dispatch splitting:

```go
{"deleteWidget",       "DELETE", true},
{"updateWidget",       "PUT",    true},
{"handleWidgetDelete", "DELETE", true},
{"widget",             "GET",    false},  // DefaultMethod: fallback, not evidence
{"budgetReport",       "GET",    false},
```

### Also removed

The `InferFromContext` config field and its only setting (`DefaultMethodExtractionConfig`). Config loading is non-strict `yaml.Unmarshal` and the key is undocumented, so a stale `inferFromContext: true` in a user config is ignored rather than an error.

### Verification

Beyond the full suite: both binaries run over **all 76 `testdata/` fixtures produce byte-identical specs**. Library coverage holds at 96.0% (floor 96). Net −230/+32.

If a sibling-call verb source is wanted later, it belongs in `MethodExtractionConfig` as a call regex + arg index so every framework can declare it — with `MethodExplicit` derived from whether a verb was actually read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
