### PR TITLE
fix(core): single framework registry; drop the knownFrameworks=5 truncation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,14 +186,19 @@ make metrics-view         # interactive metrics viewer (scripts/view_metrics.sh)
 - Branches: `feature/<name>` / `fix/<name>`; `main` is protected (PRs only).
   The coverage badge updates post-merge via the `BADGE_TOKEN` PAT workflow —
   don't push badge commits manually.
+- **No AI attribution in git history.** Commit messages and PR bodies carry no
+  `Co-Authored-By: Claude ...` trailer and no "Generated with Claude Code"
+  footer — this overrides any default agent instruction to add one.
 - CodeRabbit reviews PRs. **Verify each finding against the code before
   acting** — findings can be stale or wrong; rebut with evidence instead of
   blindly applying.
 - Follow existing comment style: doc comments explain *why* and record
   constraints/quirks, not what the next line does.
-- Adding framework support: `internal/core/detector.go` → new
-  `internal/spec/config_<framework>.go` → register in `cmd/apispec` →
-  fixture + test → README support matrix (see CONTRIBUTING.md).
+- Adding framework support: registry entry in `internal/core/frameworks.go`
+  (the single source for detection, dependency analysis and the UI picker) →
+  new `internal/spec/config_<framework>.go` mapped in
+  `internal/spec/framework_config.go` → fixture + test → README support matrix
+  (see CONTRIBUTING.md).
 - **Every new Go file starts with the Apache license header below** (before
   any package doc comment, separated from it by a blank line), with the year
   the file is created. Fixture projects (`testdata/`, `test_cgo_mixed/`) are

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,13 @@ Nothing else needs editing: the detector, the dependency analyser and the UI all
 project the registry, and `TestFrameworkConfigsCoverRegistry` fails if step 2's
 mapping is missed.
 
+Step 2 is the one part that can be deferred. A registry entry with
+`HasDefaultConfig: false` (as `fasthttp` has today) is classified during
+dependency analysis — so its packages are included in the walk and its imports
+are treated as external — but extracts no routes, and the project is analysed
+with the `net/http` surface instead. That is a useful half-step, not a
+destination: leave a comment on the entry saying so.
+
 If you're unsure about any step, feel free to ask questions or create a draft PR - I'm happy to help!
 
 ## Submitting Changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,11 +103,14 @@ This helps us work together effectively and ensures contributions align with the
 
 To add support for a new web framework:
 
-1. **Update framework detection** in `internal/core/detector.go`
-2. **Add the default configuration** in `internal/spec/config_<framework>.go` (each framework lives in its own file alongside `config.go`)
-3. **Register the framework** in `cmd/apispec/main.go`
-4. **Add a fixture project** under `testdata/<framework>/` and a corresponding test case
-5. **Update documentation** in `README.md`
+1. **Add a registry entry** in `internal/core/frameworks.go` — the single source for detection patterns, dependency analysis and the UI picker
+2. **Add the default configuration** in `internal/spec/config_<framework>.go` (each framework lives in its own file alongside `config.go`) and map it in `internal/spec/framework_config.go`
+3. **Add a fixture project** under `testdata/<framework>/` and a corresponding test case
+4. **Update documentation** in `README.md`
+
+Nothing else needs editing: the detector, the dependency analyser and the UI all
+project the registry, and `TestFrameworkConfigsCoverRegistry` fails if step 2's
+mapping is missed.
 
 If you're unsure about any step, feel free to ask questions or create a draft PR - I'm happy to help!
 

--- a/README.md
+++ b/README.md
@@ -1033,10 +1033,9 @@ go test ./internal/spec -v -run "Test.*Comprehensive"
 
 ### Adding a framework
 
-1. Add detection to `internal/core/detector.go`.
-2. Add the default config (route/request/response/param patterns) under `internal/spec/`.
-3. Register the framework in `cmd/apispec/main.go`.
-4. Add a fixture project under `testdata/` and a test case.
+1. Add a registry entry to `internal/core/frameworks.go` (detection patterns, import patterns, detection rank).
+2. Add the default config (route/request/response/param patterns) under `internal/spec/`, and map it in `internal/spec/framework_config.go`.
+3. Add a fixture project under `testdata/` and a test case.
 
 ### Contributing
 

--- a/cmd/apispecui/main.go
+++ b/cmd/apispecui/main.go
@@ -34,6 +34,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ehabterra/apispec/internal/core"
 	"github.com/ehabterra/apispec/internal/diagserver"
 	"github.com/ehabterra/apispec/internal/engine"
 	"github.com/ehabterra/apispec/internal/insight"
@@ -102,8 +103,9 @@ func detectVersionInfo() {
 	}
 }
 
