### PR TITLE
feat(spec): report response patterns that match a bare call name anywhere (#294)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -287,7 +287,7 @@ Sub-keys of `framework`:
 |-----|---------|
 | `routePatterns` | How routes are registered (method/path/handler extraction). |
 | `requestBodyPatterns` | Calls that bind a request body to a Go type. |
-| `responsePatterns` | Calls that write a response (status + body type). |
+| `responsePatterns` | Calls that write a response (status + body type). **Anchor any pattern that extracts a body type** — see below. |
 | `paramPatterns` | Calls that read a parameter, and its `in:` location. |
 | `mountPatterns` | Sub-router mounting (path-prefix composition). |
 | `securityPatterns` | Where/how auth middleware is applied (scope). |
@@ -295,6 +295,49 @@ Sub-keys of `framework`:
 | `handlerInterfaceMethods` | Method names that make a type a handler (`ServeHTTP`), so a route registered with a handler *value* is followed into it. |
 | `requestContext` | Which receivers/accessors mark a "request body" source. |
 | `responseContext` | Which types are the response *writer*, for response patterns gated on write destination (`requireResponseDestination`). Parameter reads state their own exclusion per pattern (`excludeRecvOriginRegex`). |
+
+### Anchoring a response pattern
+
+A `responsePattern` matches by **call name**. If it also sets `typeFromArg` and is
+anchored to nothing else, it documents that call's argument as the endpoint's
+response body *wherever the call appears in the handler's call graph* — including
+where a client marshals a body for an **outbound** request. The endpoint then
+carries a response it can never return, and nothing in the spec indicates why.
+
+```yaml
+# Wrong: matches every json.Marshal reached from the handler, including the one
+# an HTTP client uses to build its own request body.
+- callRegex: ^Marshal$
+  typeFromArg: true
+```
+
+Any one of these anchors it — pick whichever describes the real constraint:
+
+| anchor | use when |
+|---|---|
+| `recvType` / `recvTypeRegex` | the call is made **on** the response writer or a framework renderer |
+| `requireResponseDestination` | it is a generic encoder whose destination must trace to the response writer (`json.NewEncoder(w).Encode(v)`, with `destFromReceiver`) |
+| `callerPkgPatterns` / `calleePkgPatterns` | only calls made in, or landing in, particular packages count |
+| `functionNameRegex` | the enclosing function identifies it |
+
+APISpec reports unanchored patterns at config load:
+
+```
+[config] 1 response pattern(s) match a bare call name anywhere in the call graph
+and may document an outbound request body as a response: responsePatterns[7]
+(callRegex "^Marshal$") — scope with recvType/recvTypeRegex, or set
+requireResponseDestination
+```
+
+It is advisory, not an error: a project whose serializer really is only reached
+from a response path is entitled to keep the pattern. Every shipped preset is
+anchored, so a default run never reports this.
+
+> A serializer that *returns* bytes (`json.Marshal`) has no destination for
+> `requireResponseDestination` to check. The supported way to document
+> `b, _ := json.Marshal(v); w.Write(b)` is not a `Marshal` response pattern at
+> all — it is `responseContext.bodyTransforms`, which traces the marshalled bytes
+> to the write on the response writer.
 
 ### Scoping a pattern to where the call is made
 

--- a/internal/spec/config.go
+++ b/internal/spec/config.go
@@ -1069,3 +1069,51 @@ func stdDefaults(responseStatus int) Defaults {
 		ResponseStatus:      responseStatus,
 	}
 }
