### PR TITLE
fix(apispecui): the UI was missing the per-route node budget entirely

### DIFF
--- a/cmd/apispecui/analysis_test.go
+++ b/cmd/apispecui/analysis_test.go
@@ -127,7 +127,8 @@ func TestTrackerLimitsResolved(t *testing.T) {
 	if raised.MaxNodesPerTree != 2_000_000 {
 		t.Errorf("max nodes = %d, want the requested 2000000", raised.MaxNodesPerTree)
 	}
-	if raised.MaxChildrenPerNode != defaults.MaxChildrenPerNode ||
+	if raised.MaxNodesPerRoute != defaults.MaxNodesPerRoute ||
+		raised.MaxChildrenPerNode != defaults.MaxChildrenPerNode ||
 		raised.MaxRecursionDepth != defaults.MaxRecursionDepth ||
 		raised.MaxArgsPerFunction != defaults.MaxArgsPerFunction ||
 		raised.MaxNestedArgsDepth != defaults.MaxNestedArgsDepth ||
@@ -141,8 +142,20 @@ func TestTrackerLimitsResolved(t *testing.T) {
 		t.Errorf("negative max nodes = %d, want the default", got.MaxNodesPerTree)
 	}
 
+	// The two node budgets are independent: raising a route's DETAIL allowance
+	// must not touch the budget that FINDS routes, or the UI would reproduce the
+	// coupling #264 removed.
+	perRoute := TrackerLimits{MaxNodesPerRoute: 5_000_000}.resolved()
+	if perRoute.MaxNodesPerRoute != 5_000_000 {
+		t.Errorf("max nodes per route = %d, want the requested 5000000", perRoute.MaxNodesPerRoute)
+	}
+	if perRoute.MaxNodesPerTree != defaults.MaxNodesPerTree {
+		t.Errorf("raising the per-route budget changed the discovery budget to %d", perRoute.MaxNodesPerTree)
+	}
+
 	all := TrackerLimits{
 		MaxNodesPerTree:    1,
+		MaxNodesPerRoute:   7,
 		MaxChildrenPerNode: 2,
 		MaxArgsPerFunction: 3,
 		MaxNestedArgsDepth: 4,

--- a/cmd/apispecui/assets/js/config.js
+++ b/cmd/apispecui/assets/js/config.js
@@ -882,7 +882,8 @@ function TrackerLimits() {
           The last run stopped at the ${s.nodeLimit}-node limit, so routes past that point are missing from the spec. Raise Max nodes and generate again.
         </p>`
       : ""}
-    ${row("maxNodesPerTree", "Max nodes", "Total tracker nodes the walk may build. Reaching it stops expansion, so anything not yet reached is absent from the spec — the one limit worth raising first on a large project.")}
+    ${row("maxNodesPerTree", "Max nodes (route discovery)", "Nodes the walk that FINDS route registrations may build. Reaching it means routes are missing from the spec entirely — the one limit worth raising first on a large project.")}
+    ${row("maxNodesPerRoute", "Max nodes per route", "Nodes expanded BELOW one route registration. Reaching it costs that route some detail — a schema or a body — and no other route: a named endpoint comes out less detailed rather than the spec losing endpoints.")}
     ${row("maxChildrenPerNode", "Max children per node", "How many callees one node may expand. A router that registers hundreds of routes in a single function needs this above the default.")}
     ${row("maxRecursionDepth", "Max recursion depth", "How deep a call chain may be followed through repeated frames. Deeply nested group closures need more.")}
     ${row("maxInstancesPerKey", "Max instances per key", "How many copies of one callee are expanded within a scope (roughly per handler, but per GROUP closure in practice). A response helper shared by a group exhausts this budget after that many routes, and every later route in the group silently loses its response body — raise it for a project whose groups hold many routes.")}

--- a/cmd/apispecui/main.go
+++ b/cmd/apispecui/main.go
@@ -217,6 +217,7 @@ type GenerateRequest struct {
 // limits sends nothing and gets today's behaviour.
 type TrackerLimits struct {
 	MaxNodesPerTree    int `json:"maxNodesPerTree,omitempty"`
+	MaxNodesPerRoute   int `json:"maxNodesPerRoute,omitempty"`
 	MaxChildrenPerNode int `json:"maxChildrenPerNode,omitempty"`
 	MaxArgsPerFunction int `json:"maxArgsPerFunction,omitempty"`
 	MaxNestedArgsDepth int `json:"maxNestedArgsDepth,omitempty"`
@@ -229,6 +230,7 @@ type TrackerLimits struct {
 func defaultTrackerLimits() TrackerLimits {
 	return TrackerLimits{
 		MaxNodesPerTree:    engine.DefaultMaxNodesPerTree,
+		MaxNodesPerRoute:   engine.DefaultMaxNodesPerRoute,
 		MaxChildrenPerNode: engine.DefaultMaxChildrenPerNode,
 		MaxArgsPerFunction: engine.DefaultMaxArgsPerFunction,
 		MaxNestedArgsDepth: engine.DefaultMaxNestedArgsDepth,
@@ -242,6 +244,9 @@ func (l TrackerLimits) resolved() TrackerLimits {
 	d := defaultTrackerLimits()
 	if l.MaxNodesPerTree <= 0 {
 		l.MaxNodesPerTree = d.MaxNodesPerTree
+	}
+	if l.MaxNodesPerRoute <= 0 {
+		l.MaxNodesPerRoute = d.MaxNodesPerRoute
 	}
 	if l.MaxChildrenPerNode <= 0 {
 		l.MaxChildrenPerNode = d.MaxChildrenPerNode
@@ -909,6 +914,7 @@ func (s *UIServer) handleGenerate(w http.ResponseWriter, r *http.Request) {
 		OpenAPIVersion:               req.OpenAPIVersion,
 		APISpecConfig:                apiCfg,
 		MaxNodesPerTree:              limits.MaxNodesPerTree,
+		MaxNodesPerRoute:             limits.MaxNodesPerRoute,
 		MaxChildrenPerNode:           limits.MaxChildrenPerNode,
 		MaxArgsPerFunction:           limits.MaxArgsPerFunction,
 		MaxNestedArgsDepth:           limits.MaxNestedArgsDepth,


### PR DESCRIPTION
#264 split the node budget in two — `MaxNodesPerTree` bounds the walk that **finds** route registrations, `MaxNodesPerRoute` bounds the detail expanded **below** each one — and wired both through the CLI. The UI got neither the field nor the control.

## What was and was not broken

The **default was already correct**: zero means `DefaultMaxNodesPerRoute` in the tracker, so UI runs were never unbounded and never behaved differently from the CLI at default settings.

What was missing is everything else. A user could not raise it when a deep handler truncated, could not lower it to cut wall clock, and the limits panel described a budget they had no way to change — while `--max-nodes-per-route` has existed on the CLI since #291.

## Changes

- `MaxNodesPerRoute` added to the request limits, the defaults, `resolved()`, and the engine handoff
- a row in the limits panel
- **both node budgets relabelled**, because "Max nodes" no longer means what it did:

| | symptom when reached |
|---|---|
| Max nodes (route discovery) | routes are **missing from the spec entirely** |
| Max nodes per route | one **named** endpoint is less detailed; no other route is affected |

Different symptoms and different fixes, so the panel now says which is which.

## Tests

The existing resolver test grew a case for the new field, and one asserting the two budgets are **independent** — raising a route's detail allowance must not touch the discovery budget, or the UI would reproduce the coupling #264 removed.

Full suite, `-race`, `golangci-lint`, `gofmt`, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)