### PR TITLE
feat: distribute apispecui the same way as apispec

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,14 @@ jobs:
           sed -i "s|BuildDate = \"[^\"]*\"|BuildDate = \"$BUILD_DATE\"|" cmd/apispec/main.go
           sed -i "s|GoVersion = \"[^\"]*\"|GoVersion = \"$GO_VERSION\"|" cmd/apispec/main.go
 
+          # apispecui declares the same constants (BuildTime rather than
+          # BuildDate — it reports the binary's mtime, which `make release`
+          # cannot know). Patched here for the same reason as apispec: the
+          # ldflags below cover a build, this covers a `go install` from the tag.
+          sed -i "s|Version   = \"[^\"]*\"|Version   = \"$VERSION\"|" cmd/apispecui/main.go
+          sed -i "s|Commit    = \"[^\"]*\"|Commit    = \"$COMMIT\"|" cmd/apispecui/main.go
+          sed -i "s|GoVersion = \"[^\"]*\"|GoVersion = \"$GO_VERSION\"|" cmd/apispecui/main.go
+
       - name: Build for multiple platforms
         # The Makefile declares these with `?=`, so the environment wins and no
         # command line has to be built out of untrusted values at all.
@@ -131,24 +139,29 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
-          # Checksums come from the artifacts THIS job just built, so the formula
-          # can never point at a digest the release does not have.
-          sha() { shasum -a 256 "dist/apispec-$1" | awk '{print $1}'; }
-
-          sed -e "s|__VERSION__|$VERSION|g" \
-              -e "s|__SHA_DARWIN_ARM64__|$(sha darwin-arm64)|" \
-              -e "s|__SHA_DARWIN_AMD64__|$(sha darwin-amd64)|" \
-              -e "s|__SHA_LINUX_ARM64__|$(sha linux-arm64)|" \
-              -e "s|__SHA_LINUX_AMD64__|$(sha linux-amd64)|" \
-              packaging/homebrew/apispec.rb.tmpl > /tmp/apispec.rb
+          # $1 = tool, $2 = platform. Checksums come from the artifacts THIS job
+          # just built, so a formula can never point at a digest the release
+          # does not have.
+          sha() { shasum -a 256 "dist/$1-$2" | awk '{print $1}'; }
 
           git clone --depth 1 "https://x-access-token:$HOMEBREW_TAP_TOKEN@github.com/ehabterra/homebrew-tap.git" /tmp/tap
           mkdir -p /tmp/tap/Formula
-          cp /tmp/apispec.rb /tmp/tap/Formula/apispec.rb
+
+          # Every tool the tap publishes. apispecui is a distributable tool in
+          # its own right, so it gets a formula on the same terms as apispec.
+          for tool in apispec apispecui; do
+            sed -e "s|__VERSION__|$VERSION|g" \
+                -e "s|__SHA_DARWIN_ARM64__|$(sha "$tool" darwin-arm64)|" \
+                -e "s|__SHA_DARWIN_AMD64__|$(sha "$tool" darwin-amd64)|" \
+                -e "s|__SHA_LINUX_ARM64__|$(sha "$tool" linux-arm64)|" \
+                -e "s|__SHA_LINUX_AMD64__|$(sha "$tool" linux-amd64)|" \
+                "packaging/homebrew/$tool.rb.tmpl" > "/tmp/tap/Formula/$tool.rb"
+          done
+
           cd /tmp/tap
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add Formula/apispec.rb
+          git add Formula/apispec.rb Formula/apispecui.rb
           git diff --staged --quiet || git commit -m "apispec $VERSION"
           git push
 
@@ -164,6 +177,12 @@ jobs:
             dist/apispec-darwin-arm64
             dist/apispec-windows-amd64.exe
             dist/apispec-windows-arm64.exe
