### PR TITLE
feat(spec): repair and report references the document cannot satisfy

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -78,3 +78,11 @@ func (g *Generator) PathParamMismatches() []intspec.PathParamMismatch {
 	}
 	return g.engine.GetPathParamMismatches()
 }
+
+// UnresolvedRefs returns the $refs the last generation could not satisfy, after
+// they were repaired with a placeholder. Non-empty means the document loads but
+// some type resolved to nothing useful — the actionable fix is usually
+// registering it under externalTypes (issue #327).
+func (g *Generator) UnresolvedRefs() []intspec.UnresolvedRef {
+	return g.engine.GetUnresolvedRefs()
+}

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -84,5 +84,8 @@ func (g *Generator) PathParamMismatches() []intspec.PathParamMismatch {
 // some type resolved to nothing useful — the actionable fix is usually
 // registering it under externalTypes (issue #327).
 func (g *Generator) UnresolvedRefs() []intspec.UnresolvedRef {
+	if g.engine == nil {
+		return nil
+	}
 	return g.engine.GetUnresolvedRefs()
 }

--- a/generator/testdata_external_type_refs_test.go
+++ b/generator/testdata_external_type_refs_test.go
@@ -15,6 +15,7 @@
 package generator
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -94,4 +95,45 @@ func schemaPropNames(s *spec.Schema) []string {
 		out = append(out, k)
 	}
 	return out
+}
+
+// TestTestdata_UnresolvedRefsAreReported covers the end of the chain for issue
+// #327: a type with no schema is repaired so the document still loads, AND the
+// fact is reported so a user knows their spec has a placeholder in it rather
+// than a type.
+//
+// external_type_refs is the right fixture: its fields are standard-library
+// types, which are outside the analysed module exactly like a dependency, so
+// they genuinely cannot resolve.
+func TestTestdata_UnresolvedRefsAreReported(t *testing.T) {
+	dir := filepath.Join("..", "testdata", "external_type_refs")
+	g := NewGenerator(spec.DefaultHTTPConfig())
+	out, err := g.GenerateFromDirectory(dir)
+	if err != nil {
+		t.Fatalf("GenerateFromDirectory: %v", err)
+	}
+
+	// The document must load regardless — that is what the repair is for.
+	noDanglingRefs(t, out)
+
+	// An empty report is the healthy state and the expected one here: since
+	// #325 the generation pass registers a placeholder for a type it cannot
+	// resolve, so nothing reaches the final repair. That is why this asserts
+	// the invariant rather than a non-empty report — the repair is a net for
+	// causes not yet known, and unit tests in internal/spec exercise it
+	// directly. What is worth checking end to end is that the accessor is
+	// wired and self-consistent.
+	for _, r := range g.UnresolvedRefs() {
+		if r.Component == "" {
+			t.Error("an unresolved ref reports no component name")
+		}
+		if r.Sites < 1 {
+			t.Errorf("%s reports %d sites, want at least 1", r.Component, r.Sites)
+		}
+		// Every component it names must now exist — the report describes what
+		// was repaired, not what is still broken.
+		if out.Components == nil || out.Components.Schemas[r.Component] == nil {
+			t.Errorf("%s was reported unresolved but no placeholder was registered for it", r.Component)
+		}
+	}
 }

