### PR TITLE
feat: Homebrew tap, and install instructions that actually install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,12 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    # Hoisted to the JOB so the tap step can test it in an `if:`. The `secrets`
+    # context is not available in a step-level `if` — written that way the step is
+    # skipped even when the secret IS set, which fails silently and looks like the
+    # tap simply never updates.
+    env:
+      HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
     permissions:
       contents: write  # Required to create releases and upload assets
       pull-requests: read
@@ -120,10 +126,9 @@ jobs:
       - name: Update the Homebrew tap
         # Skipped automatically when the tap token is not configured, so the
         # release still succeeds on a fork or before the tap exists.
-        if: ${{ secrets.HOMEBREW_TAP_TOKEN != '' }}
+        if: env.HOMEBREW_TAP_TOKEN != ''
         env:
           VERSION: ${{ steps.version.outputs.version }}
-          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           set -euo pipefail
           # Checksums come from the artifacts THIS job just built, so the formula
@@ -137,7 +142,7 @@ jobs:
               -e "s|__SHA_LINUX_AMD64__|$(sha linux-amd64)|" \
               packaging/homebrew/apispec.rb.tmpl > /tmp/apispec.rb
 
-          git clone --depth 1 "https://x-access-token:$TAP_TOKEN@github.com/ehabterra/homebrew-tap.git" /tmp/tap
+          git clone --depth 1 "https://x-access-token:$HOMEBREW_TAP_TOKEN@github.com/ehabterra/homebrew-tap.git" /tmp/tap
           mkdir -p /tmp/tap/Formula
           cp /tmp/apispec.rb /tmp/tap/Formula/apispec.rb
           cd /tmp/tap

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,36 @@ jobs:
           echo "=== Current working directory ==="
           pwd
 
+      - name: Update the Homebrew tap
+        # Skipped automatically when the tap token is not configured, so the
+        # release still succeeds on a fork or before the tap exists.
+        if: ${{ secrets.HOMEBREW_TAP_TOKEN != '' }}
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Checksums come from the artifacts THIS job just built, so the formula
+          # can never point at a digest the release does not have.
+          sha() { shasum -a 256 "dist/apispec-$1" | awk '{print $1}'; }
+
+          sed -e "s|__VERSION__|$VERSION|g" \
+              -e "s|__SHA_DARWIN_ARM64__|$(sha darwin-arm64)|" \
+              -e "s|__SHA_DARWIN_AMD64__|$(sha darwin-amd64)|" \
+              -e "s|__SHA_LINUX_ARM64__|$(sha linux-arm64)|" \
+              -e "s|__SHA_LINUX_AMD64__|$(sha linux-amd64)|" \
+              packaging/homebrew/apispec.rb.tmpl > /tmp/apispec.rb
+
+          git clone --depth 1 "https://x-access-token:$TAP_TOKEN@github.com/ehabterra/homebrew-tap.git" /tmp/tap
+          mkdir -p /tmp/tap/Formula
+          cp /tmp/apispec.rb /tmp/tap/Formula/apispec.rb
+          cd /tmp/tap
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/apispec.rb
+          git diff --staged --quiet || git commit -m "apispec $VERSION"
+          git push
+
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v1

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,8 @@ testdata/http_catchall_anchor/http_catchall_anchor
 
 # a `go build` inside the mount-via-helper fixture drops its binary beside main.go
 testdata/mount_via_helper/mount_via_helper
+
+# release binaries downloaded while testing the install instructions
+apispec-darwin-*
+apispec-linux-*
+apispec-windows-*

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -13,51 +13,71 @@ For the `go install` and from-source methods:
 
 ## Installation Methods
 
-### 1. Download a Pre-built Binary (Recommended)
-
-No Go toolchain required. Every release publishes a binary per platform, each with a SHA256 checksum.
-
-**macOS (Apple Silicon)**
+### 1. Homebrew (macOS and Linux)
 
 ```bash
-curl -L -O https://github.com/ehabterra/apispec/releases/latest/download/apispec-darwin-arm64
-chmod +x apispec-darwin-arm64 && sudo install -m 0755 apispec-darwin-arm64 /usr/local/bin/apispec
+brew install ehabterra/tap/apispec
 ```
 
-**macOS (Intel)** — replace `darwin-arm64` with `darwin-amd64`.
+Upgrade with `brew upgrade apispec`, remove with `brew uninstall apispec`.
+Homebrew picks the right build for your machine and puts `apispec` on your PATH.
 
-**Linux (x86_64)**
+### 2. Download a Pre-built Binary
+
+No Go toolchain and no Homebrew required. **Copy the whole block** — it detects
+your platform, verifies the checksum, and installs `apispec` onto your PATH.
+
+**macOS / Linux**
 
 ```bash
-curl -L -O https://github.com/ehabterra/apispec/releases/latest/download/apispec-linux-amd64
-chmod +x apispec-linux-amd64 && sudo install -m 0755 apispec-linux-amd64 /usr/local/bin/apispec
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+case "$ARCH" in x86_64|amd64) ARCH=amd64 ;; arm64|aarch64) ARCH=arm64 ;; esac
+ASSET="apispec-${OS}-${ARCH}"
+BASE="https://github.com/ehabterra/apispec/releases/latest/download"
+
+curl -fsSL -O "$BASE/$ASSET"
+curl -fsSL -O "$BASE/$ASSET.sha256"
+shasum -a 256 -c "$ASSET.sha256" 2>/dev/null || sha256sum -c "$ASSET.sha256"
+
+sudo install -m 0755 "$ASSET" /usr/local/bin/apispec
+rm -f "$ASSET" "$ASSET.sha256"
+
+apispec --version
 ```
 
