### PR TITLE
perf(spec): raise the default instance cap to 100 (#224)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ openapi*.yaml
 
 # Local, machine-specific external project list for scripts/compare-spec.sh
 scripts/compare-spec.paths
+# scripts/compare-spec.sh writes a project's stderr here and removes it again;
+# an interrupted run leaves the file behind, which must not read as a change.
+.compare_err
 
 # Test output
 *.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`--max-instances-per-key` now defaults to 100 (was 25).** The reason is how
+  25 failed, not how often: on a 374-route service, adding three handlers in an
+  unrelated feature pushed a shared response helper past 25 copies and silently
+  removed the response body of an endpoint nobody had touched. A threshold that
+  moves when you edit somewhere else cannot be verified safe by any project. At
+  100 that service documents all nine bodies it was missing, for about 1s.
+  (#224)
+- **Some projects pay for that and gain nothing.** The cost is uneven: medium
+  projects show no measurable change, but a 163-route service emits a
+  byte-identical spec and takes 1.8× as long (7s → 13s), because its instance
+  cap fires millions of times inside error-formatting call diamonds that no
+  response body depends on. If your spec is unchanged at
+  `--max-instances-per-key 25`, set it explicitly — you give up only the
+  guarantee that the number stays safe as the code grows. (#224)
+
 ## [0.5.6] - 2026-08-08
 
 The largest correctness release so far. On a ~900-route project the documented

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unrelated feature pushed a shared response helper past 25 copies and silently
   removed the response body of an endpoint nobody had touched. A threshold that
   moves when you edit somewhere else cannot be verified safe by any project. At
-  100 that service documents all nine bodies it was missing, for about 1s; this
-  repo's own spec gains one body it had been missing. (#224)
+  100 that service documents all nine bodies it was missing, for about 1.1× the
+  run time; this repo's own spec gains one body it had been missing. (#224)
 - **Some projects pay for that and gain nothing.** The cost is uneven: medium
   projects show no measurable change, but a 163-route service emits a
   byte-identical spec and takes 1.8× as long (7s → 13s), because its instance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unrelated feature pushed a shared response helper past 25 copies and silently
   removed the response body of an endpoint nobody had touched. A threshold that
   moves when you edit somewhere else cannot be verified safe by any project. At
-  100 that service documents all nine bodies it was missing, for about 1s.
-  (#224)
+  100 that service documents all nine bodies it was missing, for about 1s; this
+  repo's own spec gains one body it had been missing. (#224)
 - **Some projects pay for that and gain nothing.** The cost is uneven: medium
   projects show no measurable change, but a 163-route service emits a
   byte-identical spec and takes 1.8× as long (7s → 13s), because its instance

--- a/README.md
+++ b/README.md
@@ -987,10 +987,11 @@ But how high that ancestor sits depends on how the app is wired, and that is wha
 | 40  | 391 / 391 | 82s | — | — | — |
 | 100 (default) | 391 / 391 | — | 0 bodies empty, 9s | identical spec, 13s | 0 bodies empty, 9.2s |
 
-The last three columns are one measurement session on one machine; absolute wall
-clock varies with hardware, so only the difference between rows is comparable.
-"Empty" means a response that rendered as `application/json: {}` — content
-present, schema missing.
+The last three columns are one measurement session on one machine. Absolute wall
+clock varies with hardware, and so does the gap between two rows — what carries
+across machines is the **ratio**: the 163-route service's 13s / 7s = 1.8× is the
+comparable figure, not the "+6s". "Empty" means a response that rendered as
+`application/json: {}` — content present, schema missing.
 
 The default moved from 25 to 100 because of how 25 failed rather than how often:
 on the 374-route service, adding three handlers in an unrelated feature pushed a
@@ -999,8 +1000,8 @@ an endpoint nobody had touched. The threshold moves when you edit elsewhere, so
 no project can tell whether it is safe.
 
 **The cost is uneven, and on some projects it is large.** Medium projects (~20
-paths) show no measurable change. The 374-route service pays about 1s for the
-nine bodies it gains, and this repo about 0.6s for one. But a 163-route service
+paths) show no measurable change. The 374-route service pays about 1.1× for the
+nine bodies it gains, and this repo about 1.07× for one. But a 163-route service
 produced a byte-identical spec and took **1.8× as long** (7s → 13s) — it pays
 the whole cost for nothing, because its cap fires 3.6M times inside
 error-formatting call diamonds that no response body depends on. If your

--- a/README.md
+++ b/README.md
@@ -976,14 +976,21 @@ So the two flags fail in different ways, and the warnings say which happened:
 
 Instead of the recursion-depth / nested-args caps, the lazy engine bounds copies of one callee **within an instance scope**: it keeps a copy of a shared helper per route so per-route value tracing stays accurate, but cuts the combinatorial copies a call diamond inside a single handler would otherwise create — the role the eager tree's per-ID recursion cap plays.
 
-The scope is the nearest argument ancestor — in practice the handler, including for routes registered inside a group closure (`r.Route("/x", func(r chi.Router) {…})`, where the handler argument node, not the closure, is the nearest ancestor; `testdata/group_closure_instances` pins this). What exhausts a scope is therefore a call diamond *inside one handler's* reach: a shared response helper reached along enough distinct paths runs out of copies, and the route silently loses its response body. Raising `--max-instances-per-key` is the remedy until the cap is scoped per route (issue #224); it is a real trade, measured across several services:
+The scope is the nearest argument ancestor. For a route registered directly — or inside a group closure (`r.Route("/x", func(r chi.Router) {…})`) — that is the **handler**, not the closure; `testdata/group_closure_instances` pins this, and it is why a group of 15 routes sharing one responder keeps every body down to a cap of 1.
 
-| `--max-instances-per-key` | success bodies (330-route service) | time (107-route service) | 374-route service | 163-route service |
-|---|---|---|---|---|
-| 5   | 77 / 391  | — | — | — |
-| 25 (previous default) | 391 / 391 | 66s | 9 bodies empty, 8s | identical spec, 7s |
-| 40  | 391 / 391 | 82s | — | — |
-| 100 (default) | 391 / 391 | — | 0 bodies empty, 9s | identical spec, 13s |
+But how high that ancestor sits depends on how the app is wired, and that is what makes a fixed number unsafe. On the 374-route service below, the first scope to run out was the argument node of a constructor call in the composition root — above every handler it reaches, so those handlers share one allowance and the routes that lose their bodies are decided by expansion order rather than by anything about themselves. Raising `--max-instances-per-key` is the remedy until the cap is scoped per route (issue #224); it is a real trade, measured across several services:
+
+| `--max-instances-per-key` | success bodies (330-route service) | time (107-route service) | 374-route service | 163-route service | this repo (34 routes) |
+|---|---|---|---|---|---|
+| 5   | 77 / 391  | — | — | — | — |
+| 25 (previous default) | 391 / 391 | 66s | 9 bodies empty, 8s | identical spec, 7s | 1 body empty, 8.6s |
+| 40  | 391 / 391 | 82s | — | — | — |
+| 100 (default) | 391 / 391 | — | 0 bodies empty, 9s | identical spec, 13s | 0 bodies empty, 9.2s |
+
+The last three columns are one measurement session on one machine; absolute wall
+clock varies with hardware, so only the difference between rows is comparable.
+"Empty" means a response that rendered as `application/json: {}` — content
+present, schema missing.
 
 The default moved from 25 to 100 because of how 25 failed rather than how often:
 on the 374-route service, adding three handlers in an unrelated feature pushed a
@@ -993,8 +1000,10 @@ no project can tell whether it is safe.
 
 **The cost is uneven, and on some projects it is large.** Medium projects (~20
 paths) show no measurable change. The 374-route service pays about 1s for the
-nine bodies it gains. But a 163-route service produced a byte-identical spec and
-took **1.8× as long** (7s → 13s) — it pays the whole cost for nothing. If your
+nine bodies it gains, and this repo about 0.6s for one. But a 163-route service
+produced a byte-identical spec and took **1.8× as long** (7s → 13s) — it pays
+the whole cost for nothing, because its cap fires 3.6M times inside
+error-formatting call diamonds that no response body depends on. If your
 spec does not change when you set `--max-instances-per-key 25`, set it: the
 lower cap is safe *for the code as it stands today*, which is exactly the
 guarantee the default gives up in exchange for not depending on where the next

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ apispec --output openapi.yaml --skip-cgo
 | `--max-args`                | `-ma`     | Max arguments per function                             | `100`                           |
 | `--max-nested-args`         | `-md`     | Max depth for nested arguments                         | `100`                           |
 | `--max-recursion-depth`     | `-mrd`    | Max recursion depth (anti-loop)                        | `10`                            |
-| `--max-instances-per-key`   |           | Max copies of one callee within an instance scope (lazy engine) | `25`                   |
+| `--max-instances-per-key`   |           | Max copies of one callee within an instance scope (lazy engine) | `100`                  |
 | `--legacy-tracker`          |           | Use the legacy (eager) tracker tree instead of the default lazy tracker | `false`        |
 | `--skip-cgo`                |           | Skip CGO packages                                      | `true`                          |
 | `--include-file`            |           | Include files matching pattern (repeatable)            | `""`                            |
@@ -965,7 +965,7 @@ APISpec applies safeguards to prevent runaway analysis. **Not every knob applies
 | Max args / function  | 100      | `--max-args`            | both                                                                       |
 | Max nested arg depth | 100      | `--max-nested-args`     | **eager only**                                                             |
 | Max recursion depth  | 10       | `--max-recursion-depth` | **eager only**                                                             |
-| Max instances / key  | 25       | `--max-instances-per-key` | **lazy only**                                                            |
+| Max instances / key  | 100      | `--max-instances-per-key` | **lazy only**                                                            |
 
 The lazy engine's node budget is **two budgets, and they are independent**. That split is what keeps truncation local (issue #264). With one global budget the walk is depth-first, so whatever expands first spends it and every route not yet *reached* is lost outright — on a ~900-route project the allowance was gone inside configuration and logging packages, and the run documented **12 paths**. Bounding a route's detail separately, and charging its keys only to its own allowance, took the same project to **640**.
 
@@ -976,15 +976,32 @@ So the two flags fail in different ways, and the warnings say which happened:
 
 Instead of the recursion-depth / nested-args caps, the lazy engine bounds copies of one callee **within an instance scope**: it keeps a copy of a shared helper per route so per-route value tracing stays accurate, but cuts the combinatorial copies a call diamond inside a single handler would otherwise create — the role the eager tree's per-ID recursion cap plays.
 
-The scope is the nearest argument ancestor, which is "per handler" only when routes are registered directly. Register them inside a group closure (`r.Route("/x", func(r chi.Router) {…})`) and the *closure* becomes the scope for every route in the group, so a response helper shared across it exhausts the budget after that many routes and every later route in the group silently loses its response body. Raising `--max-instances-per-key` is the remedy until the cap is scoped per route (issue #224); it is a real trade, measured on a ~330-route service and a 107-route service:
+The scope is the nearest argument ancestor — in practice the handler, including for routes registered inside a group closure (`r.Route("/x", func(r chi.Router) {…})`, where the handler argument node, not the closure, is the nearest ancestor; `testdata/group_closure_instances` pins this). What exhausts a scope is therefore a call diamond *inside one handler's* reach: a shared response helper reached along enough distinct paths runs out of copies, and the route silently loses its response body. Raising `--max-instances-per-key` is the remedy until the cap is scoped per route (issue #224); it is a real trade, measured across several services:
 
-| `--max-instances-per-key` | success bodies (330-route service) | time (107-route service) |
-|---|---|---|
-| 5   | 77 / 391  | — |
-| 25 (default) | 391 / 391 | 66s |
-| 40  | 391 / 391 | 82s |
+| `--max-instances-per-key` | success bodies (330-route service) | time (107-route service) | 374-route service | 163-route service |
+|---|---|---|---|---|
+| 5   | 77 / 391  | — | — | — |
+| 25 (previous default) | 391 / 391 | 66s | 9 bodies empty, 8s | identical spec, 7s |
+| 40  | 391 / 391 | 82s | — | — |
+| 100 (default) | 391 / 391 | — | 0 bodies empty, 9s | identical spec, 13s |
 
-Raise it when success responses are missing bodies on a project with large route groups; leave it alone otherwise, since the cost is paid by every project regardless of shape.
+The default moved from 25 to 100 because of how 25 failed rather than how often:
+on the 374-route service, adding three handlers in an unrelated feature pushed a
+shared response helper past 25 copies and silently removed the response body of
+an endpoint nobody had touched. The threshold moves when you edit elsewhere, so
+no project can tell whether it is safe.
+
+**The cost is uneven, and on some projects it is large.** Medium projects (~20
+paths) show no measurable change. The 374-route service pays about 1s for the
+nine bodies it gains. But a 163-route service produced a byte-identical spec and
+took **1.8× as long** (7s → 13s) — it pays the whole cost for nothing. If your
+spec does not change when you set `--max-instances-per-key 25`, set it: the
+lower cap is safe *for the code as it stands today*, which is exactly the
+guarantee the default gives up in exchange for not depending on where the next
+endpoint is added.
+
+Raise it above 100 when success responses are still missing bodies on a project
+with very large route groups.
 
 When a limit is reached, APISpec logs a clear warning, e.g.:
 

--- a/generator/testdata_group_closure_instances_test.go
+++ b/generator/testdata_group_closure_instances_test.go
@@ -53,8 +53,11 @@ func TestTestdata_GroupClosureInstances(t *testing.T) {
 	)
 
 	// One is the harshest cap that still permits a single copy of each callee.
-	// If the scope spanned the group, this could not document 15 routes.
-	for _, cap := range []int{1, 25} {
+	// If the scope spanned the group, this could not document 15 routes. The
+	// shipped default is read from the constant rather than written out, so
+	// raising or lowering it re-runs this sweep at the value that actually
+	// ships (the per-route sweep below does the same).
+	for _, cap := range []int{1, intspec.DefaultMaxInstancesPerKey} {
 		t.Run(fmt.Sprintf("cap=%d", cap), func(t *testing.T) {
 			cfg := engine.DefaultEngineConfig()
 			cfg.InputDir = filepath.Join("..", "testdata", fixture)

--- a/internal/spec/lazytree.go
+++ b/internal/spec/lazytree.go
@@ -288,16 +288,46 @@ const (
 //	 40   390 / 390 bodies     82s  (107 paths)
 //	400   390 / 390 bodies    ~2x again
 //
-// 25 recovers 99.2% of the bodies for +0.6s on the starved service, while 40
-// buys the last three and costs the second service another 16s for no extra
-// route at all. So 25, and the remaining three wait for the real fix.
+// 25 recovered 99.2% of the bodies for +0.6s on the starved service, while 40
+// bought the last three and cost the second service another 16s for no extra
+// route at all.
 //
-// That asymmetry is the argument for #224: the cap is being applied to the wrong
-// UNIT. Scoped per route instead of per argument ancestor, a handful of copies
-// would be ample everywhere and no project would pay for another's shape. Until
-// then this stays a mitigation — a group with more than ~25 routes sharing one
-// helper still starves, silently.
-const DefaultMaxInstancesPerKey = 25
+// RAISED TO 100. 25 held for as long as it took another service to grow into
+// it, and the way it failed is the argument: on a ~374-route service, adding
+// three handlers in an unrelated feature pushed a shared response helper past
+// 25 copies and silently deleted the body of an endpoint nobody had touched.
+// Nine 2xx bodies were empty at 25 and none at 100. The failure is not "large
+// projects need more" — it is that the threshold moves when you edit somewhere
+// else, so no project can know it is safe (evidence on #224).
+//
+// Re-measured for the new value:
+//
+//	                          cap 25            cap 100
+//	374-route chi service     13.4s, 9 empty    15.3s, 0 empty
+//	this repo (34 routes)     13.2s, 0 empty    14.5s, 0 empty
+//	163-route chi service      7.0s, identical  12.8s, identical
+//	19-path medium project     1s, identical     1s, identical
+//
+// The thing being bought changed, which is why this trade reads differently
+// from the 25-vs-40 one above: 40 bought three bodies, 100 buys the property
+// that adding an endpoint cannot silently remove documentation from another.
+//
+// The cost is NOT uniform, and the third row is the honest part of this
+// decision: that service emits a byte-identical spec at both caps and takes
+// 1.8x as long at 100 — it pays the entire cost for nothing. The cap fires
+// there 3.6M times, first inside an error-formatting diamond (fmt.Errorf in a
+// mongo mapper) that no response body depends on: the cap is doing its job, and
+// a higher cap simply buys each of those dead copies 4x more work. Projects in
+// that position should set --max-instances-per-key 25 explicitly; what they
+// give up by doing so is only the guarantee that the number stays safe when
+// the code is edited somewhere else.
+//
+// This is still a mitigation, not the fix. The cap is applied to the wrong
+// UNIT (#224): scoped per route rather than per argument ancestor, a handful of
+// copies would be ample everywhere and no project would pay for another's
+// shape. A group with more than ~100 routes sharing one helper still starves,
+// silently — the number moved, the shape did not.
+const DefaultMaxInstancesPerKey = 100
 
 // instanceBudget is the cap in force for this tree: the configured value, or the
 // default. It is configurable because the right number depends on a project's

--- a/internal/spec/lazytree.go
+++ b/internal/spec/lazytree.go
@@ -274,10 +274,12 @@ const (
 // `--max-instances-per-key 1` — because the handler argument node, not the group
 // closure, is the nearest argument ancestor and therefore the scope.
 //
-// So the cap is per-handler in that shape, and the starving service has a shape
-// not yet reproduced. Rather than guess again, noteInstanceTruncation now names
-// the scope that ran out whenever the cap fires, which is the one fact that
-// distinguishes a bounded diamond from a starved route.
+// So the cap is per-handler in that shape. Rather than guess again,
+// noteInstanceTruncation names the scope that ran out whenever the cap fires,
+// which is the one fact that distinguishes a bounded diamond from a starved
+// route — and that report is what finally identified the real shape: an
+// argument node ABOVE the handlers, not below them. See the bottom of this
+// comment.
 //
 // The value is measured, not guessed — and the measurement is a TRADE, because
 // raising the cap costs projects that gain nothing from it:
@@ -300,19 +302,23 @@ const (
 // projects need more" — it is that the threshold moves when you edit somewhere
 // else, so no project can know it is safe (evidence on #224).
 //
-// Re-measured for the new value:
+// Re-measured for the new value. All four rows are ONE session on one machine,
+// because absolute wall clock is machine-dependent and earlier runs of the top
+// row on other hardware read 13.4s / 15.3s — only the ratio between the two
+// columns is comparable, and "empty" means a 2xx that rendered as
+// `application/json: {}`, content present and schema missing:
 //
 //	                          cap 25            cap 100
-//	374-route chi service     13.4s, 9 empty    15.3s, 0 empty
-//	this repo (34 routes)     13.2s, 0 empty    14.5s, 0 empty
-//	163-route chi service      7.0s, identical  12.8s, identical
+//	374-route chi service      8s, 9 empty       9s, 0 empty
+//	163-route chi service      7s, identical    13s, identical
+//	this repo (34 routes)      8.6s, 1 empty     9.2s, 0 empty
 //	19-path medium project     1s, identical     1s, identical
 //
 // The thing being bought changed, which is why this trade reads differently
 // from the 25-vs-40 one above: 40 bought three bodies, 100 buys the property
 // that adding an endpoint cannot silently remove documentation from another.
 //
-// The cost is NOT uniform, and the third row is the honest part of this
+// The cost is NOT uniform, and the second row is the honest part of this
 // decision: that service emits a byte-identical spec at both caps and takes
 // 1.8x as long at 100 — it pays the entire cost for nothing. The cap fires
 // there 3.6M times, first inside an error-formatting diamond (fmt.Errorf in a
@@ -325,15 +331,23 @@ const (
 // This is still a mitigation, not the fix. The cap is applied to the wrong
 // UNIT (#224): scoped per route rather than per argument ancestor, a handful of
 // copies would be ample everywhere and no project would pay for another's
-// shape. A group with more than ~100 routes sharing one helper still starves,
-// silently — the number moved, the shape did not.
+// shape.
+//
+// The number moved; the shape did not. What still starves is an argument node
+// whose subtree spans many routes — NOT the group closure the retracted
+// explanation above blamed. On the 374-route service the first scope to run out
+// at 25 was `notify.New.params`: the argument node of a constructor call in the
+// composition root, above every handler it reaches. Which node that is depends
+// on how an app is wired, which is precisely why no fixed number is safe.
 const DefaultMaxInstancesPerKey = 100
 
 // instanceBudget is the cap in force for this tree: the configured value, or the
 // default. It is configurable because the right number depends on a project's
-// shape — a group closure holding 40 routes needs more than one holding 5, and
-// until the cap is scoped per route (issue #224) the only way to document such a
-// project is to raise it.
+// shape — an argument node whose subtree reaches 40 routes needs more than one
+// reaching 5 — and until the cap is scoped per route (issue #224) raising it is
+// the only way to document a project whose wiring puts that node high. Lowering
+// it is equally legitimate: see DefaultMaxInstancesPerKey for a service that
+// pays 1.8x at the default for a byte-identical spec.
 func (t *LazyTree) instanceBudget() int {
 	if t.limits.MaxInstancesPerKey > 0 {
 		return t.limits.MaxInstancesPerKey


### PR DESCRIPTION
Raises `--max-instances-per-key` from 25 to 100.

## Why 25 had to move

Not because large projects need more, but because of *how* 25 failed. On a
374-route service, adding three handlers in an unrelated feature pushed a shared
response helper past 25 copies and silently removed the response body of an
endpoint nobody had touched. The threshold moves when you edit somewhere else,
so no project can tell whether its current value is safe.

Nine 2xx bodies were empty at 25 and none at 100. The empty shape is
`application/json: {}` — content present, schema missing — which is worth noting
because a "missing content" count reports **zero** difference and hides the
entire effect.

## The cost is uneven, and one measurement argues against this

|  | cap 25 | cap 100 |
|---|---|---|
| 374-route chi service | 9 bodies empty, 8s | 0 bodies empty, 9s |
| 163-route chi service | identical spec, 7s | identical spec, 13s |
| ~19-path medium project | identical spec, 1s | identical spec, 1s |
| this repo (34 routes) | 0 empty, 13.2s | 0 empty, 14.5s |

The 163-route service emits a **byte-identical** spec at both caps and takes
**1.8× as long** at 100 — it pays the entire cost for nothing. Its cap fires
3.6M times, first inside a `fmt.Errorf` diamond in a mongo mapper that no
response body depends on; a higher cap just buys each dead copy 4× more work.

That is documented in the comment, the README and the CHANGELOG rather than
buried, along with the remedy: projects whose spec is unchanged at
`--max-instances-per-key 25` should pin it. What they give up by doing so is
only the guarantee that the number stays safe as the code grows.

This remains a mitigation. The cap is applied to the wrong UNIT (#224) — scoped
per route rather than per argument ancestor, a handful of copies would be ample
everywhere and no project would pay for another's shape.

## Measured and deliberately NOT changed

`--max-nodes-per-route` (1,000,000) truncates 2 of 163 route subtrees on that
same service, which looked like the next candidate. Raising it to 4M produces a
byte-identical spec, so the truncation costs nothing and the default stays.

## Also in here

- **The README asserted a mechanism the fixture disproves.** It said a chi group
  closure becomes the instance scope for every route in the group.
  `testdata/group_closure_instances` shows the *handler* argument node is the
  nearest ancestor, and the code comment had already retracted the claim — the
  README now matches the fixture.
- **`TestTestdata_GroupClosureInstances` swept a hardcoded `25`**, the old
  default. It now reads the shipped constant, as the per-route sweep beside it
  already did, so changing the default re-runs the sweep at the value that ships.
- **`.gitignore`**: `compare-spec.sh` leaves a `.compare_err` behind when
  interrupted, which read as a working-tree change.

## Verification

`make lint`, `go vet`, `gofmt` and the full `go test ./...` pass. No golden or
fixture drift — the fixture suites are unchanged apart from the sweep constant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Increased the default maximum instances per key from 25 to 100, improving coverage and stability across routes.
  * Clarified how lazy-engine limits are scoped and how instance budgets affect results and performance.
* **Documentation**
  * Updated CLI guidance, limit descriptions, performance details, and instructions for retaining or adjusting the limit.
  * Added release notes documenting the changed default and its trade-offs.
* **Chores**
  * Prevented temporary comparison error files from being included in version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->