+
+// UnanchoredResponsePatterns reports response patterns that extract a body type
+// but are anchored to nothing, so they match a bare call NAME anywhere in the
+// handler's call graph (issue #294).
+//
+// The shape that motivated this is a hand-written or exported-then-frozen
+// pattern for a serializer:
+//
+//	responsePatterns:
+//	  - callRegex: ^Marshal$
+//	    typeFromArg: true
+//
+// json.Marshal returns bytes. It has no destination argument, so
+// RequireResponseDestination cannot gate it and no receiver type distinguishes
+// one call from another — which means the pattern also matches the body a client
+// marshals for an OUTBOUND request. Measured on a ~500-route service, one such
+// pattern put a third-party provider's request struct on 16 operations as their
+// response, and accounted for 40 of the 41 spurious `default:` blocks in that
+// spec; removing it took the count to 1.
+//
+// Every shipped framework preset anchors its response patterns — to the response
+// writer's type, to the framework's render package, or (for the generic encoder)
+// to requireResponseDestination — so this reports nothing for a default config.
+// It is advisory rather than an error: a pattern like this is usually a mistake,
+// but a project whose serializer really is only ever reached from a response
+// path is entitled to keep it, and refusing to run would be worse than saying so.
+//
+// The test is structural, NOT a list of serializer names: the question is whether
+// the pattern has ANY way to tell a response from an unrelated call, and a
+// name-based test of the user's own regex would be the guessing this exists to
+// stop.
+func (c *APISpecConfig) UnanchoredResponsePatterns() []string {
+	var out []string
+	for i, p := range c.Framework.ResponsePatterns {
+		if !p.TypeFromArg {
+			continue // claims no body type, so it cannot misattribute one
+		}
+		anchored := p.RecvType != "" || p.RecvTypeRegex != "" || p.FunctionNameRegex != "" ||
+			p.RequireResponseDestination ||
+			len(p.CallerPkgPatterns) > 0 || len(p.CallerRecvTypePatterns) > 0 ||
+			len(p.CalleePkgPatterns) > 0 || len(p.CalleeRecvTypePatterns) > 0
+		if anchored {
+			continue
+		}
+		out = append(out, fmt.Sprintf("responsePatterns[%d] (callRegex %q)", i, p.CallRegex))
+	}
+	return out
+}