-**Linux (arm64)** — replace `linux-amd64` with `linux-arm64`.
+The checksum step prints `apispec-darwin-arm64: OK` (or your platform's name). If
+it prints `FAILED`, stop — do not install the file.
+
+> The binary is **downloaded under the asset's own name** because the published
+> `.sha256` file names the asset; `curl -o apispec` would rename it out from
+> under the check. The `install` line is what gives it the short name and puts it
+> on your PATH — the `rm` afterwards is why nothing is left in your working
+> directory.
+
+Installing somewhere else, e.g. no `sudo`:
+
+```bash
+mkdir -p ~/.local/bin && install -m 0755 "$ASSET" ~/.local/bin/apispec
+# ensure ~/.local/bin is on your PATH
+```
 
 **Windows (PowerShell)**
 
 ```powershell
-Invoke-WebRequest -Uri https://github.com/ehabterra/apispec/releases/latest/download/apispec-windows-amd64.exe -OutFile apispec.exe
-# then move apispec.exe somewhere on your PATH
+$asset = "apispec-windows-amd64.exe"   # or apispec-windows-arm64.exe on ARM
+$base  = "https://github.com/ehabterra/apispec/releases/latest/download"
+
+Invoke-WebRequest -Uri "$base/$asset" -OutFile $asset
+Invoke-WebRequest -Uri "$base/$asset.sha256" -OutFile "$asset.sha256"
+$expected = (Get-Content "$asset.sha256").Split(" ")[0]
+if ((Get-FileHash $asset -Algorithm SHA256).Hash -ne $expected) { throw "checksum mismatch" }
+
+New-Item -ItemType Directory -Force "$env:LOCALAPPDATA\Programs\apispec" | Out-Null
+Move-Item -Force $asset "$env:LOCALAPPDATA\Programs\apispec\apispec.exe"
+# add that directory to your PATH, then:
+apispec --version
 ```
-
-Windows on ARM: use `apispec-windows-arm64.exe`.
-
-**Verify before installing** (recommended). Download the binary under its
-original name — the checksum file names the asset, so `curl -o apispec` would
-rename it out from under the check:
-
-```bash
-curl -L -O https://github.com/ehabterra/apispec/releases/latest/download/apispec-darwin-arm64
-curl -L -O https://github.com/ehabterra/apispec/releases/latest/download/apispec-darwin-arm64.sha256
-
-shasum -a 256 -c apispec-darwin-arm64.sha256      # macOS
-sha256sum -c apispec-linux-amd64.sha256           # Linux
-```
-
-Expect `apispec-darwin-arm64: OK`. Then install it under the name you want, as
-the commands above do with `install -m 0755 … /usr/local/bin/apispec`.
 
 To pin a version, swap `latest/download` for `download/v0.5.6` (any tag).
 
@@ -66,10 +86,10 @@ To pin a version, swap `latest/download` for `download/v0.5.6` (any tag).
 - Exact, reproducible version with a published checksum
 
 **Cons:**
-- Manual updates (re-download to upgrade)
+- Manual updates (re-run the block to upgrade)
 - Only `apispec` is published as a binary — `apispecui` and `apidiag` are built from source
 
-### 2. Go Install
+### 3. Go Install
 
 If you already have Go:
 
@@ -86,7 +106,7 @@ go install github.com/ehabterra/apispec/cmd/apispec@latest
 - Requires Go to be installed
 - Binary is stored in Go's module cache
 
-### 3. From Source
+### 4. From Source
 
 If you want to build from source or contribute to the project:
 
@@ -111,7 +131,7 @@ make install
 - More complex setup
 - Need to manually update
 
-### 4. Using Installation Script
+### 5. Using Installation Script
 
 We provide a convenient installation script:
 
@@ -132,20 +152,17 @@ Supported arguments: `go-install` (default), `source-local`, `source-system`, `h
 
 ## Platform-Specific Instructions
 
-> There is no Homebrew tap. `brew install apispec` will not work.
-
 ### macOS
 
 ```bash
-# Pre-built binary (Apple Silicon; use darwin-amd64 on Intel)
-curl -L -O https://github.com/ehabterra/apispec/releases/latest/download/apispec-darwin-arm64
-chmod +x apispec-darwin-arm64 && sudo install -m 0755 apispec-darwin-arm64 /usr/local/bin/apispec
-
-# Or with Go
-go install github.com/ehabterra/apispec/cmd/apispec@latest
+brew install ehabterra/tap/apispec
 ```
 
-macOS may quarantine a downloaded binary. If Gatekeeper blocks it:
+Or use the copy-paste block in [Installation Method 2](#2-download-a-pre-built-binary), which
+detects Apple Silicon vs Intel for you.
+
+macOS may quarantine a downloaded binary (Homebrew installs are unaffected). If
+Gatekeeper blocks it:
 
 ```bash
 xattr -d com.apple.quarantine /usr/local/bin/apispec
@@ -154,23 +171,16 @@ xattr -d com.apple.quarantine /usr/local/bin/apispec
 ### Linux
 
 ```bash
-# Pre-built binary (use linux-arm64 on arm64)
-curl -L -O https://github.com/ehabterra/apispec/releases/latest/download/apispec-linux-amd64
-chmod +x apispec-linux-amd64 && sudo install -m 0755 apispec-linux-amd64 /usr/local/bin/apispec
-
-# Or with Go
-go install github.com/ehabterra/apispec/cmd/apispec@latest
+brew install ehabterra/tap/apispec        # if you use Homebrew on Linux
 ```
+
+Otherwise use the copy-paste block in [Installation Method 2](#2-download-a-pre-built-binary),
+which detects amd64 vs arm64 for you.
 
 ### Windows
 
-```powershell
-# Pre-built binary (use windows-arm64.exe on ARM)
-Invoke-WebRequest -Uri https://github.com/ehabterra/apispec/releases/latest/download/apispec-windows-amd64.exe -OutFile apispec.exe
-
-# Or with Go
-go install github.com/ehabterra/apispec/cmd/apispec@latest
-```
+Use the PowerShell block in [Installation Method 2](#2-download-a-pre-built-binary), or
+`go install github.com/ehabterra/apispec/cmd/apispec@latest` if you have Go.
 
 ## Setting Up PATH
 
@@ -227,8 +237,13 @@ Go version: go1.21.0
 
 ## Updating
 
+### Homebrew
+```bash
+brew upgrade apispec
+```
+
 ### Pre-built Binary
-Re-download it — the same command as installation, which always fetches the newest release.
+Re-run the install block — it always fetches the newest release.
 
 ### Go Install Method
 ```bash
@@ -243,6 +258,11 @@ make install-local
 ```
 
 ## Uninstalling
+
+### Homebrew
+```bash
+brew uninstall apispec
+```
 
 ### Pre-built Binary
 ```bash

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,6 +1,26 @@
 # Installation Guide
 
-This guide covers all the ways to install and use apispec.
+Install, update and remove apispec — four ways to do it, and how to tell which
+one you are running when more than one is installed.
+
+## At a glance
+
+Pick a row and stay in it: the commands are not interchangeable, and installing a
+second way does not replace the first (see
+[Switching between methods](#switching-between-installation-methods)).
+
+| | Install | Update | Uninstall |
+|---|---|---|---|
+| **[Homebrew](#1-homebrew-macos-and-linux)** — macOS/Linux, no Go needed | `brew install ehabterra/tap/apispec` | `brew upgrade apispec` | `brew uninstall apispec` |
+| **[Pre-built binary](#2-download-a-pre-built-binary)** — any platform, no Go needed | [copy-paste block](#2-download-a-pre-built-binary) | re-run the same block | `sudo rm /usr/local/bin/apispec` |
+| **[Go install](#3-go-install)** — needs Go 1.26+ | `go install github.com/ehabterra/apispec/cmd/apispec@latest` | same command again | `rm "$(go env GOPATH)/bin/apispec"` |
+| **[From source](#4-from-source)** — for development | `make install-local` | `git pull && make install-local` | `make uninstall-local` |
+
+Not sure what you have? → [Which apispec am I running?](#which-apispec-am-i-running)
+
+Only the `apispec` CLI is distributed as a binary. `apispecui` (browser config &
+preview) and `apidiag` (call-graph server) are built from source — see
+[Development Installation](#development-installation).
 
 ## Prerequisites
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -235,6 +235,28 @@ Go version: go1.21.0
 
 > **Note:** Version information depends on how `apispec` was built. When using `go install`, Go automatically embeds VCS information when available, providing accurate version details.
 
+## Which apispec am I running?
+
+Do this before updating or uninstalling anything. More than one copy can be
+installed at once, and the **first on your PATH wins** — so an upgrade can appear
+to do nothing while a stale copy keeps answering.
+
+```bash
+which -a apispec     # every copy, in the order your shell searches
+apispec --version    # the one that actually runs
+```
+
+Typical locations:
+
+| path | came from |
+|---|---|
+| `$(brew --prefix)/bin/apispec` | Homebrew (a symlink into `Cellar/`) |
+| `/usr/local/bin/apispec` | the pre-built binary block, or `make install` |
+| `$(go env GOPATH)/bin/apispec` | `go install`, or `make install-local` |
+
+If `apispec --version` disagrees with the version you just installed, you have
+more than one — see [Switching between methods](#switching-between-installation-methods).
+
 ## Updating
 
 ### Homebrew
@@ -243,45 +265,79 @@ brew upgrade apispec
 ```
 
 ### Pre-built Binary
-Re-run the install block — it always fetches the newest release.
+Re-run the install block from [Method 2](#2-download-a-pre-built-binary); it always
+fetches the newest release and overwrites in place.
 
-### Go Install Method
+### Go Install
 ```bash
 go install github.com/ehabterra/apispec/cmd/apispec@latest
 ```
 
 ### From Source
 ```bash
-cd apispec
-git pull
-make install-local
+cd apispec && git pull && make install-local
 ```
 
 ## Uninstalling
 
+Each method has to be undone its own way — removing one does not remove another.
+
 ### Homebrew
 ```bash
 brew uninstall apispec
+brew untap ehabterra/tap    # optional, if you want the tap gone too
 ```
 
 ### Pre-built Binary
 ```bash
-sudo rm /usr/local/bin/apispec
+sudo rm /usr/local/bin/apispec      # or wherever you installed it
 ```
 
-### Go Install Method
+### Go Install
 ```bash
-go clean -i github.com/ehabterra/apispec/cmd/apispec
+rm "$(go env GOPATH)/bin/apispec"
 ```
+
+> `go clean -i github.com/ehabterra/apispec/cmd/apispec` is **not** a reliable
+> uninstall: run outside a module it fails with "go.mod file not found", which is
+> the normal situation after `go install …@latest`. Remove the binary directly.
 
 ### From Source
 ```bash
-# If installed locally
-make uninstall-local
-
-# If installed system-wide
-make uninstall
+make uninstall-local    # if installed to ~/go/bin
+make uninstall          # if installed system-wide
 ```
+
+## Switching between installation methods
+
+Installing a second way does not replace the first — it just adds another copy,
+and the PATH order decides which one you get. Two symptoms:
+
+**`apispec --version` shows the old version.** An earlier copy is ahead on your
+PATH. Find them all and remove the ones you do not want:
+
+```bash
+which -a apispec
+rm "$(go env GOPATH)/bin/apispec"     # e.g. a stale go install build
+sudo rm /usr/local/bin/apispec        # e.g. an earlier manual install
+```
+
+**Homebrew installed it but `apispec` is still the old one.** Homebrew will not
+overwrite a file it does not own, so if `/usr/local/bin/apispec` already exists
+as a plain file, the formula installs into `Cellar/` but never gets linked:
+
+```bash
+brew list --versions apispec          # installed?
+brew link apispec                     # reports the conflicting path
+sudo rm /usr/local/bin/apispec        # remove it, then
+brew link apispec
+```
+
+`brew link --overwrite apispec` does the removal for you; run it with
+`--dry-run` first to see what it would delete.
+
+To go the other way — from Homebrew back to a manual install — `brew uninstall
+apispec` first, or the manual binary will be the one that gets shadowed.
 
 ## Troubleshooting
 
@@ -292,17 +348,22 @@ make uninstall
    - Verify the installation location
    - Restart your terminal after PATH changes
 
-2. **Permission denied errors**
+2. **`apispec --version` shows a version you did not install**
+   - More than one copy is installed; the first on your PATH wins
+   - `which -a apispec` lists them all — see
+     [Switching between methods](#switching-between-installation-methods)
+
+3. **Permission denied errors**
    - Use `make install-local` instead of `make install`
    - Check file permissions
    - Ensure you have write access to the target directory
 
-3. **Go version compatibility** (source / `go install` only)
+4. **Go version compatibility** (source / `go install` only)
    - Ensure you have Go 1.26 or later — the module declares `go 1.26.0`
    - Run `go version` to check
    - Not applicable to the pre-built binaries, which bundle their runtime
 
-4. **Build failures**
+5. **Build failures**
    - Ensure all dependencies are installed
    - Run `go mod download` and `go mod tidy`
    - Check Go environment variables
@@ -338,7 +399,7 @@ make release
 
 ## Release Downloads
 
-Every release on the [GitHub Releases page](https://github.com/ehabterra/apispec/releases) publishes these assets — see [Installation Method 1](#1-download-a-pre-built-binary-recommended) for the commands.
+Every release on the [GitHub Releases page](https://github.com/ehabterra/apispec/releases) publishes these assets — see [Installation Method 2](#2-download-a-pre-built-binary) for the commands.
 
 | Platform | Asset |
 |---|---|

--- a/internal/packaging/homebrew_test.go
+++ b/internal/packaging/homebrew_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package packaging holds tests for the distribution artifacts. There is no
+// package code — the formula is data, and these are the only checks that can
+// catch it going wrong before a release does.
+package packaging
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+const (
+	formulaPath  = "../../packaging/homebrew/apispec.rb"
+	templatePath = "../../packaging/homebrew/apispec.rb.tmpl"
+)
+
+// TestHomebrewFormulaMatchesTemplate pins that the readable formula is exactly
+// what the template renders.
+//
+// The release workflow ships the TEMPLATE, filled with checksums of the
+// artifacts it just built; the .rb is the copy a human reads and runs
+// `brew audit` against. If an edit lands in one and not the other, the file
+// people review stops describing the file people install — and the failure is
+// invisible until someone's `brew install` fetches a binary whose digest does
+// not match.
+func TestHomebrewFormulaMatchesTemplate(t *testing.T) {
+	formula := readFile(t, formulaPath)
+	tmpl := readFile(t, templatePath)
+
+	// Render the template the way release.yml does: substitute placeholders with
+	// whatever the formula currently carries. What must match is everything else.
+	version := captureOne(t, formula, `version "([^"]+)"`)
+	rendered := strings.ReplaceAll(tmpl, "__VERSION__", version)
+
+	shas := regexp.MustCompile(`sha256 "([0-9a-f]{64})"`).FindAllStringSubmatch(formula, -1)
+	if len(shas) != 4 {
+		t.Fatalf("formula declares %d sha256 values, want 4 (darwin/linux × arm64/amd64)", len(shas))
+	}
+	for i, ph := range []string{
+		"__SHA_DARWIN_ARM64__", "__SHA_DARWIN_AMD64__",
+		"__SHA_LINUX_ARM64__", "__SHA_LINUX_AMD64__",
+	} {
+		rendered = strings.ReplaceAll(rendered, ph, shas[i][1])
+	}
+
+	if rendered != formula {
+		t.Errorf("packaging/homebrew/apispec.rb is not what apispec.rb.tmpl renders.\n"+
+			"Edit the TEMPLATE, then regenerate the .rb — the workflow ships the template, "+
+			"so a change made only in the .rb never reaches anyone.\n\n--- rendered\n%s\n--- committed\n%s",
+			rendered, formula)
+	}
+}
+
+// TestHomebrewTemplateHasEveryPlaceholder keeps the workflow's substitutions and
+// the template in agreement. A placeholder dropped from the template does not
+// fail the release — it silently ships the PREVIOUS version's URL or digest.
+func TestHomebrewTemplateHasEveryPlaceholder(t *testing.T) {
+	tmpl := readFile(t, templatePath)
+	for _, ph := range []string{
+		"__VERSION__",
+		"__SHA_DARWIN_ARM64__", "__SHA_DARWIN_AMD64__",
+		"__SHA_LINUX_ARM64__", "__SHA_LINUX_AMD64__",
+	} {
+		if !strings.Contains(tmpl, ph) {
+			t.Errorf("template is missing %s; the release would ship a stale value there", ph)
+		}
+	}
+	// A literal digest left in the template would survive substitution and be
+	// served for a version it was never built from.
+	if m := regexp.MustCompile(`sha256 "[0-9a-f]{64}"`).FindString(tmpl); m != "" {
+		t.Errorf("template carries a hard-coded %s — it must be a placeholder", m)
+	}
+}
+
+// TestHomebrewFormulaTargetsThePublishedAssets pins the formula against the
+// names the release actually publishes. Homebrew reports a wrong URL only as a
+// 404 at install time, on the user's machine.
+func TestHomebrewFormulaTargetsThePublishedAssets(t *testing.T) {
+	formula := readFile(t, formulaPath)
+	for _, asset := range []string{
+		"apispec-darwin-arm64", "apispec-darwin-amd64",
+		"apispec-linux-arm64", "apispec-linux-amd64",
+	} {
+		if !strings.Contains(formula, asset) {
+			t.Errorf("formula never references %s, which the release publishes", asset)
+		}
+	}
+	if strings.Contains(formula, "windows") {
+		t.Error("formula references a windows asset; Homebrew does not install those")
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}
+
+func captureOne(t *testing.T, s, pattern string) string {
+	t.Helper()
+	m := regexp.MustCompile(pattern).FindStringSubmatch(s)
+	if len(m) < 2 {
+		t.Fatalf("pattern %q did not match", pattern)
+	}
+	return m[1]
+}

--- a/internal/packaging/homebrew_test.go
+++ b/internal/packaging/homebrew_test.go
@@ -45,7 +45,11 @@ func TestHomebrewFormulaMatchesTemplate(t *testing.T) {
 
 	// Render the template the way release.yml does: substitute placeholders with
 	// whatever the formula currently carries. What must match is everything else.
-	version := captureOne(t, formula, `version "([^"]+)"`)
+	//
+	// The version is read out of a URL because the formula deliberately has no
+	// `version` stanza: Homebrew scans it from the download path, and declaring
+	// it as well is a `brew audit --strict` failure.
+	version := captureOne(t, formula, `releases/download/v([^/]+)/`)
 	rendered := strings.ReplaceAll(tmpl, "__VERSION__", version)
 
 	shas := regexp.MustCompile(`sha256 "([0-9a-f]{64})"`).FindAllStringSubmatch(formula, -1)
@@ -103,6 +107,13 @@ func TestHomebrewFormulaTargetsThePublishedAssets(t *testing.T) {
 	}
 	if strings.Contains(formula, "windows") {
 		t.Error("formula references a windows asset; Homebrew does not install those")
+	}
+
+	// `brew audit --strict` rejects an explicit version when the URL already
+	// carries one, and every URL here does.
+	if regexp.MustCompile(`(?m)^\s*version "`).MatchString(formula) {
+		t.Error("formula declares a version stanza; it is redundant with the version " +
+			"scanned from the download URL and fails brew audit --strict")
 	}
 }
 

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -1,0 +1,58 @@
+# Homebrew packaging
+
+`brew install ehabterra/tap/apispec` installs the **pre-built release binary**,
+so it needs no Go toolchain and takes seconds.
+
+## Files here
+
+| file | role |
+|---|---|
+| `apispec.rb` | the current formula, readable in this repo — a copy of what the tap serves |
+| `apispec.rb.tmpl` | the same formula with `__VERSION__` / `__SHA_*__` placeholders |
+
+The formula users install from lives in a separate repository, because Homebrew
+requires a tap to be named `homebrew-<name>`:
+
+    ehabterra/homebrew-tap → Formula/apispec.rb
+
+`.github/workflows/release.yml` renders the template and pushes it there on every
+tag. The checksums are computed from the artifacts that job just built, so the
+formula cannot point at a digest the release does not have.
+
+## One-time setup
+
+1. Create a **public** repo `ehabterra/homebrew-tap` (any description; no files needed).
+2. Create a fine-grained PAT with **Contents: read and write** on that repo only.
+3. Add it to *this* repo as the secret `HOMEBREW_TAP_TOKEN`.
+
+Until the secret exists the release workflow skips the step, so releases keep
+working — a fork will never fail here either.
+
+## Seeding the tap by hand
+
+Only needed once, or to fix the tap without cutting a release:
+
+```bash
+git clone https://github.com/ehabterra/homebrew-tap.git
+mkdir -p homebrew-tap/Formula
+cp packaging/homebrew/apispec.rb homebrew-tap/Formula/apispec.rb
+cd homebrew-tap && git add Formula/apispec.rb && git commit -m "apispec 0.5.6" && git push
+```
+
+## Verifying a change
+
+```bash
+brew install --build-from-source ./packaging/homebrew/apispec.rb
+brew test apispec
+brew audit --strict --formula ./packaging/homebrew/apispec.rb
+```
+
+`brew audit` is worth running before a release: it catches a stale `version`,
+an unreachable `url`, and a `sha256` that does not match what the URL serves.
+
+## Why not homebrew-core?
+
+homebrew-core has notability requirements (roughly: a meaningful number of
+stars/forks/watchers, or demonstrable wide use). A tap has none and can be
+submitted to core later without changing the install command for anyone who
+already used the tap.

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -11,9 +11,30 @@ so it needs no Go toolchain and takes seconds.
 | `apispec.rb.tmpl` | the same formula with `__VERSION__` / `__SHA_*__` placeholders |
 
 The formula users install from lives in a separate repository, because Homebrew
-requires a tap to be named `homebrew-<name>`:
+requires a tap repo to be named `homebrew-<name>`:
 
-    ehabterra/homebrew-tap → Formula/apispec.rb
+    ehabterra/homebrew-tap
+    └── Formula/
+        └── apispec.rb        → brew install ehabterra/tap/apispec
+
+## Why one tap, not one per tool
+
+A tap is a repo with a `Formula/` directory, and it holds **any number** of
+formulae. Adding a second tool means adding a second file, not a second repo:
+
+    ehabterra/homebrew-tap
+    └── Formula/
+        ├── apispec.rb        → brew install ehabterra/tap/apispec
+        └── apidiag.rb        → brew install ehabterra/tap/apidiag
+
+A repo per tool (`homebrew-apispec`, `homebrew-apidiag`) would mean one PAT,
+one secret and one workflow step each, users tapping every one separately, and
+an install string that stutters — `brew install ehabterra/apispec/apispec`,
+because the tap name sits between the owner and the formula. The single-tap
+layout is what goreleaser, hashicorp and charmbracelet use.
+
+A tool that needs its own release cadence can still get its own tap later
+without changing the command for anyone already on this one.
 
 `.github/workflows/release.yml` renders the template and pushes it there on every
 tag. The checksums are computed from the artifacts that job just built, so the

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -42,16 +42,58 @@ formula cannot point at a digest the release does not have.
 
 ## One-time setup
 
-1. Create a **public** repo `ehabterra/homebrew-tap` (any description; no files needed).
-2. Create a fine-grained PAT with **Contents: read and write** on that repo only.
-3. Add it to *this* repo as the secret `HOMEBREW_TAP_TOKEN`.
+The tap repo already exists and is seeded. What is left is the token that lets
+the release workflow push to it.
 
-Until the secret exists the release workflow skips the step, so releases keep
-working — a fork will never fail here either.
+### 1. Create the token
+
+Go to **<https://github.com/settings/personal-access-tokens/new>**
+(GitHub → your avatar → Settings → Developer settings → Personal access tokens →
+Fine-grained tokens → *Generate new token*), then set:
+
+| field | value |
+|---|---|
+| Token name | `apispec-homebrew-tap` |
+| Expiration | your call — a dated token is a dead release step on the day it expires; 1 year with a calendar reminder is a reasonable trade |
+| Resource owner | `ehabterra` |
+| Repository access | **Only select repositories** → `ehabterra/homebrew-tap` |
+| Permissions → Repository permissions → **Contents** | **Read and write** |
+
+`Metadata: Read-only` is added automatically and is required — leave it.
+
+Grant nothing else. This token only needs to commit one file to one repo; it
+should not be able to touch `apispec` itself.
+
+Click **Generate token** and copy it. GitHub shows it once.
+
+### 2. Add it to the apispec repo
+
+Paste it into
+**<https://github.com/ehabterra/apispec/settings/secrets/actions/new>**
+with the name `HOMEBREW_TAP_TOKEN`.
+
+Or from a terminal, which avoids the clipboard:
+
+```bash
+gh secret set HOMEBREW_TAP_TOKEN --repo ehabterra/apispec
+# paste the token at the prompt, then press Ctrl-D
+```
+
+Verify it registered (this prints the name and date, never the value):
+
+```bash
+gh secret list --repo ehabterra/apispec
+```
+
+### 3. Nothing else
+
+The next tag pushes an updated `Formula/apispec.rb` automatically. Until the
+secret exists the step is skipped, so releases and forks keep working.
 
 ## Seeding the tap by hand
 
-Only needed once, or to fix the tap without cutting a release:
+The tap is already seeded with 0.5.6. This is how to re-seed it, or to fix it
+without cutting a release:
 
 ```bash
 git clone https://github.com/ehabterra/homebrew-tap.git

--- a/packaging/homebrew/apispec.rb
+++ b/packaging/homebrew/apispec.rb
@@ -9,27 +9,26 @@
 class Apispec < Formula
   desc "Generate OpenAPI 3.1 specs from Go source by static analysis"
   homepage "https://github.com/ehabterra/apispec"
-  version "0.5.6"
   license "Apache-2.0"
 
   on_macos do
     on_arm do
-      url "https://github.com/ehabterra/apispec/releases/download/v#{version}/apispec-darwin-arm64"
+      url "https://github.com/ehabterra/apispec/releases/download/v0.5.6/apispec-darwin-arm64"
       sha256 "04f9e3a6abc957bc8300c0f0225084c68f609cb1225d751e5d81a373c870414c"
     end
     on_intel do
-      url "https://github.com/ehabterra/apispec/releases/download/v#{version}/apispec-darwin-amd64"
+      url "https://github.com/ehabterra/apispec/releases/download/v0.5.6/apispec-darwin-amd64"
       sha256 "245ff783ee542f077dd944eb79f9cdb8e3206795970ef37493d29d308b301f80"
     end
   end
 
   on_linux do
     on_arm do
-      url "https://github.com/ehabterra/apispec/releases/download/v#{version}/apispec-linux-arm64"
+      url "https://github.com/ehabterra/apispec/releases/download/v0.5.6/apispec-linux-arm64"
       sha256 "31af9982727b85f6ab60dbf178d00dca03be6a6763527e63c9a29eea34556bfc"
     end
     on_intel do
-      url "https://github.com/ehabterra/apispec/releases/download/v#{version}/apispec-linux-amd64"
+      url "https://github.com/ehabterra/apispec/releases/download/v0.5.6/apispec-linux-amd64"
       sha256 "f7ad52b8d1e19ca9499e41d1d5394a5ea24649dd4f0658daac28e1e60c5dd1c2"
     end
   end

--- a/packaging/homebrew/apispec.rb
+++ b/packaging/homebrew/apispec.rb
@@ -1,0 +1,45 @@
+# Homebrew formula for apispec: installs the pre-built release binary, so
+# `brew install` needs no Go toolchain.
+#
+# packaging/homebrew/apispec.rb.tmpl is the SOURCE; apispec.rb is it rendered at
+# the current release. .github/workflows/release.yml renders the template with
+# the checksums of the artifacts it just built and pushes the result to the tap
+# (ehabterra/homebrew-tap, Formula/apispec.rb). TestHomebrewFormulaMatchesTemplate
+# keeps the two from drifting.
+class Apispec < Formula
+  desc "Generate OpenAPI 3.1 specs from Go source by static analysis"
+  homepage "https://github.com/ehabterra/apispec"
+  version "0.5.6"
+  license "Apache-2.0"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/ehabterra/apispec/releases/download/v#{version}/apispec-darwin-arm64"
+      sha256 "04f9e3a6abc957bc8300c0f0225084c68f609cb1225d751e5d81a373c870414c"
+    end
+    on_intel do
+      url "https://github.com/ehabterra/apispec/releases/download/v#{version}/apispec-darwin-amd64"
+      sha256 "245ff783ee542f077dd944eb79f9cdb8e3206795970ef37493d29d308b301f80"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/ehabterra/apispec/releases/download/v#{version}/apispec-linux-arm64"
+      sha256 "31af9982727b85f6ab60dbf178d00dca03be6a6763527e63c9a29eea34556bfc"
+    end
+    on_intel do
+      url "https://github.com/ehabterra/apispec/releases/download/v#{version}/apispec-linux-amd64"
+      sha256 "f7ad52b8d1e19ca9499e41d1d5394a5ea24649dd4f0658daac28e1e60c5dd1c2"
+    end
+  end
+
+  def install
+    # The download keeps its asset name; install it under the short one.
+    bin.install Dir["apispec-*"].first => "apispec"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/apispec --version")
+  end
+end

--- a/packaging/homebrew/apispec.rb.tmpl
+++ b/packaging/homebrew/apispec.rb.tmpl
@@ -9,27 +9,26 @@
 class Apispec < Formula
   desc "Generate OpenAPI 3.1 specs from Go source by static analysis"
   homepage "https://github.com/ehabterra/apispec"
-  version "__VERSION__"
   license "Apache-2.0"
 
   on_macos do
     on_arm do
-      url "https://github.com/ehabterra/apispec/releases/download/v#{version}/apispec-darwin-arm64"
+      url "https://github.com/ehabterra/apispec/releases/download/v__VERSION__/apispec-darwin-arm64"
       sha256 "__SHA_DARWIN_ARM64__"
     end
     on_intel do
-      url "https://github.com/ehabterra/apispec/releases/download/v#{version}/apispec-darwin-amd64"
+      url "https://github.com/ehabterra/apispec/releases/download/v__VERSION__/apispec-darwin-amd64"
       sha256 "__SHA_DARWIN_AMD64__"
     end
   end
 
   on_linux do
     on_arm do
-      url "https://github.com/ehabterra/apispec/releases/download/v#{version}/apispec-linux-arm64"
+      url "https://github.com/ehabterra/apispec/releases/download/v__VERSION__/apispec-linux-arm64"
       sha256 "__SHA_LINUX_ARM64__"
     end
     on_intel do
-      url "https://github.com/ehabterra/apispec/releases/download/v#{version}/apispec-linux-amd64"
+      url "https://github.com/ehabterra/apispec/releases/download/v__VERSION__/apispec-linux-amd64"
       sha256 "__SHA_LINUX_AMD64__"
     end
   end

--- a/packaging/homebrew/apispec.rb.tmpl
+++ b/packaging/homebrew/apispec.rb.tmpl
@@ -1,0 +1,45 @@
+# Homebrew formula for apispec: installs the pre-built release binary, so
+# `brew install` needs no Go toolchain.
+#
+# packaging/homebrew/apispec.rb.tmpl is the SOURCE; apispec.rb is it rendered at
+# the current release. .github/workflows/release.yml renders the template with
+# the checksums of the artifacts it just built and pushes the result to the tap
+# (ehabterra/homebrew-tap, Formula/apispec.rb). TestHomebrewFormulaMatchesTemplate
+# keeps the two from drifting.
+class Apispec < Formula
+  desc "Generate OpenAPI 3.1 specs from Go source by static analysis"
+  homepage "https://github.com/ehabterra/apispec"
+  version "__VERSION__"
+  license "Apache-2.0"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/ehabterra/apispec/releases/download/v#{version}/apispec-darwin-arm64"
+      sha256 "__SHA_DARWIN_ARM64__"
+    end
+    on_intel do
+      url "https://github.com/ehabterra/apispec/releases/download/v#{version}/apispec-darwin-amd64"
+      sha256 "__SHA_DARWIN_AMD64__"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/ehabterra/apispec/releases/download/v#{version}/apispec-linux-arm64"
+      sha256 "__SHA_LINUX_ARM64__"
+    end
+    on_intel do
+      url "https://github.com/ehabterra/apispec/releases/download/v#{version}/apispec-linux-amd64"
+      sha256 "__SHA_LINUX_AMD64__"
+    end
+  end
+
+  def install
+    # The download keeps its asset name; install it under the short one.
+    bin.install Dir["apispec-*"].first => "apispec"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/apispec --version")
+  end
+end


### PR DESCRIPTION
Following the macOS instructions left `./apispec-darwin-amd64` sitting in the working directory — not on PATH, not named `apispec`.

## Why that happened

The recommended **"Verify before installing"** block was a *separate* sequence: it downloaded the asset and then ended in **prose** — "then install it under the name you want, as the commands above do". Anyone reading top to bottom ran that block and stopped. The install command was in a different block, above, for a different architecture.

## The fix

Each platform is now **one copy-paste block** that:

1. detects the architecture (`uname -m` → `amd64`/`arm64`) — no "replace `darwin-arm64` with `darwin-amd64`" step to get wrong
2. downloads the asset **and** its checksum
3. verifies, and says to stop if it fails
4. `install -m 0755` to `/usr/local/bin/apispec`
5. removes the download
6. prints `apispec --version`

Tested as written on darwin/amd64. Also adds a no-`sudo` `~/.local/bin` variant, and a real PowerShell equivalent — the old Windows snippet had **no checksum step at all**.

## Homebrew

```bash
brew install ehabterra/tap/apispec
```

Now the first-listed method. The formula installs the **pre-built release binary**, so it needs no Go toolchain and takes seconds.

Homebrew requires a tap to live in a repo named `homebrew-<name>`, so the formula users install from cannot live here. `release.yml` renders it and pushes to `ehabterra/homebrew-tap` on every tag, with **checksums computed from the artifacts that job just built** — the formula cannot point at a digest the release does not have. The step is `if:`-guarded on `HOMEBREW_TAP_TOKEN`, so releases and forks keep working before the tap exists.

### Drift protection

The `.tmpl` is what ships; the `.rb` is what a human reads and runs `brew audit` against — so they can drift. `internal/packaging` tests that:

- the `.rb` is **exactly** what the template renders
- no placeholder was dropped — a dropped one does not fail the release, it silently ships the **previous** version's digest
- the referenced asset names are the ones the release actually publishes, since Homebrew surfaces a wrong URL only as a 404 on the user's machine

Verified against the real v0.5.6 assets: the template renders **byte-identical** to the committed formula.

## Still needs you (documented in `packaging/homebrew/README.md`)

1. Create a **public** repo `ehabterra/homebrew-tap`
2. Fine-grained PAT, **Contents: read/write** on that repo only
3. Add it here as the secret `HOMEBREW_TAP_TOKEN`
4. Seed `Formula/apispec.rb` once (one `cp` + commit, command in the README)

I have not created the repo — that publishes something new under your account.

Also gitignores downloaded release binaries; one 14MB asset nearly went in with this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Homebrew installation support for macOS and Linux on ARM and Intel.
  * Added checksum-verified binary installation instructions for macOS, Linux, and Windows.
  * Added upgrade, uninstall, and multi-installation guidance.

* **Documentation**
  * Expanded Homebrew setup, verification, troubleshooting, and platform-specific installation guidance.

* **Bug Fixes**
  * Release publishing can automatically update the Homebrew formula with current versions and checksums.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->