### PR TITLE
docs(homebrew): core-ready formula, and the submission is one-time not per release

### DIFF
--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -113,9 +113,66 @@ brew audit --strict --formula ./packaging/homebrew/apispec.rb
 `brew audit` is worth running before a release: it catches a stale `version`,
 an unreachable `url`, and a `sha256` that does not match what the URL serves.
 
-## Why not homebrew-core?
+## Getting into homebrew-core (the formulae.brew.sh search)
 
-homebrew-core has notability requirements (roughly: a meaningful number of
-stars/forks/watchers, or demonstrable wide use). A tap has none and can be
-submitted to core later without changing the install command for anyone who
-already used the tap.
+<https://formulae.brew.sh/formula/> indexes **homebrew-core only**. A tap is never
+listed there, however it is configured — so appearing in that search means getting
+the formula accepted into core.
+
+### Where apispec stands
+
+| requirement | status |
+|---|---|
+| Notable enough — Homebrew's heuristic is 75 stars **or** 30 forks **or** 30 watchers | **83 stars** — clears it |
+| Open-source with an OSI licence | Apache-2.0 |
+| Stable, versioned releases | v0.5.6, tagged and signed |
+| Maintained, not a duplicate of an existing formula | yes |
+| **Builds from source** | this is the work — see below |
+
+### The one blocking difference
+
+core formulae **build from source**; the tap formula downloads a pre-built
+binary, which core does not accept. `apispec-homebrew-core.rb` in this directory
+is the source-building version, verified locally:
+
+```bash
+brew install --build-from-source <tap>/apispec    # compiles with Go, binary reports its version
+brew test <tap>/apispec                           # passes
+brew audit --new --strict --formula <tap>/apispec # clean
+```
+
+### Submitting
+
+```bash
+brew tap --force homebrew/core
+cd "$(brew --repository homebrew/core)"
+git checkout -b apispec
+
+cp /path/to/apispec/packaging/homebrew/apispec-homebrew-core.rb Formula/a/apispec.rb
+# update url + sha256 to the release you are submitting:
+#   curl -sL https://github.com/ehabterra/apispec/archive/refs/tags/vX.Y.Z.tar.gz | shasum -a 256
+
+brew audit --new --strict --online --formula apispec
+brew install --build-from-source apispec && brew test apispec
+
+gh repo fork Homebrew/homebrew-core --remote
+git commit -am "apispec X.Y.Z (new formula)" && git push -u origin apispec
+gh pr create --repo Homebrew/homebrew-core
+```
+
+`--online` matters: it checks the URL resolves and the checksum matches, which
+the offline audit cannot.
+
+### What changes if it is accepted
+
+- apispec appears in the formulae.brew.sh search, and `brew install apispec`
+  works with no tap
+- **Homebrew maintainers own the formula.** Their bots open version-bump PRs when
+  they notice a new tag; you no longer control when an update ships, and a
+  breaking change to flags is their problem to discover
+- the tap keeps working, so anyone already on `ehabterra/tap/apispec` is
+  unaffected. Keeping both is normal: the tap can ship a release the same day,
+  core lands when it lands
+
+Nothing about the tap has to change to try this, and a rejection costs only the
+PR.

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -158,12 +158,25 @@ brew audit --new --strict --online --formula apispec
 brew install --build-from-source apispec && brew test apispec
 
 gh repo fork Homebrew/homebrew-core --remote
