### PR TITLE
fix(spec): a type's enum is all of its constants, not its largest const block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ testdata/response_header_param/response_header_param
 
 # a `go build` inside the wrapper-router fixture drops its binary beside main.go
 testdata/wrapper_router/wrapper_router
+
+# a `go build` inside the split-const-block enum fixture drops its binary beside main.go
+testdata/enum_split_const_blocks/enum_split_const_blocks

--- a/generator/testdata_enum_split_const_blocks_test.go
+++ b/generator/testdata_enum_split_const_blocks_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/engine"
+	intspec "github.com/ehabterra/apispec/internal/spec"
+)
+
+// TestTestdata_EnumSplitConstBlocks pins that a type's enum is ALL of its
+// constants, however they are arranged in source.
+//
+// Enum detection used to document the single largest `const (...)` block and
+// drop the rest. Any enum big enough to be worth writing down is grouped by
+// meaning — creation triggers here, terminal transitions there, each under its
+// own comment — so this hit real types hard: a 32-value type was documented with
+// 6 values, and clients validating against it would reject 26 legitimate ones.
+//
+// The failure also MOVED. The winner was the biggest block, ties to the earliest,
+// so appending a constant to a tied block flipped the whole enum to a different
+// block's values — spec drift with no source change that explains it, and no
+// signal that anything was dropped either time.
+func TestTestdata_EnumSplitConstBlocks(t *testing.T) {
+	cfg := engine.DefaultEngineConfig()
+	cfg.InputDir = filepath.Join("..", "testdata", "enum_split_const_blocks")
+
+	out, err := engine.NewEngine(cfg).GenerateOpenAPI()
+	if err != nil {
+		t.Fatalf("GenerateOpenAPI: %v", err)
+	}
+
+	schema := findSchemaBySuffix(t, out, "_Candidate")
+
+	// Reason's constants live in three blocks of 3, 2 and 3 — two of them tied
+	// for largest, which is what made the old answer flip.
+	assertEnum(t, schema, "reason", []string{
+		"deadline_passed", "hw_completed", "lesson_completed", "over_maximum",
+		"quiz_announced", "quiz_boundary", "unenrolled", "within_target",
+	})
+
+	// Kind is the control: one block, and unioning must not pull in Reason's
+	// values just because both are string-underlying (issue #229).
+	assertEnum(t, schema, "kind", []string{"exercise", "quiz"})
+}
+
+// findSchemaBySuffix returns the one component schema whose name ends in suffix.
+func findSchemaBySuffix(t *testing.T, out *intspec.OpenAPISpec, suffix string) *intspec.Schema {
+	t.Helper()
+	var found *intspec.Schema
+	for name, s := range out.Components.Schemas {
+		if strings.HasSuffix(name, suffix) {
+			if found != nil {
+				t.Fatalf("more than one component ends in %q", suffix)
+			}
+			found = s
+		}
+	}
+	if found == nil {
+		t.Fatalf("no component schema ends in %q", suffix)
+	}
+	return found
+}
+
+// assertEnum compares a property's enum against want, as sorted strings.
+func assertEnum(t *testing.T, schema *intspec.Schema, property string, want []string) {
+	t.Helper()
+	prop, ok := schema.Properties[property]
+	if !ok {
+		t.Fatalf("property %q missing", property)
+	}
+	got := make([]string, 0, len(prop.Enum))
+	for _, v := range prop.Enum {
+		s, ok := v.(string)
+		if !ok {
+			t.Fatalf("property %q enum holds a non-string %T", property, v)
+		}
+		got = append(got, s)
+	}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("property %q enum =\n  %v\nwant\n  %v\n"+
+			"every constant declared with the type belongs to it; a `const (...)` block is "+
+			"source arrangement, not membership", property, got, want)
+	}
+}

