### PR TITLE
docs(spec): drop the deleted type resolver from the package README

### DIFF
--- a/internal/spec/README.md
+++ b/internal/spec/README.md
@@ -61,8 +61,7 @@ The extractor walks the tracker tree, dispatching each node to the
 configured pattern matchers (routes, mounts, request bodies, responses,
 params). Each matcher is a small struct backed by a regex/index pattern
 from `FrameworkConfig`. Cross-cutting helpers live in companion files:
-`context_provider.go`, `schema_mapper.go`, `type_resolver.go`,
-`body_source.go`.
+`context_provider.go`, `schema_mapper.go`, `body_source.go`.
 
 ```go
 type Extractor struct {
@@ -70,7 +69,6 @@ type Extractor struct {
     cfg             *APISpecConfig
     contextProvider ContextProvider
     schemaMapper    SchemaMapper
-    typeResolver    TypeResolver
     overrideApplier OverrideApplier
 
     routeMatchers    []RoutePatternMatcher


### PR DESCRIPTION
Follow-up to #280/#281.

`internal/spec/README.md` still listed `type_resolver.go` among the extractor's companion files, and still showed a `typeResolver TypeResolver` field in the `Extractor` struct it documents. Both were removed with the dead resolver:

```console
$ ls internal/spec/type_resolver.go
ls: internal/spec/type_resolver.go: No such file or directory
$ grep -c typeResolver internal/spec/extractor.go
0
```

Docs only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)