### PR TITLE
fix(spec): bound expansion per route, so finding routes and detailing them stop competing (#264)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ apispec --output openapi.yaml --skip-cgo
 | `--diagram`                 | `-g`      | Write call-graph HTML to this path                     | `""`                            |
 | `--paginated-diagram`       | `-pd`     | Use paginated rendering for the diagram                | `false`                         |
 | `--diagram-page-size`       | `-dps`    | Nodes per page in paginated diagram (50–500)           | `100`                           |
-| `--max-nodes`               | `-mn`     | Max nodes in the call graph                            | `50000`                         |
+| `--max-nodes`               | `-mn`     | Max nodes in the walk that finds route registrations   | `50000`                         |
+| `--max-nodes-per-route`     |           | Max nodes expanded below one route registration (lazy engine) | `1000000`                |
 | `--max-children`            | `-mc`     | Max children per node                                  | `500`                           |
 | `--max-args`                | `-ma`     | Max arguments per function                             | `100`                           |
 | `--max-nested-args`         | `-md`     | Max depth for nested arguments                         | `100`                           |
@@ -652,7 +653,7 @@ APISpec turns Go source into an OpenAPI document through a fixed sequence of sta
 - *Importance:* Nothing downstream touches the raw AST again — metadata is the substrate. String-pooling plus sorted iteration at every boundary make the output **deterministic** (clean release diffs and reliable golden tests), and `--write-metadata` dumps this model so a missed route can be debugged.
 
 **6. Build the tracker tree**
-- *Role:* Starting from each route-registration call site, expand the call graph down to the actual handler and the calls made inside it — through wrappers, groups, mounts, handler factories, and helper functions — bounded by engine-specific limits (see [Performance & Limits](#performance--limits)). The default **lazy** tree expands subtrees on demand and is bounded by `--max-nodes`/`--max-children`/`--max-args`/`--max-instances-per-key`; the eager tree (`--legacy-tracker`) materializes them up front and additionally honors `--max-recursion-depth` and `--max-nested-args`.
+- *Role:* Starting from each route-registration call site, expand the call graph down to the actual handler and the calls made inside it — through wrappers, groups, mounts, handler factories, and helper functions — bounded by engine-specific limits (see [Performance & Limits](#performance--limits)). The default **lazy** tree expands subtrees on demand and is bounded by `--max-nodes` (finding registrations) / `--max-nodes-per-route` (detail below one) / `--max-children`/`--max-args`/`--max-instances-per-key`; the eager tree (`--legacy-tracker`) materializes them up front and additionally honors `--max-recursion-depth` and `--max-nested-args`.
 - *Purpose:* Connect a route to the concrete code that actually serves it, following real control flow rather than assuming the handler lives where the route is declared.
 - *Importance:* In real codebases the handler is rarely at the registration site — it's behind middleware, a group closure, a mounted sub-router, or a factory. This traversal is what makes detection work across those styles. The bounds are the safety brake that turns a pathological (deep or cyclic) call graph into a truncation warning instead of a hang or out-of-memory.
 
@@ -940,16 +941,24 @@ Choose with `--legacy-tracker` on the CLI, or the analysis-engine selector in th
 
 ### Limits
 
-APISpec applies safeguards to prevent runaway analysis. **Not every knob applies to both engines** — the eager engine bounds recursion with explicit depth caps, while the lazy engine replaces those with a cumulative node budget plus an internal per-scope instance cap:
+APISpec applies safeguards to prevent runaway analysis. **Not every knob applies to both engines** — the eager engine bounds recursion with explicit depth caps, while the lazy engine replaces those with node budgets plus an internal per-scope instance cap:
 
 | Parameter            | Default  | CLI flag                | Applies to                                                                 |
 |----------------------|----------|-------------------------|----------------------------------------------------------------------------|
-| Max nodes / tree     | 50,000   | `--max-nodes`           | **both** — eager: nodes per route tree; lazy: cumulative budget of distinct callees materialized across the whole on-demand expansion (then leaf stubs) |
+| Max nodes / tree     | 50,000   | `--max-nodes`           | **both** — eager: nodes per route tree; lazy: distinct callees materialized by the walk that *finds* route registrations |
+| Max nodes / route    | 1,000,000 | `--max-nodes-per-route` | **lazy only** — nodes expanded *below* one registration                   |
 | Max children / node  | 500      | `--max-children`        | both                                                                       |
 | Max args / function  | 100      | `--max-args`            | both                                                                       |
 | Max nested arg depth | 100      | `--max-nested-args`     | **eager only**                                                             |
 | Max recursion depth  | 10       | `--max-recursion-depth` | **eager only**                                                             |
 | Max instances / key  | 25       | `--max-instances-per-key` | **lazy only**                                                            |
+
+The lazy engine's node budget is **two budgets, and they are independent**. That split is what keeps truncation local (issue #264). With one global budget the walk is depth-first, so whatever expands first spends it and every route not yet *reached* is lost outright — on a ~900-route project the allowance was gone inside configuration and logging packages, and the run documented **12 paths**. Bounding a route's detail separately, and charging its keys only to its own allowance, took the same project to **640**.
+
+So the two flags fail in different ways, and the warnings say which happened:
+
+- `--max-nodes` spent → routes are **missing**. Raise it.
+- `--max-nodes-per-route` spent → a named route is **less detailed** (a schema or body may be absent), and no other route is affected. Raise it, or ignore it for endpoints you don't need in full.
 
 Instead of the recursion-depth / nested-args caps, the lazy engine bounds copies of one callee **within an instance scope**: it keeps a copy of a shared helper per route so per-route value tracing stays accurate, but cuts the combinatorial copies a call diamond inside a single handler would otherwise create — the role the eager tree's per-ID recursion cap plays.
 

--- a/cmd/apispec/main.go
+++ b/cmd/apispec/main.go
@@ -290,7 +290,7 @@ func parseFlags(args []string) (*CLIConfig, error) {
 	fs.IntVar(&config.MaxInstancesPerKey, "max-instances-per-key", engine.DefaultMaxInstancesPerKey,
 		"Maximum copies of one callee within an instance scope (raise it when a group closure holds more routes than the default budget covers)")
 	fs.IntVar(&config.MaxNodesPerRoute, "max-nodes-per-route", engine.DefaultMaxNodesPerRoute,
-		"Maximum tree nodes expanded below one route registration (bounds a route's detail without starving the others)")
+		"Maximum tree nodes expanded below one route registration, bounding a route's detail without starving the others (lazy tracker only; ignored with --legacy-tracker)")
 
 	fs.BoolVar(&config.LegacyTracker, "legacy-tracker", false, "Use the legacy (eager) tracker tree instead of the default lazy tracker")
 

--- a/cmd/apispec/main.go
+++ b/cmd/apispec/main.go
@@ -155,6 +155,7 @@ type CLIConfig struct {
 	MaxNestedArgsDepth           int
 	MaxRecursionDepth            int
 	MaxInstancesPerKey           int
+	MaxNodesPerRoute             int
 	LegacyTracker                bool
 	ShowVersion                  bool
 	OutputFlagSet                bool
@@ -287,6 +288,8 @@ func parseFlags(args []string) (*CLIConfig, error) {
 	fs.IntVar(&config.MaxRecursionDepth, "mrd", engine.DefaultMaxRecursionDepth, "Shorthand for --max-recursion-depth")
 	fs.IntVar(&config.MaxInstancesPerKey, "max-instances-per-key", engine.DefaultMaxInstancesPerKey,
 		"Maximum copies of one callee within an instance scope (raise it when a group closure holds more routes than the default budget covers)")
+	fs.IntVar(&config.MaxNodesPerRoute, "max-nodes-per-route", engine.DefaultMaxNodesPerRoute,
+		"Maximum tree nodes expanded below one route registration (bounds a route's detail without starving the others)")
 
 	fs.BoolVar(&config.LegacyTracker, "legacy-tracker", false, "Use the legacy (eager) tracker tree instead of the default lazy tracker")
 
@@ -390,6 +393,7 @@ func runGeneration(config *CLIConfig) (*spec.OpenAPISpec, *engine.Engine, error)
 		MaxNestedArgsDepth:           config.MaxNestedArgsDepth,
 		MaxRecursionDepth:            config.MaxRecursionDepth,
 		MaxInstancesPerKey:           config.MaxInstancesPerKey,
+		MaxNodesPerRoute:             config.MaxNodesPerRoute,
 		UseLazyTracker:               !config.LegacyTracker,
 		IncludeFiles:                 config.IncludeFiles,
 		IncludePackages:              config.IncludePackages,

--- a/cmd/apispec/main.go
+++ b/cmd/apispec/main.go
@@ -272,7 +272,8 @@ func parseFlags(args []string) (*CLIConfig, error) {
 	fs.IntVar(&config.DiagramPageSize, "diagram-page-size", 100, "Number of nodes per page in paginated diagram (50-500)")
 	fs.IntVar(&config.DiagramPageSize, "dps", 100, "Shorthand for --diagram-page-size")
 
-	fs.IntVar(&config.MaxNodesPerTree, "max-nodes", engine.DefaultMaxNodesPerTree, "Maximum nodes per tracker tree")
+	fs.IntVar(&config.MaxNodesPerTree, "max-nodes", engine.DefaultMaxNodesPerTree,
+		"Maximum nodes in the walk that finds route registrations (eager tracker: nodes per tree). Spending it costs whole routes; see --max-nodes-per-route for a route's detail")
 	fs.IntVar(&config.MaxNodesPerTree, "mn", engine.DefaultMaxNodesPerTree, "Shorthand for --max-nodes")
 
 	fs.IntVar(&config.MaxChildrenPerNode, "max-children", engine.DefaultMaxChildrenPerNode, "Maximum children per node")

--- a/cmd/apispecui/main.go
+++ b/cmd/apispecui/main.go
@@ -1607,7 +1607,7 @@ func analysisInfo(primary string, detected []string, lazy bool, ep spec.Entrypoi
 	// Either shortfall is worth reporting, and they are independent: the
 	// instance cap can starve response bodies on a run whose node budget was
 	// never reached (issue #224).
-	if expansion.Truncated || expansion.InstanceTruncations > 0 {
+	if expansion.Truncated || expansion.InstanceTruncations > 0 || expansion.RouteTruncations > 0 {
 		info.Expansion = &insight.ExpansionInfo{
 			NodesBuilt:          expansion.NodesBuilt,
 			NodesMaterialized:   expansion.NodesMaterialized,
@@ -1617,6 +1617,10 @@ func analysisInfo(primary string, detected []string, lazy bool, ep spec.Entrypoi
 			InstanceLimit:       expansion.InstanceLimit,
 			InstanceFirstScope:  expansion.InstanceFirstScope,
 			InstanceFirstKey:    expansion.InstanceFirstKey,
+			RouteTruncations:    expansion.RouteTruncations,
+			RouteLimit:          expansion.RouteLimit,
+			RouteFirstTruncated: expansion.RouteFirstTruncated,
+			RoutesScoped:        expansion.RoutesScoped,
 		}
 	}
 	if lazy {

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -31,8 +31,11 @@ Every run prints per-stage progress:
   wasn't loaded (separate module, build tags, cgo). See `--skip-cgo`,
   `--include-package`, and make sure you point `--dir` at the module root.
 - **Fewer paths than expected?** Continue below.
-- A stderr warning like `MaxNodesPerTree limit (50000) reached, truncating
-  lazy expansion` means case 4: raise `--max-nodes`.
+- A stderr warning like `MaxNodesPerTree limit (50000) reached, truncating the
+  walk that finds routes` means case 4: raise `--max-nodes`. The sibling warning
+  `MaxNodesPerRoute limit (…) reached` is a different symptom — the routes are
+  all there, but the named one is documented in less detail; raise
+  `--max-nodes-per-route`.
 
 ## Step 1 — check which config actually ran
 
@@ -115,7 +118,8 @@ issues, and a Markdown export you can attach to a bug report as-is.
 | Framework router mounted under a `net/http` mux: routes present but missing the mount prefix (`/users` instead of `/api/users`) | cross-framework mount composition not implemented yet | tracked in [#138](https://github.com/ehabterra/apispec/issues/138); until then apply the prefix via a config override or mount inside one framework |
 | Routes behind `for … range routeTable` missing | runtime values, statically unknowable | register statically, or accept the gap |
 | Verb-less registrations show POST | historic default for unknown method | handlers that `switch r.Method` split automatically; otherwise the default applies |
-| Deep/dense project: some routes missing + truncation warning | node budget hit | raise `--max-nodes` |
+| Deep/dense project: some routes missing + truncation warning | the budget for the walk that *finds* registrations is spent | raise `--max-nodes` |
+| Named route present but under-detailed + `MaxNodesPerRoute` warning | that one route's own allowance is spent; no other route is affected | raise `--max-nodes-per-route` |
 | Route present, body/params empty | handler not located / binding style unrecognised | insight report (Step 4), check `handlerFound` |
 | Path shows `{someFunc}` placeholder | path built by a function call | statically unknowable; name comes from the called function |
 

--- a/generator/testdata_group_closure_instances_test.go
+++ b/generator/testdata_group_closure_instances_test.go
@@ -158,9 +158,11 @@ func TestGroupClosurePerRouteBudgetIsScopedPerRoute(t *testing.T) {
 		routes  = 15
 	)
 
-	// 5 is far below one route's needs (every subtree truncates); 20000 is the
-	// shipped default and truncates nothing. The assertions hold at both ends.
-	for _, budget := range []int{5, 50, 500, 20000} {
+	// 5 is far below one route's needs, so every subtree truncates; the shipped
+	// default is read from the constant rather than written out, so raising or
+	// lowering it re-runs this sweep at the value that actually ships. The
+	// assertions hold at both ends.
+	for _, budget := range []int{5, 50, 500, intspec.DefaultMaxNodesPerRoute} {
 		t.Run(fmt.Sprintf("budget=%d", budget), func(t *testing.T) {
 			cfg := engine.DefaultEngineConfig()
 			cfg.InputDir = filepath.Join("..", "testdata", fixture)
@@ -193,10 +195,10 @@ func TestGroupClosurePerRouteBudgetIsScopedPerRoute(t *testing.T) {
 			if budget == 5 && stats.RouteTruncations == 0 {
 				t.Error("a budget of 5 truncated nothing; the fixture is not exercising the per-route limit")
 			}
-			if budget == 20000 && stats.RouteTruncations != 0 {
-				t.Errorf("the shipped default truncated %d of this fixture's route subtrees — "+
+			if budget == intspec.DefaultMaxNodesPerRoute && stats.RouteTruncations != 0 {
+				t.Errorf("the shipped default (%d) truncated %d of this fixture's route subtrees — "+
 					"a default that starves a 15-route fixture starves every real project",
-					stats.RouteTruncations)
+					budget, stats.RouteTruncations)
 			}
 		})
 	}

--- a/generator/testdata_group_closure_instances_test.go
+++ b/generator/testdata_group_closure_instances_test.go
@@ -129,6 +129,79 @@ func TestGroupClosureInstanceCapIsReported(t *testing.T) {
 	}
 }
 
+// TestGroupClosurePerRouteBudgetIsScopedPerRoute pins WHAT OPENS A PER-ROUTE
+// BUDGET SCOPE, which is the question issue #264 turns on — the same question
+// as #224 above, one limit further down.
+//
+// The reach predicate that answers "does this subtree lead to a route?" has to
+// say yes for `r.Route("/api", …)`, or the entire group is written off. Using
+// that same predicate to open a BUDGET scope makes the group the scope, so
+// every route inside shares one allowance and the routes past the first few are
+// never discovered. That took a real 246-route chi service to 32 paths, which is
+// why the two questions now have two predicates: RouteRegistrationMatcher for
+// reachability, TerminalRouteMatcher for scoping.
+//
+// This fixture is the shape that separates them: 15 routes in ONE group
+// closure. The budget is driven far below what a single route needs — at 5 all
+// 15 subtrees truncate — and the assertions are the two facts a per-route
+// budget must have:
+//
+//   - every route is still DISCOVERED. Truncation costs a route its detail; it
+//     must never cost a sibling its existence. A group-scoped budget fails here
+//     immediately, since one exhausted allowance would swallow the rest.
+//   - the run reports 15 scopes, not 1. The path count alone cannot tell a
+//     correctly-scoped budget from one that was simply never reached, so the
+//     scope count is asserted directly.
+func TestGroupClosurePerRouteBudgetIsScopedPerRoute(t *testing.T) {
+	const (
+		fixture = "group_closure_instances"
+		routes  = 15
+	)
+
+	// 5 is far below one route's needs (every subtree truncates); 20000 is the
+	// shipped default and truncates nothing. The assertions hold at both ends.
+	for _, budget := range []int{5, 50, 500, 20000} {
+		t.Run(fmt.Sprintf("budget=%d", budget), func(t *testing.T) {
+			cfg := engine.DefaultEngineConfig()
+			cfg.InputDir = filepath.Join("..", "testdata", fixture)
+			cfg.MaxNodesPerRoute = budget
+
+			eng := engine.NewEngine(cfg)
+			out, err := eng.GenerateOpenAPI()
+			if err != nil {
+				t.Fatalf("GenerateOpenAPI: %v", err)
+			}
+
+			if got := len(out.Paths); got != routes {
+				t.Errorf("documented %d paths at --max-nodes-per-route %d, want all %d — "+
+					"a per-route budget bounds a route's DETAIL; if routes disappear it is being "+
+					"charged to a scope that spans them (the group closure, #264)",
+					got, budget, routes)
+			}
+
+			stats := eng.GetExpansionStats()
+			if stats.RoutesScoped != routes {
+				t.Errorf("%d budget scopes for %d routes — one scope per terminal route is the "+
+					"whole point; %d would mean the group opened it",
+					stats.RoutesScoped, routes, 1)
+			}
+			if stats.RouteLimit != budget {
+				t.Errorf("reported per-route limit %d, want the configured %d", stats.RouteLimit, budget)
+			}
+			// The harshest setting must actually exercise the limit, or the
+			// assertions above prove nothing about truncation.
+			if budget == 5 && stats.RouteTruncations == 0 {
+				t.Error("a budget of 5 truncated nothing; the fixture is not exercising the per-route limit")
+			}
+			if budget == 20000 && stats.RouteTruncations != 0 {
+				t.Errorf("the shipped default truncated %d of this fixture's route subtrees — "+
+					"a default that starves a 15-route fixture starves every real project",
+					stats.RouteTruncations)
+			}
+		})
+	}
+}
+
 // namesAComponent reports whether a response body resolves to a component,
 // directly or as an array's element type.
 func namesAComponent(content map[string]intspec.MediaType) bool {

--- a/generator/testdata_shared_body_helper_test.go
+++ b/generator/testdata_shared_body_helper_test.go
@@ -67,21 +67,34 @@ func TestTestdata_SharedBodyHelper(t *testing.T) {
 		want["/api/"+name] = strings.ToUpper(name[:1]) + name[1:] + "Request"
 	}
 
-	// Each pair starves resolution differently: the instance cap bounds copies
+	// Each triple starves resolution differently: the instance cap bounds copies
 	// of the shared helper, the node budget cuts expansion short. Both are ways
 	// a route can lose its own binding, which is when substitution was observed.
+	//
+	// perRoute sweeps the OTHER direction, and it is the reason this fixture is
+	// swept at all. #269 was found by expanding MORE, not less: #264's per-route
+	// budget stopped the global limit applying below a registration, route
+	// subtrees went deeper than any shipped version had reached, and four
+	// endpoints flipped to a sibling's DTO. Depth is a starvation setting in
+	// reverse — more of it gives a wrong candidate more chances to win — so the
+	// same assertion has to hold with the budget raised far past the default.
 	for _, tc := range []struct {
 		instanceCap int
 		maxNodes    int
+		perRoute    int
 	}{
-		{0, 0},     // defaults
-		{1, 0},     // harshest cap: one copy of the shared helper
-		{5, 0},     // fewer copies than routes
-		{0, 20000}, // budget above what the fixture needs
-		{0, 400},   // budget that truncates most routes
-		{0, 150},   // budget that truncates nearly everything
+		{0, 0, 0},         // defaults
+		{1, 0, 0},         // harshest cap: one copy of the shared helper
+		{5, 0, 0},         // fewer copies than routes
+		{0, 20000, 0},     // budget above what the fixture needs
+		{0, 400, 0},       // budget that truncates most routes
+		{0, 150, 0},       // budget that truncates nearly everything
+		{0, 0, 10},        // per-route budget that truncates every route
+		{0, 0, 2000000},   // per-route budget far past the default: expand everything
+		{1, 0, 2000000},   // deepest expansion with the copies capped to one
+		{0, 150, 2000000}, // wiring truncated, route subtrees unbounded
 	} {
-		t.Run(fmt.Sprintf("cap=%d/nodes=%d", tc.instanceCap, tc.maxNodes), func(t *testing.T) {
+		t.Run(fmt.Sprintf("cap=%d/nodes=%d/perRoute=%d", tc.instanceCap, tc.maxNodes, tc.perRoute), func(t *testing.T) {
 			cfg := engine.DefaultEngineConfig()
 			cfg.InputDir = filepath.Join("..", "testdata", fixture)
 			if tc.instanceCap > 0 {
@@ -89,6 +102,9 @@ func TestTestdata_SharedBodyHelper(t *testing.T) {
 			}
 			if tc.maxNodes > 0 {
 				cfg.MaxNodesPerTree = tc.maxNodes
+			}
+			if tc.perRoute > 0 {
+				cfg.MaxNodesPerRoute = tc.perRoute
 			}
 
 			out, err := engine.NewEngine(cfg).GenerateOpenAPI()

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -795,7 +795,8 @@ func (e *Engine) GenerateOpenAPI() (*spec.OpenAPISpec, error) {
 		tree = intspec.NewLazyTree(meta, limits,
 			intspec.WithHandlerInterfaceMethods(apispecConfig.Framework.HandlerInterfaceMethods),
 			intspec.WithEntrypoints(apispecConfig.Framework.EntrypointPatterns,
-				intspec.RouteRegistrationMatcher(apispecConfig, meta), NewVerboseLogger(e.config.Verbose)))
+				intspec.RouteRegistrationMatcher(apispecConfig, meta), NewVerboseLogger(e.config.Verbose)),
+			intspec.WithTerminalRouteMatcher(intspec.TerminalRouteMatcher(apispecConfig, meta)))
 		e.reportPhase("tracker tree ready (lazy)", time.Since(tTree))
 	} else {
 		tree = intspec.NewTrackerTree(meta, limits, NewVerboseLogger(e.config.Verbose),

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -98,10 +98,12 @@ const (
 	// DefaultMaxInstancesPerKey mirrors the lazy tree's own default, so the
 	// engine reports one number rather than two that can drift.
 	DefaultMaxInstancesPerKey = intspec.DefaultMaxInstancesPerKey
-	DefaultMetadataFile       = "metadata.yaml"
-	CopyrightNotice           = "apispec - Copyright 2026 Ehab Terra"
-	LicenseNotice             = "Licensed under the Apache License 2.0. See LICENSE and NOTICE."
-	FullLicenseNotice         = "\n\nCopyright 2026 Ehab Terra. Licensed under the Apache License 2.0. See LICENSE and NOTICE."
+	// DefaultMaxNodesPerRoute mirrors the lazy tree's own default.
+	DefaultMaxNodesPerRoute = intspec.DefaultMaxNodesPerRoute
+	DefaultMetadataFile     = "metadata.yaml"
+	CopyrightNotice         = "apispec - Copyright 2026 Ehab Terra"
+	LicenseNotice           = "Licensed under the Apache License 2.0. See LICENSE and NOTICE."
+	FullLicenseNotice       = "\n\nCopyright 2026 Ehab Terra. Licensed under the Apache License 2.0. See LICENSE and NOTICE."
 )
 
 // EngineConfig holds configuration for the OpenAPI generation engine
@@ -134,6 +136,10 @@ type EngineConfig struct {
 	// MaxInstancesPerKey bounds copies of one callee within an instance scope.
 	// Zero uses DefaultMaxInstancesPerKey.
 	MaxInstancesPerKey int
+	// MaxNodesPerRoute bounds the nodes expanded below ONE route registration,
+	// so a deep handler cannot consume the allowance the undiscovered routes
+	// still need. Zero uses DefaultMaxNodesPerRoute.
+	MaxNodesPerRoute int
 
 	// Include/exclude filters
 	IncludeFiles                 []string
@@ -778,6 +784,7 @@ func (e *Engine) GenerateOpenAPI() (*spec.OpenAPISpec, error) {
 		MaxNestedArgsDepth: e.config.MaxNestedArgsDepth,
 		MaxRecursionDepth:  e.config.MaxRecursionDepth,
 		MaxInstancesPerKey: e.config.MaxInstancesPerKey,
+		MaxNodesPerRoute:   e.config.MaxNodesPerRoute,
 	}
 	if err := e.ctx().Err(); err != nil {
 		return nil, err
@@ -826,6 +833,12 @@ func (e *Engine) GenerateOpenAPI() (*spec.OpenAPISpec, error) {
 			// Louder than the tree's own stderr line: a truncated expansion means
 			// the spec is incomplete, which is a result, not a debug detail.
 			e.reportPhase(fmt.Sprintf("expansion truncated at the %d-node limit — the spec is incomplete", e.expansionStats.Limit), 0)
+		}
+		if n := e.expansionStats.RouteTruncations; n > 0 {
+			// Local, unlike the whole-walk truncation above: these routes are
+			// documented in less detail and no other route is affected (#264).
+			e.reportPhase(fmt.Sprintf("per-route limit (%d) truncated %d of %d route subtrees — those routes are less detailed (first at %s)",
+				e.expansionStats.RouteLimit, n, e.expansionStats.RoutesScoped, e.expansionStats.RouteFirstTruncated), 0)
 		}
 		if n := e.expansionStats.InstanceTruncations; n > 0 {
 			// The other, quieter shortfall, reported separately because it is a

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -138,7 +138,9 @@ type EngineConfig struct {
 	MaxInstancesPerKey int
 	// MaxNodesPerRoute bounds the nodes expanded below ONE route registration,
 	// so a deep handler cannot consume the allowance the undiscovered routes
-	// still need. Zero uses DefaultMaxNodesPerRoute.
+	// still need. Zero uses DefaultMaxNodesPerRoute. Lazy tracker only: the
+	// eager tree bounds a route with MaxRecursionDepth instead and never reads
+	// this.
 	MaxNodesPerRoute int
 
 	// Include/exclude filters

--- a/internal/insight/overview.go
+++ b/internal/insight/overview.go
@@ -152,6 +152,15 @@ type ExpansionInfo struct {
 	InstanceLimit       int    `json:"instanceLimit,omitempty"`
 	InstanceFirstScope  string `json:"instanceFirstScope,omitempty"`
 	InstanceFirstKey    string `json:"instanceFirstKey,omitempty"`
+
+	// RouteTruncations is the LOCAL shortfall: route subtrees cut short by their
+	// own allowance. Unlike Truncated, it costs those routes some detail and
+	// leaves every other route intact, so it is a much milder statement about
+	// the spec (issue #264). RoutesScoped gives it a denominator.
+	RouteTruncations    int    `json:"routeTruncations,omitempty"`
+	RouteLimit          int    `json:"routeLimit,omitempty"`
+	RouteFirstTruncated string `json:"routeFirstTruncated,omitempty"`
+	RoutesScoped        int    `json:"routesScoped,omitempty"`
 }
 
 // AnalysisInfo describes HOW the spec was produced rather than what is in it.

--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -1323,6 +1323,18 @@ type TrackerLimits struct {
 	// see the lazy tree's DefaultMaxInstancesPerKey for what the number trades
 	// off. Zero means that default.
 	MaxInstancesPerKey int
+
+	// MaxNodesPerRoute bounds the nodes materialised BELOW one route
+	// registration, so a single deep handler cannot consume the allowance the
+	// rest of the routes still need. MaxNodesPerTree then bounds only the
+	// wiring walk that finds registrations in the first place.
+	//
+	// The split is the point (issue #264): with one global budget spent
+	// depth-first, truncation is total — the routes not yet discovered are lost
+	// outright. Per route it is local: a handler too deep to document fully
+	// costs its own detail and nothing else's. Zero means
+	// DefaultMaxNodesPerRoute.
+	MaxNodesPerRoute int
 }
 
 // ProcessFunctionReturnTypes processes all functions and methods in the metadata

--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -1334,6 +1334,10 @@ type TrackerLimits struct {
 	// outright. Per route it is local: a handler too deep to document fully
 	// costs its own detail and nothing else's. Zero means
 	// DefaultMaxNodesPerRoute.
+	//
+	// Read by the lazy tree only. The eager tree has no notion of a route scope
+	// and bounds a route with MaxRecursionDepth, so setting this changes nothing
+	// under --legacy-tracker.
 	MaxNodesPerRoute int
 }
 

--- a/internal/spec/entrypoint_roots.go
+++ b/internal/spec/entrypoint_roots.go
@@ -257,4 +257,15 @@ type ExpansionStats struct {
 	InstanceLimit       int
 	InstanceFirstScope  string
 	InstanceFirstKey    string
+
+	// RouteTruncations counts route subtrees cut short by their OWN budget, and
+	// RouteFirstTruncated names the first. This shortfall is local: the route is
+	// documented in less detail and no other route is affected, which is the
+	// whole point of splitting the budget (issue #264). RoutesScoped is how many
+	// registrations got their own allowance, so the two numbers can be read
+	// against each other.
+	RouteTruncations    int
+	RouteLimit          int
+	RouteFirstTruncated string
+	RoutesScoped        int
 }

--- a/internal/spec/entrypoint_roots.go
+++ b/internal/spec/entrypoint_roots.go
@@ -166,6 +166,29 @@ func reachesMatch(meta *metadata.Metadata, match func(*metadata.CallGraphEdge) b
 // pattern's receiver instead. What it will not do is invent a root for a
 // subcommand that calls `cache.Get`.
 func RouteRegistrationMatcher(cfg *APISpecConfig, meta *metadata.Metadata) func(*metadata.CallGraphEdge) bool {
+	// Mounts count too: a subcommand whose only routing act is mounting a
+	// sub-router still leads to routes.
+	return registrationMatcher(cfg, meta, true)
+}
+
+// TerminalRouteMatcher matches only the calls that register ONE route — a verb
+// call — and not the mount or group calls that contain many.
+//
+// The distinction exists because the two questions are different. "Does this
+// subtree lead to a route?" must say yes for `r.Route("/api", …)`, or the whole
+// group is written off. "Is this node the route whose detail I am budgeting?"
+// must say NO for it, or every route inside the group shares one allowance and
+// the ones past it are never discovered.
+//
+// Measured: scoping the per-route budget on the mount-inclusive predicate took a
+// 246-route chi service down to 32 paths, the budget for a whole `Mux.Route`
+// group being spent inside its first few routes. That is the #224 mistake in a
+// new place — a limit applied to a group where it was meant to apply to a route.
+func TerminalRouteMatcher(cfg *APISpecConfig, meta *metadata.Metadata) func(*metadata.CallGraphEdge) bool {
+	return registrationMatcher(cfg, meta, false)
+}
+
+func registrationMatcher(cfg *APISpecConfig, meta *metadata.Metadata, includeMounts bool) func(*metadata.CallGraphEdge) bool {
 	if cfg == nil || meta == nil {
 		return func(*metadata.CallGraphEdge) bool { return false }
 	}
@@ -176,11 +199,11 @@ func RouteRegistrationMatcher(cfg *APISpecConfig, meta *metadata.Metadata) func(
 			gates = append(gates, gate{p.CallRegex, p.RecvTypeRegex, p.RecvType})
 		}
 	}
-	// Mounts count too: a subcommand whose only routing act is mounting a
-	// sub-router still leads to routes.
-	for _, p := range cfg.Framework.MountPatterns {
-		if p.CallRegex != "" {
-			gates = append(gates, gate{p.CallRegex, p.RecvTypeRegex, p.RecvType})
+	if includeMounts {
+		for _, p := range cfg.Framework.MountPatterns {
+			if p.CallRegex != "" {
+				gates = append(gates, gate{p.CallRegex, p.RecvTypeRegex, p.RecvType})
+			}
 		}
 	}
 	if len(gates) == 0 {

--- a/internal/spec/lazytree.go
+++ b/internal/spec/lazytree.go
@@ -153,6 +153,11 @@ type LazyTree struct {
 	// routeMatch gates which entrypoints earn a root: only those whose subtree
 	// can reach a route registration.
 	routeMatch func(*metadata.CallGraphEdge) bool
+	// terminalRouteMatch matches only the calls that register ONE route. It is
+	// what opens a budget scope; routeMatch (which also matches mounts and
+	// groups) must not, or every route inside a group shares one allowance —
+	// see TerminalRouteMatcher.
+	terminalRouteMatch func(*metadata.CallGraphEdge) bool
 	// routeReach is routeMatch's transitive closure — the functions whose
 	// expansion leads to a route registration. Used to ORDER a node's callee
 	// children so the budget is spent on routing code first (issue #264); never
@@ -167,6 +172,10 @@ type LazyTree struct {
 	routeScopeNodes []int
 	// routeScopeKeys names the registration each id stands for, for reporting.
 	routeScopeKeys []string
+	// routeScopeCut marks scopes already counted as truncated, so the report
+	// counts ROUTES rather than blocked expansion attempts — a truncated scope is
+	// re-entered many times as the walk unwinds, which read as "58 of 6".
+	routeScopeCut []bool
 	// routeTruncations counts route subtrees cut short by their own budget, and
 	// routeFirstTruncated names the first. Unlike the whole-walk truncation this
 	// is LOCAL — the rest of the routes are unaffected — so it is reported
@@ -399,7 +408,7 @@ func (t *LazyTree) scopeOf(n *LazyNode) int {
 	if n == nil {
 		return 0
 	}
-	if n.routeScope != 0 || t.routeMatch == nil || n.edge == nil || !t.routeMatch(n.edge) {
+	if n.routeScope != 0 || t.terminalRouteMatch == nil || n.edge == nil || !t.terminalRouteMatch(n.edge) {
 		return n.routeScope
 	}
 	// First registration on this path: open a scope for it.
@@ -432,6 +441,13 @@ func (t *LazyTree) routeBudgetExhausted(scope int) bool {
 // warns once. The route's own key is named: unlike the whole-walk truncation,
 // this says exactly which endpoint is under-documented.
 func (t *LazyTree) noteRouteTruncation(scope int) {
+	for len(t.routeScopeCut) <= scope {
+		t.routeScopeCut = append(t.routeScopeCut, false)
+	}
+	if t.routeScopeCut[scope] {
+		return // already counted: one route, however often its subtree is re-entered
+	}
+	t.routeScopeCut[scope] = true
 	t.routeTruncations++
 	key := ""
 	if scope < len(t.routeScopeKeys) {
@@ -680,6 +696,14 @@ func WithEntrypoints(patterns []EntrypointPattern, routeMatch func(*metadata.Cal
 		t.routeMatch = routeMatch
 		t.logger = logger
 	}
+}
+
+// WithTerminalRouteMatcher supplies the predicate that decides which node opens a
+// per-route budget scope: a single route registration, never a mount or group
+// (issue #264). Without it no scope is opened and expansion is bounded only by
+// MaxNodesPerTree, as it was before.
+func WithTerminalRouteMatcher(match func(*metadata.CallGraphEdge) bool) LazyTreeOption {
+	return func(t *LazyTree) { t.terminalRouteMatch = match }
 }
 
 // addEntrypointRoots appends a root per qualifying entrypoint. Called from

--- a/internal/spec/lazytree.go
+++ b/internal/spec/lazytree.go
@@ -153,6 +153,12 @@ type LazyTree struct {
 	// routeMatch gates which entrypoints earn a root: only those whose subtree
 	// can reach a route registration.
 	routeMatch func(*metadata.CallGraphEdge) bool
+	// routeReach is routeMatch's transitive closure — the functions whose
+	// expansion leads to a route registration. Used to ORDER a node's callee
+	// children so the budget is spent on routing code first (issue #264); never
+	// to drop any. Built once, on first use.
+	routeReach     map[string]bool
+	routeReachOnce bool
 	// logger reports how many entrypoints were rooted vs skipped.
 	logger metadata.VerboseLogger
 
@@ -288,6 +294,62 @@ func scopeLabel(scope string) string {
 		return "<router wiring>"
 	}
 	return scope
+}
+
+// leadsToRoute reports whether expanding a callee key can reach a route
+// registration. Unknown answers "yes": this orders work, and a wrong "no" would
+// push real routing code behind everything else.
+func (t *LazyTree) leadsToRoute(key string) bool {
+	if t.routeMatch == nil {
+		return true
+	}
+	if !t.routeReachOnce {
+		t.routeReachOnce = true
+		t.routeReach = routeReachSet(t.meta, t.routeMatch)
+	}
+	if t.routeReach == nil {
+		return true
+	}
+	return t.routeReach[metadata.StripToBase(key)]
+}
+
+// orderTowardRoutes moves the callee children that lead to a route registration
+// ahead of those that do not, leaving each group's relative order alone.
+//
+// This is the whole of issue #264 at the tree level. The node budget is one
+// allowance for the entire walk, and the extractor's traversal is depth-first:
+// whatever is expanded first spends it. On a ~900-route project that was
+// `modules/setting` and `modules/log`, and the run documented 12 paths before
+// truncating — not because routing code is expensive, but because the budget was
+// gone before the walk reached it.
+//
+// Ordering rather than pruning is the safe half of that fix. Nothing is dropped,
+// so a subtree the reach set misses — and it will miss some, since reachability
+// through data flow is undecidable in general — is merely expanded later. Pruning
+// was tried and reverted: it deleted 124 of 312 operations.
+//
+// ARGUMENT children are deliberately left in place at the front. A route group's
+// closure is an argument, not a callee, and it is the single most route-dense
+// child a node can have; reordering around it could only hurt.
+func (t *LazyTree) orderTowardRoutes(plan []childSpec, from int) {
+	if t.routeMatch == nil || from >= len(plan) {
+		return
+	}
+	seg := plan[from:]
+	leading := make([]childSpec, 0, len(seg))
+	trailing := make([]childSpec, 0, len(seg))
+	for _, spec := range seg {
+		if t.leadsToRoute(spec.key) {
+			leading = append(leading, spec)
+		} else {
+			trailing = append(trailing, spec)
+		}
+	}
+	if len(leading) == 0 || len(trailing) == 0 {
+		return // nothing to reorder; keep the slice untouched
+	}
+	copy(seg, leading)
+	copy(seg[len(leading):], trailing)
 }
 
 // budgetExhausted reports whether the cumulative node budget is spent.
@@ -947,6 +1009,9 @@ func (t *LazyTree) buildPlan(n *LazyNode) []childSpec {
 	}
 
 	// Callee children: the function's own calls, then relation-derived ones.
+	// calleeStart marks where they begin, so orderTowardRoutes can reorder them
+	// without disturbing the argument children ahead of them (issue #264).
+	calleeStart := len(plan)
 	added := map[string]bool{}
 	appendCalleeOpts := func(edge *metadata.CallGraphEdge, chainParented, genericFilter bool) {
 		calleeID := strings.TrimPrefix(edge.Callee.ID(), "*")
@@ -1040,6 +1105,9 @@ func (t *LazyTree) buildPlan(n *LazyNode) []childSpec {
 	for _, edge := range t.receiverChildren[n.key] {
 		appendCallee(edge, false)
 	}
+
+	// Spend the budget on routing code first — see orderTowardRoutes.
+	t.orderTowardRoutes(plan, calleeStart)
 	return plan
 }
 

--- a/internal/spec/lazytree.go
+++ b/internal/spec/lazytree.go
@@ -159,6 +159,21 @@ type LazyTree struct {
 	// to drop any. Built once, on first use.
 	routeReach     map[string]bool
 	routeReachOnce bool
+
+	// routeScopeNodes counts nodes materialised under each route registration,
+	// indexed by scope id (0 is the shared wiring walk above every
+	// registration). Slice rather than map: ids are dense and handed out in
+	// order, and this is read on every materialised node.
+	routeScopeNodes []int
+	// routeScopeKeys names the registration each id stands for, for reporting.
+	routeScopeKeys []string
+	// routeTruncations counts route subtrees cut short by their own budget, and
+	// routeFirstTruncated names the first. Unlike the whole-walk truncation this
+	// is LOCAL — the rest of the routes are unaffected — so it is reported
+	// separately rather than folded into Truncated.
+	routeTruncations    int
+	routeFirstTruncated string
+	routeWarned         bool
 	// logger reports how many entrypoints were rooted vs skipped.
 	logger metadata.VerboseLogger
 
@@ -352,9 +367,85 @@ func (t *LazyTree) orderTowardRoutes(plan []childSpec, from int) {
 	copy(seg[len(leading):], trailing)
 }
 
-// budgetExhausted reports whether the cumulative node budget is spent.
+// DefaultMaxNodesPerRoute bounds the nodes materialised below ONE route
+// registration.
+//
+// It exists because a single global budget makes truncation total: expansion is
+// depth-first, so the routes not yet reached when it runs out are lost outright
+// rather than documented in less detail. Measured on a ~900-route project, that
+// was 12 paths of ~900 — the budget spent inside modules/setting before the walk
+// reached the routers at all.
+//
+// Per route, a handler too deep to document fully costs its own detail and
+// nothing else's, which is the difference between a spec that is missing 98% of
+// its endpoints and one where a few endpoints are missing a schema.
+const DefaultMaxNodesPerRoute = 20000
+
+// routeBudget is the per-registration cap in force for this tree.
+func (t *LazyTree) routeBudget() int {
+	if t.limits.MaxNodesPerRoute > 0 {
+		return t.limits.MaxNodesPerRoute
+	}
+	return DefaultMaxNodesPerRoute
+}
+
+// scopeOf returns the budget scope a child of n belongs to: a new one when n is
+// itself a route registration, otherwise n's own.
+//
+// A registration opens a scope rather than joining one, so everything the route
+// pulls in — its handler, that handler's helpers, their types — is charged to
+// that route and to nothing else.
+func (t *LazyTree) scopeOf(n *LazyNode) int {
+	if n == nil {
+		return 0
+	}
+	if n.routeScope != 0 || t.routeMatch == nil || n.edge == nil || !t.routeMatch(n.edge) {
+		return n.routeScope
+	}
+	// First registration on this path: open a scope for it.
+	if len(t.routeScopeNodes) == 0 {
+		t.routeScopeNodes = []int{0} // id 0 is the wiring walk
+		t.routeScopeKeys = []string{""}
+	}
+	t.routeScopeNodes = append(t.routeScopeNodes, 0)
+	t.routeScopeKeys = append(t.routeScopeKeys, n.key)
+	return len(t.routeScopeNodes) - 1
+}
+
+// budgetExhausted reports whether the WIRING budget is spent — the walk that
+// finds route registrations in the first place.
+//
+// It no longer bounds the whole tree. Detail below a registration is bounded per
+// route (routeBudget), so a deep handler cannot consume the allowance the
+// undiscovered routes still need (issue #264).
 func (t *LazyTree) budgetExhausted() bool {
 	return t.limits.MaxNodesPerTree > 0 && t.nodesBuilt >= t.limits.MaxNodesPerTree
+}
+
+// routeBudgetExhausted reports whether this node's route has spent its own
+// allowance. Scope 0 — the wiring walk — is bounded by budgetExhausted instead.
+func (t *LazyTree) routeBudgetExhausted(scope int) bool {
+	return scope > 0 && scope < len(t.routeScopeNodes) && t.routeScopeNodes[scope] >= t.routeBudget()
+}
+
+// noteRouteTruncation records a route subtree cut short by its own budget, and
+// warns once. The route's own key is named: unlike the whole-walk truncation,
+// this says exactly which endpoint is under-documented.
+func (t *LazyTree) noteRouteTruncation(scope int) {
+	t.routeTruncations++
+	key := ""
+	if scope < len(t.routeScopeKeys) {
+		key = t.routeScopeKeys[scope]
+	}
+	if t.routeFirstTruncated == "" {
+		t.routeFirstTruncated = key
+	}
+	if !t.routeWarned {
+		t.routeWarned = true
+		fmt.Fprintf(os.Stderr,
+			"Warning: MaxNodesPerRoute limit (%d) reached, truncating one route's detail (first at %s)\n",
+			t.routeBudget(), key)
+	}
 }
 
 // genericTypesOf is a memoized metadata.ExtractGenericTypes.
@@ -680,6 +771,10 @@ func (t *LazyTree) ExpansionStats() ExpansionStats {
 		InstanceLimit:       t.instanceBudget(),
 		InstanceFirstScope:  t.instanceFirstScope,
 		InstanceFirstKey:    t.instanceFirstKey,
+		RouteTruncations:    t.routeTruncations,
+		RouteLimit:          t.routeBudget(),
+		RouteFirstTruncated: t.routeFirstTruncated,
+		RoutesScoped:        max(len(t.routeScopeNodes)-1, 0),
 	}
 }
 
@@ -721,6 +816,16 @@ type LazyNode struct {
 	typeParams map[string]string // GetTypeParamMap cache
 
 	children []TrackerNodeInterface // nil = not yet expanded
+
+	// routeScope identifies which budget this node's expansion is charged to:
+	// the id of the nearest route-registration ancestor, or 0 for the wiring
+	// walk above every registration (issue #264).
+	//
+	// Computed once, at creation, by inheriting the parent's — walking up to
+	// find it per expansion would be O(depth) work on every child, which goes
+	// quadratic over deep graphs and is the shape that shows up in profiles as
+	// GC dominance rather than as the guilty frame.
+	routeScope int
 
 	argType    ArgumentType
 	isArgument bool
@@ -843,17 +948,29 @@ func (n *LazyNode) GetChildren() []TrackerNodeInterface {
 	if n.expanded {
 		return n.children
 	}
-	if n.tree.budgetExhausted() {
+	// Two budgets, and which one applies depends on where this node sits. Above
+	// every route registration the WIRING budget bounds the walk that finds them;
+	// below one, that route's own allowance bounds its detail. Splitting them is
+	// what makes truncation local instead of total (issue #264).
+	if n.routeScope == 0 && n.tree.budgetExhausted() {
 		n.tree.truncated = true
 		if !n.tree.budgetWarned {
 			n.tree.budgetWarned = true
 			fmt.Fprintf(os.Stderr,
-				"Warning: MaxNodesPerTree limit (%d) reached, truncating lazy expansion (first at %s)\n",
+				"Warning: MaxNodesPerTree limit (%d) reached, truncating the walk that finds routes (first at %s)\n",
 				n.tree.limits.MaxNodesPerTree, n.key)
 		}
 		return nil // budget spent: further expansion yields leaves (cheap unwind)
 	}
+	if n.tree.routeBudgetExhausted(n.routeScope) {
+		n.tree.noteRouteTruncation(n.routeScope)
+		return nil // this route is documented in less detail; the others are not affected
+	}
 	n.expanded = true
+
+	// A registration opens its own scope, so everything it pulls in is charged
+	// to that route. Resolved once here rather than per child.
+	childScope := n.tree.scopeOf(n)
 
 	scope := n.instanceScope()
 	if n.tree.instanceCount == nil {
@@ -889,6 +1006,7 @@ func (n *LazyNode) GetChildren() []TrackerNodeInterface {
 		child.key = spec.key
 		child.parent = n
 		child.edge = spec.edge
+		child.routeScope = childScope
 		if spec.arg != nil {
 			child.edge = spec.argEdge
 			child.arg = spec.arg
@@ -917,6 +1035,9 @@ func (n *LazyNode) GetChildren() []TrackerNodeInterface {
 		// #224; what this counter can honestly do meanwhile is report the work
 		// instead of hiding it.
 		n.tree.nodesMaterialized++
+		if childScope > 0 && childScope < len(n.tree.routeScopeNodes) {
+			n.tree.routeScopeNodes[childScope]++
+		}
 		if n.tree.seenKeys == nil {
 			n.tree.seenKeys = map[string]bool{}
 		}

--- a/internal/spec/lazytree.go
+++ b/internal/spec/lazytree.go
@@ -222,8 +222,36 @@ type LazyTree struct {
 	// the same graph-sized unit as the eager tree's shared-node cap —
 	// deliberately NOT scoped, or many scopes would exhaust the budget with
 	// copies of the same graph.
-	seenKeys map[string]bool
+	//
+	// The value is a bit set, not a bool, because two counts are needed over the
+	// same keys and a second map would double the largest allocation in the run:
+	// seenAny is the reported total (nodesBuilt), seenWiring the subset first
+	// reached ABOVE any route registration — the only keys the wiring budget may
+	// be charged for. Keeping those apart is what makes the two budgets of #264
+	// independent; see wiringNodesBuilt.
+	seenKeys map[string]uint8
+
+	// wiringNodesBuilt counts distinct callee keys reached by the WIRING walk —
+	// the keys above every route registration. MaxNodesPerTree bounds this, not
+	// nodesBuilt.
+	//
+	// Charging the wiring budget for keys discovered INSIDE route subtrees makes
+	// the two budgets one budget again, and inverts the whole fix: expanding a
+	// route in more detail then costs the walk its ability to find the NEXT
+	// route. Measured on a ~900-route project before the split was completed,
+	// raising the per-route allowance made the spec smaller — 181 paths at
+	// 20,000, 163 at 200,000, 103 at 1,000,000 — which is the same "improving
+	// expansion makes the spec worse" defect #264 exists to remove, reintroduced
+	// one level down.
+	wiringNodesBuilt int
 }
+
+// Bits in seenKeys. seenAny is every key ever materialized; seenWiring marks the
+// keys the wiring walk reached, which is the subset MaxNodesPerTree bounds.
+const (
+	seenAny uint8 = 1 << iota
+	seenWiring
+)
 
 // DefaultMaxInstancesPerKey bounds node copies of the same callee WITHIN one
 // instance scope (the subtree of the nearest argument-node ancestor —
@@ -388,7 +416,26 @@ func (t *LazyTree) orderTowardRoutes(plan []childSpec, from int) {
 // Per route, a handler too deep to document fully costs its own detail and
 // nothing else's, which is the difference between a spec that is missing 98% of
 // its endpoints and one where a few endpoints are missing a schema.
-const DefaultMaxNodesPerRoute = 20000
+//
+// THE VALUE IS SET BY WHAT IT MUST NOT COST, not by what it saves. A per-route
+// cap is a NEW restriction: before it, a route's detail was bounded only by the
+// global budget, so every project that never hit that budget was effectively
+// unbounded below its registrations. Anything low enough to be a useful ceiling
+// is therefore a regression for those projects, and a silent one — a truncated
+// route loses a request body or a response schema, not a path, so the spec still
+// looks complete. Measured against per-project snapshots: at 20,000 three real
+// projects lost detail on endpoints they had always documented; 200,000 cleared
+// all but one endpoint, whose four responses need somewhere past 400,000; a
+// million restores exact parity everywhere.
+//
+// It buys the ceiling cheaply because deep routes are rare. On the project with
+// that endpoint, a million costs nothing measurable (9.0s either way) — only the
+// one deep route expands further. Where routes ARE deep it is the whole trade:
+// a ~900-route project documents 491 paths at 20,000, 581 at 200,000 and 640 at
+// a million, for 66s / 112s / 166s. Paying that by default is the right way
+// round, because a project with no deep route does not pay it at all, and one
+// that has them was losing endpoints silently.
+const DefaultMaxNodesPerRoute = 1000000
 
 // routeBudget is the per-registration cap in force for this tree.
 func (t *LazyTree) routeBudget() int {
@@ -426,9 +473,32 @@ func (t *LazyTree) scopeOf(n *LazyNode) int {
 //
 // It no longer bounds the whole tree. Detail below a registration is bounded per
 // route (routeBudget), so a deep handler cannot consume the allowance the
-// undiscovered routes still need (issue #264).
+// undiscovered routes still need (issue #264) — which is why the count it reads
+// is wiringNodesBuilt and not the global nodesBuilt.
 func (t *LazyTree) budgetExhausted() bool {
-	return t.limits.MaxNodesPerTree > 0 && t.nodesBuilt >= t.limits.MaxNodesPerTree
+	return t.limits.MaxNodesPerTree > 0 && t.wiringNodesBuilt >= t.limits.MaxNodesPerTree
+}
+
+// countKey records that a callee key was materialised in the given budget
+// scope, keeping the two counts the two budgets read.
+//
+// The wiring bit is set on its own occasion rather than only the first time a
+// key is seen at all: a key can be reached below a route first and by the wiring
+// walk afterwards, and skipping it then would let a walk that happens to descend
+// into a route early understate its own cost without bound.
+func (t *LazyTree) countKey(key string, scope int) {
+	if t.seenKeys == nil {
+		t.seenKeys = map[string]uint8{}
+	}
+	seen := t.seenKeys[key]
+	if seen&seenAny == 0 {
+		t.nodesBuilt++
+	}
+	if scope == 0 && seen&seenWiring == 0 {
+		seen |= seenWiring
+		t.wiringNodesBuilt++
+	}
+	t.seenKeys[key] = seen | seenAny
 }
 
 // routeBudgetExhausted reports whether this node's route has spent its own
@@ -1062,13 +1132,7 @@ func (n *LazyNode) GetChildren() []TrackerNodeInterface {
 		if childScope > 0 && childScope < len(n.tree.routeScopeNodes) {
 			n.tree.routeScopeNodes[childScope]++
 		}
-		if n.tree.seenKeys == nil {
-			n.tree.seenKeys = map[string]bool{}
-		}
-		if !n.tree.seenKeys[spec.key] {
-			n.tree.seenKeys[spec.key] = true
-			n.tree.nodesBuilt++
-		}
+		n.tree.countKey(spec.key, childScope)
 		n.children = append(n.children, child)
 	}
 	return n.children

--- a/internal/spec/route_reach.go
+++ b/internal/spec/route_reach.go
@@ -1,0 +1,91 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import "github.com/ehabterra/apispec/internal/metadata"
+
+// routeReachSet returns the function base keys from which a route registration
+// is transitively reachable — the set the tree uses to decide which subtree to
+// spend its budget on first (issue #264).
+//
+// It is a backward walk from every registration site rather than the extractor's
+// bottom-up pass over the SCC condensation, for one reason: it must follow
+// FUNC LITERALS, and the call graph does not.
+//
+// A closure passed as an argument — `r.Route("/api", func(api chi.Router){ … })`,
+// which is how most real projects group routes — is not a callee of the function
+// that writes it, so no call edge leads there. Reachability that only follows
+// call edges therefore reports that the enclosing function reaches no route,
+// which is false for exactly the code that matters most. That blind spot is why
+// an earlier attempt to PRUNE by pattern reachability deleted 124 of 312
+// operations: `chi.Group` matches no route pattern and reaches none, yet every
+// route lives inside its closure.
+//
+// So two relations propagate "leads to a registration" backwards:
+//
+//   - callee -> caller, the ordinary one;
+//   - closure -> the function that lexically defines it, so a group closure's
+//     routes count for the function that writes the group.
+//
+// The result is a HINT, never a gate. Ordering by it defers work; it never drops
+// any, so a function this set misses is expanded late rather than not at all.
+func routeReachSet(meta *metadata.Metadata, match func(*metadata.CallGraphEdge) bool) map[string]bool {
+	if meta == nil || match == nil {
+		return nil
+	}
+
+	// Predecessors: for a key, the functions whose own expansion leads to it.
+	preds := make(map[string][]string, len(meta.CallGraph))
+	addPred := func(of, pred string) {
+		if of == "" || pred == "" || of == pred {
+			return
+		}
+		preds[of] = append(preds[of], pred)
+	}
+
+	reaches := make(map[string]bool)
+	var queue []string
+	mark := func(key string) {
+		if key == "" || reaches[key] {
+			return
+		}
+		reaches[key] = true
+		queue = append(queue, key)
+	}
+
+	for i := range meta.CallGraph {
+		edge := &meta.CallGraph[i]
+		caller := edge.Caller.BaseID()
+		addPred(edge.Callee.BaseID(), caller)
+		if edge.ParentFunction != nil {
+			// The closure's body is written inside its parent, so reaching a
+			// registration from the closure means the parent's subtree leads to
+			// one — even though nothing CALLS the closure.
+			addPred(caller, edge.ParentFunction.BaseID())
+		}
+		if match(edge) {
+			mark(caller)
+		}
+	}
+
+	for len(queue) > 0 {
+		key := queue[0]
+		queue = queue[1:]
+		for _, pred := range preds[key] {
+			mark(pred)
+		}
+	}
+	return reaches
+}

--- a/internal/spec/route_reach_test.go
+++ b/internal/spec/route_reach_test.go
@@ -192,3 +192,69 @@ func TestOrderTowardRoutesLeavesUniformPlansAlone(t *testing.T) {
 		}
 	})
 }
+
+// TestRouteBudgetIsPerRegistrationNotGlobal is the property that turns 12
+// documented paths into 210: a route's detail is charged to that route, so a
+// handler too deep to expand fully costs its own detail and nothing else's.
+//
+// With one global budget, truncation is TOTAL — expansion is depth-first, so the
+// routes not yet reached when it runs out are lost outright rather than
+// documented in less detail.
+func TestRouteBudgetIsPerRegistrationNotGlobal(t *testing.T) {
+	m := closureMeta(t)
+	tree := &LazyTree{meta: m, routeMatch: registersRoute(m)}
+
+	// A node that is not a registration stays in the wiring scope.
+	wiring := &LazyNode{tree: tree, key: "example.com/app.main"}
+	if got := tree.scopeOf(wiring); got != 0 {
+		t.Errorf("a non-registration node opened scope %d, want the shared wiring scope 0", got)
+	}
+
+	// Each registration opens its OWN scope, so two routes never share a budget.
+	regEdge := &m.CallGraph[2] // the chi Get edge
+	first := &LazyNode{tree: tree, key: "route-1", edge: regEdge}
+	second := &LazyNode{tree: tree, key: "route-2", edge: regEdge}
+	a, b := tree.scopeOf(first), tree.scopeOf(second)
+	if a == 0 || b == 0 {
+		t.Fatalf("a registration did not open its own scope: got %d and %d", a, b)
+	}
+	if a == b {
+		t.Errorf("two registrations share scope %d; one route's expansion could then starve the other", a)
+	}
+
+	// Spending one route's allowance must not touch the other's, nor the wiring
+	// walk's.
+	tree.limits.MaxNodesPerRoute = 2
+	tree.routeScopeNodes[a] = 2
+	if !tree.routeBudgetExhausted(a) {
+		t.Error("a route that spent its allowance was not reported as exhausted")
+	}
+	if tree.routeBudgetExhausted(b) {
+		t.Error("one route's exhausted budget also exhausted another's — the budgets are not independent")
+	}
+	if tree.routeBudgetExhausted(0) {
+		t.Error("the wiring scope must be bounded by MaxNodesPerTree, not by the per-route limit")
+	}
+}
+
+// TestRouteTruncationNamesTheRoute keeps the report actionable: the count alone
+// cannot tell you which endpoint is under-documented.
+func TestRouteTruncationNamesTheRoute(t *testing.T) {
+	m := closureMeta(t)
+	tree := &LazyTree{meta: m, routeMatch: registersRoute(m)}
+	regEdge := &m.CallGraph[2]
+	scope := tree.scopeOf(&LazyNode{tree: tree, key: "GET /things", edge: regEdge})
+
+	tree.noteRouteTruncation(scope)
+	tree.noteRouteTruncation(scope)
+
+	if tree.routeTruncations != 2 {
+		t.Errorf("counted %d route truncations, want 2", tree.routeTruncations)
+	}
+	if tree.routeFirstTruncated != "GET /things" {
+		t.Errorf("first truncated route = %q, want the registration's key", tree.routeFirstTruncated)
+	}
+	if !tree.routeWarned {
+		t.Error("a truncated route produced no warning")
+	}
+}

--- a/internal/spec/route_reach_test.go
+++ b/internal/spec/route_reach_test.go
@@ -15,6 +15,7 @@
 package spec
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -302,5 +303,75 @@ func TestRouteTruncationCountsRoutesNotAttempts(t *testing.T) {
 	}
 	if tree.routeTruncations != 1 {
 		t.Errorf("counted %d truncations for one route re-entered 20 times, want 1", tree.routeTruncations)
+	}
+}
+
+// TestWiringBudgetIsNotChargedForRouteDetail pins that the two budgets of #264
+// are actually two.
+//
+// Splitting the limit is only half the fix. The keys a route's own subtree
+// discovers were still counted into the single global nodesBuilt that
+// MaxNodesPerTree reads, so expanding one route in more detail spent the
+// allowance the walk needed to FIND the next route. That inverts the whole
+// point: measured on a ~900-route project, raising the per-route allowance made
+// the spec smaller — 181 paths at 20,000, 163 at 200,000, 103 at 1,000,000 —
+// which is "improving expansion makes the spec worse" all over again, one level
+// down from where #264 found it.
+//
+// The invariant: only keys the WIRING walk reaches may exhaust MaxNodesPerTree.
+func TestWiringBudgetIsNotChargedForRouteDetail(t *testing.T) {
+	m := closureMeta(t)
+	tree := &LazyTree{meta: m, routeMatch: registersRoute(m), terminalRouteMatch: registersRoute(m)}
+	tree.limits.MaxNodesPerTree = 2
+
+	// Two keys reached by the wiring walk, and two more reached only below a
+	// route registration — the shape of any handler with a helper under it.
+	tree.countKey("example.com/app.main", 0)
+	tree.countKey("example.com/app.registerAPI", 0)
+	tree.countKey("example.com/app.decodeBody", 7)
+	tree.countKey("example.com/app.respond", 7)
+
+	if tree.nodesBuilt != 4 {
+		t.Errorf("nodesBuilt = %d, want all 4 distinct keys — it is the reported total", tree.nodesBuilt)
+	}
+	if tree.wiringNodesBuilt != 2 {
+		t.Errorf("wiringNodesBuilt = %d, want only the 2 keys above a registration; "+
+			"charging route detail to the wiring budget makes deeper expansion cost route DISCOVERY (#264)",
+			tree.wiringNodesBuilt)
+	}
+	if !tree.budgetExhausted() {
+		t.Error("the wiring budget of 2 was not reported as spent by 2 wiring keys")
+	}
+
+	// Route detail beyond the wiring budget must not push it further.
+	for i := 0; i < 50; i++ {
+		tree.countKey(fmt.Sprintf("example.com/app.deep%d", i), 7)
+	}
+	if tree.wiringNodesBuilt != 2 {
+		t.Errorf("50 keys reached below a route moved the wiring count to %d; "+
+			"a route's detail must never spend the walk's allowance", tree.wiringNodesBuilt)
+	}
+}
+
+// TestWiringKeyCountedWhenReachedLater pins the ordering case: a key first seen
+// inside a route subtree, later reached by the wiring walk, still counts for the
+// wiring budget. Marking it "already seen" and skipping it would let a walk that
+// happens to descend a route first understate its own cost without bound.
+func TestWiringKeyCountedWhenReachedLater(t *testing.T) {
+	m := closureMeta(t)
+	tree := &LazyTree{meta: m}
+
+	tree.countKey("example.com/app.shared", 3) // first seen under a route
+	if tree.wiringNodesBuilt != 0 {
+		t.Fatalf("wiringNodesBuilt = %d after a route-only key, want 0", tree.wiringNodesBuilt)
+	}
+	tree.countKey("example.com/app.shared", 0) // then reached by the wiring walk
+
+	if tree.wiringNodesBuilt != 1 {
+		t.Errorf("wiringNodesBuilt = %d, want 1 — a key the wiring walk reaches counts for it "+
+			"whenever that happens, not only if it was seen there first", tree.wiringNodesBuilt)
+	}
+	if tree.nodesBuilt != 1 {
+		t.Errorf("nodesBuilt = %d, want 1 — the same key twice is still one distinct key", tree.nodesBuilt)
 	}
 }

--- a/internal/spec/route_reach_test.go
+++ b/internal/spec/route_reach_test.go
@@ -202,7 +202,7 @@ func TestOrderTowardRoutesLeavesUniformPlansAlone(t *testing.T) {
 // documented in less detail.
 func TestRouteBudgetIsPerRegistrationNotGlobal(t *testing.T) {
 	m := closureMeta(t)
-	tree := &LazyTree{meta: m, routeMatch: registersRoute(m)}
+	tree := &LazyTree{meta: m, routeMatch: registersRoute(m), terminalRouteMatch: registersRoute(m)}
 
 	// A node that is not a registration stays in the wiring scope.
 	wiring := &LazyNode{tree: tree, key: "example.com/app.main"}
@@ -241,20 +241,66 @@ func TestRouteBudgetIsPerRegistrationNotGlobal(t *testing.T) {
 // cannot tell you which endpoint is under-documented.
 func TestRouteTruncationNamesTheRoute(t *testing.T) {
 	m := closureMeta(t)
-	tree := &LazyTree{meta: m, routeMatch: registersRoute(m)}
+	tree := &LazyTree{meta: m, routeMatch: registersRoute(m), terminalRouteMatch: registersRoute(m)}
 	regEdge := &m.CallGraph[2]
 	scope := tree.scopeOf(&LazyNode{tree: tree, key: "GET /things", edge: regEdge})
 
 	tree.noteRouteTruncation(scope)
-	tree.noteRouteTruncation(scope)
 
-	if tree.routeTruncations != 2 {
-		t.Errorf("counted %d route truncations, want 2", tree.routeTruncations)
+	if tree.routeTruncations != 1 {
+		t.Errorf("counted %d route truncations, want 1", tree.routeTruncations)
 	}
 	if tree.routeFirstTruncated != "GET /things" {
 		t.Errorf("first truncated route = %q, want the registration's key", tree.routeFirstTruncated)
 	}
 	if !tree.routeWarned {
 		t.Error("a truncated route produced no warning")
+	}
+}
+
+// TestGroupCallDoesNotOpenARouteScope is the regression guard for the worst bug
+// this work produced, caught on a real 246-route chi service.
+//
+// The reach predicate deliberately matches mounts and groups too — "does this
+// subtree lead to a route?" must say yes for `r.Route("/api", …)`, or the whole
+// group is written off. Using that same predicate to open a BUDGET scope means
+// every route inside the group shares one allowance, and the routes past the
+// first few are never discovered at all: 246 paths became 32.
+//
+// So scoping uses a terminal-route predicate, and a group must not open a scope.
+func TestGroupCallDoesNotOpenARouteScope(t *testing.T) {
+	m := closureMeta(t)
+	// routeMatch matches the group call as well (it is the reach predicate);
+	// terminalRouteMatch matches only the verb call.
+	groupOrRoute := func(edge *metadata.CallGraphEdge) bool {
+		name := m.StringPool.GetString(edge.Callee.Name)
+		return name == "Get" || name == "Route"
+	}
+	tree := &LazyTree{meta: m, routeMatch: groupOrRoute, terminalRouteMatch: registersRoute(m)}
+
+	groupEdge := &m.CallGraph[1] // chi.Router.Route — a group
+	if got := tree.scopeOf(&LazyNode{tree: tree, key: "group", edge: groupEdge}); got != 0 {
+		t.Errorf("a group call opened budget scope %d; every route inside it would then share one allowance (#264)", got)
+	}
+
+	routeEdge := &m.CallGraph[2] // chi.Router.Get — one route
+	if got := tree.scopeOf(&LazyNode{tree: tree, key: "route", edge: routeEdge}); got == 0 {
+		t.Error("a terminal route registration did not open its own budget scope")
+	}
+}
+
+// TestRouteTruncationCountsRoutesNotAttempts pins that the report counts routes.
+// A truncated subtree is re-entered many times as the walk unwinds, which once
+// read as "truncated 58 of 6 route subtrees".
+func TestRouteTruncationCountsRoutesNotAttempts(t *testing.T) {
+	m := closureMeta(t)
+	tree := &LazyTree{meta: m, routeMatch: registersRoute(m), terminalRouteMatch: registersRoute(m)}
+	scope := tree.scopeOf(&LazyNode{tree: tree, key: "GET /things", edge: &m.CallGraph[2]})
+
+	for i := 0; i < 20; i++ {
+		tree.noteRouteTruncation(scope)
+	}
+	if tree.routeTruncations != 1 {
+		t.Errorf("counted %d truncations for one route re-entered 20 times, want 1", tree.routeTruncations)
 	}
 }

--- a/internal/spec/route_reach_test.go
+++ b/internal/spec/route_reach_test.go
@@ -69,6 +69,21 @@ func registersRoute(m *metadata.Metadata) func(*metadata.CallGraphEdge) bool {
 	}
 }
 
+// edgeTo returns the fixture edge whose callee is named name. Addressing
+// closureMeta's edges by position instead would keep compiling — and often keep
+// passing — if an edge were ever inserted ahead of the one a test means, while
+// silently asserting nothing about a route registration.
+func edgeTo(t *testing.T, m *metadata.Metadata, name string) *metadata.CallGraphEdge {
+	t.Helper()
+	for i := range m.CallGraph {
+		if m.StringPool.GetString(m.CallGraph[i].Callee.Name) == name {
+			return &m.CallGraph[i]
+		}
+	}
+	t.Fatalf("fixture has no edge calling %q", name)
+	return nil
+}
+
 // TestRouteReachSetFollowsFuncLiterals is the property the whole of #264 rests
 // on, and the one a plain call-graph walk gets wrong.
 //
@@ -212,7 +227,7 @@ func TestRouteBudgetIsPerRegistrationNotGlobal(t *testing.T) {
 	}
 
 	// Each registration opens its OWN scope, so two routes never share a budget.
-	regEdge := &m.CallGraph[2] // the chi Get edge
+	regEdge := edgeTo(t, m, "Get")
 	first := &LazyNode{tree: tree, key: "route-1", edge: regEdge}
 	second := &LazyNode{tree: tree, key: "route-2", edge: regEdge}
 	a, b := tree.scopeOf(first), tree.scopeOf(second)
@@ -243,7 +258,7 @@ func TestRouteBudgetIsPerRegistrationNotGlobal(t *testing.T) {
 func TestRouteTruncationNamesTheRoute(t *testing.T) {
 	m := closureMeta(t)
 	tree := &LazyTree{meta: m, routeMatch: registersRoute(m), terminalRouteMatch: registersRoute(m)}
-	regEdge := &m.CallGraph[2]
+	regEdge := edgeTo(t, m, "Get")
 	scope := tree.scopeOf(&LazyNode{tree: tree, key: "GET /things", edge: regEdge})
 
 	tree.noteRouteTruncation(scope)
@@ -279,12 +294,12 @@ func TestGroupCallDoesNotOpenARouteScope(t *testing.T) {
 	}
 	tree := &LazyTree{meta: m, routeMatch: groupOrRoute, terminalRouteMatch: registersRoute(m)}
 
-	groupEdge := &m.CallGraph[1] // chi.Router.Route — a group
+	groupEdge := edgeTo(t, m, "Route") // a group
 	if got := tree.scopeOf(&LazyNode{tree: tree, key: "group", edge: groupEdge}); got != 0 {
 		t.Errorf("a group call opened budget scope %d; every route inside it would then share one allowance (#264)", got)
 	}
 
-	routeEdge := &m.CallGraph[2] // chi.Router.Get — one route
+	routeEdge := edgeTo(t, m, "Get") // one route
 	if got := tree.scopeOf(&LazyNode{tree: tree, key: "route", edge: routeEdge}); got == 0 {
 		t.Error("a terminal route registration did not open its own budget scope")
 	}
@@ -296,7 +311,7 @@ func TestGroupCallDoesNotOpenARouteScope(t *testing.T) {
 func TestRouteTruncationCountsRoutesNotAttempts(t *testing.T) {
 	m := closureMeta(t)
 	tree := &LazyTree{meta: m, routeMatch: registersRoute(m), terminalRouteMatch: registersRoute(m)}
-	scope := tree.scopeOf(&LazyNode{tree: tree, key: "GET /things", edge: &m.CallGraph[2]})
+	scope := tree.scopeOf(&LazyNode{tree: tree, key: "GET /things", edge: edgeTo(t, m, "Get")})
 
 	for i := 0; i < 20; i++ {
 		tree.noteRouteTruncation(scope)

--- a/internal/spec/route_reach_test.go
+++ b/internal/spec/route_reach_test.go
@@ -1,0 +1,194 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// closureMeta builds a call graph in the shape that matters for #264:
+//
+//	main        -> registerAPI          (a plain call)
+//	registerAPI -> chi.Router.Route     (the group call; its closure is an ARGUMENT)
+//	FuncLit     -> chi.Router.Get       (the registration, written inside the closure)
+//	main        -> loadSettings         (a plain call that leads nowhere near a route)
+//	loadSettings-> ini.Section.Key
+//
+// The closure's edges carry ParentFunction = registerAPI, which is the only link
+// back to the function that writes the group — nothing CALLS the closure.
+func closureMeta(t *testing.T) *metadata.Metadata {
+	t.Helper()
+	m := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	call := func(pkg, recv, name string) metadata.Call {
+		return metadata.Call{
+			Meta: m, Name: m.StringPool.Get(name), Pkg: m.StringPool.Get(pkg),
+			RecvType: m.StringPool.Get(recv), Position: -1, Scope: -1, SignatureStr: -1,
+		}
+	}
+	const app = "example.com/app"
+	const chi = "github.com/go-chi/chi/v5"
+
+	registerAPI := call(app, "", "registerAPI")
+	edges := []metadata.CallGraphEdge{
+		{Caller: call(app, "", "main"), Callee: registerAPI},
+		{Caller: registerAPI, Callee: call(chi, "Router", "Route")},
+		// Written inside registerAPI's closure; reachable only via ParentFunction.
+		{
+			Caller:         call(app, "", "FuncLit:main.go:10:20"),
+			Callee:         call(chi, "Router", "Get"),
+			ParentFunction: &registerAPI,
+		},
+		{Caller: call(app, "", "main"), Callee: call(app, "", "loadSettings")},
+		{Caller: call(app, "", "loadSettings"), Callee: call("gopkg.in/ini.v1", "Section", "Key")},
+	}
+	m.CallGraph = append(m.CallGraph, edges...)
+	m.BuildCallGraphMaps()
+	return m
+}
+
+// registersRoute matches the chi verb call the fixture registers with.
+func registersRoute(m *metadata.Metadata) func(*metadata.CallGraphEdge) bool {
+	return func(edge *metadata.CallGraphEdge) bool {
+		return m.StringPool.GetString(edge.Callee.Name) == "Get"
+	}
+}
+
+// TestRouteReachSetFollowsFuncLiterals is the property the whole of #264 rests
+// on, and the one a plain call-graph walk gets wrong.
+//
+// A group closure is an ARGUMENT, not a callee, so nothing calls it. Reachability
+// that follows only call edges therefore reports that `registerAPI` reaches no
+// route — false for the single most common way real projects group routes, and
+// exactly why an earlier attempt to PRUNE by pattern reachability deleted 124 of
+// 312 operations.
+func TestRouteReachSetFollowsFuncLiterals(t *testing.T) {
+	m := closureMeta(t)
+	reach := routeReachSet(m, registersRoute(m))
+
+	const app = "example.com/app"
+	for _, key := range []string{
+		app + ".FuncLit:main.go:10:20", // registers directly
+		app + ".registerAPI",           // only via the closure it writes
+		app + ".main",                  // only via registerAPI
+	} {
+		if !reach[key] {
+			t.Errorf("%s does not lead to a route registration; a closure's routes must count for the function that writes it", key)
+		}
+	}
+
+	for _, key := range []string{
+		app + ".loadSettings",
+		"gopkg.in/ini.v1.Section.Key",
+	} {
+		if reach[key] {
+			t.Errorf("%s was marked as leading to a route; nothing below it registers one", key)
+		}
+	}
+}
+
+// TestRouteReachSetIsInertWithoutAPredicate covers the callers that supply none.
+func TestRouteReachSetIsInertWithoutAPredicate(t *testing.T) {
+	m := closureMeta(t)
+	if got := routeReachSet(m, nil); got != nil {
+		t.Errorf("routeReachSet with no predicate = %v, want nil", got)
+	}
+	if got := routeReachSet(nil, registersRoute(m)); got != nil {
+		t.Errorf("routeReachSet with no metadata = %v, want nil", got)
+	}
+}
+
+// TestOrderTowardRoutesDefersOnlyAndStably pins the two properties that make
+// ordering safe where pruning was not: nothing is removed, and equal-class
+// children keep their relative order so the output stays deterministic (golden
+// rule #1).
+func TestOrderTowardRoutesDefersOnlyAndStably(t *testing.T) {
+	m := closureMeta(t)
+	tree := &LazyTree{meta: m, routeMatch: registersRoute(m)}
+
+	const app = "example.com/app"
+	plan := []childSpec{
+		{key: "arg-child"}, // an argument child, ahead of the callee segment
+		{key: app + ".loadSettings"},
+		{key: app + ".registerAPI"},
+		{key: "gopkg.in/ini.v1.Section.Key"},
+		{key: app + ".main"},
+	}
+	before := append([]childSpec(nil), plan...)
+
+	tree.orderTowardRoutes(plan, 1)
+
+	if plan[0].key != "arg-child" {
+		t.Errorf("argument child moved to %q; a group closure is an argument and must stay ahead of the callee segment", plan[0].key)
+	}
+	wantOrder := []string{
+		"arg-child",
+		app + ".registerAPI", // leads to a route, kept in its original relative order
+		app + ".main",
+		app + ".loadSettings", // does not, deferred
+		"gopkg.in/ini.v1.Section.Key",
+	}
+	var gotOrder []string
+	for _, spec := range plan {
+		gotOrder = append(gotOrder, spec.key)
+	}
+	if !reflect.DeepEqual(gotOrder, wantOrder) {
+		t.Errorf("order = %v, want %v", gotOrder, wantOrder)
+	}
+
+	// Nothing dropped: ordering defers, it never prunes. This is the property
+	// that makes an imperfect reach set safe — a subtree it misses is expanded
+	// late rather than not at all.
+	if len(plan) != len(before) {
+		t.Fatalf("plan went from %d children to %d; ordering must not drop any", len(before), len(plan))
+	}
+	seen := map[string]int{}
+	for _, spec := range plan {
+		seen[spec.key]++
+	}
+	for _, spec := range before {
+		if seen[spec.key] != 1 {
+			t.Errorf("child %q appears %d times after ordering, want exactly once", spec.key, seen[spec.key])
+		}
+	}
+}
+
+// TestOrderTowardRoutesLeavesUniformPlansAlone keeps the common case free: when
+// every child is in the same class there is nothing to reorder, and the slice
+// must not be touched.
+func TestOrderTowardRoutesLeavesUniformPlansAlone(t *testing.T) {
+	m := closureMeta(t)
+	const app = "example.com/app"
+
+	t.Run("all lead to routes", func(t *testing.T) {
+		tree := &LazyTree{meta: m, routeMatch: registersRoute(m)}
+		plan := []childSpec{{key: app + ".registerAPI"}, {key: app + ".main"}}
+		tree.orderTowardRoutes(plan, 0)
+		if plan[0].key != app+".registerAPI" || plan[1].key != app+".main" {
+			t.Errorf("uniform plan was reordered: %v", plan)
+		}
+	})
+
+	t.Run("no predicate leaves the plan alone", func(t *testing.T) {
+		tree := &LazyTree{meta: m}
+		plan := []childSpec{{key: app + ".loadSettings"}, {key: app + ".registerAPI"}}
+		tree.orderTowardRoutes(plan, 0)
+		if plan[0].key != app+".loadSettings" {
+			t.Errorf("a tree with no route predicate reordered its plan: %v", plan)
+		}
+	})
+}


### PR DESCRIPTION
Fixes #264.

The node budget was one allowance for the whole walk, spent depth-first, with no notion of which subtree leads to a route registration. On a ~900-route project it was gone inside configuration and logging packages before the walk reached the routers: **12 paths documented out of ~900**, and every improvement to the call graph — in either direction — made that worse, which is why #248, #249 and #253 are all gated on this.

This restores the two reverted parts (#265, #266 — reverted by #268 because of #269, now fixed by #271/#273), plus the group-scope fix, and then fixes the defect that made the split ineffective.

## The split was only half done

Bounding a route's detail separately is the fix, but the keys a route's own subtree discovered were still counted into the single global `nodesBuilt` that `MaxNodesPerTree` reads. Expanding one route in more detail therefore spent the allowance the walk needed to **find** the next route, so raising the per-route budget made the spec **smaller**:

| `--max-nodes-per-route` | 20,000 | 200,000 | 1,000,000 |
|---|---|---|---|
| paths (before this commit) | 181 | 163 | **103** |
| paths (after) | 491 | 581 | **640** |

That first row is #264's own "improving expansion makes the spec worse", reproduced one level down from where the issue found it. Only keys the wiring walk reaches may exhaust `MaxNodesPerTree`; `seenKeys` carries a bit set rather than a bool so the second count costs no second map — it is the largest allocation in the run.

The wiring bit is set on its own occasion, not only when a key is first seen at all: a key reached below a route first and by the wiring walk later still costs the walk, or a traversal that happens to descend early understates its own cost without bound.

## The default is set by what it must not cost

A per-route cap is a **new** restriction. Before it, a route's detail was bounded only by the global budget, so every project that never hit that budget was effectively unbounded below its registrations — and any useful ceiling is a silent regression for them, since a truncated route loses a schema, not a path, so the spec still looks complete.

Measured against per-project snapshots: **20,000** lost detail on three real projects; **200,000** cleared all but one endpoint, whose four responses need somewhere past 400,000; **1,000,000** restores exact parity everywhere. It is cheap because deep routes are rare — on the project holding that endpoint a million costs nothing measurable (9.0s either way).

## Results

| | before | after |
|---|---|---|
| ~900-route project | 12 paths, 46s, 2.9GB | **640 paths**, 166s, 7.3GB |
| 10 other real projects | — | paths identical, wall clock within noise (worst +1.1s) |

## Gate

`scripts/compare-spec.sh` over all 74 fixtures and 11 real projects — the harness that caught all three traps recorded on #264 while the fixture suite stayed green. **Zero drift**, except 12 CHANGED enum values on one project that `main` produces identically (verified by diffing the two runs). Wall clock and path counts unchanged on every project that was fine before.

Full suite, `-race`, `golangci-lint`, `gofmt`, `go vet` all clean.

## Tests

Both fixtures #264 required before a retry:

- **`TestGroupClosurePerRouteBudgetIsScopedPerRoute`** — trap 1. 15 routes in one group closure, budget driven to 5 so every subtree truncates; asserts all 15 routes are still **discovered** and that **15** scopes are opened, not 1. A group-scoped budget fails it immediately. (`RouteRegistrationMatcher` must keep matching groups for reachability; only `TerminalRouteMatcher` may open a scope.)
- **`testdata/shared_body_helper`** (the #269 fixture) now also sweeps `--max-nodes-per-route`, including 2,000,000 — the direction that exposed the wrong-DTO regression in the first place. Depth is a starvation setting in reverse, so the same assertion has to hold with the budget raised far past the default.
- **`TestWiringBudgetIsNotChargedForRouteDetail`** / **`TestWiringKeyCountedWhenReachedLater`** — the accounting invariant. Mutation-checked: both fail against the broken accounting.

## Note for reviewers

`--max-nodes` changes meaning: it now bounds only the walk that finds route registrations, and the two limits fail differently — `--max-nodes` spent means routes are **missing**, `--max-nodes-per-route` spent means one **named** route is less detailed and no other route is affected. README, `docs/DEBUGGING.md` and the flag help are updated.

Unblocks #248, #249 and #270; #245 next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `--max-nodes-per-route` CLI option to independently limit analysis detail for each route.
  * Route-level analysis budgets are scoped independently, helping preserve route discovery while controlling detailed expansion.
  * Analysis results now report route truncation counts, limits, affected routes, and the first truncated route.

* **Documentation**
  * Updated CLI, debugging, and limits documentation to explain global versus per-route limits and related warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->