### PR TITLE
fix(spec): a Mount written inside a helper keeps its prefix (#275)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ testdata/enum_split_const_blocks/enum_split_const_blocks
 
 # a `go build` inside the map-envelope fixture drops its binary beside main.go
 testdata/map_literal_envelope/map_literal_envelope
+
+# a `go build` inside the mount-via-helper fixture drops its binary beside main.go
+testdata/mount_via_helper/mount_via_helper

--- a/generator/testdata_mount_via_helper_test.go
+++ b/generator/testdata_mount_via_helper_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/engine"
+)
+
+// TestTestdata_MountViaHelper pins that a Mount written inside a helper still
+// applies its prefix (issue #275).
+//
+// A mount prefix reaches nested routes by tree containment. With the Mount one
+// function deeper the sub-router was built at the CALL SITE, so its routes hang
+// under the caller's argument while the Mount node sits in the helper's body —
+// siblings, not ancestor and descendant. The routes were documented at the wrong
+// paths, with nothing to indicate the path was incomplete.
+func TestTestdata_MountViaHelper(t *testing.T) {
+	cfg := engine.DefaultEngineConfig()
+	cfg.InputDir = filepath.Join("..", "testdata", "mount_via_helper")
+
+	out, err := engine.NewEngine(cfg).GenerateOpenAPI()
+	if err != nil {
+		t.Fatalf("GenerateOpenAPI: %v", err)
+	}
+
+	noDanglingRefs(t, out)
+	noUnresolvedPlaceholders(t, out)
+
+	for _, want := range []string{
+		"/direct/things", // control: mounted at the call site
+		"/api/things",    // literal prefix inside a helper — the fix
+	} {
+		if _, ok := out.Paths[want]; !ok {
+			got := make([]string, 0, len(out.Paths))
+			for p := range out.Paths {
+				got = append(got, p)
+			}
+			t.Errorf("missing %s; documented %v — a Mount in a helper must still apply its prefix", want, got)
+		}
+	}
+
+	// The un-prefixed form must NOT survive alongside the prefixed one: the
+	// sub-router's subtree is reached both directly and through the mount, and
+	// dropSubsumedMountPrefixes is what keeps only the most-mounted form.
+	if _, ok := out.Paths["/things"]; ok {
+		t.Error("/things is documented as well as its mounted forms — the un-prefixed " +
+			"duplicate must be dropped, or every helper-mounted route appears twice")
+	}
+
+	// CHANGE DETECTOR, not an endorsement: the prefix-as-parameter forms are a
+	// different gap — resolving the sub-router's position is done, resolving the
+	// PREFIX through a parameter is not (resolvePathArg does not trace
+	// parameters). Asserted at today's wrong behaviour so this test fails, and
+	// gets updated, the moment that is fixed.
+	t.Run("prefix through a parameter is still unresolved", func(t *testing.T) {
+		for _, notYet := range []string{"/param/things", "/named/things"} {
+			if _, ok := out.Paths[notYet]; ok {
+				t.Errorf("%s now resolves — the parameter-prefix gap is fixed; "+
+					"update this subtest to assert it properly and close the follow-up", notYet)
+			}
+		}
+	})
+}

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -847,6 +847,31 @@ func (e *Extractor) handleMountNode(node TrackerNodeInterface, mountInfo MountIn
 		e.handleRouterAssignment(mountInfo, mountPath, mountTags, childDynParams, subtreeMW, routes, visited)
 	}
 
