### PR TITLE
perf(metadata): prune the enclosing-function-literal walk (37% faster end to end)

### DIFF
--- a/internal/metadata/analysis.go
+++ b/internal/metadata/analysis.go
@@ -107,7 +107,18 @@ func getEnclosingFunctionName(file *ast.File, pos token.Pos, info *types.Info, f
 	return "", "", ""
 }
 
-// findEnclosingFunctionLiteral recursively searches for the innermost function literal containing the position
+// findEnclosingFunctionLiteral returns the innermost function literal
+// containing pos, or nil when pos is not inside one.
+//
+// The walk prunes: a child's range nests inside its parent's, so a subtree
+// whose range excludes pos cannot contain it anywhere below either. Descending
+// regardless visited every node of the file for every call expression, which
+// is O(calls x file size) and measured at 13% of a full run on this repo
+// (issue #225). Pruned, each query walks one root-to-leaf path.
+//
+// Nodes with invalid positions are descended into rather than pruned — their
+// range says nothing about their children — which keeps the result identical
+// to the exhaustive walk.
 func findEnclosingFunctionLiteral(file *ast.File, pos token.Pos) *ast.FuncLit {
 	var found *ast.FuncLit
 
@@ -116,13 +127,15 @@ func findEnclosingFunctionLiteral(file *ast.File, pos token.Pos) *ast.FuncLit {
 			return true
 		}
 
-		// Check if this node contains our position
-		if n.Pos()+1 <= pos && pos <= n.End()-1 {
-			if funcLit, ok := n.(*ast.FuncLit); ok {
-				// This is a function literal that contains our position
-				// Keep the innermost one (most recent)
-				found = funcLit
-			}
+		if n.Pos()+1 > pos || pos > n.End()-1 {
+			// Outside this node. Prune only when the range is trustworthy.
+			return !n.Pos().IsValid() || !n.End().IsValid()
+		}
+
+		if funcLit, ok := n.(*ast.FuncLit); ok {
+			// Pre-order, so ancestors arrive outermost first and the last
+			// literal recorded is the innermost.
+			found = funcLit
 		}
 
 		return true

--- a/internal/metadata/analysis_funclit_test.go
+++ b/internal/metadata/analysis_funclit_test.go
@@ -1,0 +1,199 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// funcLitSrc exercises the shapes the pruned walk has to get right: a plain
+// function (no literal), a literal, a literal nested in a literal, sibling
+// literals that must not be confused for each other, and a literal in a
+// composite-literal field.
+const funcLitSrc = `package p
+
+import "net/http"
+
+func plain(w http.ResponseWriter, r *http.Request) {
+	println("plain")
+}
+
+func outer() {
+	f := func() {
+		println("inner-one")
+		g := func() {
+			println("innermost")
+		}
+		g()
+	}
+	f()
+	h := func() { println("sibling") }
+	h()
+}
+
+type handlers struct{ fn func() }
+
+func composite() {
+	_ = handlers{fn: func() { println("in-composite") }}
+}
+`
+
+// exhaustiveEnclosingFuncLit is the pre-#225 implementation: it visits every
+// node in the file and never prunes. Kept here purely as the oracle the pruned
+// version is diffed against.
+func exhaustiveEnclosingFuncLit(file *ast.File, pos token.Pos) *ast.FuncLit {
+	var found *ast.FuncLit
+	ast.Inspect(file, func(n ast.Node) bool {
+		if n == nil {
+			return true
+		}
+		if n.Pos()+1 <= pos && pos <= n.End()-1 {
+			if funcLit, ok := n.(*ast.FuncLit); ok {
+				found = funcLit
+			}
+		}
+		return true
+	})
+	return found
+}
+
+// TestFindEnclosingFunctionLiteralMatchesExhaustiveWalk is the guard for the
+// pruning in #225: for every position in the file — inside literals, between
+// them, in a plain function, and outside the declarations entirely — the pruned
+// walk must return exactly what the exhaustive walk returned.
+func TestFindEnclosingFunctionLiteralMatchesExhaustiveWalk(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "p.go", funcLitSrc, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	tf := fset.File(file.Pos())
+	if tf == nil {
+		t.Fatal("no token.File")
+	}
+
+	var checked, inside int
+	for off := 0; off <= tf.Size(); off++ {
+		pos := tf.Pos(off)
+		want := exhaustiveEnclosingFuncLit(file, pos)
+		got := findEnclosingFunctionLiteral(file, pos)
+		checked++
+		if want != nil {
+			inside++
+		}
+		if got != want {
+			t.Fatalf("offset %d (%s): pruned walk = %v, exhaustive walk = %v",
+				off, fset.Position(pos), describeFuncLit(fset, got), describeFuncLit(fset, want))
+		}
+	}
+
+	// Guard the fixture itself: if it stopped containing literals the
+	// comparison above would pass trivially.
+	if inside == 0 {
+		t.Fatal("no position in the fixture landed inside a function literal")
+	}
+	t.Logf("compared %d positions, %d inside a function literal", checked, inside)
+}
+
+func describeFuncLit(fset *token.FileSet, fl *ast.FuncLit) string {
+	if fl == nil {
+		return "nil"
+	}
+	return "funcLit@" + fset.Position(fl.Pos()).String()
+}
+
+// TestFindEnclosingFunctionLiteralInnermost states the contract directly rather
+// than by comparison: nested literals resolve to the innermost one.
+func TestFindEnclosingFunctionLiteralInnermost(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "p.go", funcLitSrc, 0)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	// Collect literals by the line their body starts on.
+	lits := map[string]*ast.FuncLit{}
+	ast.Inspect(file, func(n ast.Node) bool {
+		fl, ok := n.(*ast.FuncLit)
+		if !ok {
+			return true
+		}
+		ast.Inspect(fl.Body, func(m ast.Node) bool {
+			bl, ok := m.(*ast.BasicLit)
+			if ok && bl.Kind == token.STRING {
+				if _, seen := lits[bl.Value]; !seen {
+					lits[bl.Value] = fl
+				}
+			}
+			return true
+		})
+		return true
+	})
+
+	for _, name := range []string{`"innermost"`, `"sibling"`, `"in-composite"`} {
+		lit, ok := lits[name]
+		if !ok {
+			t.Fatalf("fixture no longer contains %s", name)
+		}
+		// A position inside that literal's body must resolve to it, not to an
+		// enclosing literal.
+		pos := lit.Body.Lbrace + 1
+		if got := findEnclosingFunctionLiteral(file, pos); got != lit {
+			t.Errorf("%s: got %s, want %s", name, describeFuncLit(fset, got), describeFuncLit(fset, lit))
+		}
+	}
+
+	// A call inside a plain function is in no literal at all.
+	var plainBody *ast.BlockStmt
+	for _, decl := range file.Decls {
+		if fn, ok := decl.(*ast.FuncDecl); ok && fn.Name.Name == "plain" {
+			plainBody = fn.Body
+		}
+	}
+	if plainBody == nil {
+		t.Fatal("fixture no longer declares plain()")
+	}
+	if got := findEnclosingFunctionLiteral(file, plainBody.Lbrace+1); got != nil {
+		t.Errorf("inside plain(): got %s, want nil", describeFuncLit(fset, got))
+	}
+}
+
+// BenchmarkFindEnclosingFunctionLiteral measures the shape #225 is about: the
+// cost per query against a file, which the unpruned walk paid in full for every
+// call expression.
+func BenchmarkFindEnclosingFunctionLiteral(b *testing.B) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "p.go", funcLitSrc, 0)
+	if err != nil {
+		b.Fatalf("parse: %v", err)
+	}
+	tf := fset.File(file.Pos())
+	pos := tf.Pos(tf.Size() / 2)
+
+	b.Run("pruned", func(b *testing.B) {
+		for b.Loop() {
+			_ = findEnclosingFunctionLiteral(file, pos)
+		}
+	})
+	b.Run("exhaustive", func(b *testing.B) {
+		for b.Loop() {
+			_ = exhaustiveEnclosingFuncLit(file, pos)
+		}
+	})
+}


