### PR TITLE
perf(metadata): resolve lookup ordering once instead of per call

### DIFF
--- a/internal/metadata/lookup_cache_test.go
+++ b/internal/metadata/lookup_cache_test.go
@@ -354,3 +354,32 @@ func TestLookupCachesAreRaceFree(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+// TestLookupCachesTolerateNilFiles covers a nil entry in Package.Files. Every
+// reader of that map in the spec layer skips nil, and the index build here
+// does too — the shape fingerprint did not, so computing it panicked before a
+// single lookup could run. Metadata is deserialised from YAML as well as
+// generated, so a package need not be as well-formed as the generator makes it.
+func TestLookupCachesTolerateNilFiles(t *testing.T) {
+	present := &Type{Name: 1}
+	m := &Metadata{StringPool: NewStringPool()}
+	m.Packages = map[string]*Package{
+		"app": {Files: map[string]*File{
+			"a.go": {Types: map[string]*Type{"Present": present}},
+			"b.go": nil,
+		}},
+	}
+
+	if got := m.TypeInPackage("app", "Present"); got != present {
+		t.Errorf("TypeInPackage = %p, want %p", got, present)
+	}
+	if got := m.TypeInPackage("app", "Absent"); got != nil {
+		t.Errorf("absent type = %p, want nil", got)
+	}
+	if got := m.SortedTypeNames("app", "b.go"); got != nil {
+		t.Errorf("SortedTypeNames of a nil file = %v, want nil", got)
+	}
+	if got := m.SortedTypeNames("app", "a.go"); !reflect.DeepEqual(got, []string{"Present"}) {
+		t.Errorf("SortedTypeNames = %v, want [Present]", got)
+	}
+}

--- a/internal/metadata/lookup_cache_test.go
+++ b/internal/metadata/lookup_cache_test.go
@@ -17,6 +17,7 @@ package metadata
 import (
 	"go/types"
 	"reflect"
+	"sync"
 	"testing"
 )
 
@@ -219,4 +220,137 @@ func TestSortedFileNames(t *testing.T) {
 	if got := m.SortedFileNames("missing"); got != nil {
 		t.Errorf("unknown package = %v, want nil", got)
 	}
+}
+
+func TestSortedTypeNames(t *testing.T) {
+	m := &Metadata{StringPool: NewStringPool()}
+	m.Packages = map[string]*Package{
+		"app": {Files: map[string]*File{
+			"a.go": {Types: map[string]*Type{"Zebra": {}, "Apple": {}, "Mango": {}}},
+			"b.go": {Types: map[string]*Type{"Only": {}}},
+		}},
+	}
+
+	want := []string{"Apple", "Mango", "Zebra"}
+	if got := m.SortedTypeNames("app", "a.go"); !reflect.DeepEqual(got, want) {
+		t.Errorf("SortedTypeNames = %v, want %v", got, want)
+	}
+	if got := m.SortedTypeNames("app", "a.go"); !reflect.DeepEqual(got, want) {
+		t.Errorf("cached SortedTypeNames = %v, want %v", got, want)
+	}
+	// Per file, not per package: b.go must not see a.go's names.
+	if got := m.SortedTypeNames("app", "b.go"); !reflect.DeepEqual(got, []string{"Only"}) {
+		t.Errorf("b.go = %v, want [Only]", got)
+	}
+
+	// A file that gains a type must not keep serving the stale order — these
+	// lookups run while metadata is still being assembled.
+	m.Packages["app"].Files["a.go"].Types["Banana"] = &Type{}
+	if got := m.SortedTypeNames("app", "a.go"); !reflect.DeepEqual(got, []string{"Apple", "Banana", "Mango", "Zebra"}) {
+		t.Errorf("after adding a type = %v, want the new name in sorted position", got)
+	}
+
+	if got := m.SortedTypeNames("missing", "a.go"); got != nil {
+		t.Errorf("unknown package = %v, want nil", got)
+	}
+	if got := m.SortedTypeNames("app", "missing.go"); got != nil {
+		t.Errorf("unknown file = %v, want nil", got)
+	}
+}
+
+// TestTypeInPackageMatchesSortedScan is the correctness guard for the index:
+// it must answer exactly what scanning the files in sorted order answered,
+// including which declaration wins when a name appears in two files. Go
+// forbids that, but the replaced code had a defined answer and the index must
+// not quietly pick the other one.
+func TestTypeInPackageMatchesSortedScan(t *testing.T) {
+	inA, inB, inC := &Type{Name: 1}, &Type{Name: 2}, &Type{Name: 3}
+	m := &Metadata{StringPool: NewStringPool()}
+	m.Packages = map[string]*Package{
+		"app": {Files: map[string]*File{
+			"z.go": {Types: map[string]*Type{"Dup": inC, "OnlyZ": {}}},
+			"a.go": {Types: map[string]*Type{"Dup": inA, "OnlyA": {}}},
+			"m.go": {Types: map[string]*Type{"Dup": inB}},
+		}},
+	}
+
+	// Reference: the scan the index replaced.
+	scan := func(pkgName, typeName string) *Type {
+		pkg := m.Packages[pkgName]
+		for _, fileName := range m.SortedFileNames(pkgName) {
+			if typ, ok := pkg.Files[fileName].Types[typeName]; ok {
+				return typ
+			}
+		}
+		return nil
+	}
+
+	for _, name := range []string{"Dup", "OnlyA", "OnlyZ", "Absent"} {
+		if got, want := m.TypeInPackage("app", name), scan("app", name); got != want {
+			t.Errorf("TypeInPackage(%q) = %p, sorted scan = %p", name, got, want)
+		}
+	}
+	// State it directly too: a.go sorts first, so its declaration wins.
+	if got := m.TypeInPackage("app", "Dup"); got != inA {
+		t.Errorf("Dup resolved to the declaration in the wrong file: %p, want a.go's %p", got, inA)
+	}
+}
+
+// TestTypeInPackageInvalidatesOnGrowth covers the reason the index carries a
+// (files, types) fingerprint rather than being built once: these lookups can
+// run before metadata has finished being assembled, and a package that gains a
+// type afterwards must not keep answering from the stale index.
+func TestTypeInPackageInvalidatesOnGrowth(t *testing.T) {
+	m := &Metadata{StringPool: NewStringPool()}
+	m.Packages = map[string]*Package{
+		"app": {Files: map[string]*File{"a.go": {Types: map[string]*Type{"First": {}}}}},
+	}
+	if m.TypeInPackage("app", "First") == nil {
+		t.Fatal("First should resolve")
+	}
+
+	// A type added to an existing file.
+	added := &Type{Name: 7}
+	m.Packages["app"].Files["a.go"].Types["Second"] = added
+	if got := m.TypeInPackage("app", "Second"); got != added {
+		t.Errorf("type added to an existing file = %p, want %p", got, added)
+	}
+
+	// A whole new file.
+	inNew := &Type{Name: 8}
+	m.Packages["app"].Files["b.go"] = &File{Types: map[string]*Type{"Third": inNew}}
+	if got := m.TypeInPackage("app", "Third"); got != inNew {
+		t.Errorf("type in a newly added file = %p, want %p", got, inNew)
+	}
+
+	if got := m.TypeInPackage("missing", "First"); got != nil {
+		t.Errorf("unknown package = %p, want nil", got)
+	}
+}
+
+// TestLookupCachesAreRaceFree exercises the two caches concurrently; the value
+// of this test is under -race, which CI runs.
+func TestLookupCachesAreRaceFree(t *testing.T) {
+	m := &Metadata{StringPool: NewStringPool()}
+	m.Packages = map[string]*Package{
+		"app": {Files: map[string]*File{
+			"a.go": {Types: map[string]*Type{"A": {}, "B": {}}},
+			"b.go": {Types: map[string]*Type{"C": {}}},
+		}},
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				_ = m.TypeInPackage("app", "A")
+				_ = m.TypeInPackage("app", "C")
+				_ = m.SortedTypeNames("app", "a.go")
+				_ = m.SortedFileNames("app")
+			}
+		}()
+	}
+	wg.Wait()
 }

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -1802,7 +1802,7 @@ func astFileFromFn(pkgName, fnName, recvType string, pkgs map[string]map[string]
 				funcFallback = pkgs[pkgName][fileName]
 			}
 		}