--- a/internal/spec/config_response_anchor_test.go
+++ b/internal/spec/config_response_anchor_test.go
@@ -1,0 +1,120 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestUnanchoredResponsePatternsReportsBareCallNames pins the rule of issue
+// #294: a response pattern that extracts a body type but is anchored to nothing
+// matches a bare call NAME anywhere in the handler's call graph, so it documents
+// whatever that call happens to carry — including the body a client marshals for
+// an OUTBOUND request.
+//
+// The test is over the ANCHORS, not over serializer names. Which calls are
+// dangerous is not knowable from a regex; whether a pattern has any way to tell
+// a response from an unrelated call is.
+func TestUnanchoredResponsePatternsReportsBareCallNames(t *testing.T) {
+	bare := ResponsePattern{CallRegex: `^Marshal$`, TypeFromArg: true, Deref: true}
+
+	t.Run("bare call name is reported", func(t *testing.T) {
+		cfg := &APISpecConfig{Framework: FrameworkConfig{ResponsePatterns: []ResponsePattern{bare}}}
+		got := cfg.UnanchoredResponsePatterns()
+		if len(got) != 1 {
+			t.Fatalf("got %v, want the one unanchored pattern", got)
+		}
+		// The message has to name which pattern, or a config with twenty of them
+		// is no more actionable than no message at all.
+		if !strings.Contains(got[0], "responsePatterns[0]") || !strings.Contains(got[0], "^Marshal$") {
+			t.Errorf("report %q names neither the index nor the regex", got[0])
+		}
+	})
+
+	// Each of these is a way to tell a response from an unrelated call, so each
+	// must silence the report on its own.
+	for name, anchor := range map[string]func(*ResponsePattern){
+		"recvType":                   func(p *ResponsePattern) { p.RecvType = "net/http.ResponseWriter" },
+		"recvTypeRegex":              func(p *ResponsePattern) { p.RecvTypeRegex = `^net/http\.ResponseWriter$` },
+		"functionNameRegex":          func(p *ResponsePattern) { p.FunctionNameRegex = `.*Handler$` },
+		"requireResponseDestination": func(p *ResponsePattern) { p.RequireResponseDestination = true },
+		"callerPkgPatterns":          func(p *ResponsePattern) { p.CallerPkgPatterns = []string{"^example.com/api"} },
+		"callerRecvTypePatterns":     func(p *ResponsePattern) { p.CallerRecvTypePatterns = []string{"^example.com/api"} },
+		"calleePkgPatterns":          func(p *ResponsePattern) { p.CalleePkgPatterns = []string{"^encoding/json$"} },
+		"calleeRecvTypePatterns":     func(p *ResponsePattern) { p.CalleeRecvTypePatterns = []string{"^example.com/api"} },
+	} {
+		t.Run("anchored by "+name, func(t *testing.T) {
+			p := bare
+			anchor(&p)
+			cfg := &APISpecConfig{Framework: FrameworkConfig{ResponsePatterns: []ResponsePattern{p}}}
+			if got := cfg.UnanchoredResponsePatterns(); len(got) != 0 {
+				t.Errorf("%s anchors the pattern, but it was reported: %v", name, got)
+			}
+		})
+	}
+
+	// A pattern that extracts no body type cannot misattribute one, whatever it
+	// matches — the status-only patterns (WriteHeader, Status) are exactly this.
+	t.Run("no body type extracted", func(t *testing.T) {
+		p := ResponsePattern{CallRegex: `^WriteHeader$`, StatusFromArg: true}
+		cfg := &APISpecConfig{Framework: FrameworkConfig{ResponsePatterns: []ResponsePattern{p}}}
+		if got := cfg.UnanchoredResponsePatterns(); len(got) != 0 {
+			t.Errorf("a status-only pattern was reported: %v", got)
+		}
+	})
+
+	t.Run("empty config", func(t *testing.T) {
+		if got := (&APISpecConfig{}).UnanchoredResponsePatterns(); len(got) != 0 {
+			t.Errorf("got %v, want nothing", got)
+		}
+	})
+}
+
+// TestPresetsAnchorTheirResponsePatterns keeps the check honest in the direction
+// that matters most: it must not become noise a user cannot act on. Every pattern
+// APISpec itself ships is anchored, so a default run reports nothing.
+//
+// The net/http catch-all is the one exception, and it is a real one rather than a
+// tolerated false positive — it matches JSON/String/Data/File/Redirect by bare
+// name in any reached package (issue #302). It is asserted here as the CURRENT
+// state so this test flips the moment it is fixed, instead of the exception
+// quietly outliving the defect.
+func TestPresetsAnchorTheirResponsePatterns(t *testing.T) {
+	for name, cfg := range map[string]*APISpecConfig{
+		"chi":   DefaultChiConfig(),
+		"gin":   DefaultGinConfig(),
+		"echo":  DefaultEchoConfig(),
+		"fiber": DefaultFiberConfig(),
+		"mux":   DefaultMuxConfig(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := cfg.UnanchoredResponsePatterns(); len(got) != 0 {
+				t.Errorf("%s preset ships an unanchored response pattern: %v", name, got)
+			}
+		})
+	}
+
+	t.Run("http (known gap, issue #302)", func(t *testing.T) {
+		got := DefaultHTTPConfig().UnanchoredResponsePatterns()
+		if len(got) != 1 {
+			t.Fatalf("got %d unanchored patterns, want exactly the known net/http catch-all; "+
+				"if #302 is fixed, delete this subtest and add http to the table above", len(got))
+		}
+		if !strings.Contains(got[0], "JSON|String|XML") {
+			t.Errorf("the unanchored net/http pattern is %q, not the catch-all this exception covers", got[0])
+		}
+	})
+}

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -108,6 +108,18 @@ func LoadAPISpecConfig(path string) (*APISpecConfig, error) {
 		return nil, err
 	}
 
