### PR TITLE
fix(metadata): classify project packages by module path, not path shape

### DIFF
--- a/generator/testdata_module_prefix_packages_test.go
+++ b/generator/testdata_module_prefix_packages_test.go
@@ -15,6 +15,7 @@
 package generator
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/ehabterra/apispec/spec"
@@ -77,11 +78,32 @@ func TestTestdata_ModulePrefixPackages(t *testing.T) {
 		}
 	}
 
-	// The request body on POST /widgets resolves through the api package's own
-	// type — a component, not an empty schema.
-	if item, ok := out.Paths["/widgets"]; ok {
-		if op := opFor(item, "POST"); op != nil && op.RequestBody == nil {
-			t.Error("POST /widgets: request body missing")
-		}
+	// The request body on POST /widgets must resolve through the api package's
+	// own Widget type — the api package is one of the two whose classification
+	// this fix changes, so a body that degraded to an empty schema would mean
+	// the package stopped being analysed.
+	item, ok := out.Paths["/widgets"]
+	if !ok {
+		return
+	}
+	op := opFor(item, "POST")
+	if op == nil || op.RequestBody == nil {
+		t.Fatal("POST /widgets: request body missing")
+	}
+	mt, ok := op.RequestBody.Content["application/json"]
+	if !ok || mt.Schema == nil {
+		t.Fatal("POST /widgets: no application/json schema")
+	}
+	if !strings.HasSuffix(mt.Schema.Ref, "Widget") {
+		t.Fatalf("POST /widgets: body should $ref the api package's Widget, got ref=%q type=%q", mt.Schema.Ref, mt.Schema.Type)
+	}
+	// noDanglingRefs covers reachable refs generally; name the component here so
+	// the failure says which type went missing.
+	name := mt.Schema.Ref[strings.LastIndex(mt.Schema.Ref, "/")+1:]
+	if out.Components == nil || out.Components.Schemas == nil {
+		t.Fatal("POST /widgets: body $refs a component but the spec has no components")
+	}
+	if _, ok := out.Components.Schemas[name]; !ok {
+		t.Errorf("POST /widgets: body $refs %q, which is not in components.schemas", name)
 	}
 }