--- a/internal/spec/enum_identity_test.go
+++ b/internal/spec/enum_identity_test.go
@@ -16,6 +16,7 @@ package spec
 
 import (
 	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/ehabterra/apispec/internal/metadata"
@@ -105,5 +106,121 @@ func TestTypeMatchesRejectsSharedUnderlyingType(t *testing.T) {
 	}
 	if !typeMatches("Status", "Status", meta) {
 		t.Error("a type no longer matches itself")
+	}
+}
+
+// splitBlockMeta declares ONE type whose constants sit in three `const (...)`
+// blocks of sizes 3, 2 and 3 — the ordinary way an enum with more than a handful
+// of members is written, grouped by meaning under its own comment.
+//
+// Two blocks are tied for largest on purpose: that is the state a real 32-value
+// type was in when two constants were appended to the tied block, which silently
+// replaced the whole documented enum with the other block's values.
+func splitBlockMeta() *metadata.Metadata {
+	sp := metadata.NewStringPool()
+	constant := func(name, declaredType, value string, group int) *metadata.Variable {
+		return &metadata.Variable{
+			Name:          sp.Get(name),
+			Type:          sp.Get(declaredType),
+			ResolvedType:  sp.Get("string"),
+			Tok:           sp.Get("const"),
+			Value:         sp.Get(value),
+			ComputedValue: value,
+			GroupIndex:    group,
+		}
+	}
+	return &metadata.Metadata{
+		StringPool: sp,
+		Packages: map[string]*metadata.Package{
+			"app": {Files: map[string]*metadata.File{
+				"reason.go": {
+					Types: map[string]*metadata.Type{"Reason": {Name: sp.Get("Reason"), Kind: sp.Get("string")}},
+					Variables: map[string]*metadata.Variable{
+						// Block 1 — 3 values.
+						"ReasonLessonCompleted": constant("ReasonLessonCompleted", "Reason", "lesson_completed", 1),
+						"ReasonHWCompleted":     constant("ReasonHWCompleted", "Reason", "hw_completed", 1),
+						"ReasonQuizAnnounced":   constant("ReasonQuizAnnounced", "Reason", "quiz_announced", 1),
+						// Block 2 — 2 values, the smallest.
+						"ReasonWithinTarget": constant("ReasonWithinTarget", "Reason", "within_target", 2),
+						"ReasonOverMaximum":  constant("ReasonOverMaximum", "Reason", "over_maximum", 2),
+						// Block 3 — 3 values, tied with block 1.
+						"ReasonDeadlinePassed": constant("ReasonDeadlinePassed", "Reason", "deadline_passed", 3),
+						"ReasonQuizBoundary":   constant("ReasonQuizBoundary", "Reason", "quiz_boundary", 3),
+						"ReasonUnenrolled":     constant("ReasonUnenrolled", "Reason", "unenrolled", 3),
+					},
+				},
+			}},
+		},
+	}
+}
+
+// TestDetectEnumUnionsEveryConstBlock pins that a `const (...)` block is source
+// arrangement, not membership.
+//
+// Detection used to document the largest block and silently drop the others, so
+// a type's enum was a subset chosen by how its source happened to be laid out.
+// Every constant here declares Reason, which is a fact about each one; nothing
+// in the source says a block is authoritative, because none of them is.
+func TestDetectEnumUnionsEveryConstBlock(t *testing.T) {
+	meta := splitBlockMeta()
+
+	want := []interface{}{
+		"deadline_passed", "hw_completed", "lesson_completed", "over_maximum",
+		"quiz_announced", "quiz_boundary", "unenrolled", "within_target",
+	}
+	got := detectEnumFromConstants("Reason", "app", meta)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Reason enum =\n  %v\nwant all 8 constants\n  %v", got, want)
+	}
+}
+
+// TestDetectEnumIsStableWhenABlockGrows is the regression guard for how this was
+// FOUND: as unexplained spec drift.
+//
+// With the largest block winning and ties going to the earliest, appending a
+// constant to a tied block did not add a value — it swapped the entire enum for
+// a different block's. The values already documented must never depend on the
+// relative sizes of the blocks.
+func TestDetectEnumIsStableWhenABlockGrows(t *testing.T) {
+	meta := splitBlockMeta()
+	before := detectEnumFromConstants("Reason", "app", meta)
+
+	// Append two constants to block 3, breaking the tie it had with block 1.
+	sp := meta.StringPool
+	file := meta.Packages["app"].Files["reason.go"]
+	for name, value := range map[string]string{
+		"ReasonReenrolled":      "reenrolled",
+		"ReasonMidtermBoundary": "midterm_boundary",
+	} {
+		file.Variables[name] = &metadata.Variable{
+			Name: sp.Get(name), Type: sp.Get("Reason"), ResolvedType: sp.Get("string"),
+			Tok: sp.Get("const"), Value: sp.Get(value), ComputedValue: value, GroupIndex: 3,
+		}
+	}
+
+	after := detectEnumFromConstants("Reason", "app", meta)
+	if len(after) != len(before)+2 {
+		t.Fatalf("after adding 2 constants the enum went from %d to %d values:\n  %v\n"+
+			"growing one block must ADD to the enum, never replace it", len(before), len(after), after)
+	}
+	for _, v := range before {
+		if !slices.Contains(after, v) {
+			t.Errorf("%v was documented before a constant was added elsewhere and is gone now", v)
+		}
+	}
+}
+
+// TestExtractEnumValuesDeduplicates keeps the union from producing an invalid
+// schema: OpenAPI requires enum members to be unique, and two constants of one
+// type may legitimately share a value (a renamed member kept as a deprecated
+// alias) — which unioning the blocks now brings together.
+func TestExtractEnumValuesDeduplicates(t *testing.T) {
+	got := extractEnumValues([]EnumConstant{
+		{Name: "A", Value: "active"},
+		{Name: "ALegacy", Value: "active"},
+		{Name: "R", Value: "retired"},
+	})
+	if want := []interface{}{"active", "retired"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("enum values = %v, want %v — duplicates make the schema invalid", got, want)
 	}
 }

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -2460,21 +2460,35 @@ func detectEnumFromConstants(goType string, pkgName string, meta *metadata.Metad
 		return nil
 	}
 