-		for _, typeName := range slices.Sorted(maps.Keys(f.Types)) {
+		for _, typeName := range metadata.SortedTypeNames(pkgName, fileName) {
 			for _, method := range f.Types[typeName].Methods {
 				if metadata.StringPool.GetString(method.Name) != fnName {
 					continue

--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -355,6 +355,13 @@ type pkgShape struct{ files, types int }
 func shapeOf(pkg *Package) pkgShape {
 	shape := pkgShape{files: len(pkg.Files)}
 	for _, f := range pkg.Files {
+		// A nil file entry counts towards files but has no types — the same
+		// guard the index build below applies, and the convention every reader
+		// of Package.Files follows (a deserialised metadata.yaml need not be
+		// as well-formed as a generated one).
+		if f == nil {
+			continue
+		}
 		shape.types += len(f.Types)
 	}
 	return shape

--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -167,7 +167,20 @@ type Metadata struct {
 	sortedFiles      map[string][]string
 	sortedFilesFor   map[string]int
 	sortedFilesMutex sync.RWMutex
-	Args             map[string][]*CallGraphEdge `yaml:"-"`
+	// sortedTypeNames caches each FILE's type names in sorted order, with the
+	// type count they were sorted at — the same shape and the same reason as
+	// sortedFiles above, for the inner loop of astFileFromFn.
+	sortedTypeNames      map[fileKey][]string
+	sortedTypeNamesFor   map[fileKey]int
+	sortedTypeNamesMutex sync.RWMutex
+	// typeIndex maps a package's declared type names to their declaration,
+	// resolved once in sorted-file order so the answer matches a scan.
+	// pkgShape records the (files, types) the index was built at, since these
+	// lookups can run while metadata is still being assembled.
+	typeIndex      map[string]map[string]*Type
+	typeIndexFor   map[string]pkgShape
+	typeIndexMutex sync.RWMutex
+	Args           map[string][]*CallGraphEdge `yaml:"-"`
 
 	roots []*CallGraphEdge `yaml:"-"`
 
@@ -330,6 +343,114 @@ func (m *Metadata) SortedFileNames(pkgName string) []string {
 	m.sortedFiles[pkgName] = names
 	m.sortedFilesFor[pkgName] = len(pkg.Files)
 	return names
+}
+
+// fileKey identifies one file within one package.
+type fileKey struct{ pkg, file string }
+
+// pkgShape is a cheap fingerprint of a package's contents: enough to notice
+// that more was recorded since a derived index was built, without hashing it.
+type pkgShape struct{ files, types int }
+
+func shapeOf(pkg *Package) pkgShape {
+	shape := pkgShape{files: len(pkg.Files)}
+	for _, f := range pkg.Files {
+		shape.types += len(f.Types)
+	}
+	return shape
+}
+
+// SortedTypeNames returns a file's type names in sorted order.
+//
+// Like SortedFileNames, the order IS the determinism guarantee — astFileFromFn
+// picks the first method matching a name, so the order decides which file (and
+// therefore which types.Info) a lookup resolves to. This caches the order; it
+// never changes it.
+func (m *Metadata) SortedTypeNames(pkgName, fileName string) []string {
+	pkg, ok := m.Packages[pkgName]
+	if !ok || pkg == nil {
+		return nil
+	}
+	f, ok := pkg.Files[fileName]
+	if !ok || f == nil {
+		return nil
+	}
+
+	key := fileKey{pkg: pkgName, file: fileName}
+	m.sortedTypeNamesMutex.RLock()
+	names, cached := m.sortedTypeNames[key]
+	builtFor := m.sortedTypeNamesFor[key]
+	m.sortedTypeNamesMutex.RUnlock()
+	if cached && builtFor == len(f.Types) {
+		return names
+	}
+
+	m.sortedTypeNamesMutex.Lock()
+	defer m.sortedTypeNamesMutex.Unlock()
+	if names, ok := m.sortedTypeNames[key]; ok && m.sortedTypeNamesFor[key] == len(f.Types) {
+		return names // another goroutine won the race
+	}
+	names = slices.Sorted(maps.Keys(f.Types))
+	if m.sortedTypeNames == nil {
+		m.sortedTypeNames = make(map[fileKey][]string)
+		m.sortedTypeNamesFor = make(map[fileKey]int)
+	}
+	m.sortedTypeNames[key] = names
+	m.sortedTypeNamesFor[key] = len(f.Types)
+	return names
+}
+
+// TypeInPackage returns the type a package declares under typeName, or nil.
+//
+// Equivalent to scanning the package's files in sorted order and taking the
+// first declaration of that name, which is what callers did per lookup —
+// allocating and sorting every file name each time, for every package, on a
+// path that falls back to scanning all packages (issue #322). The scan order is
+// preserved exactly: the index is filled in sorted-file order and an earlier
+// file wins, so a name declared twice resolves to the same type it did before.
+func (m *Metadata) TypeInPackage(pkgName, typeName string) *Type {
+	pkg, ok := m.Packages[pkgName]
+	if !ok || pkg == nil {
+		return nil
+	}
+	shape := shapeOf(pkg)
+
+	m.typeIndexMutex.RLock()
+	idx, cached := m.typeIndex[pkgName]
+	builtFor := m.typeIndexFor[pkgName]
+	m.typeIndexMutex.RUnlock()
+	if cached && builtFor == shape {
+		return idx[typeName]
+	}
+
+	m.typeIndexMutex.Lock()
+	defer m.typeIndexMutex.Unlock()
+	if idx, ok := m.typeIndex[pkgName]; ok && m.typeIndexFor[pkgName] == shape {
+		return idx[typeName] // another goroutine won the race
+	}
+	idx = make(map[string]*Type, shape.types)
+	// Safe under typeIndexMutex: SortedFileNames takes sortedFilesMutex only.
+	for _, fileName := range m.SortedFileNames(pkgName) {
+		f := pkg.Files[fileName]
+		if f == nil {
+			continue
+		}
+		// Within one file a type name is unique, so map order cannot decide
+		// anything here; across files the first (sorted) file wins, which is
+		// the order the replaced scan used.
+		for name, typ := range f.Types {
+			if _, seen := idx[name]; !seen {
+				idx[name] = typ
+			}
+		}
+	}
+	if m.typeIndex == nil {
+		m.typeIndex = make(map[string]map[string]*Type, len(m.Packages))
+		m.typeIndexFor = make(map[string]pkgShape, len(m.Packages))
+	}
+	m.typeIndex[pkgName] = idx
+	m.typeIndexFor[pkgName] = shape
+	return idx[typeName]
 }
 
 // ImplementersOf returns "pkg.Type" for every recorded type that implements the

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -1114,10 +1114,8 @@ func typeByName(pkgName, typeName string, meta *metadata.Metadata) *metadata.Typ
 	}
 
 	if pkgName != "" && typeName != "" {
-		if pkg, exists := meta.Packages[pkgName]; exists {
-			if typ := typeInPackage(pkg, typeName); typ != nil {
-				return typ
-			}
+		if typ := meta.TypeInPackage(pkgName, typeName); typ != nil {
+			return typ
 		}
 	}
 
@@ -1126,27 +1124,7 @@ func typeByName(pkgName, typeName string, meta *metadata.Metadata) *metadata.Typ
 	// runs — otherwise map iteration would pick a different package's type and
 	// flip the schema between runs.
 	for _, pkg := range meta.SortedPackageNames() {
-		if typ := typeInPackage(meta.Packages[pkg], typeName); typ != nil {
-			return typ
-		}
-	}
-	return nil
-}
-
-// typeInPackage returns the named type from a package, scanning files in stable
-// order (Files is a map).
-func typeInPackage(pkg *metadata.Package, typeName string) *metadata.Type {
-	if pkg == nil {
-		return nil
-	}
-	// A type lives in exactly one file, but iterate deterministically anyway.
-	var fileNames []string
-	for fileName := range pkg.Files {
-		fileNames = append(fileNames, fileName)
-	}
-	sort.Strings(fileNames)
-	for _, fileName := range fileNames {
-		if typ, exists := pkg.Files[fileName].Types[typeName]; exists {
+		if typ := meta.TypeInPackage(pkg, typeName); typ != nil {
 			return typ
 		}
 	}

--- a/internal/spec/mapper_sweep_test.go
+++ b/internal/spec/mapper_sweep_test.go
@@ -308,9 +308,16 @@ func TestTypeByName_NilMetadata(t *testing.T) {
 	}
 }
 
-func TestTypeInPackage_NilPackage(t *testing.T) {
-	if got := typeInPackage(nil, "User"); got != nil {
-		t.Errorf("expected nil, got %v", got)
+func TestTypeInPackage_MissingPackage(t *testing.T) {
+	meta, _ := sweepMeta(t)
+	if got := meta.TypeInPackage("no/such/pkg", "User"); got != nil {
+		t.Errorf("missing package: expected nil, got %v", got)
+	}
+	if got := meta.TypeInPackage("main", "NoSuchType"); got != nil {
+		t.Errorf("missing type: expected nil, got %v", got)
+	}
+	if got := meta.TypeInPackage("main", "User"); got == nil {
+		t.Error("main.User should resolve")
 	}
 }
 


### PR DESCRIPTION
Closes #322. First of the five performance issues from the profiling pass, picked because it is the self-contained one: two functions, no design decision, and it cannot change what is documented.

## What was happening

`typeInPackage` allocated and sorted every file name in a package on **every lookup**, to find a type its own comment says lives in exactly one file:

```go
// A type lives in exactly one file, but iterate deterministically anyway.
var fileNames []string
for fileName := range pkg.Files { fileNames = append(fileNames, fileName) }
sort.Strings(fileNames)
```

Its caller falls back to scanning *all* packages for a bare type name, so that cost was paid per package per unresolved name. `astFileFromFn` did the same thing one level down — `slices.Sorted(maps.Keys(f.Types))` inside its loop over the package's files, per call.

Determinism is the reason both sorted (golden rule #1), and both were correct. The problem was only *where* the order got established: recomputed per lookup rather than once into an index.

## The fix

`Metadata.TypeInPackage` and `Metadata.SortedTypeNames`, both modelled on the existing `SortedFileNames` — same RWMutex discipline, same rebuild-when-it-grows guard, since these lookups can run while metadata is still being assembled. `TypeInPackage` fingerprints `(files, types)` rather than file count alone, because a type can be added to a file that already exists.

**The order is preserved, not just the answer.** The index is filled by walking `SortedFileNames` with an earlier file winning — exactly what the replaced scan did — so a name declared in two files resolves to the same declaration it did before. Go forbids that case, but the old code had a defined answer and this must not quietly pick the other one; `TestTypeInPackageMatchesSortedScan` asserts the index against the scan it replaces, that case included.

## Measured

On this repo generating its own spec:

| | before | after |
|---|---|---|
| total allocated | 2209 MB | **1995 MB** (−9.7%) |
| `typeInPackage` | 79.05 MB (3.58%) | gone from the profile |
| `slices.Sorted` (via `astFileFromFn`) | 66.52 MB (3.01%) | gone from the profile |
| wall clock | 9.35s | 9.09s (~3%) |
| generated spec | — | **byte-identical** |

## A note on how the timing was measured

Measured sequentially, this change first looked like a **15% regression** — and the profile attributed the extra time to `GetChildren`, which this PR does not touch. That inconsistency was the tell: the three runs trended upward (10.3 → 10.7 → 11.5s), i.e. machine drift, not code.

Interleaving base and change within each repetition removed it, and the ordering then reversed consistently across all four pairs:

```
base=9.670  change=9.064
base=9.721  change=9.494
base=9.104  change=9.038
base=8.918  change=8.753
```

Flagging it because the allocation numbers are the reliable ones here; the ~3% wall clock is real but close to this machine's noise floor, and I would not want it quoted as a firm figure.

## Coverage

- `TestTypeInPackageMatchesSortedScan` — index vs the sorted scan it replaces, over present, absent and duplicated names.
- `TestTypeInPackageInvalidatesOnGrowth` — a type added to an existing file, and a whole new file, must both become visible; this is what the `(files, types)` fingerprint is for.
- `TestSortedTypeNames` — order, caching, per-file scoping, growth invalidation, unknown package and unknown file.
- `TestLookupCachesAreRaceFree` — the two caches hammered concurrently; the value is under `-race`, which CI runs. Passes locally under `-race` too.
- `TestTypeInPackage_NilPackage` in the spec sweep covered the deleted function's nil guard; replaced with the equivalent against the new API rather than dropped.

Full suite passes unchanged — the goldens and determinism tests are the drift check for a change like this, and none moved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved type lookup consistency across packages and files.
  - Ensured lookups correctly reflect newly added files and types.
  - Preserved deterministic type resolution using sorted file and type names.
  - Improved reliability during concurrent metadata access.

- **Tests**
  - Added coverage for cache invalidation, missing types and packages, sorted lookups, and concurrent access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->