### PR TITLE
fix(homebrew): go is a runtime dependency, not a build one

### DIFF
--- a/packaging/homebrew/apispec-homebrew-core.rb
+++ b/packaging/homebrew/apispec-homebrew-core.rb
@@ -27,7 +27,11 @@ class Apispec < Formula
   license "Apache-2.0"
   head "https://github.com/ehabterra/apispec.git", branch: "main"
 
-  depends_on "go" => :build
+  # RUNTIME, not :build. apispec analyses a project by loading its packages
+  # through go/packages, which shells out to `go list` — without the go binary on
+  # PATH it exits with "go command required, not found". A :build dependency is
+  # also absent from `brew test`, so the test block would fail on CI.
+  depends_on "go"
 
   def install
     # A core formula builds from a release tarball, which carries no git data, so

--- a/packaging/homebrew/apispec.rb
+++ b/packaging/homebrew/apispec.rb
@@ -11,6 +11,11 @@ class Apispec < Formula
   homepage "https://github.com/ehabterra/apispec"
   license "Apache-2.0"
 
+  # apispec analyses a project by loading its packages through go/packages, which
+  # shells out to `go list`. The pre-built binary still needs the go toolchain on
+  # PATH at RUNTIME — without it every run exits with "go command required".
+  depends_on "go"
+
   on_macos do
     on_arm do
       url "https://github.com/ehabterra/apispec/releases/download/v0.5.6/apispec-darwin-arm64"

--- a/packaging/homebrew/apispec.rb.tmpl
+++ b/packaging/homebrew/apispec.rb.tmpl
@@ -11,6 +11,11 @@ class Apispec < Formula
   homepage "https://github.com/ehabterra/apispec"
   license "Apache-2.0"
 
+  # apispec analyses a project by loading its packages through go/packages, which
+  # shells out to `go list`. The pre-built binary still needs the go toolchain on
+  # PATH at RUNTIME — without it every run exits with "go command required".
+  depends_on "go"
+
   on_macos do
     on_arm do
       url "https://github.com/ehabterra/apispec/releases/download/v__VERSION__/apispec-darwin-arm64"


### PR DESCRIPTION
apispec analyses a project by loading its packages through `go/packages`, which shells out to `go list`. Without the go binary on PATH, every run exits with:

```
failed to load filtered packages: err: go command required, not found
```

Two formulae were wrong about this, in different ways:

| formula | was | consequence |
|---|---|---|
| **tap** (`apispec.rb`) | no `depends_on` at all | `brew install ehabterra/tap/apispec` on a machine without Go produces a tool that cannot analyse anything — **this is shipping today** |
| **homebrew-core candidate** | `depends_on "go" => :build` | build deps are absent from `brew test`, so the test block **would fail on Homebrew CI** |

## How it was missed

`brew test` passed locally — because the machine running it had Go on PATH for other reasons. It went green for the wrong reason, which is the failure mode a build-vs-runtime dependency error always has.

The check that actually catches it is running the keg with the ambient toolchain removed:

```console
$ env -i PATH=/usr/bin:/bin <keg>/bin/apispec --dir . --output out.yaml
failed to load filtered packages: err: go command required, not found
```

## Verified with the fix

- `brew deps --formula …` → `go`
- builds in ~5s, `brew test` passes
- `brew audit --new --strict --online` clean
- the keg generates a spec running with **only Homebrew's go on PATH** (`env -i PATH=$(brew --prefix)/bin:/usr/bin:/bin`) — the check that would have caught this the first time

The live tap has already been updated, so new installs get the dependency.

## Action needed on the homebrew-core branch

`ehabterra/homebrew-core@apispec-1` still carries `=> :build`. It must be replaced with the corrected formula before submitting, or CI will reject it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Homebrew installation reliability by ensuring the required Go toolchain is available when running the installed application.
  * Updated Homebrew package metadata and templates to accurately reflect this runtime requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->