-git commit -am "apispec X.Y.Z (new formula)" && git push -u origin apispec
+git commit -am "apispec 0.5.6 (new formula)"     # the REAL version, not a placeholder
+git push -u origin apispec
 gh pr create --repo Homebrew/homebrew-core
 ```
 
 `--online` matters: it checks the URL resolves and the checksum matches, which
 the offline audit cannot.
+
+**The commit message is a convention, not a formality.** homebrew-core expects
+`<formula> <version> (new formula)` with the real version, and it becomes the PR
+title:
+
+    apispec 0.5.6 (new formula)      ✅
+    apispec X.Y.Z (new formula)      ❌ placeholder left in
+    Add apispec formula              ❌ wrong shape
+
+Recent core merges look exactly like this — `oxvg 0.0.7 (new formula)`,
+`network-doctor 1.10.7 (new formula)`. Later version bumps drop the suffix and
+are just `apispec 0.5.7`, which is what BrewTestBot will open on your behalf.
 
 ### Do I resubmit every release?
 

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -155,7 +155,11 @@ cp /path/to/apispec/packaging/homebrew/apispec-homebrew-core.rb Formula/a/apispe
 #   curl -sL https://github.com/ehabterra/apispec/archive/refs/tags/vX.Y.Z.tar.gz | shasum -a 256
 
 brew audit --new --strict --online --formula apispec
-brew install --build-from-source apispec && brew test apispec
+
+# HOMEBREW_NO_INSTALL_FROM_API=1 is REQUIRED when the formula is in your local
+# homebrew/core checkout — without it brew ignores your file and uses the API.
+HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source apispec
+brew test apispec
 
 gh repo fork Homebrew/homebrew-core --remote
 git commit -am "apispec 0.5.6 (new formula)"     # the REAL version, not a placeholder
@@ -165,6 +169,18 @@ gh pr create --repo Homebrew/homebrew-core
 
 `--online` matters: it checks the URL resolves and the checksum matches, which
 the offline audit cannot.
+
+`HOMEBREW_NO_INSTALL_FROM_API=1` matters more. Homebrew installs from its API by
+default, and its own FAQ is blunt about the consequence:
+
+> if you are editing a core formula or cask you must set
+> `HOMEBREW_NO_INSTALL_FROM_API=1` before using `brew install` or `brew update`
+> otherwise they will ignore your local changes and default to the API
+
+Without it the install step quietly tests something other than the file you are
+about to submit — the worst kind of green. It is only needed for a formula inside
+the **homebrew/core** checkout; a third-party tap like `ehabterra/tap` is always
+read from disk, which is why the tap instructions above do not use it.
 
 **The commit message is a convention, not a formality.** homebrew-core expects
 `<formula> <version> (new formula)` with the real version, and it becomes the PR

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -141,7 +141,9 @@ brew test <tap>/apispec                           # passes
 brew audit --new --strict --formula <tap>/apispec # clean
 ```
 
-### Submitting
+### Submitting (once)
+
+This is a one-time submission — see [Do I resubmit every release?](#do-i-resubmit-every-release).
 
 ```bash
 brew tap --force homebrew/core
@@ -162,6 +164,32 @@ gh pr create --repo Homebrew/homebrew-core
 
 `--online` matters: it checks the URL resolves and the checksum matches, which
 the offline audit cannot.
+
+### Do I resubmit every release?
+
+**No.** The sequence above is for the **initial** new-formula submission, once.
+After that core keeps itself up to date:
+
+- **Autobump is the default.** `Formula#autobump?` is true unless a formula opts
+  out with `no_autobump!` (`Library/Homebrew/formula.rb`), so apispec would be on
+  the autobump list automatically. Homebrew's scheduled job notices a new
+  upstream release and BrewTestBot opens the version-bump PR itself.
+- **Detection already works with no `livecheck` block** — the default strategy
+  reads tags from the GitHub URL. Checked against the candidate formula:
+  `brew livecheck` reports `apispec: 0.5.6 ==> 0.5.6`, i.e. it found the current
+  release and agreed with it. When 0.5.7 is tagged that becomes
+  `0.5.6 ==> 0.5.7`, and the bump PR follows.
+- **To push a release in yourself** — a bot outage, or wanting it in core the
+  same day — it is one command, not the fork sequence:
+
+  ```bash
+  brew bump-formula-pr --version=0.5.7 apispec
+  ```
+
+  It forks, branches, updates `url` and `sha256`, commits and opens the PR.
+
+So the ongoing cost of being in core is close to zero: the one-time submission,
+plus reviewing the occasional bot PR when something breaks.
 
 ### What changes if it is accepted
 

--- a/packaging/homebrew/apispec-homebrew-core.rb
+++ b/packaging/homebrew/apispec-homebrew-core.rb
@@ -7,10 +7,15 @@
 # Submitting this is what puts apispec in the formulae.brew.sh search — a tap is
 # never indexed there. See README.md, "Getting into homebrew-core".
 #
-# Verified locally before committing:
-#   brew install --build-from-source <tap>/apispec   → builds, binary reports 0.5.6
-#   brew test <tap>/apispec                          → passes
+# Verified locally before committing, from a scratch tap (a third-party tap is
+# always read from disk, so no env var is needed there):
+#   brew install --build-from-source <tap>/apispec    → builds, binary reports 0.5.6
+#   brew test <tap>/apispec                           → passes
 #   brew audit --new --strict --formula <tap>/apispec → clean
+#
+# Testing it inside the homebrew/core checkout is NOT the same: set
+# HOMEBREW_NO_INSTALL_FROM_API=1 or brew ignores the local file and uses the API.
+# See README.md, "Submitting (once)".
 #
 # Bump `url` and `sha256` to the release being submitted:
 #   curl -sL https://github.com/ehabterra/apispec/archive/refs/tags/vX.Y.Z.tar.gz | shasum -a 256

--- a/packaging/homebrew/apispec-homebrew-core.rb
+++ b/packaging/homebrew/apispec-homebrew-core.rb
@@ -1,0 +1,56 @@
+# CANDIDATE FORMULA FOR homebrew-core — not used by the tap.
+#
+# The tap formula (apispec.rb) installs the pre-built release binary. homebrew-core
+# does not accept that: core formulae build from source, so this one compiles with
+# Go from the release tarball. Keep both; they serve different places.
+#
+# Submitting this is what puts apispec in the formulae.brew.sh search — a tap is
+# never indexed there. See README.md, "Getting into homebrew-core".
+#
+# Verified locally before committing:
+#   brew install --build-from-source <tap>/apispec   → builds, binary reports 0.5.6
+#   brew test <tap>/apispec                          → passes
+#   brew audit --new --strict --formula <tap>/apispec → clean
+#
+# Bump `url` and `sha256` to the release being submitted:
+#   curl -sL https://github.com/ehabterra/apispec/archive/refs/tags/vX.Y.Z.tar.gz | shasum -a 256
+class Apispec < Formula
+  desc "Generate OpenAPI 3.1 specs from Go source by static analysis"
+  homepage "https://github.com/ehabterra/apispec"
+  url "https://github.com/ehabterra/apispec/archive/refs/tags/v0.5.6.tar.gz"
+  sha256 "8f911576f3284988af11708fcb7c6e3a6e4742a1e39e32b27bdc181aec05da61"
+  license "Apache-2.0"
+  head "https://github.com/ehabterra/apispec.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    # A core formula builds from a release tarball, which carries no git data, so
+    # only the values that are knowable are injected. main.go falls back to
+    # runtime/debug build info for the rest.
+    ldflags = %W[
+      -s -w
+      -X main.Version=#{version}
+      -X main.BuildDate=#{time.iso8601}
+    ]
+    system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/apispec"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/apispec --version")
+
+    (testpath/"go.mod").write "module example.com/t\n\ngo 1.21\n"
+    (testpath/"main.go").write <<~GO
+      package main
+
+      import "net/http"
+
+      func main() {
+        http.HandleFunc("/things", func(w http.ResponseWriter, r *http.Request) {})
+        _ = http.ListenAndServe(":8080", nil)
+      }
+    GO
+    system bin/"apispec", "--dir", testpath, "--output", testpath/"openapi.yaml"
+    assert_match "/things", (testpath/"openapi.yaml").read
+  end
+end