+	// The mounted sub-router may have been built at the CALLER and passed in, with
+	// the Mount written one function deeper (issue #275):
+	//
+	//	func MountServer(r *chi.Mux, server http.Handler) { r.Mount("/api", server) }
+	//	MountServer(root, Server())
+	//
+	// The prefix reaches nested routes by tree containment, and here it cannot:
+	// the sub-router's routes hang under the argument at the CALL SITE, while the
+	// Mount node sits in the helper's body — siblings, not ancestor and
+	// descendant. So the routes were documented, at the wrong paths, without
+	// their prefix.
+	//
+	// Resolving the parameter back to the caller's argument gives the subtree the
+	// prefix belongs to. The plain traversal still reaches that subtree with no
+	// prefix, which is what makes the un-prefixed copy appear; it is dropped by
+	// dropSubsumedMountPrefixes, whose whole job is that a route reached through
+	// several contexts keeps only its most-mounted form.
+	if mountInfo.RouterArg != nil {
+		if callerArg, _ := resolveArgThroughParams(mountInfo.RouterArg, node); callerArg != nil && callerArg != mountInfo.RouterArg {
+			if target := e.findTargetNode(callerArg); target != nil {
+				e.mountRouterSubtree(target, mountPath, mountTags, childDynParams, subtreeMW, routes, visited)
+			}
+		}
+	}
+
 	// Continue traversing children
 	for _, child := range node.GetChildren() {
 		var newTags []string
@@ -969,23 +994,27 @@ func mergeRouteExtraction(existing, next *RouteInfo) {
 // handleRouterAssignment handles router assignment for mounts
 func (e *Extractor) handleRouterAssignment(mountInfo MountInfo, mountPath string, mountTags []string, mountDynParams []string, mountMW []MiddlewareRef, routes *[]*RouteInfo, visited map[string]bool) {
 	// Find the target node for the assignment
-	targetNode := e.findTargetNode(mountInfo.Assignment)
-	if targetNode != nil {
-		// Router-scope middleware among the assigned router's children (e.g.
-		// a `Use` registered on the sub-router) guards its routes, correlated
-		// per caller.
-		children := targetNode.GetChildren()
-		routerByCaller := e.collectRouterSecurityByCaller(children)
-		for _, child := range children {
-			var newTags []string
-			if mountPath != "" {
-				newTags = []string{mountPath}
-			} else {
-				newTags = mountTags
-			}
-			childMW := mergeMW(mountMW, routerByCaller[e.callerKey(child)])
-			e.traverseForRoutesWithVisited(child, mountPath, newTags, mountDynParams, childMW, routes, visited)
+	if targetNode := e.findTargetNode(mountInfo.Assignment); targetNode != nil {
+		e.mountRouterSubtree(targetNode, mountPath, mountTags, mountDynParams, mountMW, routes, visited)
+	}
+}
+
+// mountRouterSubtree walks a sub-router's subtree as if it were nested under the
+// mount, so its routes inherit the prefix. Shared by the two ways a mounted
+// router can live outside the mount node's own subtree: assigned to a variable
+// (`api := r.Group(...)`) and passed in as a parameter (issue #275).
+func (e *Extractor) mountRouterSubtree(target TrackerNodeInterface, mountPath string, mountTags []string, mountDynParams []string, mountMW []MiddlewareRef, routes *[]*RouteInfo, visited map[string]bool) {
+	// Router-scope middleware among the sub-router's children (e.g. a `Use`
+	// registered on it) guards its routes, correlated per caller.
+	children := target.GetChildren()
+	routerByCaller := e.collectRouterSecurityByCaller(children)
+	for _, child := range children {
+		newTags := mountTags
+		if mountPath != "" {
+			newTags = []string{mountPath}
 		}
+		childMW := mergeMW(mountMW, routerByCaller[e.callerKey(child)])
+		e.traverseForRoutesWithVisited(child, mountPath, newTags, mountDynParams, childMW, routes, visited)
 	}
 }
 

--- a/internal/spec/mount_subtree_test.go
+++ b/internal/spec/mount_subtree_test.go
@@ -1,0 +1,144 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// TestMountRouterSubtreeCarriesTheMountContext pins what a sub-router's subtree
+// inherits when it is walked as if nested under the mount (issue #275).
+//
+// mountRouterSubtree is the shared body of the two ways a mounted router can
+// live OUTSIDE the mount node's own subtree — assigned to a variable
+// (`api := r.Group(...)`) and passed in as a parameter (`mount(r, Server())`).
+// Sharing it is the point: before #275 only the assignment case existed, so the
+// parameter case inherited nothing at all, and a second copy of this walk would
+// be free to drift from it.
+//
+// The visited key is `node@mountPath`, so it doubles as the assertion that the
+// prefix was actually carried into the traversal rather than dropped.
+func TestMountRouterSubtreeCarriesTheMountContext(t *testing.T) {
+	newFixture := func() (*Extractor, *TrackerNode, *TrackerNode) {
+		meta := exSweepMeta()
+		tree := NewMockTrackerTree(meta, metadata.TrackerLimits{})
+		ext := NewExtractor(tree, &APISpecConfig{})
+		child := sweepNode(sweepEdge(meta, "routes", "app", "Get", "chi", "Mux", ""))
+		target := &TrackerNode{key: "sub-router", Children: []*TrackerNode{child}}
+		tree.AddRoot(target)
+		return ext, target, child
+	}
+
+	t.Run("the prefix reaches the subtree", func(t *testing.T) {
+		ext, target, child := newFixture()
+		var routes []*RouteInfo
+		visited := map[string]bool{}
+
+		ext.mountRouterSubtree(target, "/api", nil, nil, nil, &routes, visited)
+
+		if !visited[child.GetKey()+"@/api"] {
+			t.Errorf("the sub-router's child was not traversed under /api; visited = %v", visited)
+		}
+		// Walking it at the prefix must NOT also claim the un-prefixed context:
+		// that is the duplicate dropSubsumedMountPrefixes then has to clean up.
+		if visited[child.GetKey()+"@"] {
+			t.Error("the subtree was also walked with no prefix")
+		}
+	})
+
+	// A mount with a path names its own tag; one without inherits the tags it was
+	// given. Getting this backwards silently retags every route under a mount.
+	t.Run("tags: a path names its own, an empty path inherits", func(t *testing.T) {
+		for name, tc := range map[string]struct {
+			mountPath string
+			inherited []string
+		}{
+			"with path":    {"/api", []string{"inherited"}},
+			"without path": {"", []string{"inherited"}},
+		} {
+			t.Run(name, func(t *testing.T) {
+				ext, target, child := newFixture()
+				var routes []*RouteInfo
+				visited := map[string]bool{}
+
+				ext.mountRouterSubtree(target, tc.mountPath, tc.inherited, nil, nil, &routes, visited)
+
+				if !visited[child.GetKey()+"@"+tc.mountPath] {
+					t.Errorf("child not traversed at %q; visited = %v", tc.mountPath, visited)
+				}
+			})
+		}
+	})
+
+	// Dynamic params and middleware are threaded through rather than reset. With
+	// no route patterns configured nothing is emitted, so this pins the contract
+	// that the call is made and does not panic on the inherited slices — the
+	// end-to-end effect is the fixture's job.
+	t.Run("dynamic params and middleware are passed through", func(t *testing.T) {
+		ext, target, child := newFixture()
+		var routes []*RouteInfo
+		visited := map[string]bool{}
+
+		ext.mountRouterSubtree(target, "/api/{tenant}", nil,
+			[]string{"tenant"}, []MiddlewareRef{{FunctionName: "auth", Pkg: "app"}}, &routes, visited)
+
+		if !visited[child.GetKey()+"@/api/{tenant}"] {
+			t.Errorf("child not traversed under the dynamic prefix; visited = %v", visited)
+		}
+		if len(routes) != 0 {
+			t.Errorf("no route patterns are configured, so nothing should be emitted: %v", routes)
+		}
+	})
+
+	t.Run("a target with no children is a no-op", func(t *testing.T) {
+		meta := exSweepMeta()
+		tree := NewMockTrackerTree(meta, metadata.TrackerLimits{})
+		ext := NewExtractor(tree, &APISpecConfig{})
+		var routes []*RouteInfo
+		visited := map[string]bool{}
+
+		ext.mountRouterSubtree(&TrackerNode{key: "empty"}, "/api", nil, nil, nil, &routes, visited)
+
+		if len(routes) != 0 || len(visited) != 0 {
+			t.Errorf("routes = %v, visited = %v, want both empty", routes, visited)
+		}
+	})
+}
+
+// TestHandleMountNodeIgnoresAnUnresolvableRouterArg keeps the new parameter hop
+// from firing on the ordinary case. When the mounted router is NOT a parameter
+// bound to a caller's argument, resolveArgThroughParams returns the same
+// argument, and re-walking the mount's own subtree at its own prefix would
+// duplicate every route under it.
+func TestHandleMountNodeIgnoresAnUnresolvableRouterArg(t *testing.T) {
+	meta := exSweepMeta()
+	tree := NewMockTrackerTree(meta, metadata.TrackerLimits{})
+	ext := NewExtractor(tree, &APISpecConfig{})
+
+	// A plain local ident bound to nothing: there is no caller argument to reach.
+	routerArg := sweepIdent(meta, "server")
+	routerArg.SetPkg("app")
+
+	var routes []*RouteInfo
+	visited := map[string]bool{}
+	ext.handleMountNode(&TrackerNode{}, MountInfo{Path: "/api", RouterArg: routerArg},
+		"", nil, nil, nil, &routes, visited)
+
+	if len(routes) != 0 {
+		t.Errorf("routes = %v, want none — nothing resolves and no patterns are configured", routes)
+	}
+}

--- a/testdata/mount_via_helper/go.mod
+++ b/testdata/mount_via_helper/go.mod
@@ -1,0 +1,5 @@
+module github.com/ehabterra/apispec/testdata/mount_via_helper
+
+go 1.23
+
+require github.com/go-chi/chi/v5 v5.3.0

--- a/testdata/mount_via_helper/go.sum
+++ b/testdata/mount_via_helper/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.3.0 h1:halUjDxhshgXHMrao5bB8eNBXo/rnzwr8m5m36glehM=
+github.com/go-chi/chi/v5 v5.3.0/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=

--- a/testdata/mount_via_helper/main.go
+++ b/testdata/mount_via_helper/main.go
@@ -1,0 +1,76 @@
+// Fixture: a Mount performed inside a helper function (issue #275).
+//
+// A mount prefix reaches nested routes by tree containment. When the Mount is
+// written one function deeper, the sub-router was built at the CALL SITE, so its
+// routes hang under the caller's argument while the Mount node sits in the
+// helper's body — siblings, not ancestor and descendant. The routes were still
+// documented, at the wrong paths, without their prefix, which is worse than not
+// documenting them: nothing in the output says the path is incomplete.
+//
+// Centralising mounts in a small helper is the normal shape once a codebase has
+// more than a couple of modules, and it is what a DI-wired or generated server
+// produces.
+//
+// The four mounts differ only in WHERE the Mount is written and how the prefix
+// arrives, because they could fail for different reasons:
+//
+//	/direct    mounted at the call site — the control, which always worked
+//	/api       literal prefix, inside the helper — FIXED
+//	/param     prefix as a plain string parameter — STILL BROKEN
+//	/named     prefix as a named string type, converted at the Mount — STILL BROKEN
+//
+// The last two are a DIFFERENT gap and are asserted here at their current
+// (wrong) behaviour, so the test flips when they are fixed rather than the gap
+// going unnoticed. Getting the sub-router's routes under the mount is what this
+// fixture's fix does; resolving the PREFIX itself through a parameter is path
+// resolution, and resolvePathArg does not trace parameters — note that
+// resolvePathOperand already has callerArgFor for exactly this, but only for
+// concatenated paths.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type Thing struct {
+	ID string `json:"id"`
+}
+
+// RoutePrefix is a named string type, so the Mount call takes a conversion
+// rather than the parameter itself.
+type RoutePrefix string
+
+func Server() http.Handler {
+	r := chi.NewRouter()
+	r.Get("/things", func(w http.ResponseWriter, req *http.Request) {
+		_ = json.NewEncoder(w).Encode(Thing{ID: "1"})
+	})
+	return r
+}
+
+// mountLiteral writes the prefix as a literal, inside the helper.
+func mountLiteral(r *chi.Mux, server http.Handler) {
+	r.Mount("/api", server)
+}
+
+// mountParam takes the prefix as a plain string parameter.
+func mountParam(prefix string, r *chi.Mux, server http.Handler) {
+	r.Mount(prefix, server)
+}
+
+// mountNamed takes a named type and converts it at the Mount call.
+func mountNamed(prefix RoutePrefix, r *chi.Mux, server http.Handler) {
+	r.Mount(string(prefix), server)
+}
+
+func main() {
+	root := chi.NewRouter()
+	root.Mount("/direct", Server())
+	mountLiteral(root, Server())
+	mountParam("/param", root, Server())
+	mountNamed(RoutePrefix("/named"), root, Server())
+	_ = http.ListenAndServe(":8080", root)
+}


### PR DESCRIPTION
Fixes #275 (partially — see *What is not fixed*).

`r.Mount(prefix, server)` applied its prefix at the registration site and lost it silently one function deeper, documenting the routes at paths nothing serves.

## The cause is tree position, not resolution

A mount prefix reaches nested routes by **tree containment**. With the Mount written in a helper, the sub-router was built at the **call site**, so its routes hang under the caller's argument while the Mount node sits in the helper's body — siblings, not ancestor and descendant. The prefix had nothing to apply to.

That explains the part of the issue that looked strange: all three helper forms failed identically, *including* the one with a literal prefix and no parameter anywhere. The prefix was never the problem.

```
main
└── mountLiteral (call)
    ├── arg: Server()          → chi.NewRouter, r.Get("/things")   ← the routes
    └── body: r.Mount("/api", server)                              ← the prefix
```

Resolving the mounted router back through its parameter to the caller's argument gives the subtree the prefix belongs to.

The plain traversal still reaches that subtree unprefixed, which is what would make a duplicate appear — `dropSubsumedMountPrefixes` already exists for exactly that (a route reached through several contexts keeps only its most-mounted form), and the fixture asserts the un-prefixed `/things` does **not** survive alongside `/api/things`.

`handleRouterAssignment`'s body becomes `mountRouterSubtree`, now shared by the two ways a mounted router can live outside the mount node's subtree: assigned to a variable, and passed in as a parameter.

## What is not fixed

A prefix that is itself a **parameter** (`mountParam(prefix string, r, server)`) or a **named-type conversion** (`r.Mount(string(prefix), server)`). Those are path resolution rather than tree position: `resolvePathArg` does not trace parameters.

The fixture asserts them at today's wrong behaviour, so the test **fails and forces an update** when they are fixed rather than the gap going unnoticed.

For whoever picks that up: `resolvePathOperand` already has `callerArgFor` for precisely this case, but it is only wired into *concatenated* paths, not plain path arguments. I tried extending it inside this change and reverted — unwrapping the conversion made the named form resolve to its **type** name (`/github.com/…/RoutePrefix/things`), trading one wrong path for another, which is not progress.

## Verification

- fixture `testdata/mount_via_helper` covers all four forms: mounted at the call site (control), literal prefix in a helper (the fix), and the two parameter forms (change detectors)
- **A/B across 11 real projects: zero paths, statuses, schemas or components differ.** None of them mounts through a helper, so the fixture is the coverage — worth knowing when weighing the gate
- full suite, `-race`, `golangci-lint`, `gofmt`, `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenAPI generation now applies route prefixes when mounts are declared inside helper functions.
  * Routes inherited through helper-provided routers retain applicable tags, parameters, and middleware.

* **Bug Fixes**
  * Improved handling of mounted sub-router routes to prevent missing prefixed routes and incorrect unprefixed duplicates.

* **Tests**
  * Added integration coverage for helper-based mounts, generated references, placeholders, and related routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->