-	// The largest group of that type, chosen over sorted keys so the answer cannot
-	// depend on map order, and ties resolve to the earliest declaration.
-	var bestEnumValues []interface{}
-	var maxGroupSize int
+	// EVERY group of that type, not the biggest one.
+	//
+	// A `const (...)` block is a way of arranging source, not a statement about
+	// membership: any enum with more than a handful of values is written as
+	// several blocks grouped by meaning, each under its own comment. Every
+	// constant that reached this point declares the target type (typeMatches
+	// demands identity, not a shared underlying type — issue #229) or sits in a
+	// block with one that does, so all of them belong to it and taking one block
+	// is data loss.
+	//
+	// It was also unstable in the worst way. The winner was the largest block with
+	// ties going to the earliest, so ADDING a constant to one block could flip the
+	// entire enum to a different block's values: a real 30-value type documented 6
+	// creation triggers until two constants were appended to a tied block, after
+	// which it documented 8 terminal transitions instead and neither set was ever
+	// complete. Nothing in the source says which block is authoritative, because
+	// none of them is — and the drift arrives with no source change that explains
+	// it.
+	//
+	// Sorted keys throughout, so map order cannot reach the output (golden rule #1).
+	var all []EnumConstant
 	for _, declaredType := range slices.Sorted(maps.Keys(constantGroups)) {
 		groups := constantGroups[declaredType]
 		for _, groupIndex := range slices.Sorted(maps.Keys(groups)) {
-			if group := groups[groupIndex]; len(group) > maxGroupSize {
-				maxGroupSize = len(group)
-				bestEnumValues = extractEnumValues(group)
-			}
+			all = append(all, groups[groupIndex]...)
 		}
 	}
 
-	return bestEnumValues
+	return extractEnumValues(all)
 }
 
 // sortedVariables returns a file's variables in name order. Enum detection reads
@@ -2529,6 +2543,20 @@ func extractEnumValues(constants []EnumConstant) []interface{} {
 		valJ := fmt.Sprintf("%v", values[j])
 		return valI < valJ
 	})
+
+	// OpenAPI requires enum members to be unique, and two constants of one type
+	// may legitimately share a value (a renamed member kept as a deprecated
+	// alias). Deduplicating after the sort keeps that a documentation detail
+	// rather than an invalid schema.
+	if len(values) > 1 {
+		unique := values[:1]
+		for _, v := range values[1:] {
+			if fmt.Sprintf("%v", unique[len(unique)-1]) != fmt.Sprintf("%v", v) {
+				unique = append(unique, v)
+			}
+		}
+		values = unique
+	}
 
 	return values
 }

--- a/testdata/enum_split_const_blocks/go.mod
+++ b/testdata/enum_split_const_blocks/go.mod
@@ -1,0 +1,3 @@
+module github.com/ehabterra/apispec/testdata/enum_split_const_blocks
+
+go 1.21

