### PR TITLE
fix(insight): serialize analysis, which shares mutable state per request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--max-instances-per-key 25`, set it explicitly — you give up only the
   guarantee that the number stays safe as the code grows. (#224)
 
+### Fixed
+
+- **The UI could crash with `fatal error: concurrent map writes`.** Two insight
+  requests in flight at once — two browser tabs, or one tab firing the endpoint
+  and export requests together — walked the same metadata and tracker tree
+  simultaneously. Analysis memoizes as it walks (identifier caches, type-param
+  maps, expansion plans), so a "read" writes, and the resulting map corruption
+  killed the whole server process rather than failing one request. Insight
+  analysis is now serialized. The CLI was never affected: it is single-threaded
+  and does not pay for the fix.
+
 ## [0.5.6] - 2026-08-08
 
 The largest correctness release so far. On a ~900-route project the documented

--- a/internal/insight/concurrency_test.go
+++ b/internal/insight/concurrency_test.go
@@ -67,13 +67,16 @@ func TestConcurrentInsightAnalysis(t *testing.T) {
 		AutoExcludeTests:             true,
 		AutoExcludeMocks:             true,
 	})
+	// Every setup failure below is fatal rather than a skip: this is a
+	// regression guard, and a skipped guard silently stops guarding. The
+	// generator fixture suites hard-fail on the same call for the same reason.
 	out, err := eng.GenerateOpenAPI()
 	if err != nil {
-		t.Skipf("engine generate unavailable in this environment: %v", err)
+		t.Fatalf("GenerateOpenAPI: %v", err)
 	}
 	meta := eng.GetMetadata()
 	if out == nil || meta == nil || len(out.Paths) == 0 {
-		t.Skip("no spec/metadata produced")
+		t.Fatal("no spec/metadata produced, so nothing would be walked concurrently")
 	}
 
 	// Route list comes from a warm-up overview, so the concurrent phase below
@@ -81,7 +84,7 @@ func TestConcurrentInsightAnalysis(t *testing.T) {
 	// the race must not depend on starting cold.
 	warm := BuildOverview(out, meta)
 	if len(warm.Endpoints) == 0 {
-		t.Skip("no endpoints in overview")
+		t.Fatal("no endpoints in overview, so the concurrent phase would walk nothing")
 	}
 
 	const goroutines = 8

--- a/internal/insight/concurrency_test.go
+++ b/internal/insight/concurrency_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package insight
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/engine"
+	"github.com/ehabterra/apispec/internal/spec"
+)
+
+// TestConcurrentInsightAnalysis pins that two insight requests over ONE
+// metadata cannot corrupt it.
+//
+// The UI server is the only concurrent consumer of the analysis pipeline: it
+// holds a single *Metadata and a single tracker tree, takes s.mu only long
+// enough to COPY those pointers, and then runs the whole analysis outside the
+// lock. Two browser tabs — or one tab firing the endpoint and export requests
+// together — therefore walked the same structures at the same time.
+//
+// That is not a benign race. Nearly every identity in the analysis pipeline is
+// computed lazily and memoized in place (CallIdentifier.idCache, Call's
+// base/instance ID caches, the tracker tree's plan/trace/generic caches), so a
+// read path writes maps. It crashed a real session with:
+//
+//	fatal error: concurrent map writes
+//	  metadata.(*CallIdentifier).ID(...)
+//	  metadata.(*Call).BaseID(...)
+//	  spec.(*Extractor).followsControlFlow(...)
+//	  insight.analyzeFromTrackerTree(...)
+//	  main.(*UIServer).handleInsightEndpoint(...)
+//
+// which is unrecoverable — no handler recover() can save the process.
+//
+// Run under -race this test fails on the write/write pair; without -race it
+// reproduces the fatal error often enough to matter. Both endpoints are
+// exercised because they reach the shared state by different routes:
+// BuildEndpointWithSource walks the tracker tree, BuildOverview walks the call
+// graph, and both mutate the metadata's identifier caches.
+func TestConcurrentInsightAnalysis(t *testing.T) {
+	cfg := spec.DefaultEchoConfig()
+	eng := engine.NewEngine(&engine.EngineConfig{
+		InputDir:                     "../../testdata/echo",
+		APISpecConfig:                cfg,
+		OpenAPIVersion:               "3.1.0",
+		MaxNodesPerTree:              engine.DefaultMaxNodesPerTree,
+		MaxChildrenPerNode:           engine.DefaultMaxChildrenPerNode,
+		MaxArgsPerFunction:           engine.DefaultMaxArgsPerFunction,
+		MaxNestedArgsDepth:           engine.DefaultMaxNestedArgsDepth,
+		MaxRecursionDepth:            engine.DefaultMaxRecursionDepth,
+		SkipCGOPackages:              true,
+		AnalyzeFrameworkDependencies: true,
+		AutoIncludeFrameworkPackages: true,
+		AutoExcludeTests:             true,
+		AutoExcludeMocks:             true,
+	})
+	out, err := eng.GenerateOpenAPI()
+	if err != nil {
+		t.Skipf("engine generate unavailable in this environment: %v", err)
+	}
+	meta := eng.GetMetadata()
+	if out == nil || meta == nil || len(out.Paths) == 0 {
+		t.Skip("no spec/metadata produced")
+	}
+
+	// Route list comes from a warm-up overview, so the concurrent phase below
+	// starts from whatever caches a first request would already have filled —
+	// the race must not depend on starting cold.
+	warm := BuildOverview(out, meta)
+	if len(warm.Endpoints) == 0 {
+		t.Skip("no endpoints in overview")
+	}
+
+	const goroutines = 8
+	var wg sync.WaitGroup
+	for i := range goroutines {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			// Half the workers take the tracker path and half the overview
+			// path, so the two ways into the shared state overlap.
+			if i%2 == 0 {
+				for _, ep := range warm.Endpoints {
+					if rep := BuildEndpointWithSource(out, meta, cfg, ep.Method, ep.Path, TraceSourceTracker); rep == nil {
+						t.Errorf("nil endpoint report for %s %s", ep.Method, ep.Path)
+						return
+					}
+				}
+				return
+			}
+			if rep := BuildOverview(out, meta); rep == nil || len(rep.Endpoints) != len(warm.Endpoints) {
+				t.Errorf("overview disagreed with the warm-up run under concurrency")
+			}
+		}(i)
+	}
+	wg.Wait()
+}

--- a/internal/insight/endpoint.go
+++ b/internal/insight/endpoint.go
@@ -134,6 +134,11 @@ func BuildEndpoint(s *spec.OpenAPISpec, meta *metadata.Metadata, method, path st
 // raw edges. cfg enables the tracker tree (route→handler resolution); when nil
 // or the route isn't found, it falls back to the call graph.
 func BuildEndpointWithSource(s *spec.OpenAPISpec, meta *metadata.Metadata, cfg *spec.APISpecConfig, method, path, traceSource string) *EndpointReport {
+	// Walking meta memoizes into it, so concurrent callers would corrupt it —
+	// see analysisMu. Held for the whole build, not just the tree lookup.
+	analysisMu.Lock()
+	defer analysisMu.Unlock()
+
 	rep := &EndpointReport{
 		Method:    strings.ToUpper(method),
 		Path:      path,

--- a/internal/insight/metrics.go
+++ b/internal/insight/metrics.go
@@ -275,7 +275,7 @@ func analyzeAdjacency(meta *metadata.Metadata, root string, callersOf func(strin
 // route isn't found in the tree (or has no body there) it falls back to the
 // call graph augmented with structural interface resolution.
 func analyzeFromTrackerTree(meta *metadata.Metadata, cfg *spec.APISpecConfig, method, path, fallbackRoot string) (Metrics, TraceGraph, bool) {
-	if tree := cachedTrackerTree(meta); tree != nil && cfg != nil {
+	if tree := cachedTrackerTreeLocked(meta); tree != nil && cfg != nil {
 		for _, r := range spec.NewExtractor(tree, cfg).ExtractRoutes() {
 			if r == nil || r.Node == nil || !strings.EqualFold(r.Method, method) || r.OpenAPIPath() != path {
 				continue
@@ -624,20 +624,43 @@ func trackerLimits() metadata.TrackerLimits {
 	}
 }
 
+// analysisMu serializes ALL analysis over a shared *Metadata.
+//
+// The analysis pipeline is single-threaded by construction: nearly every
+// identity it computes is memoized in place on first use — CallIdentifier's
+// idCache, Call's base/instance ID caches, TrackerNode.TypeParams, the lazy
+// tree's plan/trace/generic caches. Those are the optimizations that make a CLI
+// run affordable, and they mean a "read" of the graph WRITES to it. Two
+// goroutines walking one metadata is therefore not a benign data race but
+// `fatal error: concurrent map writes`, which no recover() can catch.
+//
+// The UI is the only concurrent consumer: it holds one metadata and one tree
+// across requests, so two tabs (or one tab's endpoint + export requests) walked
+// them together. Serializing here rather than locking the pipeline itself is
+// deliberate — per-node synchronization would tax every CLI run, which is
+// single-threaded and cannot race, to fix a bug only the server has.
+//
+// The cost is that concurrent insight requests queue. That is acceptable: the
+// tree is built once and cached, so a queued request waits on a walk, not on a
+// rebuild. TestConcurrentInsightAnalysis guards this.
+var analysisMu sync.Mutex
+
 // cachedTrackerTree builds and memoizes the tracker tree for a metadata,
 // rebuilding only when the metadata pointer changes (after a regenerate).
 var (
-	treeMu  sync.Mutex
 	treeKey *metadata.Metadata
 	treeVal spec.TrackerTreeInterface
 )
 
-func cachedTrackerTree(meta *metadata.Metadata) spec.TrackerTreeInterface {
+// cachedTrackerTreeLocked returns the memoized tree. The caller MUST hold
+// analysisMu — and must keep holding it for as long as it walks the result,
+// which is the part a self-locking accessor could not express: handing back a
+// mutable shared tree from under a lock is what made this racy in the first
+// place.
+func cachedTrackerTreeLocked(meta *metadata.Metadata) spec.TrackerTreeInterface {
 	if meta == nil {
 		return nil
 	}
-	treeMu.Lock()
-	defer treeMu.Unlock()
 	if treeKey == meta && treeVal != nil {
 		return treeVal
 	}

--- a/internal/insight/metrics_sweep_test.go
+++ b/internal/insight/metrics_sweep_test.go
@@ -380,7 +380,9 @@ func TestAnalyzeTrackerSubtree(t *testing.T) {
 }
 
 func TestCachedTrackerTree_NilMeta(t *testing.T) {
-	if cachedTrackerTree(nil) != nil {
+	analysisMu.Lock()
+	defer analysisMu.Unlock()
+	if cachedTrackerTreeLocked(nil) != nil {
 		t.Error("nil metadata must yield a nil tree")
 	}
 }

--- a/internal/insight/overview.go
+++ b/internal/insight/overview.go
@@ -276,6 +276,11 @@ func operationsOf(pi spec.PathItem) []struct {
 // BuildOverview projects a generated spec + metadata into an
 // OverviewReport. Both inputs may be nil (returns a zero-value report).
 func BuildOverview(s *spec.OpenAPISpec, meta *metadata.Metadata) *OverviewReport {
+	// Walking meta memoizes into it, so concurrent callers would corrupt it —
+	// see analysisMu.
+	analysisMu.Lock()
+	defer analysisMu.Unlock()
+
 	rep := &OverviewReport{}
 	if s == nil {
 		return rep


### PR DESCRIPTION
The UI crashed with `fatal error: concurrent map writes` while building an
endpoint insight report:

```
metadata.(*CallIdentifier).ID          metadata.go:129
metadata.(*Call).BaseID                types.go:1256
spec.(*Extractor).followsControlFlow   request_provenance.go:91
insight.analyzeFromTrackerTree         metrics.go:279
main.(*UIServer).handleInsightEndpoint main.go:1752
```

## Why

The server holds one `*Metadata` and one tracker tree across requests, and takes
`s.mu` only long enough to **copy those pointers** — the analysis then runs
outside the lock. Two requests in flight (two browser tabs, or one tab firing
the endpoint and export requests together) walk the same structures at once.

That is not a benign race. Nearly every identity in the pipeline is computed
lazily and memoized in place — `CallIdentifier.idCache`, `Call`'s base/instance
ID caches, `TrackerNode.TypeParams`, the lazy tree's plan and trace caches — so
**a read of the graph writes to it**. The result is a fatal error that takes the
whole server process down; no handler `recover()` can catch it.

The traceback names one such pair, but it is not the only one. Under `-race` the
new test flags `TrackerNode.TypeParams` first, in `spec` rather than `metadata`.
Any of them can be the one that kills the process.

## The fix

`analysisMu` serializes the exported builders (`BuildOverview`,
`BuildEndpointWithSource`), **held for the whole walk** rather than just the
tree lookup.

Fixing it at the consumer rather than in the pipeline is deliberate: the caches
are what make a CLI run affordable, and per-node synchronization would tax every
CLI run — single-threaded, and unable to race — to fix a bug only the server
has.

The cost is that concurrent insight requests queue. That is acceptable because
the tree is built once and cached, so a queued request waits on a walk, not on a
rebuild.

`cachedTrackerTree` becomes `cachedTrackerTreeLocked`. Handing a mutable shared
tree back from under a lock that is then released is precisely what made this
racy, and a self-locking accessor cannot express "keep holding it while you walk
the result" — the name now says so.

## Verification

`TestConcurrentInsightAnalysis` reproduces the crash on the unfixed code
(reliably under `-race`, and often as the fatal error without it) and guards
both entry paths, since the tracker and overview builders reach the shared state
by different routes. It fails before the fix and passes after.

Full `go test ./... -race` and `make lint` are clean.

## Checked and deliberately left alone

- `summarizeMetadata` walks `meta.Packages` but runs during generation, on
  metadata not yet published to `s.currentMeta`.
- `StringPool.GetString` is a pure slice read.
- Two concurrent `/generate` requests would each run a full engine — wasteful,
  but safe, since they build separate objects. Out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes and inconsistent results when insight analyses run concurrently.
  * Improved reliability of endpoint and overview analysis during simultaneous operations.

* **Tests**
  * Added coverage for concurrent insight analysis across multiple simultaneous operations.

* **Documentation**
  * Documented the concurrency fix in the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->