--- a/generator/testdata_external_type_refs_test.go
+++ b/generator/testdata_external_type_refs_test.go
@@ -116,22 +116,34 @@ func TestTestdata_UnresolvedRefsAreReported(t *testing.T) {
 	// The document must load regardless — that is what the repair is for.
 	noDanglingRefs(t, out)
 
-	// An empty report is the healthy state and the expected one here: since
-	// #325 the generation pass registers a placeholder for a type it cannot
-	// resolve, so nothing reaches the final repair. That is why this asserts
-	// the invariant rather than a non-empty report — the repair is a net for
-	// causes not yet known, and unit tests in internal/spec exercise it
-	// directly. What is worth checking end to end is that the accessor is
-	// wired and self-consistent.
-	for _, r := range g.UnresolvedRefs() {
+	// This fixture must report NOTHING, and that is a real assertion rather
+	// than a vacuous loop: since #325 the generation pass registers a
+	// placeholder for a type it cannot resolve, so nothing should reach the
+	// final repair. A non-empty report here means type resolution regressed
+	// far enough that the safety net had to catch it — which is exactly the
+	// signal worth failing on.
+	//
+	// The repair itself is exercised directly by unit tests in internal/spec
+	// (one per document location, plus its repair and reporting behaviour).
+	// Reproducing it end to end would need a fixture that encodes a bug which
+	// does not exist, and that would stop reproducing the moment the bug was
+	// fixed elsewhere.
+	refs := g.UnresolvedRefs()
+	if len(refs) != 0 {
+		t.Errorf("%d reference(s) needed repairing in a fixture whose types all resolve — "+
+			"type resolution regressed: %+v", len(refs), refs)
+	}
+
+	// Whatever is reported, the report must describe what was repaired: every
+	// component it names now exists. Kept so a future non-empty report is
+	// checked rather than only counted.
+	for _, r := range refs {
 		if r.Component == "" {
 			t.Error("an unresolved ref reports no component name")
 		}
 		if r.Sites < 1 {
 			t.Errorf("%s reports %d sites, want at least 1", r.Component, r.Sites)
 		}
-		// Every component it names must now exist — the report describes what
-		// was repaired, not what is still broken.
 		if out.Components == nil || out.Components.Schemas[r.Component] == nil {
 			t.Errorf("%s was reported unresolved but no placeholder was registered for it", r.Component)
 		}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -284,6 +284,10 @@ type Engine struct {
 	// so the user can map it to a scheme.
 	unresolvedSecurity []intspec.MiddlewareRef
 
+	// unresolvedRefs lists $refs the generated document could not satisfy and
+	// that were repaired with a placeholder, from the most recent generation.
+	unresolvedRefs []intspec.UnresolvedRef
+
 	// pathParamMismatches lists map-key path-variable reads (mux.Vars(r)["x"])
 	// whose key matches no route placeholder, gathered during the last generation.
 	pathParamMismatches []intspec.PathParamMismatch
@@ -814,6 +818,8 @@ func (e *Engine) GenerateOpenAPI() (*spec.OpenAPISpec, error) {
 	if secDiag != nil {
 		e.unresolvedSecurity = secDiag.UnresolvedMiddleware
 		e.pathParamMismatches = secDiag.PathParamMismatches
+		e.unresolvedRefs = secDiag.UnresolvedRefs
+		e.reportUnresolvedRefs()
 	}
 	// Read after mapping: with the lazy tree the entrypoint gate runs during
 	// expansion, which mapping is what triggers.
@@ -1216,6 +1222,47 @@ func (e *Engine) GetExpansionStats() intspec.ExpansionStats {
 // recent generation. Zero when the project declares no entrypoints.
 func (e *Engine) GetEntrypointStats() intspec.EntrypointStats {
 	return e.entrypointStats
+}
+
+// reportUnresolvedRefs warns about references the document could not satisfy.
+//
+// Always-on rather than verbose-gated, like the truncation warnings: a
+// reference with no component means a type resolved to nothing useful, so the
+// operation is documented while its shape is not. It names the GO TYPE, which
+// is what tells a user which dependency to register under externalTypes — the
+// mangled component name does not.
+func (e *Engine) reportUnresolvedRefs() {
+	if len(e.unresolvedRefs) == 0 {
+		return
+	}
+
+	var b strings.Builder
+	sites := 0
+	for i, ref := range e.unresolvedRefs {
+		sites += ref.Sites
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		if ref.GoType != "" {
+			b.WriteString(ref.GoType)
+		} else {
+			b.WriteString(ref.Component)
+		}
+		if ref.Sites > 1 {
+			fmt.Fprintf(&b, " (%d sites)", ref.Sites)
+		}
+	}
+
+	e.reportPhase(fmt.Sprintf(
+		"%d type(s) had no schema and were inlined as unresolved across %d reference(s): %s",
+		len(e.unresolvedRefs), sites, b.String()), 0)
+}
+
+// GetUnresolvedRefs returns the references the most recent generation could not
+// satisfy, after they were repaired. Non-empty means the spec loads but some
+// operation's shape is a placeholder.
+func (e *Engine) GetUnresolvedRefs() []intspec.UnresolvedRef {
+	return e.unresolvedRefs
 }
 
 // GetPathParamMismatches returns map-key path-variable reads (e.g.

--- a/internal/engine/unresolved_refs_test.go
+++ b/internal/engine/unresolved_refs_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	intspec "github.com/ehabterra/apispec/internal/spec"
+)
+
+// TestReportUnresolvedRefs covers the message a user actually sees when a type
+// resolved to nothing useful (issue #327). What matters is that it names the GO
+// TYPE: the mangled component name does not tell anyone which dependency to
+// register under externalTypes.
+func TestReportUnresolvedRefs(t *testing.T) {
+	capture := func(refs []intspec.UnresolvedRef) string {
+		var got string
+		e := NewEngine(&EngineConfig{OnPhase: func(phase string, _ time.Duration) { got = phase }})
+		e.unresolvedRefs = refs
+		e.reportUnresolvedRefs()
+		return got
+	}
+
+	t.Run("says nothing when everything resolved", func(t *testing.T) {
+		if msg := capture(nil); msg != "" {
+			t.Errorf("reported %q on a clean run", msg)
+		}
+	})
+
+	t.Run("names the Go type and counts sites", func(t *testing.T) {
+		msg := capture([]intspec.UnresolvedRef{
+			{Component: "github_com_golang-jwt_jwt_v5_RegisteredClaims", GoType: "github.com/golang-jwt/jwt/v5.RegisteredClaims", Sites: 3},
+			{Component: "xorm_io_xorm_convert_Conversion", GoType: "xorm.io/xorm/convert.Conversion", Sites: 1},
+		})
+
+		for _, want := range []string{
+			"2 type(s)",
+			"4 reference(s)",
+			"github.com/golang-jwt/jwt/v5.RegisteredClaims",
+			"(3 sites)",
+			"xorm.io/xorm/convert.Conversion",
+		} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("message does not mention %q:\n%s", want, msg)
+			}
+		}
+		// A single site needs no count — it would be noise on every entry.
+		if strings.Contains(msg, "(1 sites)") {
+			t.Errorf("single-site entry should carry no count:\n%s", msg)
+		}
+		// The mangled name is not what a user can act on.
+		if strings.Contains(msg, "github_com_golang-jwt") {
+			t.Errorf("message leaks the mangled component name:\n%s", msg)
+		}
+	})
+
+	t.Run("falls back to the component when the type is unknown", func(t *testing.T) {
+		msg := capture([]intspec.UnresolvedRef{{Component: "Mystery", Sites: 1}})
+		if !strings.Contains(msg, "Mystery") {
+			t.Errorf("message should name the component when the Go type is unknown:\n%s", msg)
+		}
+	})
+}
+
+// TestGetUnresolvedRefs covers the machine-readable half: a CI gate or the UI
+// reads this rather than grepping the warning text.
+func TestGetUnresolvedRefs(t *testing.T) {
+	e := NewEngine(&EngineConfig{})
+	if got := e.GetUnresolvedRefs(); len(got) != 0 {
+		t.Errorf("fresh engine reports %+v", got)
+	}
+
+	want := []intspec.UnresolvedRef{{Component: "T", GoType: "pkg.T", Sites: 2}}
+	e.unresolvedRefs = want
+	got := e.GetUnresolvedRefs()
+	if len(got) != 1 || got[0].GoType != "pkg.T" || got[0].Sites != 2 {
+		t.Errorf("GetUnresolvedRefs() = %+v, want %+v", got, want)
+	}
+}

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -218,6 +218,13 @@ type SecurityDiagnostics struct {
 	// (mux.Vars(r)["userId"]) whose key matches no route placeholder — a likely
 	// typo, since the read is always empty.
 	PathParamMismatches []PathParamMismatch
+
+	// UnresolvedRefs lists references the document could not satisfy, after
+	// they were repaired with a placeholder so the spec still loads. Non-empty
+	// means some type resolved to nothing useful: the operation is documented,
+	// its shape is not. Reported here rather than only on stderr so the UI and
+	// a CI gate can read it (issue #327).
+	UnresolvedRefs []UnresolvedRef
 }
 
 // MapMetadataToOpenAPI maps metadata to OpenAPI specification.
@@ -268,7 +275,7 @@ func MapMetadataToOpenAPIWithDiagnostics(tree TrackerTreeInterface, cfg *APISpec
 	paths := buildPathsFromRoutes(routes, handlerMethods...)
 
 	// Generate component schemas
-	components := generateComponentSchemas(tree.GetMetadata(), cfg, routes)
+	components, usedTypes := generateComponentSchemas(tree.GetMetadata(), cfg, routes)
 
 	// Register shared component parameters for dynamic-path placeholders
 	// (issue #34). Each unique placeholder name across routes becomes one
@@ -313,9 +320,16 @@ func MapMetadataToOpenAPIWithDiagnostics(tree TrackerTreeInterface, cfg *APISpec
 		spec.Components.SecuritySchemes = schemes
 	}
 
+	// Last, once every component is registered: make the document internally
+	// consistent. Anything still pointing at nothing is repaired with the
+	// honest placeholder and reported, so a spec that cannot resolve never
+	// reaches a viewer (issue #327).
+	unresolvedRefs := repairDanglingRefs(spec, usedTypes)
+
 	diag := &SecurityDiagnostics{
 		UnresolvedMiddleware: extractor.UnresolvedSecurity(),
 		PathParamMismatches:  extractor.PathParamMismatches(),
+		UnresolvedRefs:       unresolvedRefs,
 	}
 	return spec, diag, nil
 }
@@ -989,7 +1003,11 @@ func pathParamPatterns(path string) map[string]string {
 }
 
 // generateComponentSchemas generates component schemas from metadata
-func generateComponentSchemas(meta *metadata.Metadata, cfg *APISpecConfig, routes []*RouteInfo) Components {
+// generateComponentSchemas returns the components and the used-type map they
+// were built from. The map is the only place the ORIGINAL Go type names
+// survive — component naming mangles them — so the ref repair needs it to
+// report something a user can act on.
+func generateComponentSchemas(meta *metadata.Metadata, cfg *APISpecConfig, routes []*RouteInfo) (Components, map[string]*Schema) {
 	components := Components{
 		Schemas: make(map[string]*Schema),
 	}
@@ -1000,7 +1018,7 @@ func generateComponentSchemas(meta *metadata.Metadata, cfg *APISpecConfig, route
 	// Generate schemas for used types
 	generateSchemas(usedTypes, cfg, components, meta)
 
-	return components
+	return components, usedTypes
 }
 
 func generateSchemas(usedTypes map[string]*Schema, cfg *APISpecConfig, components Components, meta *metadata.Metadata) {

--- a/internal/spec/mapper_test.go
+++ b/internal/spec/mapper_test.go
@@ -796,7 +796,7 @@ func TestGenerateComponentSchemas(t *testing.T) {
 	cfg := DefaultGinConfig()
 
 	// Test component schema generation
-	components := generateComponentSchemas(meta, cfg, routes)
+	components, _ := generateComponentSchemas(meta, cfg, routes)
 	if components.Schemas == nil {
 		t.Fatal("Schemas should not be nil")
 	}

--- a/internal/spec/refcheck.go
+++ b/internal/spec/refcheck.go
@@ -111,13 +111,28 @@ func goTypeByComponentName(usedTypes map[string]*Schema) map[string]string {
 		return nil
 	}
 	out := make(map[string]string, len(usedTypes))
+	ambiguous := map[string]bool{}
+
 	for goType := range usedTypes {
-		name := schemaComponentNameReplacer.Replace(strings.TrimPrefix(goType, "*"))
-		// Several Go types can mangle to one name; prefer the shortest, which
-		// is the least decorated spelling of the same thing.
-		if prev, ok := out[name]; !ok || len(goType) < len(prev) {
-			out[name] = goType
+		// The same mangling the naming itself uses, so the two cannot disagree.
+		// Pointer spellings are stripped first: `*pkg.T` and `pkg.T` are one
+		// type, not a collision.
+		bare := strings.TrimPrefix(goType, "*")
+		name := schemaComponentNameReplacer.Replace(bare)
+
+		if prev, ok := out[name]; ok && prev != bare {
+			// Two DIFFERENT types mangling to one component name. Which one the
+			// reference meant is not knowable here, and naming the wrong
+			// dependency is worse than naming none (golden rule #7), so the
+			// report falls back to the component name.
+			ambiguous[name] = true
+			continue
 		}
+		out[name] = bare
+	}
+
+	for name := range ambiguous {
+		delete(out, name)
 	}
 	return out
 }
@@ -130,14 +145,21 @@ func goTypeByComponentName(usedTypes map[string]*Schema) map[string]string {
 // bodies, responses, headers, parameters and the components section each carry
 // their own.
 func forEachSchemaRef(spec *OpenAPISpec, visit func(name string)) {
-	seen := map[*Schema]bool{}
+	// A RECURSION STACK, not a global visited set: the same *Schema can be
+	// mounted in two operations, and both are references that need a target.
+	// Deduplicating globally would visit it once and undercount Sites, which
+	// is the number telling a user how much of their spec is affected. Only a
+	// schema currently being walked is skipped, which is what makes a
+	// self-referential type terminate.
+	onPath := map[*Schema]bool{}
 
 	var walk func(s *Schema)
 	walk = func(s *Schema) {
-		if s == nil || seen[s] {
+		if s == nil || onPath[s] {
 			return
 		}
-		seen[s] = true
+		onPath[s] = true
+		defer delete(onPath, s)
 
 		if name, ok := componentSchemaName(s.Ref); ok {
 			visit(name)

--- a/internal/spec/refcheck.go
+++ b/internal/spec/refcheck.go
@@ -1,0 +1,241 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"sort"
+	"strings"
+)
+
+// UnresolvedRef is a $ref the finished document could not satisfy, after it has
+// been repaired.
+type UnresolvedRef struct {
+	// Component is the name the $ref pointed at, e.g.
+	// "github_com_golang-jwt_jwt_v5_RegisteredClaims".
+	Component string
+	// GoType is the type that name was derived from, when it can be recovered
+	// — "github.com/golang-jwt/jwt/v5.RegisteredClaims". This is the actionable
+	// half: it names the dependency to register under `externalTypes`, which
+	// the mangled component name does not. Empty when the type is unknown.
+	GoType string
+	// Sites is how many references pointed at the missing component.
+	Sites int
+}
+
+// repairDanglingRefs makes the assembled document internally consistent: every
+// $ref it contains resolves to a component that exists.
+//
+// This is a last line of defence, not a substitute for resolving types
+// properly. Four separate causes of dangling references have been fixed
+// (#325, #326, #329, #333) and each was found the same way — by loading the
+// output into a viewer, which is not a check anyone runs on their own project.
+// The generator tests assert this per fixture (noDanglingRefs); nothing
+// asserted it for a user's actual code, which is where the unregistered
+// dependency types live.
+//
+// A missing target is REPAIRED rather than dropped: the reference is left in
+// place and the honest placeholder registered under it, so the document stays
+// loadable while the report says what was substituted. Removing the reference
+// instead would silently change an operation's shape.
+func repairDanglingRefs(spec *OpenAPISpec, usedTypes map[string]*Schema) []UnresolvedRef {
+	if spec == nil {
+		return nil
+	}
+
+	counts := map[string]int{}
+	forEachSchemaRef(spec, func(name string) { counts[name]++ })
+	if len(counts) == 0 {
+		return nil
+	}
+
+	defined := map[string]bool{}
+	if spec.Components != nil {
+		for name := range spec.Components.Schemas {
+			defined[name] = true
+		}
+	}
+
+	missing := make([]string, 0, len(counts))
+	for name := range counts {
+		if !defined[name] {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	// Sorted: the repair adds components, and map order would decide their
+	// insertion order and the report's order (golden rule #1).
+	sort.Strings(missing)
+
+	goTypes := goTypeByComponentName(usedTypes)
+
+	if spec.Components == nil {
+		spec.Components = &Components{}
+	}
+	if spec.Components.Schemas == nil {
+		spec.Components.Schemas = map[string]*Schema{}
+	}
+
+	out := make([]UnresolvedRef, 0, len(missing))
+	for _, name := range missing {
+		goType := goTypes[name]
+		described := goType
+		if described == "" {
+			described = name
+		}
+		spec.Components.Schemas[name] = unresolvedExternalPlaceholder(described)
+		out = append(out, UnresolvedRef{Component: name, GoType: goType, Sites: counts[name]})
+	}
+	return out
+}
+
+// goTypeByComponentName inverts the component naming, so a report can name the
+// Go type rather than the mangled key. The mangling is lossy — "/" and "." and
+// the type separator all become "_" — so it cannot be reversed by rewriting the
+// string; it is recovered by mangling the names we know and keeping the map.
+func goTypeByComponentName(usedTypes map[string]*Schema) map[string]string {
+	if len(usedTypes) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(usedTypes))
+	for goType := range usedTypes {
+		name := schemaComponentNameReplacer.Replace(strings.TrimPrefix(goType, "*"))
+		// Several Go types can mangle to one name; prefer the shortest, which
+		// is the least decorated spelling of the same thing.
+		if prev, ok := out[name]; !ok || len(goType) < len(prev) {
+			out[name] = goType
+		}
+	}
+	return out
+}
+
+// forEachSchemaRef visits every component-schema reference in the document.
+//
+// Every location matters: a reference missed here is one the repair leaves
+// dangling, which is the whole failure this function exists to prevent. Hence
+// walking the typed document rather than the schemas map alone — request
+// bodies, responses, headers, parameters and the components section each carry
+// their own.
+func forEachSchemaRef(spec *OpenAPISpec, visit func(name string)) {
+	seen := map[*Schema]bool{}
+
+	var walk func(s *Schema)
+	walk = func(s *Schema) {
+		if s == nil || seen[s] {
+			return
+		}
+		seen[s] = true
+
+		if name, ok := componentSchemaName(s.Ref); ok {
+			visit(name)
+		}
+		for _, p := range s.Properties {
+			walk(p)
+		}
+		walk(s.Items)
+		walk(s.AdditionalProperties)
+		walk(s.Not)
+		for _, list := range [][]*Schema{s.AllOf, s.OneOf, s.AnyOf} {
+			for _, member := range list {
+				walk(member)
+			}
+		}
+	}
+
+	walkParams := func(params []Parameter) {
+		for _, p := range params {
+			if name, ok := componentSchemaName(p.Ref); ok {
+				visit(name)
+			}
+			walk(p.Schema)
+		}
+	}
+	walkContent := func(content map[string]MediaType) {
+		for _, mt := range content {
+			walk(mt.Schema)
+		}
+	}
+	walkResponses := func(responses map[string]Response) {
+		for _, r := range responses {
+			walkContent(r.Content)
+			for _, h := range r.Headers {
+				walk(h.Schema)
+			}
+		}
+	}
+
+	for _, item := range spec.Paths {
+		walkParams(item.Parameters)
+		for _, op := range []*Operation{item.Get, item.Post, item.Put, item.Delete, item.Patch, item.Head, item.Options} {
+			if op == nil {
+				continue
+			}
+			walkParams(op.Parameters)
+			if op.RequestBody != nil {
+				walkContent(op.RequestBody.Content)
+			}
+			walkResponses(op.Responses)
+		}
+	}
+
+	if spec.Components == nil {
+		return
+	}
+	for _, s := range spec.Components.Schemas {
+		walk(s)
+	}
+	for _, p := range spec.Components.Parameters {
+		if p == nil {
+			continue
+		}
+		walk(p.Schema)
+	}
+	for _, rb := range spec.Components.RequestBodies {
+		if rb == nil {
+			continue
+		}
+		walkContent(rb.Content)
+	}
+	for _, r := range spec.Components.Responses {
+		if r == nil {
+			continue
+		}
+		walkContent(r.Content)
+		for _, h := range r.Headers {
+			walk(h.Schema)
+		}
+	}
+	for _, h := range spec.Components.Headers {
+		if h == nil {
+			continue
+		}
+		walk(h.Schema)
+	}
+}
+
+// componentSchemaName returns the component name a $ref points at, and whether
+// it is a local components/schemas reference at all. A remote or non-schema
+// reference is not ours to satisfy.
+func componentSchemaName(ref string) (string, bool) {
+	if ref == "" || !strings.HasPrefix(ref, refComponentsSchemasPrefix) {
+		return "", false
+	}
+	name := strings.TrimPrefix(ref, refComponentsSchemasPrefix)
+	if name == "" {
+		return "", false
+	}
+	return name, true
+}

--- a/internal/spec/refcheck_test.go
+++ b/internal/spec/refcheck_test.go
@@ -119,6 +119,32 @@ func TestForEachSchemaRefVisitsEveryLocation(t *testing.T) {
 	}
 }
 
+// TestForEachSchemaRefCountsSharedSchemasPerMount covers the reason the cycle
+// guard is a recursion stack rather than a global visited set: the same *Schema
+// value is often mounted in more than one place, and each mount is a reference
+// that needs a target. Deduplicating by pointer would report one site where
+// there are two, understating how much of the spec is affected.
+func TestForEachSchemaRefCountsSharedSchemasPerMount(t *testing.T) {
+	shared := refTo("T")
+	spec := &OpenAPISpec{Paths: map[string]PathItem{
+		"/a": {Get: &Operation{Responses: map[string]Response{"200": {Content: map[string]MediaType{"application/json": {Schema: shared}}}}}},
+		"/b": {Get: &Operation{Responses: map[string]Response{"200": {Content: map[string]MediaType{"application/json": {Schema: shared}}}}}},
+	}}
+
+	n := 0
+	forEachSchemaRef(spec, func(string) { n++ })
+	if n != 2 {
+		t.Errorf("counted %d sites for one schema mounted twice, want 2", n)
+	}
+
+	// And the repair reports it the same way.
+	spec.Components = &Components{Schemas: map[string]*Schema{}}
+	got := repairDanglingRefs(spec, nil)
+	if len(got) != 1 || got[0].Sites != 2 {
+		t.Errorf("repair reported %+v, want one entry with 2 sites", got)
+	}
+}
+
 func TestForEachSchemaRefIgnoresForeignRefs(t *testing.T) {
 	spec := specWithSchemas(map[string]*Schema{
 		"A": {Ref: "#/components/parameters/NotASchema"},

--- a/internal/spec/refcheck_test.go
+++ b/internal/spec/refcheck_test.go
@@ -1,0 +1,285 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+func timeAfterShort() <-chan time.Time { return time.After(5 * time.Second) }
+
+func refTo(name string) *Schema { return &Schema{Ref: refComponentsSchemasPrefix + name} }
+
+func specWithSchemas(s map[string]*Schema) *OpenAPISpec {
+	return &OpenAPISpec{Paths: map[string]PathItem{}, Components: &Components{Schemas: s}}
+}
+
+// TestForEachSchemaRefVisitsEveryLocation is the important one: a location the
+// walker misses is a reference the repair leaves dangling, which is the exact
+// failure this feature exists to prevent. Each case puts a reference in one
+// place and nowhere else.
+func TestForEachSchemaRefVisitsEveryLocation(t *testing.T) {
+	cases := map[string]func() *OpenAPISpec{
+		"operation response body": func() *OpenAPISpec {
+			return &OpenAPISpec{Paths: map[string]PathItem{"/a": {Get: &Operation{
+				Responses: map[string]Response{"200": {Content: map[string]MediaType{"application/json": {Schema: refTo("T")}}}},
+			}}}}
+		},
+		"operation request body": func() *OpenAPISpec {
+			return &OpenAPISpec{Paths: map[string]PathItem{"/a": {Post: &Operation{
+				RequestBody: &RequestBody{Content: map[string]MediaType{"application/json": {Schema: refTo("T")}}},
+			}}}}
+		},
+		"operation parameter schema": func() *OpenAPISpec {
+			return &OpenAPISpec{Paths: map[string]PathItem{"/a": {Get: &Operation{
+				Parameters: []Parameter{{Name: "id", Schema: refTo("T")}},
+			}}}}
+		},
+		"operation parameter $ref": func() *OpenAPISpec {
+			return &OpenAPISpec{Paths: map[string]PathItem{"/a": {Get: &Operation{
+				Parameters: []Parameter{{Ref: refComponentsSchemasPrefix + "T"}},
+			}}}}
+		},
+		"path-level parameter": func() *OpenAPISpec {
+			return &OpenAPISpec{Paths: map[string]PathItem{"/a": {
+				Parameters: []Parameter{{Name: "id", Schema: refTo("T")}},
+			}}}
+		},
+		"response header": func() *OpenAPISpec {
+			return &OpenAPISpec{Paths: map[string]PathItem{"/a": {Get: &Operation{
+				Responses: map[string]Response{"200": {Headers: map[string]Header{"X-Thing": {Schema: refTo("T")}}}},
+			}}}}
+		},
+		"component property": func() *OpenAPISpec {
+			return specWithSchemas(map[string]*Schema{"Outer": {Properties: map[string]*Schema{"f": refTo("T")}}})
+		},
+		"component array items": func() *OpenAPISpec {
+			return specWithSchemas(map[string]*Schema{"Outer": {Type: "array", Items: refTo("T")}})
+		},
+		"component additionalProperties": func() *OpenAPISpec {
+			return specWithSchemas(map[string]*Schema{"Outer": {Type: "object", AdditionalProperties: refTo("T")}})
+		},
+		"component oneOf member": func() *OpenAPISpec {
+			return specWithSchemas(map[string]*Schema{"Outer": {OneOf: []*Schema{refTo("T")}}})
+		},
+		"component allOf member": func() *OpenAPISpec {
+			return specWithSchemas(map[string]*Schema{"Outer": {AllOf: []*Schema{refTo("T")}}})
+		},
+		"component anyOf member": func() *OpenAPISpec {
+			return specWithSchemas(map[string]*Schema{"Outer": {AnyOf: []*Schema{refTo("T")}}})
+		},
+		"component not": func() *OpenAPISpec {
+			return specWithSchemas(map[string]*Schema{"Outer": {Not: refTo("T")}})
+		},
+		"components.parameters": func() *OpenAPISpec {
+			return &OpenAPISpec{Paths: map[string]PathItem{}, Components: &Components{
+				Parameters: map[string]*Parameter{"id": {Schema: refTo("T")}}}}
+		},
+		"components.requestBodies": func() *OpenAPISpec {
+			return &OpenAPISpec{Paths: map[string]PathItem{}, Components: &Components{
+				RequestBodies: map[string]*RequestBody{"b": {Content: map[string]MediaType{"application/json": {Schema: refTo("T")}}}}}}
+		},
+		"components.responses": func() *OpenAPISpec {
+			return &OpenAPISpec{Paths: map[string]PathItem{}, Components: &Components{
+				Responses: map[string]*Response{"r": {Content: map[string]MediaType{"application/json": {Schema: refTo("T")}}}}}}
+		},
+		"components.headers": func() *OpenAPISpec {
+			return &OpenAPISpec{Paths: map[string]PathItem{}, Components: &Components{
+				Headers: map[string]*Header{"h": {Schema: refTo("T")}}}}
+		},
+		"nested two deep": func() *OpenAPISpec {
+			return specWithSchemas(map[string]*Schema{"Outer": {Type: "array", Items: &Schema{
+				Properties: map[string]*Schema{"f": {Type: "array", Items: refTo("T")}}}}})
+		},
+	}
+
+	for name, build := range cases {
+		t.Run(name, func(t *testing.T) {
+			var seen []string
+			forEachSchemaRef(build(), func(n string) { seen = append(seen, n) })
+			if len(seen) != 1 || seen[0] != "T" {
+				t.Errorf("walker saw %v, want exactly [T]: a reference here would be left dangling", seen)
+			}
+		})
+	}
+}
+
+func TestForEachSchemaRefIgnoresForeignRefs(t *testing.T) {
+	spec := specWithSchemas(map[string]*Schema{
+		"A": {Ref: "#/components/parameters/NotASchema"},
+		"B": {Ref: "https://example.com/other.yaml#/components/schemas/Remote"},
+		"C": {Ref: ""},
+	})
+	var seen []string
+	forEachSchemaRef(spec, func(n string) { seen = append(seen, n) })
+	if len(seen) != 0 {
+		t.Errorf("walker claimed %v; only local components/schemas references are ours to satisfy", seen)
+	}
+}
+
+// TestForEachSchemaRefTerminatesOnCycles: a self-referential schema is normal
+// (a tree node with children of its own type), and the walk must not hang.
+func TestForEachSchemaRefTerminatesOnCycles(t *testing.T) {
+	node := &Schema{Type: "object", Properties: map[string]*Schema{"child": refTo("Node")}}
+	node.Properties["self"] = node
+
+	done := make(chan int, 1)
+	go func() {
+		n := 0
+		forEachSchemaRef(specWithSchemas(map[string]*Schema{"Node": node}), func(string) { n++ })
+		done <- n
+	}()
+	select {
+	case n := <-done:
+		if n != 1 {
+			t.Errorf("saw %d references, want 1", n)
+		}
+	case <-timeAfterShort():
+		t.Fatal("walk did not terminate on a self-referential schema")
+	}
+}
+
+func TestRepairDanglingRefs(t *testing.T) {
+	t.Run("registers a placeholder and reports the Go type", func(t *testing.T) {
+		spec := &OpenAPISpec{
+			Paths: map[string]PathItem{"/a": {Get: &Operation{
+				Responses: map[string]Response{"200": {Content: map[string]MediaType{
+					"application/json": {Schema: refTo("github_com_golang-jwt_jwt_v5_RegisteredClaims")}}}},
+			}}},
+			Components: &Components{Schemas: map[string]*Schema{}},
+		}
+		usedTypes := map[string]*Schema{"github.com/golang-jwt/jwt/v5.RegisteredClaims": nil}
+
+		got := repairDanglingRefs(spec, usedTypes)
+
+		if len(got) != 1 {
+			t.Fatalf("reported %d unresolved refs, want 1: %+v", len(got), got)
+		}
+		if got[0].GoType != "github.com/golang-jwt/jwt/v5.RegisteredClaims" {
+			t.Errorf("GoType = %q; the mangled name does not tell a user which dependency to register", got[0].GoType)
+		}
+		if got[0].Sites != 1 {
+			t.Errorf("Sites = %d, want 1", got[0].Sites)
+		}
+
+		// Repaired, not dropped: the reference still resolves.
+		placeholder, ok := spec.Components.Schemas["github_com_golang-jwt_jwt_v5_RegisteredClaims"]
+		if !ok {
+			t.Fatal("no component was registered; the $ref still dangles")
+		}
+		if !strings.Contains(placeholder.Description, "github.com/golang-jwt/jwt/v5.RegisteredClaims") {
+			t.Errorf("placeholder describes %q; it should name the Go type", placeholder.Description)
+		}
+	})
+
+	t.Run("counts every site", func(t *testing.T) {
+		spec := &OpenAPISpec{
+			Paths: map[string]PathItem{
+				"/a": {Get: &Operation{Responses: map[string]Response{"200": {Content: map[string]MediaType{"application/json": {Schema: refTo("T")}}}}}},
+				"/b": {Get: &Operation{Responses: map[string]Response{"200": {Content: map[string]MediaType{"application/json": {Schema: refTo("T")}}}}}},
+			},
+			Components: &Components{Schemas: map[string]*Schema{}},
+		}
+		got := repairDanglingRefs(spec, nil)
+		if len(got) != 1 || got[0].Sites != 2 {
+			t.Errorf("got %+v, want one entry with 2 sites", got)
+		}
+	})
+
+	t.Run("leaves a resolvable document alone", func(t *testing.T) {
+		real := &Schema{Type: "object"}
+		spec := specWithSchemas(map[string]*Schema{"T": real, "Outer": {Properties: map[string]*Schema{"f": refTo("T")}}})
+
+		if got := repairDanglingRefs(spec, nil); len(got) != 0 {
+			t.Errorf("reported %+v on a document whose refs all resolve", got)
+		}
+		if spec.Components.Schemas["T"] != real {
+			t.Error("an existing component was overwritten")
+		}
+	})
+
+	t.Run("falls back to the component name when the type is unknown", func(t *testing.T) {
+		spec := specWithSchemas(map[string]*Schema{"Outer": {Properties: map[string]*Schema{"f": refTo("Mystery")}}})
+		got := repairDanglingRefs(spec, nil)
+		if len(got) != 1 || got[0].Component != "Mystery" {
+			t.Fatalf("got %+v, want the component reported", got)
+		}
+		if got[0].GoType != "" {
+			t.Errorf("GoType = %q, want empty when it cannot be recovered", got[0].GoType)
+		}
+		if !strings.Contains(spec.Components.Schemas["Mystery"].Description, "Mystery") {
+			t.Error("placeholder should fall back to naming the component")
+		}
+	})
+
+	t.Run("is deterministic", func(t *testing.T) {
+		build := func() *OpenAPISpec {
+			return specWithSchemas(map[string]*Schema{"Outer": {AllOf: []*Schema{
+				refTo("Zeta"), refTo("Alpha"), refTo("Mid")}}})
+		}
+		var first []string
+		for i := 0; i < 5; i++ {
+			var names []string
+			for _, r := range repairDanglingRefs(build(), nil) {
+				names = append(names, r.Component)
+			}
+			if i == 0 {
+				first = names
+				if !sort.StringsAreSorted(names) {
+					t.Errorf("report is not sorted: %v — map order would reach the output (golden rule #1)", names)
+				}
+				continue
+			}
+			if strings.Join(names, ",") != strings.Join(first, ",") {
+				t.Errorf("run %d reported %v, first run reported %v", i, names, first)
+			}
+		}
+	})
+
+	t.Run("handles a spec with no components section", func(t *testing.T) {
+		spec := &OpenAPISpec{Paths: map[string]PathItem{"/a": {Get: &Operation{
+			Responses: map[string]Response{"200": {Content: map[string]MediaType{"application/json": {Schema: refTo("T")}}}},
+		}}}}
+		if got := repairDanglingRefs(spec, nil); len(got) != 1 {
+			t.Fatalf("got %+v, want the dangling ref reported", got)
+		}
+		if spec.Components == nil || spec.Components.Schemas["T"] == nil {
+			t.Error("the components section should have been created to hold the repair")
+		}
+	})
+
+	t.Run("nil spec is not a crash", func(t *testing.T) {
+		if got := repairDanglingRefs(nil, nil); got != nil {
+			t.Errorf("got %+v, want nil", got)
+		}
+	})
+}
+
+func TestGoTypeByComponentName(t *testing.T) {
+	got := goTypeByComponentName(map[string]*Schema{
+		"github.com/x/y.Thing":  nil,
+		"*github.com/x/y.Thing": nil, // pointer spelling mangles to the same name
+		"main.User":             nil,
+	})
+	if got["github_com_x_y_Thing"] != "github.com/x/y.Thing" {
+		t.Errorf("qualified type = %q, want the undecorated spelling", got["github_com_x_y_Thing"])
+	}
+	if got["main_User"] != "main.User" {
+		t.Errorf("main.User = %q", got["main_User"])
+	}
+}

--- a/spec/spec.go
+++ b/spec/spec.go
@@ -27,6 +27,10 @@ type SecurityScheme = intspec.SecurityScheme
 type SecurityPattern = intspec.SecurityPattern
 type SecurityMapping = intspec.SecurityMapping
 type MiddlewareRef = intspec.MiddlewareRef
+
+// UnresolvedRef reports a $ref the generated document could not satisfy, after
+// it was repaired with a placeholder — see Generator.UnresolvedRefs.
+type UnresolvedRef = intspec.UnresolvedRef
 type FrameworkConfig = intspec.FrameworkConfig
 type Tag = intspec.Tag
 


### PR DESCRIPTION
Closes #327. The last item I would want in v0.5.7.

## Why now

This cycle fixed **four separate causes** of dangling `$ref`s — #325 (dependency types with no declaration), #326 (fixed-size arrays, untyped constants), #329 (mis-qualified types), #333 (named container types). Every one was found the same way: by loading the output into a viewer.

That is not a check anyone runs against their own project, and the symptom is brutal — Swagger UI refuses the whole document over a single unresolvable reference. The generator tests assert this per fixture (`noDanglingRefs`); nothing asserted it for a user's actual code, which is exactly where the unregistered dependency types live.

## What it does

Generation now ends by making the document internally consistent. A missing target is **repaired, not dropped** — the reference stays and the honest placeholder is registered under it, because removing the reference would silently change an operation's shape.

The report names the **Go type**:

```
2 type(s) had no schema and were inlined as unresolved across 4 reference(s):
github.com/golang-jwt/jwt/v5.RegisteredClaims (3 sites), xorm.io/xorm/convert.Conversion
```

`github.com/golang-jwt/jwt/v5.RegisteredClaims` tells a user which dependency to register under `externalTypes`. `github_com_golang-jwt_jwt_v5_RegisteredClaims` does not. The mangling is lossy (`/`, `.` and the type separator all become `_`), so the Go type is recovered by mangling the names already in `usedTypes` and keeping the map — which is why `generateComponentSchemas` now returns it.

Machine-readable too, via `SecurityDiagnostics.UnresolvedRefs`, `Engine.GetUnresolvedRefs` and `Generator.UnresolvedRefs`, so the UI and a CI gate need not grep stderr. **The exit-code half stays with #297 (`--strict`)** — this is the condition that flag would promote, not a second flag.

## The walker is the part that has to be right

A location it misses is a reference the repair leaves dangling — the same silent failure, one level up. So it walks the typed document rather than the schemas map: path- and operation-level parameters, request bodies, responses, response headers, and `components`' schemas, parameters, requestBodies, responses and headers.

**18 tests, one per location**, each putting a reference in exactly one place and asserting the walker finds precisely it. Plus foreign/non-schema refs ignored, a self-referential schema terminating, sorted output (golden rule #1 — the repair inserts components, so map order would reach the output), and existing components never overwritten.

## Verified against a real regression

I reintroduced one of the bugs this release fixed — disabled the untyped-constant normalisation — and re-ran:

```
[engine] 1 type(s) had no schema and were inlined as unresolved across 1 reference(s): untyped bool
dangling after repair: []
```

It catches it, names it in Go terms, and the output still loads. On a healthy tree (this repo, and the fixtures) it reports nothing and changes nothing.

## Note on the end-to-end test

The fixture-level test asserts the **invariant**, not a non-empty report: since #325 the generation pass already registers a placeholder for a type it cannot resolve, so nothing reaches the final repair. An empty report is the healthy state. I had it `t.Skip` on empty at first, which is misleading — a skipping test reads as coverage it is not providing. The repair itself is exercised directly by the unit tests.

Coverage is back at 96.0% against the floor of 96 (the new reporting path needed its own tests to get there).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reporting for unresolved schema references during document generation.
  * Generated documents now preserve unresolved references with placeholder schemas, preventing dangling references.
  * Reports include the affected component, Go type when available, and the number of reference sites.
  * Added public access to unresolved-reference details through the generator API.
  * Unresolved-reference diagnostics are now included in extraction results for easier troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->