--- a/testdata/enum_split_const_blocks/main.go
+++ b/testdata/enum_split_const_blocks/main.go
@@ -1,0 +1,66 @@
+// Fixture: one named string type whose constants are declared across SEVERAL
+// `const (...)` blocks, which is how any non-trivial enum is actually written —
+// grouped by what the values mean, with a comment over each group.
+//
+// The blocks are deliberately different sizes, and two of them are tied for
+// largest. That is the part that matters: the enum used to be the values of the
+// BIGGEST block alone, so the size of one group decided whether the others were
+// documented at all. Adding a value to a group could therefore replace the whole
+// enum with a different group's values — a silent, confident wrong answer, and
+// one that shows up as spec drift with no source change to explain it.
+//
+// Kind is the control: a type whose constants all sit in one block must keep
+// documenting exactly those.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// Reason is which rule fired. Every constant below is explicitly typed, so
+// belonging to Reason is a FACT about each one — not an inference from which
+// block it happens to sit in.
+type Reason string
+
+// Creation triggers — 3 values.
+const (
+	ReasonLessonCompleted Reason = "lesson_completed"
+	ReasonHWCompleted     Reason = "hw_completed"
+	ReasonQuizAnnounced   Reason = "quiz_announced"
+)
+
+// Placement outcomes — 2 values, the smallest block.
+const (
+	ReasonWithinTarget Reason = "within_target"
+	ReasonOverMaximum  Reason = "over_maximum"
+)
+
+// Terminal transitions — 3 values, tied with the first block for largest.
+const (
+	ReasonDeadlinePassed Reason = "deadline_passed"
+	ReasonQuizBoundary   Reason = "quiz_boundary"
+	ReasonUnenrolled     Reason = "unenrolled"
+)
+
+// Kind's constants all live in one block: the control for the case above.
+type Kind string
+
+const (
+	KindExercise Kind = "exercise"
+	KindQuiz     Kind = "quiz"
+)
+
+type Candidate struct {
+	Reason Reason `json:"reason"`
+	Kind   Kind   `json:"kind"`
+}
+
+func getCandidate(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode(Candidate{Reason: ReasonQuizAnnounced, Kind: KindQuiz})
+}
+
+func main() {
+	http.HandleFunc("/candidate", getCandidate)
+	_ = http.ListenAndServe(":8080", nil)
+}


### PR DESCRIPTION
`detectEnumFromConstants` grouped a type's constants by `const (...)` block and documented **only the biggest block**, dropping the rest with no warning:

```go
if group := groups[groupIndex]; len(group) > maxGroupSize {
    maxGroupSize = len(group)
    bestEnumValues = extractEnumValues(group)   // overwrite, not append
}
```

A block is source arrangement, not membership. Any enum past a handful of values is written as several blocks grouped by meaning, each under its own comment — so this hit exactly the types big enough to matter. A real 32-value `Reason` type was documented with **6** values, and a client validating against that spec rejects 26 legitimate ones.

Every constant that reaches the selection already declares the target type — `typeMatches` demands type identity, not a shared underlying type (#229) — or sits in a block with one that does. So all of them belong to it, and taking one block is data loss, not disambiguation.

## How it was found: the failure moves

The winner was the largest block with ties going to the earliest, so **appending a constant to a tied block did not add a value — it replaced the entire enum with a different block's**.

That `Reason` type had a 6-value creation-triggers block and a 6-value terminal-transitions block, tied, so the earliest won. Two constants were later appended to the terminal block; it became 8, won outright, and the documented enum silently became a disjoint set:

| | documented |
|---|---|
| before | `below_recovery_threshold, bundle_completed, hw_completed, hw_deadline_reached, lesson_completed, quiz_announced` |
| after | `age_out_window_reached, auto_reschedule_exhausted, deadline_passed, midterm_boundary, no_unused_variant, quiz_boundary, reenrolled, unenrolled` |

Neither set was ever complete, no value the two share, and nothing in the source explains the change. It surfaces as unexplained spec drift.

## Also

`extractEnumValues` now deduplicates. Unioning the blocks can bring together two constants of one type that share a value (a renamed member kept as a deprecated alias), and OpenAPI requires enum members to be unique.

## Verification

Measured on a real 265-route project: **0 enum values lost, 52 gained** (checked set-wise per property, not by array index — the diff below reports 12 "CHANGED" purely because entries shift position in a now-longer sorted list). `Reason` goes from 6 documented values to all 32.

`scripts/compare-spec.sh` over all 74 fixtures and 11 real projects: no other project changed at all, so nothing else in the corpus had a split-block enum. Full suite, `-race`, `golangci-lint`, `gofmt`, `go vet` clean.

## Tests

- **`testdata/enum_split_const_blocks`** + structural test — three blocks of 3/2/3 with two tied for largest (the exact state that made the real enum flip), plus a single-block `Kind` control so the union cannot pull in another string-underlying type's values (#229).
- **`TestDetectEnumUnionsEveryConstBlock`** — all 8 values, not the largest block's 3.
- **`TestDetectEnumIsStableWhenABlockGrows`** — appending 2 constants must ADD, never replace; guards the drift above directly.
- **`TestExtractEnumValuesDeduplicates`**.

All three unit tests were confirmed to fail against the previous behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