### PR DESCRIPTION
Closes #225.

## What the profile said

Profiled the CLI generating this repo's own spec (`--cpu-profile --mem-profile`), 14.3s baseline:

| | share | |
|---|---|---|
| `LazyNode.GetChildren` | 30.6% cum | tracker-tree node volume |
| `runtime.madvise` | 21.4% | all of it under `mheap.allocSpan` |
| `go/ast.Walk` | 20.0% cum | **13.3% of it one function** |

That one function is `findEnclosingFunctionLiteral`: 2.13s of 16s of samples.

## The bug

```go
ast.Inspect(file, func(n ast.Node) bool {
    if n.Pos()+1 <= pos && pos <= n.End()-1 {
        if funcLit, ok := n.(*ast.FuncLit); ok {
            found = funcLit
        }
    }
    return true   // <- always
})
```

The visitor returns `true` unconditionally, so every node of the file is visited for every call expression — including entire declarations whose range provably excludes the position. O(calls × file size).

Child ranges nest inside their parent's, so a node whose range excludes `pos` cannot contain it anywhere below either. The walk now prunes there, and each query costs one root-to-leaf path. Nodes with invalid positions are still descended into, since their range says nothing about their children — that keeps the result identical rather than merely equivalent-in-practice.

## Measured

Generating this repo's spec:

| | before | after |
|---|---|---|
| metadata stage | 6.04s | **1.28s** (4.7×) |
| total run | 14.30s | **9.03s** (−37%) |
| call edges recorded | 8188 | 8188 |
| generated spec | — | **byte-identical** |
| per query (benchmark) | 1477 ns | 509 ns |

Profile after: `findEnclosingFunctionLiteral` is gone, `go/ast.Walk` drops 20% → 6%, `madvise` 21% → 11%.

## What I did not do

- **GOGC tuning** — tried first, since 21% in `madvise` looks like GC churn. It isn't: at GOGC 100/300/600 the time was flat (13.7s/13.7s/14.1s) while peak RSS rose 1.35GB → 1.80GB. The heap here is *live* (the tracker tree holds its nodes), not churning, so trading memory buys nothing. Rejected rather than shipped as a knob.
- **`LazyNode.GetChildren`**, now 45% cumulative and the top cost by a distance. Its flat time sits on plain field stores into freshly allocated nodes, and `newNode` + `chainInterner.push` are 51% of the 2.12GB allocated — i.e. node *volume*, not logic. On this repo the instance cap drops ~9.7M call copies and 6 of 36 routes hit the per-route node limit. That is the subject of #224/#269/#270 and a design change, not a local fix, so it is untouched here.

## Coverage

`TestFindEnclosingFunctionLiteralMatchesExhaustiveWalk` keeps the pre-fix implementation as an oracle and diffs the two at **every** position in a fixture with nested closures, sibling closures, a closure in a composite literal, and a plain function — 370 positions, 144 of them inside a literal. It also asserts the fixture still contains literals, so the comparison cannot pass trivially. `TestFindEnclosingFunctionLiteralInnermost` states the innermost-wins contract directly, and a benchmark covers both implementations.

Full suite passes unchanged — the goldens, determinism tests and every framework fixture are the drift check, and none moved.