### PR DESCRIPTION
Two things, one of which is a gap I created.

## The core-ready formula never reached main

`43cc1e4` — the source-building `apispec-homebrew-core.rb` and the
"Getting into homebrew-core" docs — was pushed to the #309 branch **after** that
PR was merged, so it stayed on the branch. Cherry-picked here. It is the same
commit, verified before: `brew install --build-from-source` compiles it,
`brew test` passes, `brew audit --new --strict` is clean.

## The submission commands read as a per-release ritual

They are not — that sequence is for the **initial** new-formula PR, once. Now
documented, with evidence rather than assertion:

- **Autobump is the default.** `Formula#autobump?` is true unless a formula calls
  `no_autobump!` (`Library/Homebrew/formula.rb:284`), so an accepted apispec is on
  the autobump list and BrewTestBot opens the version-bump PR itself.
- **Detection needs no `livecheck` block.** Checked against the candidate formula:
  `brew livecheck` already resolves `apispec: 0.5.6 ==> 0.5.6` — it finds the
  current release and agrees. A 0.5.7 tag becomes `0.5.6 ==> 0.5.7`.
- **To push a release in the same day** instead of waiting for the bot:
  `brew bump-formula-pr --version=X.Y.Z apispec` — one command that forks,
  branches, updates `url`/`sha256` and opens the PR.

Net: the ongoing cost of core is close to zero — the one-time submission, plus
reviewing the occasional bot PR when something breaks.

Docs and one new formula file; no Go changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Homebrew Core candidate formula for installing `apispec`.
  - Homebrew installation builds now verify the installed version and test OpenAPI generation.

- **Documentation**
  - Expanded Homebrew guidance with eligibility requirements, source-build details, submission steps, and validation commands.
  - Documented release versioning workflows, including automatic updates and manual bumping.
  - Clarified the outcomes and next steps following Homebrew Core acceptance or rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->