--- a/generator/testdata_module_prefix_packages_test.go
+++ b/generator/testdata_module_prefix_packages_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/spec"
+)
+
+// TestTestdata_ModulePrefixPackages guards issue #282. The two route-carrying
+// packages are `.../module_prefix_packages/api` and `.../app`, whose import
+// paths share the byte prefix `.../ap` but no whole path segment beyond the
+// module. The dependency analyser used to infer the project root as the
+// byte-wise longest common prefix and then use it as a HasPrefix membership
+// test; it now takes the module path from go.mod.
+//
+// The fix narrows what counts as a project package, so the thing worth
+// asserting is that nothing legitimate was narrowed away: both packages'
+// routes, their params and their bodies must survive.
+func TestTestdata_ModulePrefixPackages(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "module_prefix_packages", spec.DefaultChiConfig())
+	noDanglingRefs(t, out)
+
+	want := map[string][]string{
+		"/widgets/{id}":     {"GET"},
+		"/widgets":          {"POST"},
+		"/sessions/{token}": {"GET"},
+	}
+	for path, methods := range want {
+		item, ok := out.Paths[path]
+		if !ok {
+			t.Errorf("path %q missing; have %v", path, mapPathKeys(out.Paths))
+			continue
+		}
+		for _, m := range methods {
+			if opFor(item, m) == nil {
+				t.Errorf("%s %s: expected operation, missing", m, path)
+			}
+		}
+	}
+
+	// Path params come from the handlers in both sibling packages, so a package
+	// wrongly classified as external would show up here as a missing parameter.
+	for _, tc := range []struct{ path, param string }{
+		{"/widgets/{id}", "id"},
+		{"/sessions/{token}", "token"},
+	} {
+		item, ok := out.Paths[tc.path]
+		if !ok {
+			continue
+		}
+		op := opFor(item, "GET")
+		if op == nil {
+			continue
+		}
+		var found bool
+		for _, p := range op.Parameters {
+			if p.Name == tc.param && p.In == "path" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("GET %s: path parameter %q missing", tc.path, tc.param)
+		}
+	}
+
+	// The request body on POST /widgets resolves through the api package's own
+	// type — a component, not an empty schema.
+	if item, ok := out.Paths["/widgets"]; ok {
+		if op := opFor(item, "POST"); op != nil && op.RequestBody == nil {
+			t.Error("POST /widgets: request body missing")
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/mod v0.38.0
 	golang.org/x/tools v0.48.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -12,6 +13,5 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 )

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -35,6 +35,7 @@ import (
 	intspec "github.com/ehabterra/apispec/internal/spec"
 	"github.com/ehabterra/apispec/pkg/patterns"
 	"github.com/ehabterra/apispec/spec"
+	"golang.org/x/mod/modfile"
 	"golang.org/x/tools/go/packages"
 	"gopkg.in/yaml.v3"
 )
@@ -999,13 +1000,13 @@ func (e *Engine) moduleImportPath() string {
 	if err != nil {
 		return ""
 	}
-	for _, line := range strings.Split(string(data), "\n") {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "module ") {
-			return strings.TrimSpace(strings.TrimPrefix(line, "module"))
-		}
-	}
-	return ""
+	// Parsed with the module-file grammar rather than by trimming a "module "
+	// prefix: the hand-rolled version missed a tab-separated directive
+	// entirely, and kept the trailing // comment or the surrounding quotes when
+	// present. Each of those silently mis-answers "which packages are ours" —
+	// an empty path reverts to the heuristics, and a path with a comment
+	// glued on matches no package at all.
+	return modfile.ModulePath(data)
 }
 
 // matchesPattern checks if a path matches a gitignore-style pattern

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1239,7 +1239,11 @@ func (e *Engine) analyzeFrameworkDependencies(
 	fileToInfo map[*ast.File]*types.Info,
 	fset *token.FileSet,
 ) (*metadata.FrameworkDependencyList, error) {
-	detector := metadata.NewFrameworkDetector()
+	// The module path from go.mod decides which packages are the project's.
+	// GenerateMetadataWithLogger has taken it since it was added; the dependency
+	// analyser was left inferring the same answer from import-path shape, and
+	// got it wrong for every domain-hosted module (issue #282).
+	detector := metadata.NewFrameworkDetectorForModule(e.moduleImportPath())
 	// Configure detector for more precise analysis
 	detector.Configure(false, 2) // Don't include external packages, max 2 levels deep
 	if e.config.SkipHTTPFramework {

--- a/internal/engine/module_path_test.go
+++ b/internal/engine/module_path_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestModuleImportPathGrammarForms covers the go.mod forms the hand-rolled parser got
+// wrong. This value decides which packages count as the project's (#282), so a
+// mis-parse is not cosmetic: an empty result silently reverts classification to
+// the path-shape heuristics, and a path with a trailing comment glued on
+// matches no package at all, making every import look external.
+func TestModuleImportPathGrammarForms(t *testing.T) {
+	const want = "github.com/acme/x"
+
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{"space separated", "module github.com/acme/x\n\ngo 1.24\n"},
+		{"tab separated", "module\tgithub.com/acme/x\n\ngo 1.24\n"},
+		{"trailing comment", "module github.com/acme/x // the module\n\ngo 1.24\n"},
+		{"quoted path", "module \"github.com/acme/x\"\n\ngo 1.24\n"},
+		{"crlf line endings", "module github.com/acme/x\r\n\r\ngo 1.24\r\n"},
+		{"require block after", "module github.com/acme/x\n\ngo 1.24\n\nrequire (\n\tgithub.com/other/lib v1.0.0\n)\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(tt.content), 0o600); err != nil {
+				t.Fatalf("write go.mod: %v", err)
+			}
+			e := &Engine{config: &EngineConfig{moduleRoot: dir}}
+			if got := e.moduleImportPath(); got != want {
+				t.Errorf("moduleImportPath() = %q, want %q", got, want)
+			}
+		})
+	}
+}

--- a/internal/metadata/dependency_analyzer.go
+++ b/internal/metadata/dependency_analyzer.go
@@ -49,8 +49,9 @@ type FrameworkDependencyList struct {
 }
 
 // FrameworkDetectorConfig holds configuration for framework detection.