+            dist/apispecui-linux-amd64
+            dist/apispecui-linux-arm64
+            dist/apispecui-darwin-amd64
+            dist/apispecui-darwin-arm64
+            dist/apispecui-windows-amd64.exe
+            dist/apispecui-windows-arm64.exe
             dist/*.sha256
           draft: false
           prerelease: false

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 APP_NAME = apispec
+UI_NAME = apispecui
 VERSION ?= 0.0.1
 COMMIT ?= $(shell git rev-parse --short HEAD)
 BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -9,17 +10,23 @@ LDFLAGS = -X 'main.Version=$(VERSION)' \
           -X 'main.BuildDate=$(BUILD_DATE)' \
           -X 'main.GoVersion=$(GO_VERSION)'
 
-.PHONY: help build test clean coverage lint fmt update-badge metrics-view metrics-generate
+.PHONY: help build build-ui build-apidiag test clean coverage lint fmt update-badge metrics-view metrics-generate \
+	install install-ui install-local install-ui-local uninstall uninstall-ui uninstall-local uninstall-ui-local
 
 # Default target
 help:
 	@echo "Available targets:"
 	@echo "  build         - Build the apispec binary"
+	@echo "  build-ui      - Build the apispecui binary (web UI)"
 	@echo "  build-apidiag - Build the apidiag binary"
 	@echo "  install       - Install apispec to /usr/local/bin (requires sudo)"
+	@echo "  install-ui    - Install apispecui to /usr/local/bin (requires sudo)"
 	@echo "  install-local - Install apispec to ~/go/bin (no sudo required)"
+	@echo "  install-ui-local - Install apispecui to ~/go/bin (no sudo required)"
 	@echo "  uninstall     - Remove apispec from /usr/local/bin"
+	@echo "  uninstall-ui  - Remove apispecui from /usr/local/bin"
 	@echo "  uninstall-local - Remove apispec from ~/go/bin"
+	@echo "  uninstall-ui-local - Remove apispecui from ~/go/bin"
 	@echo "  release       - Build for multiple platforms and create release package"
 	@echo "  create-tag    - Create a new release tag (e.g., make create-tag VERSION=1.0.0)"
 	@echo "  tags          - Show current git tags"
@@ -53,6 +60,11 @@ help:
 build:
 	@echo "Building $(APP_NAME) version $(VERSION)..."
 	go build -ldflags "$(LDFLAGS)" -o $(APP_NAME) ./cmd/apispec
+
+# Build the web UI. It embeds its assets, so the binary is self-contained.
+build-ui:
+	@echo "Building $(UI_NAME) version $(VERSION)..."
+	go build -ldflags "$(LDFLAGS)" -o $(UI_NAME) ./cmd/apispecui
 
 # Build the apidiag binary
 build-apidiag:
@@ -106,7 +118,7 @@ update-badge:
 
 # Clean build artifacts
 clean:
-	rm -f $(APP_NAME) apidiag coverage.out coverage.html
+	rm -f $(APP_NAME) $(UI_NAME) apidiag coverage.out coverage.html
 	go clean -cache
 
 # Install apispec to system (requires sudo)
@@ -115,6 +127,13 @@ install: build
 	sudo cp $(APP_NAME) /usr/local/bin/
 	@echo "$(APP_NAME) installed successfully!"
 	@echo "You can now run 'apispec --help' from anywhere"
+
+# Install apispecui to system (requires sudo)
+install-ui: build-ui
+	@echo "Installing $(UI_NAME) to /usr/local/bin/..."
+	sudo cp $(UI_NAME) /usr/local/bin/
+	@echo "$(UI_NAME) installed successfully!"
+	@echo "You can now run 'apispecui --help' from anywhere"
 
 # Install to user's local bin directory (no sudo required)
 install-local: build
@@ -125,17 +144,38 @@ install-local: build
 	@echo "Make sure ~/go/bin is in your PATH"
 	@echo "Add this to your shell profile: export PATH=\$$HOME/go/bin:\$$PATH"
 
+# Install apispecui to user's local bin directory (no sudo required)
+install-ui-local: build-ui
+	@echo "Installing $(UI_NAME) to ~/go/bin/..."
+	mkdir -p ~/go/bin
+	cp $(UI_NAME) ~/go/bin/
+	@echo "$(UI_NAME) installed successfully!"
+	@echo "Make sure ~/go/bin is in your PATH"
+	@echo "Add this to your shell profile: export PATH=\$$HOME/go/bin:\$$PATH"
+
 # Uninstall apispec from system
 uninstall:
 	@echo "Uninstalling $(APP_NAME) from /usr/local/bin/..."
 	sudo rm -f /usr/local/bin/$(APP_NAME)
 	@echo "$(APP_NAME) uninstalled successfully!"
 
+# Uninstall apispecui from system
+uninstall-ui:
+	@echo "Uninstalling $(UI_NAME) from /usr/local/bin/..."
+	sudo rm -f /usr/local/bin/$(UI_NAME)
+	@echo "$(UI_NAME) uninstalled successfully!"
+
 # Uninstall from user's local bin directory
 uninstall-local:
 	@echo "Uninstalling $(APP_NAME) from ~/go/bin/..."
 	rm -f ~/go/bin/$(APP_NAME)
 	@echo "$(APP_NAME) uninstalled successfully!"
+
+# Uninstall apispecui from user's local bin directory
+uninstall-ui-local:
+	@echo "Uninstalling $(UI_NAME) from ~/go/bin/..."
+	rm -f ~/go/bin/$(UI_NAME)
+	@echo "$(UI_NAME) uninstalled successfully!"
 
 # Build for multiple platforms and create release package
 release:

--- a/README.md
+++ b/README.md
@@ -65,13 +65,21 @@
 ### Install
 
 ```bash
+# Homebrew (macOS/Linux) — no Go toolchain needed to install
+brew install ehabterra/tap/apispec      # the CLI
+brew install ehabterra/tap/apispecui    # the web UI
+
+# or with Go
 go install github.com/ehabterra/apispec/cmd/apispec@latest
+go install github.com/ehabterra/apispec/cmd/apispecui@latest
 
 # Make sure your Go bin is on PATH:
 export PATH=$HOME/go/bin:$PATH
 ```
 
-Other install methods (Homebrew-style scripts, building from source, packaging the binary) are documented in [docs/INSTALLATION.md](docs/INSTALLATION.md).
+Both tools are published the same way — Homebrew, pre-built binaries for six
+platforms, `go install`, from source, or the install script. See
+[docs/INSTALLATION.md](docs/INSTALLATION.md).
 
 ### Generate an OpenAPI spec
 
@@ -191,12 +199,17 @@ Two things worth knowing before a first run on a large project:
 **Insight** (the ◷ tab) reports how the spec was produced, not just what is in it: which frameworks were detected and which one's patterns lead, what the CLI entry-point gate decided, and — per status code — how many responses describe their fields, are a free-form object, were found with an unresolved type, or document no body at all. The last split is the useful one: an empty body at `200` means the write was never followed, while an unresolved type means it was found and needs a type mapping.
 
 ```bash
-# Build and run
-go build -o apispecui ./cmd/apispecui
-./apispecui --dir ./my-go-project
+# Install it the same way as apispec (see Install above)
+brew install ehabterra/tap/apispecui
+# or: go install github.com/ehabterra/apispec/cmd/apispecui@latest
+
+apispecui --dir ./my-go-project
 
 # Open http://localhost:8088 — config UI
 # Open http://localhost:8088/diagram — call-graph visualization
+
+# From a clone instead:
+make build-ui && ./apispecui --dir ./my-go-project
 ```
 
 Endpoints exposed:

--- a/cmd/apispecui/main.go
+++ b/cmd/apispecui/main.go
@@ -109,11 +109,12 @@ var supportedFrameworks = core.ConfigurableFrameworkNames()
 
 // ServerConfig is the runtime config of the apispecui server.
 type ServerConfig struct {
-	Host       string
-	Port       int
-	InputDir   string
-	ConfigFile string
-	Verbose    bool
+	Host        string
+	Port        int
+	InputDir    string
+	ConfigFile  string
+	Verbose     bool
+	ShowVersion bool
 }
 
 // DetectResponse is what GET /api/detect returns: information the UI needs
@@ -380,6 +381,14 @@ func main() {
 	detectVersionInfo()
 	cfg := parseFlags()
 
+	// Before anything binds a port or walks a directory: --version must work
+	// in a sandbox with no project to analyse, which is exactly where the
+	// Homebrew formula's test runs it.
+	if cfg.ShowVersion {
+		printVersion()
+		return
+	}
+
 	diag := diagserver.New(&diagserver.Config{
 		Host:                         cfg.Host,
 		Port:                         cfg.Port,
@@ -448,6 +457,19 @@ func main() {
 	}
 }
 
+// printVersion mirrors apispec's --version output, so the two binaries report
+// themselves the same way and the Homebrew formula can assert on it.
+func printVersion() {
+	detectVersionInfo()
+
+	fmt.Printf("apispecui version: %s\n", Version)
+	fmt.Printf("Commit: %s\n", Commit)
+	fmt.Printf("Build time: %s\n", BuildTime)
+	fmt.Printf("Go version: %s\n", GoVersion)
+	fmt.Println(engine.CopyrightNotice)
+	fmt.Println(engine.LicenseNotice)
+}
+
 func parseFlags() *ServerConfig {
 	cfg := &ServerConfig{}
 	flag.StringVar(&cfg.Host, "host", "localhost", "HTTP host to bind")
@@ -457,6 +479,8 @@ func parseFlags() *ServerConfig {
 	flag.StringVar(&cfg.ConfigFile, "config", "", "Optional initial APISpec config YAML to seed the UI")
 	flag.StringVar(&cfg.ConfigFile, "c", "", "Shorthand for --config")
 	flag.BoolVar(&cfg.Verbose, "verbose", false, "Verbose logging")
+	flag.BoolVar(&cfg.ShowVersion, "version", false, "Show version information")
+	flag.BoolVar(&cfg.ShowVersion, "V", false, "Shorthand for --version")
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "apispec-ui: interactive web UI to configure and preview an OpenAPI spec\n\n")
 		fmt.Fprintf(os.Stderr, "Usage: %s [flags]\n\nFlags:\n", os.Args[0])

--- a/cmd/apispecui/version_test.go
+++ b/cmd/apispecui/version_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// buildUI builds the command under test once and returns its path.
+func buildUI(t *testing.T, version string) string {
+	t.Helper()
+
+	bin := filepath.Join(t.TempDir(), "apispecui")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+
+	build := exec.Command("go", "build",
+		"-ldflags", "-X main.Version="+version,
+		"-o", bin, ".")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("go build: %v\n%s", err, out)
+	}
+	return bin
+}
+
+// TestVersionFlag runs the real binary the way Homebrew's formula does: in a
+// directory with no Go project, asserting it prints the injected version and
+// exits instead of starting a server.
+//
+// The formula's test block is `assert_match version.to_s, shell_output(
+// "#{bin}/apispecui --version")`. If this path ever regressed — a server bound
+// before the flag was read, a non-zero exit, a version the ldflags did not
+// reach — the failure would surface as a broken `brew install` on a user's
+// machine, which nothing else here would catch.
+func TestVersionFlag(t *testing.T) {
+	const version = "9.9.9-test"
+	bin := buildUI(t, version)
+
+	for _, flag := range []string{"--version", "-V"} {
+		t.Run(flag, func(t *testing.T) {
+			// An empty working directory: --version must not depend on there
+			// being a project to analyse.
+			cmd := exec.Command(bin, flag)
+			cmd.Dir = t.TempDir()
+
+			done := make(chan struct{})
+			var out []byte
+			var err error
+			go func() {
+				out, err = cmd.CombinedOutput()
+				close(done)
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(30 * time.Second):
+				_ = cmd.Process.Kill()
+				t.Fatalf("%s did not exit: it started serving instead of printing the version", flag)
+			}
+
+			if err != nil {
+				t.Fatalf("%s exited with %v\n%s", flag, err, out)
+			}
+
+			got := string(out)
+			if !strings.Contains(got, version) {
+				t.Errorf("%s did not print the injected version %q; Homebrew's formula asserts on this.\n%s", flag, version, got)
+			}
+			if !strings.Contains(got, "apispecui version:") {
+				t.Errorf("%s output does not identify the tool:\n%s", flag, got)
+			}
+			// The server prints nothing on start, so the absence of a listen
+			// error is not proof by itself — but a bound port would have kept
+			// the process alive and tripped the timeout above.
+			if strings.Contains(got, "server failed") || strings.Contains(got, "listen") {
+				t.Errorf("%s appears to have started the server:\n%s", flag, got)
+			}
+		})
+	}
+}

--- a/cmd/apispecui/version_test.go
+++ b/cmd/apispecui/version_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -56,26 +57,20 @@ func TestVersionFlag(t *testing.T) {
 
 	for _, flag := range []string{"--version", "-V"} {
 		t.Run(flag, func(t *testing.T) {
+			// The deadline is what proves it exits rather than serves: a bound
+			// port would keep the process alive until the context kills it.
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
 			// An empty working directory: --version must not depend on there
 			// being a project to analyse.
-			cmd := exec.Command(bin, flag)
+			cmd := exec.CommandContext(ctx, bin, flag)
 			cmd.Dir = t.TempDir()
 
-			done := make(chan struct{})
-			var out []byte
-			var err error
-			go func() {
-				out, err = cmd.CombinedOutput()
-				close(done)
-			}()
-
-			select {
-			case <-done:
-			case <-time.After(30 * time.Second):
-				_ = cmd.Process.Kill()
-				t.Fatalf("%s did not exit: it started serving instead of printing the version", flag)
+			out, err := cmd.CombinedOutput()
+			if ctx.Err() != nil {
+				t.Fatalf("%s did not exit within the deadline: it started serving instead of printing the version\n%s", flag, out)
 			}
-
 			if err != nil {
 				t.Fatalf("%s exited with %v\n%s", flag, err, out)
 			}

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,7 +1,11 @@
 # Installation Guide
 
-Install, update and remove apispec — four ways to do it, and how to tell which
-one you are running when more than one is installed.
+Install, update and remove apispec and apispecui — four ways to do it, and how
+to tell which one you are running when more than one is installed.
+
+Both tools ship the same way. `apispec` is the CLI that generates a spec;
+`apispecui` is the browser UI that configures and previews one. Every method
+below installs either or both.
 
 ## At a glance
 
@@ -16,11 +20,14 @@ second way does not replace the first (see
 | **[Go install](#3-go-install)** — needs Go 1.26+ | `go install github.com/ehabterra/apispec/cmd/apispec@latest` | same command again | `rm "$(go env GOPATH)/bin/apispec"` |
 | **[From source](#4-from-source)** — for development | `make install-local` | `git pull && make install-local` | `make uninstall-local` |
 
+For the UI, substitute `apispecui` throughout — `brew install ehabterra/tap/apispecui`,
+`go install github.com/ehabterra/apispec/cmd/apispecui@latest`, `make install-ui-local`,
+and the `apispecui-*` release assets.
+
 Not sure what you have? → [Which apispec am I running?](#which-apispec-am-i-running)
 
-Only the `apispec` CLI is distributed as a binary. `apispecui` (browser config &
-preview) and `apidiag` (call-graph server) are built from source — see
-[Development Installation](#development-installation).
+`apidiag` (call-graph server) is not published as a binary and is built from
+source — see [Development Installation](#development-installation).
 
 ## Prerequisites
 
@@ -36,11 +43,17 @@ For the `go install` and from-source methods:
 ### 1. Homebrew (macOS and Linux)
 
 ```bash
-brew install ehabterra/tap/apispec
+brew install ehabterra/tap/apispec      # the CLI
+brew install ehabterra/tap/apispecui    # the web UI
 ```
 
-Upgrade with `brew upgrade apispec`, remove with `brew uninstall apispec`.
-Homebrew picks the right build for your machine and puts `apispec` on your PATH.
+Upgrade with `brew upgrade apispec`, remove with `brew uninstall apispec` (and
+the same for `apispecui`). Homebrew picks the right build for your machine and
+puts the binary on your PATH.
+
+Both formulae depend on `go`: the tools analyse a project by loading its
+packages, which shells out to the Go toolchain at **runtime**. You do not need
+Go to *install* them, but you do need it to run them.
 
 ### 2. Download a Pre-built Binary
 
@@ -53,17 +66,18 @@ your platform, verifies the checksum, and installs `apispec` onto your PATH.
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m)
 case "$ARCH" in x86_64|amd64) ARCH=amd64 ;; arm64|aarch64) ARCH=arm64 ;; esac
-ASSET="apispec-${OS}-${ARCH}"
+TOOL=apispec            # or apispecui for the web UI
+ASSET="${TOOL}-${OS}-${ARCH}"
 BASE="https://github.com/ehabterra/apispec/releases/latest/download"
 
 curl -fsSL -O "$BASE/$ASSET"
 curl -fsSL -O "$BASE/$ASSET.sha256"
 shasum -a 256 -c "$ASSET.sha256" 2>/dev/null || sha256sum -c "$ASSET.sha256"
 
-sudo install -m 0755 "$ASSET" /usr/local/bin/apispec
+sudo install -m 0755 "$ASSET" "/usr/local/bin/$TOOL"
 rm -f "$ASSET" "$ASSET.sha256"
 
-apispec --version
+"$TOOL" --version
 ```
 
 The checksum step prints `apispec-darwin-arm64: OK` (or your platform's name). If
@@ -78,14 +92,15 @@ it prints `FAILED`, stop — do not install the file.
 Installing somewhere else, e.g. no `sudo`:
 
 ```bash
-mkdir -p ~/.local/bin && install -m 0755 "$ASSET" ~/.local/bin/apispec
+mkdir -p ~/.local/bin && install -m 0755 "$ASSET" "$HOME/.local/bin/$TOOL"
 # ensure ~/.local/bin is on your PATH
 ```
 
 **Windows (PowerShell)**
 
 ```powershell
-$asset = "apispec-windows-amd64.exe"   # or apispec-windows-arm64.exe on ARM
+$tool  = "apispec"                       # or apispecui for the web UI
+$asset = "$tool-windows-amd64.exe"       # or -windows-arm64.exe on ARM
 $base  = "https://github.com/ehabterra/apispec/releases/latest/download"
 
 Invoke-WebRequest -Uri "$base/$asset" -OutFile $asset
@@ -94,9 +109,9 @@ $expected = (Get-Content "$asset.sha256").Split(" ")[0]
 if ((Get-FileHash $asset -Algorithm SHA256).Hash -ne $expected) { throw "checksum mismatch" }
 
 New-Item -ItemType Directory -Force "$env:LOCALAPPDATA\Programs\apispec" | Out-Null
-Move-Item -Force $asset "$env:LOCALAPPDATA\Programs\apispec\apispec.exe"
+Move-Item -Force $asset "$env:LOCALAPPDATA\Programs\apispec\$tool.exe"
 # add that directory to your PATH, then:
-apispec --version
+& $tool --version
 ```
 
 To pin a version, swap `latest/download` for `download/v0.5.6` (any tag).
@@ -107,7 +122,7 @@ To pin a version, swap `latest/download` for `download/v0.5.6` (any tag).
 
 **Cons:**
 - Manual updates (re-run the block to upgrade)
-- Only `apispec` is published as a binary — `apispecui` and `apidiag` are built from source
+- `apidiag` is not published as a binary — it is built from source
 
 ### 3. Go Install
 
@@ -115,6 +130,7 @@ If you already have Go:
 
 ```bash
 go install github.com/ehabterra/apispec/cmd/apispec@latest
+go install github.com/ehabterra/apispec/cmd/apispecui@latest
 ```
 
 **Pros:**
@@ -136,11 +152,16 @@ git clone https://github.com/ehabterra/apispec.git
 cd apispec
 
 # Install to user directory (no sudo required)
-make install-local
+make install-local        # apispec
+make install-ui-local     # apispecui
 
 # OR install to system directory (requires sudo)
-make install
+make install              # apispec
+make install-ui           # apispecui
 ```
+
+Remove them again with `make uninstall-local` / `make uninstall-ui-local` (or
+`make uninstall` / `make uninstall-ui` for a system install).
 
 **Pros:**
 - Full control over the build process
@@ -161,6 +182,13 @@ curl -sSL https://raw.githubusercontent.com/ehabterra/apispec/main/scripts/insta
 ```
 
 Supported arguments: `go-install` (default), `source-local`, `source-system`, `help`.
+
+It installs **both** tools by default. Add `--tool apispec` or `--tool apispecui`
+to install just one:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/ehabterra/apispec/main/scripts/install.sh | bash -s go-install --tool apispecui
+```
 
 **Pros:**
 - Automated, with error checking and validation
@@ -408,7 +436,9 @@ cd apispec
 make deps
 
 # Build for development
-make build
+make build          # apispec
+make build-ui       # apispecui
+make build-apidiag  # apidiag (source-only tool)
 
 # Run tests
 make test
@@ -421,15 +451,17 @@ make release
 
 Every release on the [GitHub Releases page](https://github.com/ehabterra/apispec/releases) publishes these assets — see [Installation Method 2](#2-download-a-pre-built-binary) for the commands.
 
-| Platform | Asset |
-|---|---|
-| macOS arm64 (Apple Silicon) | `apispec-darwin-arm64` |
-| macOS amd64 (Intel) | `apispec-darwin-amd64` |
-| Linux amd64 | `apispec-linux-amd64` |
-| Linux arm64 | `apispec-linux-arm64` |
-| Windows amd64 | `apispec-windows-amd64.exe` |
-| Windows arm64 | `apispec-windows-arm64.exe` |
+| Platform | CLI asset | Web UI asset |
+|---|---|---|
+| macOS arm64 (Apple Silicon) | `apispec-darwin-arm64` | `apispecui-darwin-arm64` |
+| macOS amd64 (Intel) | `apispec-darwin-amd64` | `apispecui-darwin-amd64` |
+| Linux amd64 | `apispec-linux-amd64` | `apispecui-linux-amd64` |
+| Linux arm64 | `apispec-linux-arm64` | `apispecui-linux-arm64` |
+| Windows amd64 | `apispec-windows-amd64.exe` | `apispecui-windows-amd64.exe` |
+| Windows arm64 | `apispec-windows-arm64.exe` | `apispecui-windows-arm64.exe` |
 
-Each binary ships a matching `<asset>.sha256` checksum file, plus a source archive (`apispec-<version>.tar.gz`) and release notes.
+Each binary ships a matching `<asset>.sha256` checksum file, plus an archive of
+them all (`apispec-<version>.tar.gz`) and release notes.
 
-Only the `apispec` CLI is published as a binary. `apispecui` (browser config & preview) and `apidiag` (call-graph server) are built from source — see [Development Installation](#development-installation).
+`apidiag` (call-graph server) is not published as a binary and is built from
+source — see [Development Installation](#development-installation).

--- a/internal/packaging/homebrew_test.go
+++ b/internal/packaging/homebrew_test.go
@@ -25,10 +25,23 @@ import (
 	"testing"
 )
 
-const (
-	formulaPath  = "../../packaging/homebrew/apispec.rb"
-	templatePath = "../../packaging/homebrew/apispec.rb.tmpl"
-)
+const packagingDir = "../../packaging/homebrew"
+
+// formulae is every tool the tap publishes. Adding a binary to the release
+// without adding it here means nobody can `brew install` it, which is a
+// silence rather than a failure — hence the list, and hence
+// TestEveryTemplateIsCovered below reading the directory rather than trusting
+// it.
+var formulae = []struct {
+	tool  string
+	asset string // release asset prefix, e.g. apispec-darwin-arm64
+}{
+	{tool: "apispec", asset: "apispec"},
+	{tool: "apispecui", asset: "apispecui"},
+}
+
+func templatePathFor(tool string) string { return filepath.Join(packagingDir, tool+".rb.tmpl") }
+func formulaPathFor(tool string) string  { return filepath.Join(packagingDir, tool+".rb") }
 
 // TestHomebrewFormulaMatchesTemplate pins that the readable formula is exactly
 // what the template renders.
@@ -40,8 +53,24 @@ const (
 // invisible until someone's `brew install` fetches a binary whose digest does
 // not match.
 func TestHomebrewFormulaMatchesTemplate(t *testing.T) {
-	formula := readFile(t, formulaPath)
-	tmpl := readFile(t, templatePath)
+	for _, f := range formulae {
+		t.Run(f.tool, func(t *testing.T) {
+			// A rendered .rb only exists once a release has published that
+			// tool's artifacts — its digests cannot be invented, and a wrong
+			// one is a failed `brew install`. Until then the template is the
+			// whole source of truth and there is nothing to drift against.
+			if _, err := os.Stat(formulaPathFor(f.tool)); os.IsNotExist(err) {
+				t.Skipf("no rendered %s.rb yet: the first release publishing %s artifacts creates it", f.tool, f.asset)
+			}
+			assertFormulaMatchesTemplate(t, f.tool)
+		})
+	}
+}
+
+func assertFormulaMatchesTemplate(t *testing.T, tool string) {
+	t.Helper()
+	formula := readFile(t, formulaPathFor(tool))
+	tmpl := readFile(t, templatePathFor(tool))
 
 	// Render the template the way release.yml does: substitute placeholders with
 	// whatever the formula currently carries. What must match is everything else.
@@ -64,7 +93,7 @@ func TestHomebrewFormulaMatchesTemplate(t *testing.T) {
 	}
 
 	if rendered != formula {
-		t.Errorf("packaging/homebrew/apispec.rb is not what apispec.rb.tmpl renders.\n"+
+		t.Errorf("packaging/homebrew/"+tool+".rb is not what "+tool+".rb.tmpl renders.\n"+
 			"Edit the TEMPLATE, then regenerate the .rb — the workflow ships the template, "+
 			"so a change made only in the .rb never reaches anyone.\n\n--- rendered\n%s\n--- committed\n%s",
 			rendered, formula)
@@ -75,7 +104,14 @@ func TestHomebrewFormulaMatchesTemplate(t *testing.T) {
 // the template in agreement. A placeholder dropped from the template does not
 // fail the release — it silently ships the PREVIOUS version's URL or digest.
 func TestHomebrewTemplateHasEveryPlaceholder(t *testing.T) {
-	tmpl := readFile(t, templatePath)
+	for _, f := range formulae {
+		t.Run(f.tool, func(t *testing.T) { assertTemplatePlaceholders(t, f.tool) })
+	}
+}
+
+func assertTemplatePlaceholders(t *testing.T, tool string) {
+	t.Helper()
+	tmpl := readFile(t, templatePathFor(tool))
 	for _, ph := range []string{
 		"__VERSION__",
 		"__SHA_DARWIN_ARM64__", "__SHA_DARWIN_AMD64__",
@@ -96,10 +132,21 @@ func TestHomebrewTemplateHasEveryPlaceholder(t *testing.T) {
 // names the release actually publishes. Homebrew reports a wrong URL only as a
 // 404 at install time, on the user's machine.
 func TestHomebrewFormulaTargetsThePublishedAssets(t *testing.T) {
-	formula := readFile(t, formulaPath)
+	for _, f := range formulae {
+		t.Run(f.tool, func(t *testing.T) {
+			// Checked on the TEMPLATE: it is what the release ships, and it
+			// exists for a tool that has not been published yet.
+			assertTargetsPublishedAssets(t, templatePathFor(f.tool), f.asset)
+		})
+	}
+}
+
+func assertTargetsPublishedAssets(t *testing.T, path, assetPrefix string) {
+	t.Helper()
+	formula := readFile(t, path)
 	for _, asset := range []string{
-		"apispec-darwin-arm64", "apispec-darwin-amd64",
-		"apispec-linux-arm64", "apispec-linux-amd64",
+		assetPrefix + "-darwin-arm64", assetPrefix + "-darwin-amd64",
+		assetPrefix + "-linux-arm64", assetPrefix + "-linux-amd64",
 	} {
 		if !strings.Contains(formula, asset) {
 			t.Errorf("formula never references %s, which the release publishes", asset)
@@ -133,4 +180,76 @@ func captureOne(t *testing.T, s, pattern string) string {
 		t.Fatalf("pattern %q did not match", pattern)
 	}
 	return m[1]
+}
+
+// tapToolList returns the tools the release workflow's tap step iterates,
+// padded with spaces so a lookup cannot match a prefix ("apispec" inside
+// "apispecui").
+func tapToolList(t *testing.T, workflow string) string {
+	t.Helper()
+	m := regexp.MustCompile(`for tool in ([^;]+);`).FindStringSubmatch(workflow)
+	if m == nil {
+		t.Fatal("release.yml has no `for tool in ...;` loop in the tap step; the rendering shape changed")
+	}
+	if !strings.Contains(workflow, `packaging/homebrew/$tool.rb.tmpl`) {
+		t.Error("release.yml's tap loop does not render packaging/homebrew/$tool.rb.tmpl")
+	}
+	return " " + strings.TrimSpace(m[1]) + " "
+}
+
+// TestEveryTemplateIsCovered reads the packaging directory rather than trusting
+// the list above. A template added without a formulae entry would be tested by
+// nothing, and a formulae entry with no template would be a release step that
+// cannot run — both fail here rather than at release time.
+func TestEveryTemplateIsCovered(t *testing.T) {
+	entries, err := os.ReadDir(packagingDir)
+	if err != nil {
+		t.Fatalf("read %s: %v", packagingDir, err)
+	}
+
+	onDisk := map[string]bool{}
+	for _, e := range entries {
+		if name, ok := strings.CutSuffix(e.Name(), ".rb.tmpl"); ok {
+			onDisk[name] = true
+		}
+	}
+
+	listed := map[string]bool{}
+	for _, f := range formulae {
+		listed[f.tool] = true
+		if !onDisk[f.tool] {
+			t.Errorf("formulae lists %q but %s does not exist; the release step would fail", f.tool, templatePathFor(f.tool))
+		}
+	}
+	for tool := range onDisk {
+		if !listed[tool] {
+			t.Errorf("%s exists but %q is not in formulae, so nothing checks it", templatePathFor(tool), tool)
+		}
+	}
+}
+
+// TestReleaseWorkflowPublishesEveryFormulaAsset ties the formulae to the
+// workflow that has to produce their downloads. A formula whose asset the
+// release never uploads installs as a 404 on a user's machine, and nothing
+// before that point notices.
+func TestReleaseWorkflowPublishesEveryFormulaAsset(t *testing.T) {
+	workflow := readFile(t, "../../.github/workflows/release.yml")
+
+	for _, f := range formulae {
+		t.Run(f.tool, func(t *testing.T) {
+			// The four Homebrew platforms; windows is published but never
+			// referenced by a formula.
+			for _, suffix := range []string{"darwin-arm64", "darwin-amd64", "linux-arm64", "linux-amd64"} {
+				asset := f.asset + "-" + suffix
+				if !strings.Contains(workflow, asset) {
+					t.Errorf("release.yml never publishes %s, which %s.rb.tmpl downloads", asset, f.tool)
+				}
+			}
+			// The tap step renders every template in a loop, so what must
+			// name the tool is the loop's list, not a literal path.
+			if !strings.Contains(tapToolList(t, workflow), " "+f.tool+" ") {
+				t.Errorf("release.yml's tap loop does not cover %q, so the tap keeps the previous version of it", f.tool)
+			}
+		})
+	}
 }

--- a/packaging/homebrew/apispecui.rb.tmpl
+++ b/packaging/homebrew/apispecui.rb.tmpl
@@ -1,0 +1,49 @@
+# Homebrew formula for apispecui: installs the pre-built release binary, so
+# `brew install` needs no Go toolchain to install it.
+#
+# packaging/homebrew/apispecui.rb.tmpl is the SOURCE; apispecui.rb is it
+# rendered at the current release. .github/workflows/release.yml renders the
+# template with the checksums of the artifacts it just built and pushes the
+# result to the tap (ehabterra/homebrew-tap, Formula/apispecui.rb).
+# TestHomebrewFormulaMatchesTemplate keeps the two from drifting.
+class Apispecui < Formula
+  desc "Interactive web UI to configure and preview an OpenAPI spec from Go source"
+  homepage "https://github.com/ehabterra/apispec"
+  license "Apache-2.0"
+
+  # Same runtime requirement as apispec: the UI analyses a project by loading
+  # its packages through go/packages, which shells out to `go list`. The web
+  # assets are embedded in the binary, so nothing else is needed.
+  depends_on "go"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/ehabterra/apispec/releases/download/v__VERSION__/apispecui-darwin-arm64"
+      sha256 "__SHA_DARWIN_ARM64__"
+    end
+    on_intel do
+      url "https://github.com/ehabterra/apispec/releases/download/v__VERSION__/apispecui-darwin-amd64"
+      sha256 "__SHA_DARWIN_AMD64__"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/ehabterra/apispec/releases/download/v__VERSION__/apispecui-linux-arm64"
+      sha256 "__SHA_LINUX_ARM64__"
+    end
+    on_intel do
+      url "https://github.com/ehabterra/apispec/releases/download/v__VERSION__/apispecui-linux-amd64"
+      sha256 "__SHA_LINUX_AMD64__"
+    end
+  end
+
+  def install
+    # The download keeps its asset name; install it under the short one.
+    bin.install Dir["apispecui-*"].first => "apispecui"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/apispecui --version")
+  end
+end

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,11 +1,18 @@
 #!/bin/bash
 
 # APISpec Installation Script
-# This script provides multiple installation options for apispec
+# This script provides multiple installation options for apispec and apispecui.
+#
+# Which tools to install is chosen with --tool (default: both), so the same
+# invocations that installed apispec keep working and now cover the UI too.
 
 set -e
 
 APP_NAME="apispec"
+UI_NAME="apispecui"
+# Tools to act on, set by --tool. Both by default: someone running the
+# installer wants a working setup, and the UI is part of one.
+TOOLS=("apispec" "apispecui")
 VERSION="0.0.1"
 REPO_URL="https://github.com/ehabterra/apispec"
 
@@ -55,22 +62,23 @@ check_go() {
 # Function to install using go install
 install_go_install() {
     print_status "Installing using 'go install'..."
-    
-    if command_exists apispec; then
-        print_warning "apispec is already installed. Updating..."
-        go install github.com/ehabterra/apispec/cmd/apispec@latest
-    else
-        go install github.com/ehabterra/apispec/cmd/apispec@latest
-    fi
-    
-    # Check if installation was successful
-    if command_exists apispec; then
-        print_status "apispec installed successfully using go install!"
-        apispec --version
-    else
-        print_error "Installation failed. Please check your Go environment."
-        exit 1
-    fi
+
+    local tool
+    for tool in "${TOOLS[@]}"; do
+        if command_exists "$tool"; then
+            print_warning "$tool is already installed. Updating..."
+        fi
+        go install "github.com/ehabterra/apispec/cmd/$tool@latest"
+
+        # Check if installation was successful
+        if command_exists "$tool"; then
+            print_status "$tool installed successfully using go install!"
+            "$tool" --version | head -n 1
+        else
+            print_error "Installation of $tool failed. Please check your Go environment."
+            exit 1
+        fi
+    done
 }
 
 # Function to install from source
@@ -85,20 +93,30 @@ install_from_source() {
     print_status "Cloning repository..."
     git clone "$REPO_URL" .
     
-    # Build and install
-    print_status "Building apispec..."
-    make build
-    
-    # Install to system
-    if [ "$1" = "system" ]; then
-        print_status "Installing to /usr/local/bin (requires sudo)..."
-        sudo cp apispec /usr/local/bin/
-        print_status "apispec installed to /usr/local/bin successfully!"
-    else
-        print_status "Installing to ~/go/bin..."
-        mkdir -p ~/go/bin
-        cp apispec ~/go/bin/
-        print_status "apispec installed to ~/go/bin successfully!"
+    # Build and install each selected tool
+    local tool target
+    for tool in "${TOOLS[@]}"; do
+        print_status "Building $tool..."
+        if [ "$tool" = "$UI_NAME" ]; then
+            make build-ui
+        else
+            make build
+        fi
+
+        if [ "$1" = "system" ]; then
+            target="/usr/local/bin"
+            print_status "Installing $tool to $target (requires sudo)..."
+            sudo cp "$tool" "$target/"
+        else
+            target="$HOME/go/bin"
+            print_status "Installing $tool to $target..."
+            mkdir -p "$target"
+            cp "$tool" "$target/"
+        fi
+        print_status "$tool installed to $target successfully!"
+    done
+
+    if [ "$1" != "system" ]; then
         print_warning "Make sure ~/go/bin is in your PATH"
         echo "Add this to your shell profile: export PATH=\$HOME/go/bin:\$PATH"
     fi
@@ -118,8 +136,14 @@ show_usage() {
     echo "  source-system  Install from source to /usr/local/bin (requires sudo)"
     echo "  help           Show this help message"
     echo ""
+    echo "Flags:"
+    echo "  --tool NAME    Which tool to install: apispec, apispecui, or both"
+    echo "                 (default: both)"
+    echo ""
     echo "Examples:"
-    echo "  $0 go-install      # Install using go install"
+    echo "  $0 go-install                    # Install both tools with go install"
+    echo "  $0 go-install --tool apispec     # CLI only"
+    echo "  $0 go-install --tool apispecui   # Web UI only"
     echo "  $0 source-local    # Build and install to user directory"
     echo "  $0 source-system   # Build and install to system directory"
 }
@@ -127,10 +151,35 @@ show_usage() {
 # Main script
 main() {
     print_header
-    
+
     # Check Go installation
     check_go
-    
+
+    # Pull --tool out of the arguments before the mode is read, so it can be
+    # given on either side of it.
+    local args=()
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --tool)
+                shift
+                case "${1:-}" in
+                    apispec)   TOOLS=("$APP_NAME") ;;
+                    apispecui) TOOLS=("$UI_NAME") ;;
+                    both|"")   TOOLS=("$APP_NAME" "$UI_NAME") ;;
+                    *)
+                        print_error "Unknown tool: $1 (expected apispec, apispecui or both)"
+                        exit 1
+                        ;;
+                esac
+                ;;
+            *) args+=("$1") ;;
+        esac
+        shift
+    done
+    set -- "${args[@]}"
+
+    print_status "Installing: ${TOOLS[*]}"
+
     # Parse arguments
     case "${1:-go-install}" in
         "go-install")
@@ -143,7 +192,10 @@ main() {
             install_from_source "system"
             ;;
         "help"|"-h"|"--help")
+            # Return rather than fall through: the summary below claims an
+            # installation happened, which printing help plainly did not.
             show_usage
+            return 0
             ;;
         *)
             print_error "Unknown option: $1"
@@ -154,10 +206,21 @@ main() {
     
     print_status "Installation completed successfully!"
     echo ""
-    echo "You can now use apispec:"
-    echo "  apispec --help          # Show help"
-    echo "  apispec --version       # Show version"
-    echo "  apispec <directory>     # Generate OpenAPI spec"
+    local tool
+    for tool in "${TOOLS[@]}"; do
+        if [ "$tool" = "$UI_NAME" ]; then
+            echo "You can now use apispecui:"
+            echo "  apispecui --help          # Show help"
+            echo "  apispecui --version       # Show version"
+            echo "  apispecui -d <directory>  # Open the web UI on http://localhost:8088"
+        else
+            echo "You can now use apispec:"
+            echo "  apispec --help          # Show help"
+            echo "  apispec --version       # Show version"
+            echo "  apispec <directory>     # Generate OpenAPI spec"
+        fi
+        echo ""
+    done
 }
 
 # Run main function

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -161,11 +161,19 @@ main() {
     while [ $# -gt 0 ]; do
         case "$1" in
             --tool)
+                # A value is required. Without this check a trailing `--tool`
+                # shifts past the end of the argument list, and the shift at the
+                # bottom of the loop then fails under `set -e` — the script
+                # exits after printing its header, with no error at all.
+                if [ $# -lt 2 ] || [ -z "$2" ]; then
+                    print_error "--tool requires a value (apispec, apispecui or both)"
+                    exit 1
+                fi
                 shift
-                case "${1:-}" in
+                case "$1" in
                     apispec)   TOOLS=("$APP_NAME") ;;
                     apispecui) TOOLS=("$UI_NAME") ;;
-                    both|"")   TOOLS=("$APP_NAME" "$UI_NAME") ;;
+                    both)      TOOLS=("$APP_NAME" "$UI_NAME") ;;
                     *)
                         print_error "Unknown tool: $1 (expected apispec, apispecui or both)"
                         exit 1

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -6,6 +6,11 @@
 set -e
 
 APP_NAME="apispec"
+# Every command this release ships, as "binary-name:package". apispecui is a
+# distributable tool in its own right, not a dev aid, so it is built for the
+# same platforms and published alongside apispec (it embeds its own assets, so
+# each binary is still self-contained).
+BINARIES=("apispec:./cmd/apispec" "apispecui:./cmd/apispecui")
 VERSION="${VERSION:-0.0.1}"  # Allow VERSION to be set from environment
 COMMIT="${COMMIT:-$(git rev-parse --short HEAD)}"
 BUILD_DATE="${BUILD_DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
@@ -52,13 +57,11 @@ check_go() {
     print_status "Found Go version: $GO_VERSION"
 }
 
-# Function to build for a specific platform
+# Function to build every binary for a specific platform
 build_for_platform() {
     local GOOS=$1
     local GOARCH=$2
     local EXTENSION=$3
-    
-    print_status "Building for $GOOS/$GOARCH..."
     
     # Set environment variables
     export GOOS=$GOOS
@@ -66,12 +69,18 @@ build_for_platform() {
     export CGO_ENABLED=0
     
     # Build flags - use environment variables if available, fallback to script variables
+    # main.BuildDate is a no-op for a binary that does not declare it (the
+    # linker ignores an -X for a missing symbol), so one flag set serves both.
     LDFLAGS="-X 'main.Version=$VERSION' -X 'main.Commit=$COMMIT' -X 'main.BuildDate=$BUILD_DATE' -X 'main.GoVersion=$GO_VERSION'"
     
-    # Build
-    go build -ldflags "$LDFLAGS" -o "dist/${APP_NAME}-${GOOS}-${GOARCH}${EXTENSION}" ./cmd/apispec
-    
-    print_status "Built: dist/${APP_NAME}-${GOOS}-${GOARCH}${EXTENSION}"
+    local entry name pkg
+    for entry in "${BINARIES[@]}"; do
+        name="${entry%%:*}"
+        pkg="${entry#*:}"
+        print_status "Building $name for $GOOS/$GOARCH..."
+        go build -ldflags "$LDFLAGS" -o "dist/${name}-${GOOS}-${GOARCH}${EXTENSION}" "$pkg"
+        print_status "Built: dist/${name}-${GOOS}-${GOARCH}${EXTENSION}"
+    done
 }
 
 # Function to create release package


### PR DESCRIPTION
`apispecui` was installable exactly one way — `go install` — while `apispec` had five. Someone without a Go toolchain could `brew install apispec` and then had no way to get the UI at all, even though it is a self-contained binary that embeds its own assets.

## Every method now covers both tools

| Method | Before | After |
|---|---|---|
| Homebrew | apispec only | `brew install ehabterra/tap/apispecui` |
| Pre-built binary | apispec only (6 platforms) | apispecui too, same 6 platforms + checksums |
| `go install` | worked, undocumented | documented |
| From source | `make install` / `install-local` | `make build-ui` / `install-ui` / `install-ui-local` (+ uninstalls) |
| `scripts/install.sh` | apispec only | both by default, `--tool` selects one |

`scripts/release.sh` now builds a **list** of commands instead of a hardcoded `./cmd/apispec`, so adding a future binary is one entry.

## Two prerequisites this needed first

**`apispecui` had no `--version` flag.** The Homebrew formula's `test do` block asserts on it, and parity wants it regardless. It now prints the same shape as `apispec` — `BuildTime` rather than `BuildDate`, keeping the existing deliberate behaviour of reporting the binary's mtime — and returns before binding a port or walking a directory, which is where the formula's sandboxed test runs it.

**The release workflow patched version constants in `cmd/apispec/main.go` only**, so a `go install` from a tag would have reported `dev` for the UI. It now patches both.

## The tests are the interesting part

They are data-driven over a list of formulae, so a tool added later is covered by default rather than by someone remembering:

- **every `*.rb.tmpl` on disk must be listed, and every listed tool must have a template** — read from the directory, not trusted from the list;
- **`release.yml` must publish the four Homebrew assets each template downloads**, and its tap loop must name the tool.

That second one earned its place immediately: it failed on my first attempt and told me exactly which assets and which rendering step were still missing. A formula whose asset the release never uploads installs as a 404 on a user's machine, and nothing before that point notices.

## No `apispecui.rb` is committed, deliberately

The rendered formula carries digests of published artifacts. Those cannot be invented, and a wrong one is a failed `brew install`. The first release that publishes `apispecui` artifacts creates it; until then the template is the whole source of truth, and the drift test skips with that explanation rather than passing silently.

## Verified end to end

Ran the release path as the workflow will:

- 12 binaries built (2 tools × 6 platforms) with checksums;
- both formulae rendered from the real digests, **zero placeholders left**;
- both binaries report the injected version, so `assert_match version.to_s, shell_output("#{bin}/apispecui --version")` passes.

```
apispecui version: 9.9.9
apispec version: 9.9.9
```

Docs updated: README quick-start now leads with Homebrew for both, the `apispecui` section installs rather than `go build`s, and `docs/INSTALLATION.md` covers both throughout — including removing its "Only the `apispec` CLI is distributed as a binary" statement, which this change makes false.

## One judgement call worth flagging

The install script installs **both** tools by default. Someone running an installer wants a working setup, and the UI is part of one — but it is a behaviour change for existing users of that script, so `--tool apispec` restores the old scope. Happy to flip the default if you would rather it stay CLI-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `apispecui` binaries to releases across supported platforms.
  * Added Homebrew installation support for `apispecui`.
  * Added `--version` and `-V` options to display build and license information.
  * Expanded the installer to support installing either or both tools.

* **Documentation**
  * Updated installation guidance with Homebrew, Go, binary, source, and script-based options for both tools.
  * Added build, installation, and uninstallation commands for `apispecui`.
  * Documented available distribution methods and clarified that `apidiag` is source-only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->