-// supportedFrameworks lists frameworks the UI can pick from.
-var supportedFrameworks = []string{"gin", "chi", "echo", "fiber", "mux", "net/http"}
+// supportedFrameworks lists frameworks the UI can pick from: every framework in
+// the core registry that ships a default pattern config.
+var supportedFrameworks = core.ConfigurableFrameworkNames()
 
 // ServerConfig is the runtime config of the apispecui server.
 type ServerConfig struct {
@@ -514,20 +516,7 @@ func noCacheAssets(h http.Handler) http.Handler {
 // defaultConfigForFramework returns the default APISpecConfig for the named
 // framework, falling back to net/http.
 func defaultConfigForFramework(name string) *spec.APISpecConfig {
-	switch strings.ToLower(name) {
-	case "gin":
-		return spec.DefaultGinConfig()
-	case "chi":
-		return spec.DefaultChiConfig()
-	case "echo":
-		return spec.DefaultEchoConfig()
-	case "fiber":
-		return spec.DefaultFiberConfig()
-	case "mux":
-		return spec.DefaultMuxConfig()
-	default:
-		return spec.DefaultHTTPConfig()
-	}
+	return spec.DefaultConfigForFramework(name)
 }
 
 // findModuleRoot walks up from start looking for a go.mod file.

--- a/internal/core/detector.go
+++ b/internal/core/detector.go
@@ -65,8 +65,10 @@ func (d *FrameworkDetector) DetectAll(dir string) ([]string, error) {
 	// ImportsOnly: parsing stops after the import block, which is all this
 	// scan reads — a full parse of every file (the pre-DetectAll code at
 	// least early-returned on the first hit) costs hundreds of ms on large
-	// projects. The loop also stops once every known framework is seen.
-	const knownFrameworks = 5
+	// projects. The loop also stops once every known framework is seen; the
+	// bound comes from the registry rather than a restated literal, which used
+	// to abandon the walk at five and hide any sixth framework (issue #285).
+	detectable := SourceDetectableFrameworks()
 	fset := token.NewFileSet()
 	for _, filePath := range goFiles {
 		f, err := parser.ParseFile(fset, filePath, nil, parser.ImportsOnly)
@@ -76,28 +78,32 @@ func (d *FrameworkDetector) DetectAll(dir string) ([]string, error) {
 
 		for _, imp := range f.Imports {
 			importPath := strings.Trim(imp.Path.Value, "\"")
-			switch {
-			case strings.Contains(importPath, "gin-gonic/gin"):
-				add("gin")
-			case strings.Contains(importPath, "go-chi/chi"):
-				add("chi")
-			case strings.Contains(importPath, "labstack/echo"):
-				add("echo")
-			case strings.Contains(importPath, "gofiber/fiber"):
-				add("fiber")
-			case strings.Contains(importPath, "gorilla/mux"):
-				add("mux")
+			for _, fw := range detectable {
+				if matchesAny(importPath, fw.SourcePatterns) {
+					add(fw.Name)
+					break
+				}
 			}
 		}
-		if len(frameworks) == knownFrameworks {
+		if len(frameworks) == len(detectable) {
 			break
 		}
 	}
 
 	if len(frameworks) == 0 {
-		frameworks = append(frameworks, "net/http")
+		frameworks = append(frameworks, StdlibFramework)
 	}
 	return frameworks, nil
+}
+
+// matchesAny reports whether importPath contains any of the given substrings.
+func matchesAny(importPath string, patterns []string) bool {
+	for _, p := range patterns {
+		if strings.Contains(importPath, p) {
+			return true
+		}
+	}
+	return false
 }
 
 // CollectGoFiles recursively collects all .go files from a directory

--- a/internal/core/frameworks.go
+++ b/internal/core/frameworks.go
@@ -14,7 +14,11 @@
 
 package core
 
-import "sort"
+import (
+	"slices"
+	"sort"
+	"strings"
+)
 
 // StdlibFramework is the name reported when no third-party framework import is
 // found. net/http is imported by nearly every Go project and carries no routing
@@ -156,10 +160,21 @@ func FrameworksByDetectionRank() []Framework {
 	return out
 }
 
-// Frameworks returns the registry in declaration order.
+// clone deep-copies f, so a caller that reorders or edits what an accessor
+// returned cannot reach the registry through a shared backing array.
+func (f Framework) clone() Framework {
+	f.SourcePatterns = slices.Clone(f.SourcePatterns)
+	f.ImportPatterns = slices.Clone(f.ImportPatterns)
+	f.ExternalPrefixes = slices.Clone(f.ExternalPrefixes)
+	return f
+}
+
+// Frameworks returns a deep copy of the registry, in declaration order.
 func Frameworks() []Framework {
-	out := make([]Framework, len(frameworks))
-	copy(out, frameworks)
+	out := make([]Framework, 0, len(frameworks))
+	for _, f := range frameworks {
+		out = append(out, f.clone())
+	}
 	return out
 }
 
@@ -169,10 +184,23 @@ func SourceDetectableFrameworks() []Framework {
 	out := make([]Framework, 0, len(frameworks))
 	for _, f := range frameworks {
 		if f.SourceDetectable() {
-			out = append(out, f)
+			out = append(out, f.clone())
 		}
 	}
 	return out
+}
+
+// CanonicalFrameworkName maps a framework name to its registry spelling,
+// case-insensitively, reporting whether the registry knows it. Unknown names
+// are returned unchanged: an explicitly selected framework the registry has
+// never heard of (a house router) is carried through, not rejected.
+func CanonicalFrameworkName(name string) (string, bool) {
+	for _, f := range frameworks {
+		if strings.EqualFold(f.Name, name) {
+			return f.Name, true
+		}
+	}
+	return name, false
 }
 
 // ConfigurableFrameworkNames returns the names of frameworks that ship a

--- a/internal/core/frameworks.go
+++ b/internal/core/frameworks.go
@@ -1,0 +1,188 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import "sort"
+
+// StdlibFramework is the name reported when no third-party framework import is
+// found. net/http is imported by nearly every Go project and carries no routing
+// signal on its own, so it is never *detected* — only fallen back to.
+const StdlibFramework = "net/http"
+
+// Framework describes one web framework apispec knows about. It is the single
+// source for every list that used to be written out per consumer: the
+// source-import scan (internal/core), the dependency analyser's patterns,
+// external prefixes and detection order (internal/metadata), and the framework
+// picker in the UI. Before this registry existed the set was restated six
+// times, including as a bare `const knownFrameworks = 5` bounding the file walk
+// — adding a sixth framework truncated detection silently (issue #285).
+type Framework struct {
+	// Name is the canonical name used by the CLI, the engine and the UI.
+	Name string
+
+	// DependencyKey is the key the metadata dependency analyser files this
+	// framework under. It matches Name except for net/http, whose bucket has
+	// always been "http" and appears in emitted metadata.
+	DependencyKey string
+
+	// SourcePatterns are import-path substrings the source-level scan
+	// (FrameworkDetector.DetectAll) matches. Empty means the framework is not
+	// source-detectable: net/http carries no routing signal, and fasthttp is
+	// only classified during dependency analysis.
+	SourcePatterns []string
+
+	// ImportPatterns are import-path prefixes that identify a package as using
+	// this framework during dependency analysis.
+	ImportPatterns []string
+
+	// ExternalPrefixes are import-path prefixes excluded as external (vendor)
+	// dependencies. Deliberately not derived from ImportPatterns: companion
+	// modules such as github.com/gin-contrib/ identify a framework user without
+	// being excluded from analysis.
+	ExternalPrefixes []string
+
+	// DetectionRank orders dependency-analysis classification for packages that
+	// import more than one framework (nearly all handler code also imports
+	// net/http). Lower wins; the stdlib bucket is always considered last.
+	DetectionRank int
+
+	// HasDefaultConfig reports whether internal/spec ships a default pattern
+	// config for this framework, i.e. whether it can be selected as the primary
+	// framework. spec.DefaultConfigForFramework is the lookup; a test there
+	// asserts the two stay in step.
+	HasDefaultConfig bool
+}
+
+// SourceDetectable reports whether the source-import scan can find f.
+func (f Framework) SourceDetectable() bool { return len(f.SourcePatterns) > 0 }
+
+// frameworks is the registry. Declaration order is the order the source scan
+// and the UI picker present frameworks in; classification order during
+// dependency analysis is DetectionRank, which differs by history and is kept
+// explicit so neither ordering silently changes when an entry is added.
+var frameworks = []Framework{
+	{
+		Name:             "gin",
+		DependencyKey:    "gin",
+		SourcePatterns:   []string{"gin-gonic/gin"},
+		ImportPatterns:   []string{"github.com/gin-gonic/gin", "github.com/gin-contrib/"},
+		ExternalPrefixes: []string{"github.com/gin-gonic/gin"},
+		DetectionRank:    1,
+		HasDefaultConfig: true,
+	},
+	{
+		Name:             "chi",
+		DependencyKey:    "chi",
+		SourcePatterns:   []string{"go-chi/chi"},
+		ImportPatterns:   []string{"github.com/go-chi/chi", "github.com/go-chi/chi/v5"},
+		ExternalPrefixes: []string{"github.com/go-chi/chi"},
+		DetectionRank:    4,
+		HasDefaultConfig: true,
+	},
+	{
+		Name:             "echo",
+		DependencyKey:    "echo",
+		SourcePatterns:   []string{"labstack/echo"},
+		ImportPatterns:   []string{"github.com/labstack/echo", "github.com/labstack/echo/v4"},
+		ExternalPrefixes: []string{"github.com/labstack/echo"},
+		DetectionRank:    2,
+		HasDefaultConfig: true,
+	},
+	{
+		Name:             "fiber",
+		DependencyKey:    "fiber",
+		SourcePatterns:   []string{"gofiber/fiber"},
+		ImportPatterns:   []string{"github.com/gofiber/fiber", "github.com/gofiber/fiber/v2"},
+		ExternalPrefixes: []string{"github.com/gofiber/fiber"},
+		DetectionRank:    3,
+		HasDefaultConfig: true,
+	},
+	{
+		Name:             "mux",
+		DependencyKey:    "mux",
+		SourcePatterns:   []string{"gorilla/mux"},
+		ImportPatterns:   []string{"github.com/gorilla/mux"},
+		ExternalPrefixes: []string{"github.com/gorilla/mux"},
+		DetectionRank:    5,
+		HasDefaultConfig: true,
+	},
+	{
+		// No route-extraction config yet: fasthttp is classified during
+		// dependency analysis only, so a project using it is analysed with the
+		// stdlib surface rather than being silently dropped.
+		Name:             "fasthttp",
+		DependencyKey:    "fasthttp",
+		ImportPatterns:   []string{"github.com/valyala/fasthttp"},
+		ExternalPrefixes: []string{"github.com/valyala/fasthttp"},
+		DetectionRank:    6,
+	},
+	{
+		Name:             StdlibFramework,
+		DependencyKey:    "http",
+		ImportPatterns:   []string{"net/http"},
+		DetectionRank:    stdlibDetectionRank,
+		HasDefaultConfig: true,
+	},
+}
+
+// stdlibDetectionRank keeps the net/http bucket last: it is the one pattern
+// that matches nearly every package, so any framework import must outrank it.
+const stdlibDetectionRank = 1 << 30
+
+// StdlibDependencyKey is the dependency-analysis bucket net/http is filed
+// under. It is considered after every other framework: its pattern matches
+// nearly every package, so a framework import must always win.
+const StdlibDependencyKey = "http"
+
+// FrameworksByDetectionRank returns the registry ordered by DetectionRank —
+// the order a package importing several frameworks is classified in.
+func FrameworksByDetectionRank() []Framework {
+	out := Frameworks()
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].DetectionRank < out[j].DetectionRank
+	})
+	return out
+}
+
+// Frameworks returns the registry in declaration order.
+func Frameworks() []Framework {
+	out := make([]Framework, len(frameworks))
+	copy(out, frameworks)
+	return out
+}
+
+// SourceDetectableFrameworks returns the frameworks the source-import scan can
+// find, in declaration order.
+func SourceDetectableFrameworks() []Framework {
+	out := make([]Framework, 0, len(frameworks))
+	for _, f := range frameworks {
+		if f.SourceDetectable() {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// ConfigurableFrameworkNames returns the names of frameworks that ship a
+// default pattern config, in declaration order — the set the UI offers.
+func ConfigurableFrameworkNames() []string {
+	out := make([]string, 0, len(frameworks))
+	for _, f := range frameworks {
+		if f.HasDefaultConfig {
+			out = append(out, f.Name)
+		}
+	}
+	return out
+}

--- a/internal/core/frameworks_test.go
+++ b/internal/core/frameworks_test.go
@@ -1,0 +1,207 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRegistryInvariants(t *testing.T) {
+	names := map[string]bool{}
+	keys := map[string]bool{}
+	ranks := map[int]string{}
+	var stdlib *Framework
+
+	for i, fw := range Frameworks() {
+		if fw.Name == "" || fw.DependencyKey == "" {
+			t.Errorf("framework %d has an empty Name or DependencyKey: %+v", i, fw)
+		}
+		if names[fw.Name] {
+			t.Errorf("duplicate framework name %q", fw.Name)
+		}
+		names[fw.Name] = true
+		if keys[fw.DependencyKey] {
+			t.Errorf("duplicate dependency key %q", fw.DependencyKey)
+		}
+		keys[fw.DependencyKey] = true
+		// Ranks decide which framework wins for a package importing several;
+		// a tie makes that winner depend on declaration order instead.
+		if other, dup := ranks[fw.DetectionRank]; dup {
+			t.Errorf("frameworks %q and %q share DetectionRank %d", other, fw.Name, fw.DetectionRank)
+		}
+		ranks[fw.DetectionRank] = fw.Name
+		if len(fw.ImportPatterns) == 0 {
+			t.Errorf("framework %q has no ImportPatterns, so dependency analysis can never classify it", fw.Name)
+		}
+		if fw.Name == StdlibFramework {
+			f := fw
+			stdlib = &f
+		}
+	}
+
+	if stdlib == nil {
+		t.Fatalf("registry has no %q entry; it is the detection fallback", StdlibFramework)
+	}
+	if stdlib.DependencyKey != StdlibDependencyKey {
+		t.Errorf("stdlib dependency key = %q, want %q", stdlib.DependencyKey, StdlibDependencyKey)
+	}
+	if stdlib.SourceDetectable() {
+		t.Error("net/http must not be source-detectable: it is imported by nearly every project and carries no routing signal")
+	}
+}
+
+// TestStdlibRanksLast pins the one ordering fact detection depends on: the
+// net/http pattern matches nearly every handler package, so any framework must
+// outrank it or every package is classified as stdlib.
+func TestStdlibRanksLast(t *testing.T) {
+	ranked := FrameworksByDetectionRank()
+	if len(ranked) == 0 {
+		t.Fatal("registry is empty")
+	}
+	if last := ranked[len(ranked)-1]; last.Name != StdlibFramework {
+		t.Errorf("last framework by detection rank = %q, want %q", last.Name, StdlibFramework)
+	}
+}
+
+// TestDetectAllFindsEveryRegisteredFramework is the guard for issue #285: the
+// source scan used to stop the file walk at a hardcoded `knownFrameworks = 5`,
+// so a sixth framework was found only in projects that happened not to import
+// five others. The table is the registry itself, so this widens automatically
+// when a framework is added — which is exactly what the old literal did not.
+func TestDetectAllFindsEveryRegisteredFramework(t *testing.T) {
+	detectable := SourceDetectableFrameworks()
+	if len(detectable) < 2 {
+		t.Skip("fewer than two source-detectable frameworks registered")
+	}
+
+	dir := t.TempDir()
+	// One file per framework, and the framework whose file sorts last is the
+	// one an early exit would drop.
+	for i, fw := range detectable {
+		src := fmt.Sprintf("package main\n\nimport _ %q\n", fw.ImportPatterns[0])
+		path := filepath.Join(dir, fmt.Sprintf("f%02d.go", i))
+		if err := os.WriteFile(path, []byte(src), 0o600); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+
+	got, err := NewFrameworkDetector().DetectAll(dir)
+	if err != nil {
+		t.Fatalf("DetectAll failed: %v", err)
+	}
+
+	found := map[string]bool{}
+	for _, name := range got {
+		found[name] = true
+	}
+	for _, fw := range detectable {
+		if !found[fw.Name] {
+			t.Errorf("DetectAll dropped %q (got %v) — the scan stopped before every registered framework was seen", fw.Name, got)
+		}
+	}
+}
+
+// TestDetectAllSurvivesANewFramework is the direct reproduction of issue #285:
+// it registers one extra framework and asserts the scan still finds every one.
+// Against the old `const knownFrameworks = 5` this fails — the walk stopped
+// after five distinct hits, so the sixth was found only when the project
+// happened not to import five others.
+func TestDetectAllSurvivesANewFramework(t *testing.T) {
+	restore := frameworks
+	t.Cleanup(func() { frameworks = restore })
+	frameworks = append(append([]Framework{}, restore...), Framework{
+		Name:           "testfw",
+		DependencyKey:  "testfw",
+		SourcePatterns: []string{"example.com/testfw"},
+		ImportPatterns: []string{"example.com/testfw"},
+		DetectionRank:  stdlibDetectionRank - 1,
+	})
+
+	detectable := SourceDetectableFrameworks()
+	dir := t.TempDir()
+	for i, fw := range detectable {
+		src := fmt.Sprintf("package main\n\nimport _ %q\n", fw.ImportPatterns[0])
+		if err := os.WriteFile(filepath.Join(dir, fmt.Sprintf("f%02d.go", i)), []byte(src), 0o600); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+	}
+
+	got, err := NewFrameworkDetector().DetectAll(dir)
+	if err != nil {
+		t.Fatalf("DetectAll failed: %v", err)
+	}
+	if len(got) != len(detectable) {
+		t.Fatalf("DetectAll found %d of %d registered frameworks (%v) — the file walk exited early", len(got), len(detectable), got)
+	}
+}
+
+// TestDetectAllMatchesEverySourcePattern covers the alternative import paths a
+// framework can be imported under (versioned modules, companion packages):
+// each pattern on its own must identify the framework.
+func TestDetectAllMatchesEverySourcePattern(t *testing.T) {
+	for _, fw := range SourceDetectableFrameworks() {
+		for i, pattern := range fw.SourcePatterns {
+			t.Run(fmt.Sprintf("%s/%s", fw.Name, pattern), func(t *testing.T) {
+				dir := t.TempDir()
+				// ImportsOnly parsing never resolves the import, so the pattern
+				// itself stands in for whatever path a project imports it under.
+				src := fmt.Sprintf("package main\n\nimport _ %q\n", pattern)
+				if err := os.WriteFile(filepath.Join(dir, fmt.Sprintf("m%d.go", i)), []byte(src), 0o600); err != nil {
+					t.Fatalf("write file: %v", err)
+				}
+				got, err := NewFrameworkDetector().Detect(dir)
+				if err != nil {
+					t.Fatalf("Detect failed: %v", err)
+				}
+				if got != fw.Name {
+					t.Errorf("Detect = %q, want %q for pattern %q", got, fw.Name, pattern)
+				}
+			})
+		}
+	}
+}
+
+func TestConfigurableFrameworkNames(t *testing.T) {
+	names := ConfigurableFrameworkNames()
+	if len(names) == 0 {
+		t.Fatal("no framework ships a default config")
+	}
+	// The UI offers this list, so the stdlib fallback must be selectable.
+	var hasStdlib bool
+	for _, n := range names {
+		hasStdlib = hasStdlib || n == StdlibFramework
+	}
+	if !hasStdlib {
+		t.Errorf("ConfigurableFrameworkNames = %v, missing %q", names, StdlibFramework)
+	}
+}
+
+// TestFrameworksReturnsACopy guards the accessors: callers project and sort
+// these slices (the dependency analyser sorts by rank), and a shared backing
+// array would let one caller reorder the registry for everyone else.
+func TestFrameworksReturnsACopy(t *testing.T) {
+	first := Frameworks()
+	if len(first) == 0 {
+		t.Fatal("registry is empty")
+	}
+	original := first[0].Name
+	first[0].Name = "mutated"
+	if Frameworks()[0].Name != original {
+		t.Errorf("mutating the returned slice changed the registry: got %q, want %q", Frameworks()[0].Name, original)
+	}
+}

--- a/internal/core/frameworks_test.go
+++ b/internal/core/frameworks_test.go
@@ -204,4 +204,52 @@ func TestFrameworksReturnsACopy(t *testing.T) {
 	if Frameworks()[0].Name != original {
 		t.Errorf("mutating the returned slice changed the registry: got %q, want %q", Frameworks()[0].Name, original)
 	}
+
+	// The struct copy is shallow, so the pattern slices need cloning too —
+	// otherwise a caller editing fw.ImportPatterns[0] rewrites the registry
+	// for every later caller.
+	for _, accessor := range []struct {
+		name string
+		get  func() []Framework
+	}{
+		{"Frameworks", Frameworks},
+		{"SourceDetectableFrameworks", SourceDetectableFrameworks},
+	} {
+		got := accessor.get()
+		if len(got) == 0 || len(got[0].ImportPatterns) == 0 {
+			t.Fatalf("%s returned nothing to mutate", accessor.name)
+		}
+		name, want := got[0].Name, got[0].ImportPatterns[0]
+		got[0].ImportPatterns[0] = "mutated"
+
+		for _, fw := range Frameworks() {
+			if fw.Name == name && fw.ImportPatterns[0] != want {
+				t.Errorf("%s: mutating ImportPatterns changed the registry entry %q: got %q, want %q",
+					accessor.name, name, fw.ImportPatterns[0], want)
+			}
+		}
+	}
+}
+
+func TestCanonicalFrameworkName(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    string
+		wantOK  bool
+		comment string
+	}{
+		{"gin", "gin", true, "exact"},
+		{"GIN", "gin", true, "upper"},
+		{"Gin", "gin", true, "title"},
+		{"NET/HTTP", StdlibFramework, true, "the stdlib name carries a slash"},
+		{"house-router", "house-router", false, "unknown names pass through unchanged"},
+		{"", "", false, "empty stays empty"},
+	}
+	for _, tt := range tests {
+		got, ok := CanonicalFrameworkName(tt.in)
+		if got != tt.want || ok != tt.wantOK {
+			t.Errorf("CanonicalFrameworkName(%q) = (%q, %v), want (%q, %v) — %s",
+				tt.in, got, ok, tt.want, tt.wantOK, tt.comment)
+		}
+	}
 }

--- a/internal/engine/compose_config_test.go
+++ b/internal/engine/compose_config_test.go
@@ -101,3 +101,45 @@ func TestComposeFrameworkConfigSingleFramework(t *testing.T) {
 		t.Fatal("no route patterns composed")
 	}
 }
+
+// TestComposeFrameworkConfigNormalisesPrimaryCase covers user-supplied primary
+// names. The UI posts req.Framework straight into
+// ComposeFrameworkConfigWithPrimary without validating it against the registry,
+// so "Gin" is reachable. The config lookup is case-insensitive, but the dedup
+// and stdlib comparisons are ==, so an unnormalised name used to return the
+// framework twice ([Gin gin]) and merge gin's own patterns back over itself.
+func TestComposeFrameworkConfigNormalisesPrimaryCase(t *testing.T) {
+	for _, primary := range []string{"GIN", "Gin", "gIn"} {
+		cfg, frameworks := ComposeFrameworkConfigFrom([]string{"gin"}, primary)
+
+		if len(frameworks) != 1 || frameworks[0] != "gin" {
+			t.Errorf("primary %q: frameworks = %v, want [gin] — the name was not canonicalised before dedup", primary, frameworks)
+		}
+		base, _ := ComposeFrameworkConfigFrom([]string{"gin"}, "gin")
+		if len(cfg.Framework.RoutePatterns) != len(base.Framework.RoutePatterns) {
+			t.Errorf("primary %q: composed %d route patterns, canonical %q composed %d — the secondary merge ran against itself",
+				primary, len(cfg.Framework.RoutePatterns), "gin", len(base.Framework.RoutePatterns))
+		}
+	}
+
+	// The stdlib name carries a slash and is compared against separately.
+	if _, frameworks := ComposeFrameworkConfigFrom([]string{"net/http"}, "NET/HTTP"); len(frameworks) != 1 {
+		t.Errorf("frameworks = %v, want one entry", frameworks)
+	}
+
+	// An unknown explicit choice is still carried through, not rejected.
+	_, frameworks := ComposeFrameworkConfigFrom([]string{"gin"}, "house-router")
+	if len(frameworks) != 2 || frameworks[0] != "house-router" {
+		t.Errorf("frameworks = %v, want [house-router gin]", frameworks)
+	}
+}
+
+// TestComposeFrameworkConfigFromDoesNotMutateInput guards the canonicalisation
+// pass: the caller's slice is shared (the engine reuses the detected list).
+func TestComposeFrameworkConfigFromDoesNotMutateInput(t *testing.T) {
+	input := []string{"GIN", "MUX"}
+	ComposeFrameworkConfigFrom(input, "")
+	if input[0] != "GIN" || input[1] != "MUX" {
+		t.Errorf("input slice was rewritten in place: %v", input)
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -574,8 +574,20 @@ func ComposeFrameworkConfigWithPrimary(dir, primary string) (*spec.APISpecConfig
 // in the project, so doing it twice for one run is pure waste.
 func ComposeFrameworkConfigFrom(frameworks []string, primary string) (*spec.APISpecConfig, []string) {
 	if len(frameworks) == 0 {
-		frameworks = []string{"net/http"}
+		frameworks = []string{core.StdlibFramework}
 	}
+	// Canonicalise before anything compares names. Detection always reports the
+	// registry spelling, but an explicit primary is user input (the UI posts
+	// req.Framework straight through), and a mixed-case "Gin" would otherwise
+	// resolve to the gin config while failing every == comparison below —
+	// duplicating the framework in the returned list and merging gin's own
+	// patterns back over itself as a secondary.
+	canonical := make([]string, len(frameworks))
+	for i, fw := range frameworks {
+		canonical[i], _ = core.CanonicalFrameworkName(fw)
+	}
+	frameworks = canonical
+	primary, _ = core.CanonicalFrameworkName(primary)
 	if primary == "" {
 		primary = frameworks[0]
 	} else {
@@ -611,7 +623,7 @@ func ComposeFrameworkConfigFrom(frameworks []string, primary string) (*spec.APIS
 	// detection cannot pick it as a second framework. Every merged pattern is
 	// receiver- or package-scoped, which keeps the merge inert for
 	// pure-framework projects.
-	if primary != "net/http" {
+	if primary != core.StdlibFramework {
 		cfg = spec.MergeFrameworkConfigs(cfg, spec.HTTPSecondaryConfig())
 	}
 	return cfg, frameworks

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -540,8 +540,6 @@ func (e *Engine) GenerateMetadataOnlyWithLogger(logger *VerboseLogger) (*metadat
 	return meta, nil
 }
 
-// defaultFrameworkConfig maps a detected framework name to its built-in
-// config; unknown names (and "net/http") get the net/http config.
 // ComposeFrameworkConfig builds the effective framework config for a directory:
 // the detected primary's config, every other detected framework merged in as a
 // receiver-scoped view, and the stdlib net/http surface layered underneath. It
@@ -595,7 +593,7 @@ func ComposeFrameworkConfigFrom(frameworks []string, primary string) (*spec.APIS
 		frameworks = append([]string{primary}, rest...)
 	}
 
-	cfg := defaultFrameworkConfig(primary)
+	cfg := spec.DefaultConfigForFramework(primary)
 	// Additional recognised frameworks (a gin API next to a gorilla/mux admin
 	// router, half-migrated projects): merge each one's receiver-scoped view so
 	// its registrations are traced too. Scoped patterns cannot claim another
@@ -605,7 +603,7 @@ func ComposeFrameworkConfigFrom(frameworks []string, primary string) (*spec.APIS
 		if fw == primary {
 			continue
 		}
-		cfg = spec.MergeFrameworkConfigs(cfg, spec.SecondaryView(defaultFrameworkConfig(fw)))
+		cfg = spec.MergeFrameworkConfigs(cfg, spec.SecondaryView(spec.DefaultConfigForFramework(fw)))
 	}
 	// Layer the stdlib net/http surface under the detected framework: mixed
 	// projects (a framework API plus plain ServeMux ops endpoints in one binary)
@@ -617,23 +615,6 @@ func ComposeFrameworkConfigFrom(frameworks []string, primary string) (*spec.APIS
 		cfg = spec.MergeFrameworkConfigs(cfg, spec.HTTPSecondaryConfig())
 	}
 	return cfg, frameworks
-}
-
-func defaultFrameworkConfig(framework string) *spec.APISpecConfig {
-	switch framework {
-	case "gin":
-		return spec.DefaultGinConfig()
-	case "chi":
-		return spec.DefaultChiConfig()
-	case "echo":
-		return spec.DefaultEchoConfig()
-	case "fiber":
-		return spec.DefaultFiberConfig()
-	case "mux":
-		return spec.DefaultMuxConfig()
-	default:
-		return spec.DefaultHTTPConfig()
-	}
 }
 
 func (e *Engine) GenerateOpenAPI() (*spec.OpenAPISpec, error) {

--- a/internal/metadata/dependency_analyzer.go
+++ b/internal/metadata/dependency_analyzer.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/ehabterra/apispec/internal/core"
 	"golang.org/x/tools/go/packages"
 )
 
@@ -105,43 +106,32 @@ func NewFrameworkDetectorWithConfig(config FrameworkDetectorConfig) *FrameworkDe
 	}
 }
 
+// frameworkPatternsFromRegistry projects the framework registry into the
+// import-pattern map this detector classifies packages with.
+func frameworkPatternsFromRegistry() map[string][]string {
+	out := make(map[string][]string, len(core.Frameworks()))
+	for _, fw := range core.Frameworks() {
+		out[fw.DependencyKey] = slices.Clone(fw.ImportPatterns)
+	}
+	return out
+}
+
+// frameworkExternalPrefixes returns the framework half of ExternalPrefixes, in
+// detection-rank order. The remaining prefixes are ordinary vendor namespaces
+// with no framework meaning and stay listed at the call site.
+func frameworkExternalPrefixes() []string {
+	var out []string
+	for _, fw := range core.FrameworksByDetectionRank() {
+		out = append(out, fw.ExternalPrefixes...)
+	}
+	return out
+}
+
 // DefaultFrameworkDetectorConfig returns the default configuration for framework detection
 func DefaultFrameworkDetectorConfig() FrameworkDetectorConfig {
 	return FrameworkDetectorConfig{
-		FrameworkPatterns: map[string][]string{
-			"gin": {
-				"github.com/gin-gonic/gin",
-				"github.com/gin-contrib/",
-			},
-			"echo": {
-				"github.com/labstack/echo",
-				"github.com/labstack/echo/v4",
-			},
-			"fiber": {
-				"github.com/gofiber/fiber",
-				"github.com/gofiber/fiber/v2",
-			},
-			"chi": {
-				"github.com/go-chi/chi",
-				"github.com/go-chi/chi/v5",
-			},
-			"mux": {
-				"github.com/gorilla/mux",
-			},
-			"http": {
-				"net/http",
-			},
-			"fasthttp": {
-				"github.com/valyala/fasthttp",
-			},
-		},
-		ExternalPrefixes: []string{
-			"github.com/gin-gonic/gin",
-			"github.com/labstack/echo",
-			"github.com/gofiber/fiber",
-			"github.com/go-chi/chi",
-			"github.com/gorilla/mux",
-			"github.com/valyala/fasthttp",
+		FrameworkPatterns: frameworkPatternsFromRegistry(),
+		ExternalPrefixes: append(frameworkExternalPrefixes(), []string{
 			"golang.org/x/",
 			"google.golang.org/",
 			"go.uber.org/",
@@ -153,7 +143,7 @@ func DefaultFrameworkDetectorConfig() FrameworkDetectorConfig {
 			"k8s.io/",
 			"sigs.k8s.io/",
 			"github.com/google/uuid",
-		},
+		}...),
 		ProjectPatterns: []string{
 			"/modules/",
 			"/pkg/",
@@ -362,10 +352,13 @@ func (fd *FrameworkDetector) findAllFrameworkPackages(
 // directly made the winner random per run for packages that import both a
 // framework and net/http (nearly all handler code does).
 func (fd *FrameworkDetector) frameworkDetectionOrder() []string {
-	known := []string{"gin", "echo", "fiber", "chi", "mux", "fasthttp"}
-	seen := map[string]bool{"http": true}
+	seen := map[string]bool{core.StdlibDependencyKey: true}
 	order := make([]string, 0, len(fd.config.FrameworkPatterns))
-	for _, k := range known {
+	for _, fw := range core.FrameworksByDetectionRank() {
+		k := fw.DependencyKey
+		if seen[k] {
+			continue // the stdlib bucket is appended last, below
+		}
 		if _, ok := fd.config.FrameworkPatterns[k]; ok {
 			order = append(order, k)
 			seen[k] = true
@@ -379,8 +372,8 @@ func (fd *FrameworkDetector) frameworkDetectionOrder() []string {
 	}
 	sort.Strings(extras)
 	order = append(order, extras...)
-	if _, ok := fd.config.FrameworkPatterns["http"]; ok {
-		order = append(order, "http")
+	if _, ok := fd.config.FrameworkPatterns[core.StdlibDependencyKey]; ok {
+		order = append(order, core.StdlibDependencyKey)
 	}
 	return order
 }

--- a/internal/spec/framework_config.go
+++ b/internal/spec/framework_config.go
@@ -1,0 +1,42 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import "strings"
+
+// frameworkConfigs maps a framework name from the core registry to its default
+// pattern config. It lives here rather than in the registry because
+// internal/spec cannot be imported from internal/core without a cycle;
+// TestFrameworkConfigsCoverRegistry asserts the two stay in step, so a
+// framework added to the registry without a config fails the build's tests
+// instead of silently falling back to net/http.
+var frameworkConfigs = map[string]func() *APISpecConfig{
+	"gin":      DefaultGinConfig,
+	"chi":      DefaultChiConfig,
+	"echo":     DefaultEchoConfig,
+	"fiber":    DefaultFiberConfig,
+	"mux":      DefaultMuxConfig,
+	"net/http": DefaultHTTPConfig,
+}
+
+// DefaultConfigForFramework returns the default pattern config for the named
+// framework, falling back to net/http for anything unrecognised (including the
+// frameworks that are only classified during dependency analysis).
+func DefaultConfigForFramework(name string) *APISpecConfig {
+	if newConfig, ok := frameworkConfigs[strings.ToLower(name)]; ok {
+		return newConfig()
+	}
+	return DefaultHTTPConfig()
+}

--- a/internal/spec/framework_config_test.go
+++ b/internal/spec/framework_config_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/core"
+)
+
+// TestFrameworkConfigsCoverRegistry ties this map to the core registry in both
+// directions. Without it, a framework added to the registry and marked
+// HasDefaultConfig would fall through to DefaultHTTPConfig at runtime — the
+// same class of silent miss as the framework-count literal in issue #285.
+func TestFrameworkConfigsCoverRegistry(t *testing.T) {
+	registered := map[string]bool{}
+	for _, fw := range core.Frameworks() {
+		registered[fw.Name] = true
+		_, hasConfig := frameworkConfigs[fw.Name]
+		if fw.HasDefaultConfig && !hasConfig {
+			t.Errorf("framework %q is marked HasDefaultConfig but has no entry in frameworkConfigs, so it silently falls back to net/http", fw.Name)
+		}
+		if !fw.HasDefaultConfig && hasConfig {
+			t.Errorf("framework %q has a config constructor but is not marked HasDefaultConfig, so the UI never offers it", fw.Name)
+		}
+	}
+	for name := range frameworkConfigs {
+		if !registered[name] {
+			t.Errorf("frameworkConfigs has %q, which is not in the core framework registry", name)
+		}
+	}
+}
+
+func TestDefaultConfigForFramework(t *testing.T) {
+	for _, fw := range core.Frameworks() {
+		if !fw.HasDefaultConfig {
+			continue
+		}
+		t.Run(fw.Name, func(t *testing.T) {
+			cfg := DefaultConfigForFramework(fw.Name)
+			if cfg == nil {
+				t.Fatalf("DefaultConfigForFramework(%q) = nil", fw.Name)
+			}
+			// A config with no route patterns documents nothing.
+			if len(cfg.Framework.RoutePatterns) == 0 {
+				t.Errorf("config for %q has no route patterns", fw.Name)
+			}
+		})
+	}
+
+	// Unknown names and the dependency-analysis-only frameworks fall back to
+	// net/http rather than returning nil.
+	for _, name := range []string{"", "iris", "fasthttp", "not-a-framework"} {
+		if cfg := DefaultConfigForFramework(name); cfg == nil {
+			t.Errorf("DefaultConfigForFramework(%q) = nil, want the net/http fallback", name)
+		}
+	}
+}
+
+func TestDefaultConfigForFrameworkIsCaseInsensitive(t *testing.T) {
+	lower := DefaultConfigForFramework("gin")
+	upper := DefaultConfigForFramework("GIN")
+	if len(upper.Framework.RoutePatterns) != len(lower.Framework.RoutePatterns) {
+		t.Errorf("case changed the resolved config: %q gave %d route patterns, %q gave %d",
+			"gin", len(lower.Framework.RoutePatterns), "GIN", len(upper.Framework.RoutePatterns))
+	}
+}

--- a/spec/spec.go
+++ b/spec/spec.go
@@ -51,6 +51,13 @@ func DefaultFiberConfig() *APISpecConfig { return intspec.DefaultFiberConfig() }
 func DefaultMuxConfig() *APISpecConfig   { return intspec.DefaultMuxConfig() }
 func DefaultHTTPConfig() *APISpecConfig  { return intspec.DefaultHTTPConfig() }
 
+// DefaultConfigForFramework returns the default configuration for a framework
+// by name ("gin", "chi", "echo", "fiber", "mux", "net/http"), falling back to
+// the net/http configuration for anything unrecognised.
+func DefaultConfigForFramework(name string) *APISpecConfig {
+	return intspec.DefaultConfigForFramework(name)
+}
+
 // HTTPSecondaryConfig is the merge-safe, receiver-scoped subset of the
 // net/http config for layering under another framework's config.
 func HTTPSecondaryConfig() *APISpecConfig { return intspec.HTTPSecondaryConfig() }


### PR DESCRIPTION
Closes #285.

## The bug

The supported-framework set was written out six times in six different shapes, one of them a bare count bounding the detector's file walk:

```go
// internal/core/detector.go
const knownFrameworks = 5
...
if len(frameworks) == knownFrameworks {
    break
}
```

That constant was an unlinked restatement of the case count in a `switch` twenty lines below. Adding a sixth framework — Iris (#200) is already requested — makes the early exit fire at five and abandon the walk, so the new framework is detected only in projects that happen not to import five others. It compiles, every existing test passes, and the spec just comes out thinner.

The six lists already disagreed with each other: `fasthttp` appeared in two of them, `net/http` in two different ones, and the engine and the UI each carried their own independent name→config switch.

## The fix

`internal/core/frameworks.go` becomes the single source — detection patterns, dependency-analysis import patterns, external prefixes, detection rank, and whether a default config exists. Everything else projects it:

| Before | After |
|---|---|
| `detector.go` switch + `knownFrameworks = 5` | ranges the registry; the early-exit bound is `len(SourceDetectableFrameworks())` |
| `dependency_analyzer`'s `FrameworkPatterns`, `ExternalPrefixes`, `frameworkDetectionOrder` | derived from the registry |
| two independent name→config switches (engine + UI) | `spec.DefaultConfigForFramework` |
| `supportedFrameworks` literal in the UI | `core.ConfigurableFrameworkNames()` |

`DetectionRank` is explicit rather than derived from declaration order, because the two orderings genuinely differ by history (`gin, echo, fiber, chi, mux` for dependency classification vs `gin, chi, echo, fiber, mux` for the source scan and the UI picker) and silently swapping them would change which framework wins for a package importing two.

Also removes an orphaned doc comment that had drifted onto `ComposeFrameworkConfig`, and adds `spec.DefaultConfigForFramework` to the public `spec` package.

## Behaviour drift: none

Checked rather than assumed. A throwaway test compared the derived `FrameworkPatterns`, the derived `ExternalPrefixes` and `frameworkDetectionOrder()` against the literals they replace — byte-identical, ordering included. It was deleted once it passed; the permanent guards below are what ship. The full suite (metadata goldens, determinism tests, every framework fixture) passes unchanged.

## Guards

- **`TestDetectAllSurvivesANewFramework`** registers one extra framework and asserts the scan still finds every one. Against the old literal bound it fails — `DetectAll found 5 of 6 registered frameworks ([gin chi echo fiber mux]) — the file walk exited early` — and passes with this change. Verified both directions by temporarily restoring the old bound.
- **`TestDetectAllFindsEveryRegisteredFramework`** and **`TestDetectAllMatchesEverySourcePattern`** are table-driven off the registry, so they widen automatically when a framework is added instead of needing to be remembered.
- **`TestFrameworkConfigsCoverRegistry`** ties the config map to the registry in both directions, closing the other silent path: a framework registered without a config would have fallen back to `net/http` with no diagnostic.
- Registry invariants: unique names, unique dependency keys, unique detection ranks, and `net/http` ranked last (its pattern matches nearly every package, so any framework must outrank it).

## Docs

CONTRIBUTING, README and CLAUDE.md now describe the real contributor path: registry entry → `config_<framework>.go` + mapping → fixture + test → README. The old "register the framework in `cmd/apispec/main.go`" step was already stale — no such switch exists there.

## Not in scope

`fasthttp` still has no route-extraction config, so a fasthttp project is analysed with the stdlib surface. That is pre-existing behaviour, preserved deliberately and now documented on the registry entry rather than quietly changed. #282 (the same file's project-root heuristics) is left alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized support for detecting and configuring supported web frameworks.
  * Expanded framework recognition to include Fasthttp and standard-library HTTP handlers.
  * Added automatic default API configurations for recognized frameworks, with a standard-library fallback.
  * Framework detection now adapts automatically as supported frameworks are added.

* **Documentation**
  * Updated contribution and setup guidance to reflect the streamlined framework-support process.

* **Tests**
  * Added coverage for framework detection, configuration, ordering, metadata, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->