+	// Advisory, and only for a config the user wrote — the presets never trip it
+	// (issue #294). Reported at load rather than at extraction because the fix is
+	// an edit to this file, and because the symptom it produces (a response body
+	// the endpoint can never return) looks like a resolution bug, not a config
+	// one, to anyone reading the generated spec.
+	if bare := config.UnanchoredResponsePatterns(); len(bare) > 0 {
+		log.Printf("[config] %d response pattern(s) match a bare call name anywhere in the call graph "+
+			"and may document an outbound request body as a response: %s — scope with "+
+			"recvType/recvTypeRegex, or set requireResponseDestination",
+			len(bare), strings.Join(bare, ", "))
+	}
+
 	return &config, nil
 }
 


### PR DESCRIPTION
Fixes #294.

A `responsePattern` matches by call **name**. One that also sets `typeFromArg` and is anchored to nothing documents that call's argument as the endpoint's response body *wherever the call appears in the handler's call graph* — including where a client marshals a body for an **outbound** request:

```yaml
responsePatterns:
  - callRegex: ^Marshal$
    typeFromArg: true
```

`json.Marshal` **returns** bytes. It has no destination argument, so `requireResponseDestination` cannot gate it, and no receiver type tells one call from another. The pattern is structurally ungateable, and APISpec accepted it in silence.

## Attribution

Measured on a ~500-route chi service, bisecting its config one pattern at a time:

| config | operations with a spurious `default:` |
|---|---|
| as written | 41 |
| \+ `requireResponseDestination` on `^Encode$` | 41 |
| − an explicit pattern for the outbound client's own `Send` | 41 |
| **− the unanchored `^Marshal$`** | **1** |

16 of the 41 were the third-party provider's request struct; one was `context.Context`. It was this pattern and only this pattern.

The consumer reasonably concluded APISpec "treats any type marshalled to JSON in the handler's call graph as a response candidate" — with that config, that is exactly what it does. The shipped presets do not have this pattern; they handle `b, _ := json.Marshal(v); w.Write(b)` through `responseContext.bodyTransforms`, which traces the bytes to the write on the response writer. That distinction was undocumented, which is half of why the pattern got written.

## The check

Over the **anchors**, not over serializer names. Which calls are dangerous is not knowable from a regex; whether a pattern has any way to tell a response from an unrelated call is. A pattern is reported only when it extracts a body type *and* has no `recvType`/`recvTypeRegex`, no `functionNameRegex`, no caller/callee package scope, and no `requireResponseDestination`.

Reported at **config load** — the fix is an edit to that file, and the symptom (a response body the endpoint can never return) reads as a resolution bug to anyone looking at the generated spec.

**Advisory, not an error.** A project whose serializer really is only reached from a response path is entitled to keep the pattern; refusing to run would be worse than saying so.

## It found one in our own preset

`DefaultHTTPConfig` ships an unanchored `JSON|String|XML|YAML|ProtoBuf|Data|File|Redirect` catch-all — same defect class, shipped by default. Filed as **#302** rather than fixed here: anchoring it needs a new `destArgIndex` config field (today `requireResponseDestination` resolves the destination only from an encoder-factory receiver), and that change can only *remove* responses, so it needs its own measurement.

`TestPresetsAnchorTheirResponsePatterns` asserts it as the **current** state with a pointer to #302, so the carve-out fails the build when it is fixed instead of quietly outliving the defect.

## Verification

- **Diagnostic only — no spec output changes.** A/B across 11 real projects: zero paths, statuses, schemas or components differ.
- Fires on exactly the offending pattern in the real config: `responsePatterns[7] (callRegex "^Marshal$")`.
- Unit tests cover the report naming the index and regex, all eight anchoring mechanisms silencing it individually, a status-only pattern (no body type extracted) being ignored, and an empty config.
- No fixture project: this changes no extraction behaviour, so there is no spec output for one to assert.
- Full suite, `-race`, `golangci-lint`, `gofmt`, `go vet` clean.

`docs/CONFIGURATION.md` gains an "Anchoring a response pattern" section with the wrong/right forms, a table of the anchors, and the note that a serializer returning bytes belongs in `bodyTransforms`, not in a response pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
