### PR TITLE
fix(spec): anchor the net/http response catch-all on the writer (#302)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ testdata/enum_split_const_blocks/enum_split_const_blocks
 
 # a `go build` inside the map-envelope fixture drops its binary beside main.go
 testdata/map_literal_envelope/map_literal_envelope
+
+# a `go build` inside the http-catchall fixture drops its binary beside main.go
+testdata/http_catchall_anchor/http_catchall_anchor

--- a/cmd/apispecui/assets/js/config.js
+++ b/cmd/apispecui/assets/js/config.js
@@ -541,6 +541,7 @@ const PATTERN_FIELDS = {
     ["defaultContentType", "Default content-type", "text", "Content-type for this pattern when not otherwise known. e.g. text/plain; charset=utf-8 for a c.String writer."],
     ["requireResponseDestination", "Require response destination", "bool", "Only classify as a response when the value being written traces to the response writer — keeps json.NewEncoder(&buf).Encode(v) or an encode to a file from being read as the response body. Pair with Response context below."],
     ["destFromReceiver", "Destination from receiver", "bool", "Resolve that destination from the call RECEIVER's factory argument — the x in json.NewEncoder(x).Encode(v)."],
+    ["destFromAnyArg", "Destination from any argument", "bool", "Satisfy the destination requirement when ANY argument traces to the response writer. For catch-all patterns matching helpers with no agreed signature, where no single argument position is the writer."],
     ...SCOPE_FILTERS,
   ],
   paramPatterns: [

--- a/generator/testdata_http_catchall_anchor_test.go
+++ b/generator/testdata_http_catchall_anchor_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/engine"
+)
+
+// TestTestdata_HTTPCatchallAnchor pins that the net/http response catch-all only
+// matches calls the response writer actually reaches (issue #302).
+//
+// The preset matches any call named JSON/String/XML/YAML/ProtoBuf/Data/File/
+// Redirect and documents its second argument as the response body. Unanchored,
+// that included calls in any reached package that merely share a name — and
+// APISpec shipped it that way, so this was a default-config defect, not a
+// misconfiguration.
+//
+// The two assertions are a pair and neither is sufficient alone: the gate must
+// drop the impostor AND keep the house renderer, since the cheapest way to pass
+// the first is to stop matching helpers altogether.
+func TestTestdata_HTTPCatchallAnchor(t *testing.T) {
+	cfg := engine.DefaultEngineConfig()
+	cfg.InputDir = filepath.Join("..", "testdata", "http_catchall_anchor")
+
+	out, err := engine.NewEngine(cfg).GenerateOpenAPI()
+	if err != nil {
+		t.Fatalf("GenerateOpenAPI: %v", err)
+	}
+	noDanglingRefs(t, out)
+	noUnresolvedPlaceholders(t, out)
+
+	refsFor := func(t *testing.T, path string) string {
+		t.Helper()
+		item, ok := out.Paths[path]
+		if !ok {
+			t.Fatalf("%s missing", path)
+		}
+		op := opFor(item, "POST")
+		if op == nil {
+			t.Fatalf("POST %s missing", path)
+		}
+		var refs []string
+		for _, resp := range op.Responses {
+			for _, mt := range resp.Content {
+				if mt.Schema != nil && mt.Schema.Ref != "" {
+					refs = append(refs, mt.Schema.Ref)
+				}
+			}
+		}
+		return strings.Join(refs, " ")
+	}
+
+	// report.Data(ctx, payload) is named like a renderer and takes a payload
+	// second, but never receives the writer — it cannot be this response.
+	widget := refsFor(t, "/widget")
+	if strings.Contains(widget, "_report_Payload") {
+		t.Errorf("/widget responses %q include the analytics payload; a call that never "+
+			"receives the response writer is not writing the response", widget)
+	}
+	if !strings.Contains(widget, "_Widget") {
+		t.Errorf("/widget responses %q lost the real body", widget)
+	}
+
+	// The catch-all's own shape, handed the writer, must still match — otherwise
+	// "anchoring" would just mean the catch-all stopped working.
+	if gadget := refsFor(t, "/gadget"); !strings.Contains(gadget, "_Gadget") {
+		t.Errorf("/gadget responses %q lost their body; a catch-all call that IS handed "+
+			"the writer must still resolve", gadget)
+	}
+}

--- a/internal/spec/config.go
+++ b/internal/spec/config.go
@@ -334,6 +334,20 @@ type ResponsePattern struct {
 	// (json.NewEncoder(x).Encode(v)) that may write to a bytes.Buffer, a hash, a
 	// log — not the response. Symmetric with RequestBodyPattern.RequireRequestSource.
 	RequireResponseDestination bool `yaml:"requireResponseDestination,omitempty" json:"requireResponseDestination,omitempty"`
+	// DestFromAnyArg satisfies RequireResponseDestination when ANY argument of the
+	// call traces to the response writer, instead of one named position.
+	//
+	// It exists for catch-all patterns, which match helpers with no agreed
+	// signature — `render.JSON(w, r, v)`, `writeJSON(w, status, v)`, `c.JSON(status,
+	// v)` — so no single DestArgIndex describes them. What IS true of all of them is
+	// that a helper which writes the response must have been handed the writer
+	// somewhere. A call where no argument reaches it is not writing this response
+	// (issue #302).
+	//
+	// Deliberately conservative in the same way ShouldDrop is: an argument whose
+	// provenance cannot be resolved counts as possibly-the-writer, so the pattern
+	// keeps matching rather than dropping a real response on ignorance.
+	DestFromAnyArg bool `yaml:"destFromAnyArg,omitempty" json:"destFromAnyArg,omitempty"`
 	// DestFromReceiver resolves the write destination from the encoder factory
 	// receiver — for json.NewEncoder(x).Encode(v), the destination is
 	// NewEncoder's first argument x. Mirrors RequestBodyPattern.BodyFromReceiver.

--- a/internal/spec/config_http.go
+++ b/internal/spec/config_http.go
@@ -66,6 +66,14 @@ func DefaultHTTPConfig() *APISpecConfig {
 			TypeArgIndex:   1,
 			TypeFromArg:    true,
 			Deref:          true,
+			// Anchored on the writer being SOMEWHERE in the call (issue #302).
+			// Unanchored, this matched any call with one of these names in any
+			// reached package — a protobuf helper, an encoding library, anything
+			// named Data or File — and documented its second argument as this
+			// endpoint's response. There is no fixed writer position to name here,
+			// because the helpers this exists for do not share a signature.
+			RequireResponseDestination: true,
+			DestFromAnyArg:             true,
 		},
 		jsonEncodePattern(""),
 	)

--- a/internal/spec/config_response_anchor_test.go
+++ b/internal/spec/config_response_anchor_test.go
@@ -87,11 +87,11 @@ func TestUnanchoredResponsePatternsReportsBareCallNames(t *testing.T) {
 // that matters most: it must not become noise a user cannot act on. Every pattern
 // APISpec itself ships is anchored, so a default run reports nothing.
 //
-// The net/http catch-all is the one exception, and it is a real one rather than a
-// tolerated false positive — it matches JSON/String/Data/File/Redirect by bare
-// name in any reached package (issue #302). It is asserted here as the CURRENT
-// state so this test flips the moment it is fixed, instead of the exception
-// quietly outliving the defect.
+// The net/http catch-all was the one exception when this check landed — it
+// matched JSON/String/Data/File/Redirect by bare name in any reached package. It
+// was asserted here as the current state precisely so this test would fail when
+// it was fixed, which is what happened: #302 anchored it on the writer being
+// somewhere in the call, and the exception is gone.
 func TestPresetsAnchorTheirResponsePatterns(t *testing.T) {
 	for name, cfg := range map[string]*APISpecConfig{
 		"chi":   DefaultChiConfig(),
@@ -99,6 +99,7 @@ func TestPresetsAnchorTheirResponsePatterns(t *testing.T) {
 		"echo":  DefaultEchoConfig(),
 		"fiber": DefaultFiberConfig(),
 		"mux":   DefaultMuxConfig(),
+		"http":  DefaultHTTPConfig(),
 	} {
 		t.Run(name, func(t *testing.T) {
 			if got := cfg.UnanchoredResponsePatterns(); len(got) != 0 {
@@ -107,14 +108,4 @@ func TestPresetsAnchorTheirResponsePatterns(t *testing.T) {
 		})
 	}
 
-	t.Run("http (known gap, issue #302)", func(t *testing.T) {
-		got := DefaultHTTPConfig().UnanchoredResponsePatterns()
-		if len(got) != 1 {
-			t.Fatalf("got %d unanchored patterns, want exactly the known net/http catch-all; "+
-				"if #302 is fixed, delete this subtest and add http to the table above", len(got))
-		}
-		if !strings.Contains(got[0], "JSON|String|XML") {
-			t.Errorf("the unanchored net/http pattern is %q, not the catch-all this exception covers", got[0])
-		}
-	})
 }

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -2402,7 +2402,14 @@ func (r *ResponsePatternMatcherImpl) ExtractResponse(node TrackerNodeInterface, 
 	// concrete value at THIS route's call site and drop the encode only when
 	// that value provably does not trace to the response writer.
 	if r.pattern.RequireResponseDestination && r.destResolver != nil && r.destResolver.Enabled() {
-		if dst, dstEdge := r.destination(node); dst != nil && r.destResolver.ShouldDrop(dst, dstEdge) {
+		if r.pattern.DestFromAnyArg {
+			// A catch-all matches helpers with no agreed signature, so there is no
+			// destination position to name; what anchors it is that a helper writing
+			// the response must have been handed the writer somewhere (issue #302).
+			if !r.destResolver.AnyArgReachesWriter(node.GetEdge()) {
+				return nil
+			}
+		} else if dst, dstEdge := r.destination(node); dst != nil && r.destResolver.ShouldDrop(dst, dstEdge) {
 			return nil
 		}
 	}

--- a/internal/spec/response_dest.go
+++ b/internal/spec/response_dest.go
@@ -84,6 +84,31 @@ func (r *responseDestResolver) ShouldDrop(arg *metadata.CallArgument, edge *meta
 	return true // resolved to something with no provenance to w — drop
 }
 
+// AnyArgReachesWriter reports whether any of the call's arguments traces to the
+// handler's response writer — the gate for a catch-all pattern that matches
+// helpers with no agreed signature (issue #302).
+//
+// An argument that cannot be resolved counts as possibly-the-writer: the whole
+// resolver is built to drop only what it can prove is NOT the response, and a
+// catch-all must not become the one place that guesses the other way.
+func (r *responseDestResolver) AnyArgReachesWriter(edge *metadata.CallGraphEdge) bool {
+	if !r.Enabled() || edge == nil {
+		return true // no writer types configured: gate is off, keep everything
+	}
+	for _, arg := range edge.Args {
+		if arg == nil {
+			continue
+		}
+		if r.reachesWriter(arg, edge, make(map[string]bool, 4)) {
+			return true
+		}
+		if t := r.leafType(arg, edge, make(map[string]bool, 4)); t == "" || matchAny(r.compatibleREs, t) {
+			return true // unresolved, or writer-compatible — cannot rule it out
+		}
+	}
+	return false
+}
+
 // reachesWriter reports whether the destination's provenance includes a value
 // of a response-writer type. It follows address-of/deref, local assignments
 // (dst := w), parameter boundaries (a helper's io.Writer param → the caller's

--- a/testdata/http_catchall_anchor/go.mod
+++ b/testdata/http_catchall_anchor/go.mod
@@ -1,0 +1,3 @@
+module github.com/ehabterra/apispec/testdata/http_catchall_anchor
+
+go 1.21

--- a/testdata/http_catchall_anchor/main.go
+++ b/testdata/http_catchall_anchor/main.go
@@ -1,0 +1,64 @@
+// Fixture: the net/http response catch-all must be anchored on the writer being
+// somewhere in the call (issue #302).
+//
+// The preset matches any call named JSON/String/XML/YAML/ProtoBuf/Data/File/
+// Redirect and documents its SECOND argument as the response body. Unanchored,
+// that included calls in any reached package that merely share a name — and
+// APISpec shipped it that way, so this was a default-config defect rather than a
+// misconfiguration.
+//
+// TWO ROUTES, because the two halves must not be able to mask each other:
+//
+//	/widget  reaches report.Data(ctx, payload) — an analytics helper that never
+//	         sees a writer. Its payload must NOT be documented. The real body
+//	         goes through writeJSON, whose name the catch-all does not match, so
+//	         nothing competes with the impostor for the slot: if the two shared a
+//	         route the lexicographic tie-break could drop the impostor on its own
+//	         and the fixture would pass without the anchor doing anything.
+//	/gadget  is rendered by Data(w, v) — the catch-all's own shape, handed the
+//	         writer. It must still resolve, or "anchoring" would just mean the
+//	         catch-all stopped working.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/ehabterra/apispec/testdata/http_catchall_anchor/report"
+)
+
+type Widget struct {
+	ID string `json:"id"`
+}
+
+type Gadget struct {
+	Name string `json:"name"`
+}
+
+// writeJSON is deliberately NOT one of the catch-all's names; its inner Encode
+// is matched by the properly anchored encoder pattern.
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// Data has the catch-all's shape and IS handed the writer.
+func Data(w http.ResponseWriter, v any) {
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func getWidget(w http.ResponseWriter, r *http.Request) {
+	_ = report.Data(r.Context(), report.Payload{Rows: 1}) // analytics, not a response
+	writeJSON(w, http.StatusOK, Widget{ID: "1"})
+}
+
+func getGadget(w http.ResponseWriter, r *http.Request) {
+	Data(w, Gadget{Name: "g"})
+}
+
+func main() {
+	http.HandleFunc("/widget", getWidget)
+	http.HandleFunc("/gadget", getGadget)
+	_ = http.ListenAndServe(":8080", nil)
+}

--- a/testdata/http_catchall_anchor/report/report.go
+++ b/testdata/http_catchall_anchor/report/report.go
@@ -1,0 +1,17 @@
+package report
+
+import "context"
+
+// Payload is INTERNAL analytics data. It is never written to a response.
+type Payload struct {
+	Rows int `json:"rows"`
+}
+
+// Data is named like a renderer and takes a payload as its second argument,
+// which is exactly the shape the net/http catch-all matches on. It receives no
+// http.ResponseWriter, so it cannot be writing this endpoint's response.
+func Data(ctx context.Context, p Payload) error {
+	_ = ctx
+	_ = p
+	return nil
+}


### PR DESCRIPTION
Fixes #302.

`DefaultHTTPConfig` shipped a response pattern matching any call named `JSON|String|XML|YAML|ProtoBuf|Data|File|Redirect` — no receiver scope, no caller/callee scope, no destination requirement. Its **second argument became the endpoint's response body, in any reached package**: an internal analytics helper named `Data`, an encoding library, a protobuf helper. Each contributed a response the endpoint can never return, silently, on a **default** config.

Found by the config check added for #294. Every other preset was clean.

## The fix

The catch-all's intent is legitimate — net/http has no framework render package to anchor on the way chi anchors on `go-chi/render`. What was missing is a way to say *the writer must be present* without naming a position, because the helpers it exists for do not share a signature: `render.JSON(w, r, v)`, `writeJSON(w, status, v)`, `c.JSON(status, v)`.

So `requireResponseDestination` gains **`destFromAnyArg`**: satisfied when *any* argument traces to the response writer.

Conservative in the same direction as `ShouldDrop` — an argument whose provenance cannot be resolved counts as possibly-the-writer, so the pattern keeps matching rather than dropping a real response on ignorance. A helper that closes over `w` instead of receiving it is unaffected: its inner `Encode` is matched by the properly anchored encoder pattern.

## The fixture has two routes, and that matters

An earlier version put the impostor and the real body on one route and **passed without the anchor doing anything** — the lexicographic tie-break in `preferResponseInfo` dropped the impostor on its own. So:

- **`/widget`** reaches `report.Data(ctx, payload)` while its real body goes through a helper the catch-all does *not* match, so nothing competes for the slot. This is the half that detects the bug.
- **`/gadget`** is rendered by `Data(w, v)` — the catch-all's own shape, handed the writer — and must still resolve, or "anchoring" would just mean the catch-all stopped working.

Verified: fails on the previous preset (2 spurious `$ref`s), passes now.

## Verification

- **A/B across 11 real projects: zero paths, statuses, schemas or components differ.** That is the acceptance criterion from the issue — this change can only remove responses, so no project losing one is the thing to prove.
- `TestPresetsAnchorTheirResponsePatterns` loses its carve-out — the change detector filed alongside #302 doing exactly its job.
- `destFromAnyArg` is editable in the UI config editor; the parity test enforces it.
- Full suite, `-race`, `golangci-lint`, `gofmt`, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)