-// This configuration allows for flexible and customizable framework detection
-// without hardcoded values, making the system adaptable to different project structures.
+// The framework patterns and external prefixes are projections of the registry
+// in internal/core; the project/test/mock patterns below are heuristics that
+// only apply when no module path is known (see FrameworkDetector.modulePath).
 type FrameworkDetectorConfig struct {
 	// FrameworkPatterns maps framework types to their import patterns.
 	// Example: "gin" -> ["github.com/gin-gonic/gin", "github.com/gin-contrib/"]
@@ -80,9 +81,14 @@ type FrameworkDetectorConfig struct {
 
 // FrameworkDetector detects framework dependencies using configurable patterns.
 // It analyzes Go packages to identify framework usage and related dependencies,
-// providing intelligent project package detection without hardcoded values.
+// and classifies each import as belonging to the project or not.
 type FrameworkDetector struct {
 	config FrameworkDetectorConfig
+	// modulePath is the module path from go.mod — the authoritative answer to
+	// "is this package ours". Empty when the caller has no module (a bare
+	// directory, or a test constructing the detector directly), which is the
+	// only case the path heuristics below run in.
+	modulePath string
 	// Package analysis results from go/packages
 	packages map[string]*packages.Package
 	// Dependency graph: package -> its dependencies
@@ -94,6 +100,15 @@ type FrameworkDetector struct {
 // NewFrameworkDetector creates a new framework detector with default configuration
 func NewFrameworkDetector() *FrameworkDetector {
 	return NewFrameworkDetectorWithConfig(DefaultFrameworkDetectorConfig())
+}
+
+// NewFrameworkDetectorForModule creates a detector that classifies project
+// packages by the given module path (as read from go.mod). Pass "" only when
+// there is no module to read — the heuristic fallback is markedly less precise.
+func NewFrameworkDetectorForModule(modulePath string) *FrameworkDetector {
+	fd := NewFrameworkDetector()
+	fd.modulePath = modulePath
+	return fd
 }
 
 // NewFrameworkDetectorWithConfig creates a new framework detector with custom configuration
@@ -591,26 +606,36 @@ func (fd *FrameworkDetector) isProjectRelatedPackage(importPath string) bool {
 	return fd.isIntelligentProjectPackage(importPath)
 }
 
-// isIntelligentProjectPackage uses context-aware analysis to determine if a package belongs to the project
+// isIntelligentProjectPackage determines whether a package belongs to the
+// project. With a module path this is an exact answer; without one it degrades
+// to inference over import paths.
 func (fd *FrameworkDetector) isIntelligentProjectPackage(importPath string) bool {
-	// Get the project root from the analyzed packages
+	// go.mod already says which packages are ours. Guessing when the answer is
+	// available was not merely redundant: for any domain-hosted module the
+	// inference below returns no root at all (the common prefix contains a dot,
+	// and no package path starts with a dot-free segment), so every third-party
+	// import that is not in ExternalPrefixes fell through to
+	// fallbackProjectPackageDetection and was classified as a project package
+	// on the strength of having two slashes in it (issue #282).
+	if fd.modulePath != "" {
+		return importPath == fd.modulePath || strings.HasPrefix(importPath, fd.modulePath+"/")
+	}
+
+	// No module to read. Infer, and say so.
 	projectRoot := fd.detectProjectRoot()
 	if projectRoot == "" {
-		// Fallback to simple heuristics if we can't detect project root
 		return fd.fallbackProjectPackageDetection(importPath)
 	}
-
-	// Check if this package is under the detected project root
-	if strings.HasPrefix(importPath, projectRoot) {
+	if importPath == projectRoot || strings.HasPrefix(importPath, projectRoot+"/") {
 		return true
 	}
-
-	// Check if this package is imported by any of our analyzed packages
-	// This catches packages that are part of the project but not under the main root
+	// Packages that are part of the project but not under the inferred root.
 	return fd.isPackageImportedByProject(importPath)
 }
 
-// detectProjectRoot analyzes the package paths to determine the common project root
+// detectProjectRoot infers a project root as the longest common path prefix of
+// the analysed packages. Only used when no module path is available; see
+// isIntelligentProjectPackage.
 func (fd *FrameworkDetector) detectProjectRoot() string {
 	if len(fd.packages) == 0 {
 		return ""
@@ -637,36 +662,29 @@ func (fd *FrameworkDetector) detectProjectRoot() string {
 		}
 	}
 
-	// If the common prefix is too short or looks like a domain, try a different approach
-	if len(commonPrefix) < 3 || strings.Contains(commonPrefix, ".") {
-		// Look for packages that don't start with a domain (github.com, etc.)
-		for _, path := range packagePaths {
-			parts := strings.Split(path, "/")
-			if len(parts) >= 2 && !strings.Contains(parts[0], ".") {
-				// This looks like a project package (e.g., "myproject/models")
-				return parts[0]
-			}
-		}
+	// A bare host ("github.com") is not a project root — it would make every
+	// package on that host project-related. Anything shorter than one segment
+	// past the host is no root at all.
+	segments := strings.Split(commonPrefix, "/")
+	if commonPrefix == "" || (len(segments) == 1 && strings.Contains(segments[0], ".")) {
 		return ""
 	}
 
 	return commonPrefix
 }
 
-// findCommonPrefix finds the longest common prefix between two strings
+// findCommonPrefix returns the longest common prefix of two import paths,
+// measured in whole path segments. Comparing bytes instead produced strings
+// that are not package paths at all — "github.com/acme/api" and
+// "github.com/acme/app" share the bytes "github.com/acme/ap" — which were then
+// used as a HasPrefix membership test (issue #282).
 func (fd *FrameworkDetector) findCommonPrefix(a, b string) string {
-	minLen := len(a)
-	if len(b) < minLen {
-		minLen = len(b)
+	as, bs := strings.Split(a, "/"), strings.Split(b, "/")
+	n := min(len(as), len(bs))
+	i := 0
+	for ; i < n && as[i] == bs[i]; i++ {
 	}
-
-	for i := 0; i < minLen; i++ {
-		if a[i] != b[i] {
-			return a[:i]
-		}
-	}
-
-	return a[:minLen]
+	return strings.Join(as[:i], "/")
 }
 
 // isPackageImportedByProject checks if a package is imported by any of the analyzed project packages

--- a/internal/metadata/dependency_analyzer_module_test.go
+++ b/internal/metadata/dependency_analyzer_module_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// TestProjectPackageClassificationByModulePath covers issue #282: the detector
+// used to infer "is this ours" from import-path shape while go.mod had the
+// answer. The inference was not merely redundant — for a domain-hosted module
+// it produced no root at all, so every third-party import outside the small
+// ExternalPrefixes allowlist was classified as a project package on the
+// strength of containing two slashes.
+func TestProjectPackageClassificationByModulePath(t *testing.T) {
+	const module = "github.com/acme/billing"
+	fd := NewFrameworkDetectorForModule(module)
+
+	tests := []struct {
+		path string
+		want bool
+		why  string
+	}{
+		{module, true, "the module root package itself"},
+		{module + "/internal/handlers", true, "under the module"},
+		{module + "/api", true, "under the module"},
+
+		// The byte-prefix trap the issue names: billingv2 shares every byte of
+		// billing but is a different module.
+		{module + "v2", false, "a sibling module sharing a byte prefix"},
+		{module + "v2/api", false, "under a sibling module sharing a byte prefix"},
+
+		// Previously true, via `strings.Count(path, "/") >= 2`.
+		{"github.com/other/lib", false, "unrelated third-party package"},
+		{"github.com/acme/otherproject", false, "same org, different module"},
+		{"gitlab.com/x/y/z", false, "unrelated, deeper"},
+	}
+
+	for _, tt := range tests {
+		if got := fd.isProjectRelatedPackage(tt.path); got != tt.want {
+			t.Errorf("isProjectRelatedPackage(%q) = %v, want %v — %s", tt.path, got, tt.want, tt.why)
+		}
+	}
+
+	// Mock/test exclusion runs before the module check and still applies.
+	if fd.isProjectRelatedPackage(module + "/internal/mocks") {
+		t.Error("mock packages under the module should still be excluded")
+	}
+}
+
+// TestProjectPackageClassificationWithoutModule pins the fallback: without a
+// module path the detector infers, and the inference must at least be
+// self-consistent — a domain-hosted root resolves instead of being discarded
+// for containing a dot.
+func TestProjectPackageClassificationWithoutModule(t *testing.T) {
+	fd := NewFrameworkDetector()
+	// Non-nil: the no-root path walks each package's syntax.
+	fd.packages["github.com/acme/x/api"] = &packages.Package{PkgPath: "github.com/acme/x/api"}
+	fd.packages["github.com/acme/x/app"] = &packages.Package{PkgPath: "github.com/acme/x/app"}
+
+	if got := fd.detectProjectRoot(); got != "github.com/acme/x" {
+		t.Fatalf("detectProjectRoot = %q, want github.com/acme/x", got)
+	}
+	if !fd.isProjectRelatedPackage("github.com/acme/x/internal/db") {
+		t.Error("a package under the inferred root should be project-related")
+	}
+	// Segment-boundary check: the root must not swallow a sibling that merely
+	// shares its bytes.
+	if fd.isProjectRelatedPackage("github.com/acme/xother/api") {
+		t.Error("github.com/acme/xother is a different project than github.com/acme/x")
+	}
+}
+
+// TestModulePathBeatsInference proves the two disagree, so the wiring matters:
+// the same path is external under the real module path and "project-related"
+// under the heuristics.
+func TestModulePathBeatsInference(t *testing.T) {
+	const path = "github.com/unrelated/library"
+
+	if NewFrameworkDetectorForModule("github.com/acme/billing").isProjectRelatedPackage(path) {
+		t.Errorf("%q must be external when go.mod says the module is github.com/acme/billing", path)
+	}
+	// The fallback still claims it — `strings.Count(path, "/") >= 2` is the last
+	// resort. Pinned deliberately: it documents why passing the module path is
+	// what makes the classification correct, and flips this test if the
+	// heuristic is ever tightened.
+	if !NewFrameworkDetector().isProjectRelatedPackage(path) {
+		t.Errorf("expected the no-module heuristic to still claim %q; if it no longer does, this test and the comment above are stale", path)
+	}
+}

--- a/internal/metadata/dependency_analyzer_test.go
+++ b/internal/metadata/dependency_analyzer_test.go
@@ -147,8 +147,14 @@ func TestDefaultFrameworkDetectorConfig(t *testing.T) {
 
 func TestFrameworkDetector_PureHelpers(t *testing.T) {
 	fd := NewFrameworkDetector()
-	if got := fd.findCommonPrefix("github.com/a/b", "github.com/a/c"); got != "github.com/a/" {
+	// Whole segments, not bytes: the old byte-wise version returned
+	// "github.com/a/" here and "github.com/acme/ap" for api+app — strings that
+	// are not package paths, then used as HasPrefix membership tests (#282).
+	if got := fd.findCommonPrefix("github.com/a/b", "github.com/a/c"); got != "github.com/a" {
 		t.Errorf("findCommonPrefix = %q", got)
+	}
+	if got := fd.findCommonPrefix("github.com/acme/api", "github.com/acme/app"); got != "github.com/acme" {
+		t.Errorf("findCommonPrefix(api, app) = %q, want github.com/acme", got)
 	}
 	if !fd.contains([]string{"x", "y"}, "y") || fd.contains([]string{"x"}, "z") {
 		t.Error("contains wrong")

--- a/internal/metadata/metadata_sweep_test.go
+++ b/internal/metadata/metadata_sweep_test.go
@@ -1285,8 +1285,10 @@ func TestSweepFrameworkDetectorHelpers(t *testing.T) {
 		t.Errorf("disabled gin still detected: %q", got)
 	}
 
-	// detectProjectRoot: empty detector, then divergent paths where the
-	// non-domain path names the root.
+	// detectProjectRoot: empty detector, then divergent paths sharing no
+	// segment. Picking "abc" here because it is the one path without a dot was
+	// a guess (#282); with no shared root the honest answer is none, and
+	// classification falls through to the documented heuristics.
 	fd3 := NewFrameworkDetector()
 	if got := fd3.detectProjectRoot(); got != "" {
 		t.Errorf("empty detector root: %q", got)
@@ -1294,8 +1296,16 @@ func TestSweepFrameworkDetectorHelpers(t *testing.T) {
 	fd3.packages["abc/x"] = nil
 	fd3.packages["zzz.io/y"] = nil
 	fd3.packages["qqq.io/z"] = nil
-	if got := fd3.detectProjectRoot(); got != "abc" {
+	if got := fd3.detectProjectRoot(); got != "" {
 		t.Errorf("divergent root: %q", got)
+	}
+	// Packages that do share a root now resolve it, including domain-hosted
+	// ones — the old "looks like a domain" branch discarded exactly those.
+	fd3b := NewFrameworkDetector()
+	fd3b.packages["github.com/acme/x/api"] = nil
+	fd3b.packages["github.com/acme/x/app"] = nil
+	if got := fd3b.detectProjectRoot(); got != "github.com/acme/x" {
+		t.Errorf("shared root: %q, want github.com/acme/x", got)
 	}
 
 	// fallbackProjectPackageDetection heuristics.

--- a/testdata/module_prefix_packages/api/api.go
+++ b/testdata/module_prefix_packages/api/api.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// Widget is returned by the api package.
+type Widget struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// Register mounts the api routes.
+func Register(r chi.Router) {
+	r.Get("/widgets/{id}", getWidget)
+	r.Post("/widgets", createWidget)
+}
+
+func getWidget(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode(Widget{ID: chi.URLParam(r, "id")})
+}
+
+func createWidget(w http.ResponseWriter, r *http.Request) {
+	var in Widget
+	_ = json.NewDecoder(r.Body).Decode(&in)
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(in)
+}

--- a/testdata/module_prefix_packages/app/app.go
+++ b/testdata/module_prefix_packages/app/app.go
@@ -1,0 +1,23 @@
+package app
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// Session is returned by the app package.
+type Session struct {
+	Token string `json:"token"`
+	User  string `json:"user"`
+}
+
+// Register mounts the app routes.
+func Register(r chi.Router) {
+	r.Get("/sessions/{token}", getSession)
+}
+
+func getSession(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode(Session{Token: chi.URLParam(r, "token")})
+}

--- a/testdata/module_prefix_packages/go.mod
+++ b/testdata/module_prefix_packages/go.mod
@@ -1,0 +1,5 @@
+module github.com/ehabterra/apispec/testdata/module_prefix_packages
+
+go 1.24.3
+
+require github.com/go-chi/chi/v5 v5.2.2

--- a/testdata/module_prefix_packages/go.sum
+++ b/testdata/module_prefix_packages/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=
+github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=

--- a/testdata/module_prefix_packages/main.go
+++ b/testdata/module_prefix_packages/main.go
@@ -1,0 +1,24 @@
+// Package main wires two sibling packages whose import paths share a byte
+// prefix but not a path-segment prefix: ".../module_prefix_packages/api" and
+// ".../module_prefix_packages/app" have the common byte prefix ".../ap".
+//
+// The dependency analyser used to infer the project root as the byte-wise
+// longest common prefix of the loaded package paths, then use that string as a
+// HasPrefix membership test (issue #282). Both packages' routes must be
+// documented; the module path from go.mod is what decides they are ours.
+package main
+
+import (
+	"net/http"
+
+	"github.com/ehabterra/apispec/testdata/module_prefix_packages/api"
+	"github.com/ehabterra/apispec/testdata/module_prefix_packages/app"
+	"github.com/go-chi/chi/v5"
+)
+
+func main() {
+	r := chi.NewRouter()
+	api.Register(r)
+	app.Register(r)
+	_ = http.ListenAndServe(":8080", r)
+}


### PR DESCRIPTION
Closes #282.

## The bug is bigger than the issue says

The issue describes `findCommonPrefix` mangling `github.com/acme/api` + `github.com/acme/app` into `github.com/acme/ap`. Probing the actual code turned up something worse: for **any domain-hosted module** — i.e. essentially every real Go project — the inference produces no root at all, and every import falls through to the last-resort heuristics.

The chain, verified by direct probe:

1. `findCommonPrefix` is byte-wise, so the common prefix of the loaded packages contains a dot (`github.com/...`).
2. `detectProjectRoot` sees the dot, decides the prefix "looks like a domain", and scans instead for a package path whose first segment has no dot. For a `github.com/...` project there is none, so it returns `""`.
3. `isIntelligentProjectPackage` falls back to `fallbackProjectPackageDetection`, which accepts anything with two slashes, or any two-segment path whose first segment has no dot.

That last rule is the standard library. Running against this repo, the packages classified as project code and appended to `IncludePackages` (both flags default to true) were:

```
compress/gzip   encoding/json   go/ast     go/build   go/constant   go/doc
go/token        go/types        hash/fnv   net/http   path/filepath runtime/debug
```

`go/types` was being treated as project code. The single-word guard above (`fmt`, `os`) catches only stdlib packages without a slash.

## The fix

`go.mod` already answers this, and the engine already reads it — `moduleImportPath()` has been passed to `GenerateMetadataWithLogger` since it was added, just never to the dependency analyser. Now it is: a package is the project's iff it is the module path or under `modulePath + "/"`.

The heuristics stay for the no-module case (a bare directory with no `go.mod`), which is the one place inference is all there is. Two supporting fixes there:

- `findCommonPrefix` compares whole path segments. Byte-wise it returned strings that are not package paths, then used them as `HasPrefix` membership tests.
- With that corrected, the "looks like a domain" branch that discarded every domain-hosted root is gone, so the fallback now resolves `github.com/acme/x` instead of giving up and guessing.

The two doc comments claiming the type provided detection "without hardcoded values" are removed — they described the opposite of the code.

## Measured, not asserted

Against this repo, before vs after:

| | before | after |
|---|---|---|
| Imported packages classified as project | 16 | 4 |
| Auto-included into `IncludePackages` | 25 | 13 |
| Generated spec | 2460 lines | 2460 lines, **byte-identical** |
| Run time | 13.6s | 13.4s (noise) |

Nothing was newly included — the diff is one-directional, and the twelve that went away are exactly the stdlib packages listed above. So this removes wasted analysis without changing a single line of output. I am not claiming a performance win; the timing difference is noise.

## Deliberate test changes

Two existing assertions pinned the old behaviour and were updated with comments explaining why:

- `findCommonPrefix("github.com/a/b", "github.com/a/c")` returned `"github.com/a/"` — a trailing slash is not a path. Now `"github.com/a"`, plus a new case for the `api`/`app` pair from the issue.
- `detectProjectRoot` named `"abc"` the root of `abc/x`, `zzz.io/y`, `qqq.io/z` because it was the one path without a dot. Three paths sharing no segment have no common root; the honest answer is none, and classification falls through to the heuristics, which classify those paths identically. A new case asserts that packages which *do* share a root now resolve it, including domain-hosted ones.

## Coverage

- `dependency_analyzer_module_test.go` — module-path classification, including the sibling-module trap (`github.com/acme/billing` must not claim `github.com/acme/billingv2`, which shares every byte), the same-org-different-module case, and mock exclusion still running first. One test pins the fallback still claiming an unrelated third-party path, which is what makes the wiring load-bearing.
- `testdata/module_prefix_packages/` — the fixture the issue asks for: sibling packages `api/` and `app/` sharing the byte prefix `.../ap` but no segment. Because the fix *narrows* what counts as project code, the structural test asserts nothing legitimate was narrowed away: both packages' routes, their path params, and the request body all survive.

## Known limit, stated rather than guessed

With a module path, "ours" means "under the module". A multi-module workspace (`go.work`) would need `packages.NeedModule` to enumerate sibling modules — `go.work` is not supported anywhere in the codebase today, so this changes nothing, but it is the one case where the old `isPackageImportedByProject` OR-branch could in principle have helped. Re-adding it would re-broaden the classification to "every direct dependency", which is the bug. If workspace support is wanted it should be its own issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved framework and project package detection for projects with explicit module paths.
  - Correctly handles module declarations with varied spacing, comments, quoting, and line endings.
  - Prevented incorrect package matching when import paths only share partial segments.
  - Improved project-root detection for domain-hosted packages.
  - Preserved path parameters and correctly resolved POST request bodies in generated API documentation.

- **Tests**
  - Added regression coverage for module parsing, package classification, root detection, and route generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->