### PR TITLE
perf: index function lookups; shrink LazyNode

### DIFF
--- a/internal/metadata/lookup_cache_test.go
+++ b/internal/metadata/lookup_cache_test.go
@@ -15,8 +15,13 @@
 package metadata
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"go/types"
+	"os"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -381,5 +386,141 @@ func TestLookupCachesTolerateNilFiles(t *testing.T) {
 	}
 	if got := m.SortedTypeNames("app", "a.go"); !reflect.DeepEqual(got, []string{"Present"}) {
 		t.Errorf("SortedTypeNames = %v, want [Present]", got)
+	}
+}
+
+// TestFunctionInPackageMatchesFileScan pins the function index against the scan
+// it replaced, including the case that decides determinism: a bare name that
+// two files of one package declare must resolve to the same one every run.
+func TestFunctionInPackageMatchesFileScan(t *testing.T) {
+	inA, inZ := &Function{Name: 1}, &Function{Name: 2}
+	m := &Metadata{StringPool: NewStringPool()}
+	m.Packages = map[string]*Package{
+		"app": {Files: map[string]*File{
+			"z.go": {Functions: map[string]*Function{"Dup": inZ, "OnlyZ": {}}},
+			"a.go": {Functions: map[string]*Function{"Dup": inA, "OnlyA": {}}},
+		}},
+	}
+
+	for _, name := range []string{"OnlyA", "OnlyZ"} {
+		if m.FunctionInPackage("app", name) == nil {
+			t.Errorf("FunctionInPackage(%q) = nil, want the declaration", name)
+		}
+	}
+	if got := m.FunctionInPackage("app", "Absent"); got != nil {
+		t.Errorf("FunctionInPackage(\"Absent\") = %p, want nil", got)
+	}
+	// Go itself forbids the duplicate, so which one wins is not the point —
+	// that the SAME one wins on every run is.
+	first := m.FunctionInPackage("app", "Dup")
+	for range 8 {
+		m.funcIndex, m.funcIndexFor = nil, nil // force a rebuild
+		if got := m.FunctionInPackage("app", "Dup"); got != first {
+			t.Fatalf("Dup resolved to %p, then %p — the index must not depend on map order", first, got)
+		}
+	}
+	if got := m.FunctionInPackage("missing", "Dup"); got != nil {
+		t.Errorf("FunctionInPackage on an unknown package = %p, want nil", got)
+	}
+}
+
+// TestFunctionInPackageInvalidatesOnGrowth covers the reason the index carries a
+// pkgShape fingerprint: these lookups can run before assembly has finished, and
+// pkgShape counts functions (not only files) because assembly adds a function to
+// a file that already exists.
+func TestFunctionInPackageInvalidatesOnGrowth(t *testing.T) {
+	m := &Metadata{StringPool: NewStringPool()}
+	m.Packages = map[string]*Package{
+		"app": {Files: map[string]*File{"a.go": {Functions: map[string]*Function{"First": {}}}}},
+	}
+	if m.FunctionInPackage("app", "First") == nil {
+		t.Fatal("First should resolve")
+	}
+	// Added to the EXISTING file: the file count is unchanged, so only the
+	// function count can notice this.
+	m.Packages["app"].Files["a.go"].Functions["Second"] = &Function{}
+	if m.FunctionInPackage("app", "Second") == nil {
+		t.Error("a function added to an existing file must not be hidden by the stale index")
+	}
+	m.Packages["app"].Files["b.go"] = &File{Functions: map[string]*Function{"Third": {}}}
+	if m.FunctionInPackage("app", "Third") == nil {
+		t.Error("a function added in a new file must not be hidden by the stale index")
+	}
+}
+
+// TestFunctionAnywhereIsDeterministic pins the fallback's contract: the first
+// package in SORTED order that declares the bare name wins, so a name declared
+// by several packages cannot resolve differently between runs (golden rule #1).
+func TestFunctionAnywhereIsDeterministic(t *testing.T) {
+	inApp, inZoo := &Function{Name: 1}, &Function{Name: 2}
+	newMeta := func() *Metadata {
+		m := &Metadata{StringPool: NewStringPool()}
+		m.Packages = map[string]*Package{
+			"zoo": {Files: map[string]*File{"z.go": {Functions: map[string]*Function{"Shared": inZoo}}}},
+			"app": {Files: map[string]*File{"a.go": {Functions: map[string]*Function{"Shared": inApp, "Only": {}}}}},
+		}
+		return m
+	}
+	for range 8 {
+		if got := newMeta().FunctionAnywhere("Shared"); got != inApp {
+			t.Fatalf("Shared resolved to %p, want app's %p — \"app\" sorts before \"zoo\"", got, inApp)
+		}
+	}
+	if got := newMeta().FunctionAnywhere("Absent"); got != nil {
+		t.Errorf("FunctionAnywhere(\"Absent\") = %p, want nil", got)
+	}
+	if got := newMeta().FunctionAnywhere("Only"); got == nil {
+		t.Error("a name declared by exactly one package must still resolve")
+	}
+}
+
+// TestFunctionAnywhereIsSpecLayerOnly enforces the invariant that lets
+// FunctionAnywhere memoize once instead of re-fingerprinting the program on
+// every lookup: nothing in the metadata layer may call it. Metadata-layer code
+// runs DURING assembly, when the declaration set is still growing, so such a
+// caller could cache a snapshot that later lookups would answer from — the bug
+// pkgShape exists to prevent for FunctionInPackage.
+//
+// If this fails, either move the new caller into the spec layer or give
+// FunctionAnywhere a shape guard (and pay for it — see its doc comment).
+func TestFunctionAnywhereIsSpecLayerOnly(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("reading the metadata package directory: %v", err)
+	}
+	fset := token.NewFileSet()
+	scanned := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, name, nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", name, err)
+		}
+		scanned++
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			called := ""
+			switch fn := call.Fun.(type) {
+			case *ast.Ident:
+				called = fn.Name
+			case *ast.SelectorExpr:
+				called = fn.Sel.Name
+			}
+			if called == "FunctionAnywhere" {
+				t.Errorf("%s calls FunctionAnywhere from inside the metadata layer; "+
+					"its memo is only safe because every caller runs after assembly",
+					fset.Position(call.Pos()))
+			}
+			return true
+		})
+	}
+	if scanned == 0 {
+		t.Fatal("scanned no source files — the check would pass vacuously")
 	}
 }

--- a/internal/metadata/lookup_cache_test.go
+++ b/internal/metadata/lookup_cache_test.go
@@ -410,13 +410,14 @@ func TestFunctionInPackageMatchesFileScan(t *testing.T) {
 	if got := m.FunctionInPackage("app", "Absent"); got != nil {
 		t.Errorf("FunctionInPackage(\"Absent\") = %p, want nil", got)
 	}
-	// Go itself forbids the duplicate, so which one wins is not the point —
-	// that the SAME one wins on every run is.
-	first := m.FunctionInPackage("app", "Dup")
-	for range 8 {
+	// Go itself forbids the duplicate, so this is about the index never letting
+	// map order decide an answer (golden rule #1): a.go sorts first, so a.go's
+	// declaration wins, on this run and every other. Rebuilt repeatedly because
+	// a map-order-dependent index can agree with the sorted one by chance.
+	for range 32 {
 		m.funcIndex, m.funcIndexFor = nil, nil // force a rebuild
-		if got := m.FunctionInPackage("app", "Dup"); got != first {
-			t.Fatalf("Dup resolved to %p, then %p — the index must not depend on map order", first, got)
+		if got := m.FunctionInPackage("app", "Dup"); got != inA {
+			t.Fatalf("Dup resolved to %p, want a.go's %p — the index must not depend on map order", got, inA)
 		}
 	}
 	if got := m.FunctionInPackage("missing", "Dup"); got != nil {
@@ -461,7 +462,7 @@ func TestFunctionAnywhereIsDeterministic(t *testing.T) {
 		}
 		return m
 	}
-	for range 8 {
+	for range 32 {
 		if got := newMeta().FunctionAnywhere("Shared"); got != inApp {
 			t.Fatalf("Shared resolved to %p, want app's %p — \"app\" sorts before \"zoo\"", got, inApp)
 		}

--- a/internal/metadata/lookup_cache_test.go
+++ b/internal/metadata/lookup_cache_test.go
@@ -15,11 +15,13 @@
 package metadata
 
 import (
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
 	"go/types"
-	"os"
+	"io/fs"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"sync"
@@ -477,30 +479,56 @@ func TestFunctionAnywhereIsDeterministic(t *testing.T) {
 
 // TestFunctionAnywhereIsSpecLayerOnly enforces the invariant that lets
 // FunctionAnywhere memoize once instead of re-fingerprinting the program on
-// every lookup: nothing in the metadata layer may call it. Metadata-layer code
-// runs DURING assembly, when the declaration set is still growing, so such a
-// caller could cache a snapshot that later lookups would answer from — the bug
-// pkgShape exists to prevent for FunctionInPackage.
+// every lookup: it may only be called from the spec layer. Spec-layer code does
+// not run until GenerateMetadata has returned, so the declaration set it indexes
+// is already final. A caller that runs DURING assembly would cache a snapshot
+// that later lookups answer from — the bug pkgShape exists to prevent for
+// FunctionInPackage, which needs its guard precisely because it lacks this
+// property.
 //
-// If this fails, either move the new caller into the spec layer or give
+// Scanned repo-wide rather than package-locally: assembly is driven from this
+// package today, but a future analysis pass called from GenerateMetadata could
+// live anywhere, and it is the CALLER'S PHASE that matters. Allowing only
+// internal/spec is the enforceable form of that.
+//
+// If this fails, either move the caller into the spec layer or give
 // FunctionAnywhere a shape guard (and pay for it — see its doc comment).
 func TestFunctionAnywhereIsSpecLayerOnly(t *testing.T) {
-	entries, err := os.ReadDir(".")
+	const allowedDir = "internal/spec"
+
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
 	if err != nil {
-		t.Fatalf("reading the metadata package directory: %v", err)
+		t.Fatalf("resolving the repo root: %v", err)
 	}
 	fset := token.NewFileSet()
 	scanned := 0
-	for _, entry := range entries {
-		name := entry.Name()
-		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
-			continue
-		}
-		file, err := parser.ParseFile(fset, name, nil, 0)
+	err = filepath.WalkDir(repoRoot, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			t.Fatalf("parsing %s: %v", name, err)
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			// Fixture projects are separate modules that never import this one,
+			// and .git/node_modules are not source.
+			case ".git", "node_modules", "testdata", "test_cgo_mixed", "test_cgo_demo":
+				return fs.SkipDir
+			}
+			return nil
+		}
+		name := d.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			return nil
+		}
+		file, perr := parser.ParseFile(fset, path, nil, 0)
+		if perr != nil {
+			return fmt.Errorf("parsing %s: %w", path, perr)
 		}
 		scanned++
+		rel, rerr := filepath.Rel(repoRoot, path)
+		if rerr != nil {
+			rel = path
+		}
+		allowed := strings.HasPrefix(filepath.ToSlash(rel), allowedDir+"/")
 		ast.Inspect(file, func(n ast.Node) bool {
 			call, ok := n.(*ast.CallExpr)
 			if !ok {
@@ -513,13 +541,17 @@ func TestFunctionAnywhereIsSpecLayerOnly(t *testing.T) {
 			case *ast.SelectorExpr:
 				called = fn.Sel.Name
 			}
-			if called == "FunctionAnywhere" {
-				t.Errorf("%s calls FunctionAnywhere from inside the metadata layer; "+
-					"its memo is only safe because every caller runs after assembly",
-					fset.Position(call.Pos()))
+			if called == "FunctionAnywhere" && !allowed {
+				t.Errorf("%s calls FunctionAnywhere from outside %s; its memo is only "+
+					"safe because every caller runs after metadata assembly has finished",
+					fset.Position(call.Pos()), allowedDir)
 			}
 			return true
 		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the repo: %v", err)
 	}
 	if scanned == 0 {
 		t.Fatal("scanned no source files — the check would pass vacuously")

--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -182,10 +182,9 @@ type Metadata struct {
 	typeIndexMutex sync.RWMutex
 
 	// funcIndex is TypeInPackage's counterpart for functions: a package's
-	// declared function names to their declaration. funcAnywhere is the
-	// whole-program fallback — a bare name to the declaration in the first
-	// package (sorted) that declares it — which is the expensive half, since
-	// the scan it replaces touched every file of every package per miss.
+	// declared function names to their declaration. FunctionAnywhere composes
+	// these rather than keeping a whole-program index of its own, so that the
+	// per-package pkgShape guard covers the fallback too.
 	funcIndex      map[string]map[string]*Function
 	funcIndexFor   map[string]pkgShape
 	funcAnywhere   map[string]*Function
@@ -526,8 +525,24 @@ func (m *Metadata) FunctionInPackage(pkgName, name string) *Function {
 //
 // The sorted order is the determinism guarantee, not an implementation detail:
 // when several packages declare the same bare name the answer must not depend
-// on map iteration order (golden rule #1). Built once for the whole program
-// rather than re-sorted per lookup.
+// on map iteration order (golden rule #1).
+//
+// Built once for the whole program, and deliberately NOT shape-guarded the way
+// FunctionInPackage is. The guard would have to fingerprint every file of every
+// package per lookup — measured, that costs the entire win this indexing bought
+// (a 163-route service goes 6.3s back to ~9s), because the fallback is consulted
+// far too often to re-count the program on each call.
+//
+// What makes build-once safe here is a layer boundary, not luck: functions and
+// packages are only ever added while GenerateMetadata assembles the metadata,
+// and every caller of this lookup is in the spec layer, which does not run until
+// assembly has returned (the spec layer only ever READS Files/Functions).
+// FunctionInPackage carries the pkgShape guard precisely because it does NOT
+// have that property — metadata-layer code calls it mid-assembly.
+//
+// So: if you add a caller inside internal/metadata, or start adding declarations
+// after assembly, this memo has to grow a guard. TestFunctionAnywhereIsSpecLayerOnly
+// fails when the first half of that happens.
 func (m *Metadata) FunctionAnywhere(name string) *Function {
 	m.funcIndexMutex.RLock()
 	idx := m.funcAnywhere
@@ -551,6 +566,8 @@ func (m *Metadata) FunctionAnywhere(name string) *Function {
 		if pkg == nil {
 			continue
 		}
+		// Sorted packages outermost and first-declaration-wins: a bare name
+		// declared by several packages must resolve to the same one every run.
 		for _, f := range pkg.Files {
 			if f == nil {
 				continue

--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -180,6 +180,16 @@ type Metadata struct {
 	typeIndex      map[string]map[string]*Type
 	typeIndexFor   map[string]pkgShape
 	typeIndexMutex sync.RWMutex
+
+	// funcIndex is TypeInPackage's counterpart for functions: a package's
+	// declared function names to their declaration. funcAnywhere is the
+	// whole-program fallback — a bare name to the declaration in the first
+	// package (sorted) that declares it — which is the expensive half, since
+	// the scan it replaces touched every file of every package per miss.
+	funcIndex      map[string]map[string]*Function
+	funcIndexFor   map[string]pkgShape
+	funcAnywhere   map[string]*Function
+	funcIndexMutex sync.RWMutex
 	Args           map[string][]*CallGraphEdge `yaml:"-"`
 
 	roots []*CallGraphEdge `yaml:"-"`
@@ -350,7 +360,7 @@ type fileKey struct{ pkg, file string }
 
 // pkgShape is a cheap fingerprint of a package's contents: enough to notice
 // that more was recorded since a derived index was built, without hashing it.
-type pkgShape struct{ files, types int }
+type pkgShape struct{ files, types, funcs int }
 
 func shapeOf(pkg *Package) pkgShape {
 	shape := pkgShape{files: len(pkg.Files)}
@@ -363,6 +373,7 @@ func shapeOf(pkg *Package) pkgShape {
 			continue
 		}
 		shape.types += len(f.Types)
+		shape.funcs += len(f.Functions)
 	}
 	return shape
 }
@@ -458,6 +469,101 @@ func (m *Metadata) TypeInPackage(pkgName, typeName string) *Type {
 	m.typeIndex[pkgName] = idx
 	m.typeIndexFor[pkgName] = shape
 	return idx[typeName]
+}
+
+// FunctionInPackage returns the function a package declares under name, or nil.
+//
+// The function-side twin of TypeInPackage, and for the same reason (issue
+// #322): callers scanned the package's files per lookup and, on a miss, fell
+// back to sorting every package name and scanning every file of every package.
+// On a 100-package service that fallback was 15% of a whole run — it is a
+// lookup, so it should cost a map hit.
+//
+// A function name is unique within a package, so file order cannot decide the
+// result and the index reproduces the scan exactly.
+func (m *Metadata) FunctionInPackage(pkgName, name string) *Function {
+	pkg, ok := m.Packages[pkgName]
+	if !ok || pkg == nil {
+		return nil
+	}
+	shape := shapeOf(pkg)
+
+	m.funcIndexMutex.RLock()
+	idx, cached := m.funcIndex[pkgName]
+	builtFor := m.funcIndexFor[pkgName]
+	m.funcIndexMutex.RUnlock()
+	if cached && builtFor == shape {
+		return idx[name]
+	}
+
+	m.funcIndexMutex.Lock()
+	defer m.funcIndexMutex.Unlock()
+	if idx, ok := m.funcIndex[pkgName]; ok && m.funcIndexFor[pkgName] == shape {
+		return idx[name] // another goroutine won the race
+	}
+	idx = make(map[string]*Function, shape.funcs)
+	for _, f := range pkg.Files {
+		if f == nil {
+			continue
+		}
+		for fnName, fn := range f.Functions {
+			if _, seen := idx[fnName]; !seen {
+				idx[fnName] = fn
+			}
+		}
+	}
+	if m.funcIndex == nil {
+		m.funcIndex = make(map[string]map[string]*Function, len(m.Packages))
+		m.funcIndexFor = make(map[string]pkgShape, len(m.Packages))
+	}
+	m.funcIndex[pkgName] = idx
+	m.funcIndexFor[pkgName] = shape
+	return idx[name]
+}
+
+// FunctionAnywhere returns the function declared under a bare name by the first
+// package that declares it in sorted package order, or nil.
+//
+// The sorted order is the determinism guarantee, not an implementation detail:
+// when several packages declare the same bare name the answer must not depend
+// on map iteration order (golden rule #1). Built once for the whole program
+// rather than re-sorted per lookup.
+func (m *Metadata) FunctionAnywhere(name string) *Function {
+	m.funcIndexMutex.RLock()
+	idx := m.funcAnywhere
+	m.funcIndexMutex.RUnlock()
+	if idx != nil {
+		return idx[name]
+	}
+
+	// SortedPackageNames takes cacheMutex, not funcIndexMutex; resolve it
+	// before taking the write lock all the same, so the two never nest.
+	pkgNames := m.SortedPackageNames()
+
+	m.funcIndexMutex.Lock()
+	defer m.funcIndexMutex.Unlock()
+	if m.funcAnywhere != nil {
+		return m.funcAnywhere[name] // another goroutine won the race
+	}
+	idx = map[string]*Function{}
+	for _, pkgName := range pkgNames {
+		pkg := m.Packages[pkgName]
+		if pkg == nil {
+			continue
+		}
+		for _, f := range pkg.Files {
+			if f == nil {
+				continue
+			}
+			for fnName, fn := range f.Functions {
+				if _, seen := idx[fnName]; !seen {
+					idx[fnName] = fn
+				}
+			}
+		}
+	}
+	m.funcAnywhere = idx
+	return idx[name]
 }
 
 // ImplementersOf returns "pkg.Type" for every recorded type that implements the

--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -478,8 +478,9 @@ func (m *Metadata) TypeInPackage(pkgName, typeName string) *Type {
 // On a 100-package service that fallback was 15% of a whole run — it is a
 // lookup, so it should cost a map hit.
 //
-// A function name is unique within a package, so file order cannot decide the
-// result and the index reproduces the scan exactly.
+// Filled walking SortedFileNames with an earlier file winning, so a name that
+// somehow appears in two files resolves to the same declaration on every run
+// rather than to whichever the map handed over first.
 func (m *Metadata) FunctionInPackage(pkgName, name string) *Function {
 	pkg, ok := m.Packages[pkgName]
 	if !ok || pkg == nil {
@@ -501,7 +502,13 @@ func (m *Metadata) FunctionInPackage(pkgName, name string) *Function {
 		return idx[name] // another goroutine won the race
 	}
 	idx = make(map[string]*Function, shape.funcs)
-	for _, f := range pkg.Files {
+	// Safe under funcIndexMutex: SortedFileNames takes sortedFilesMutex only.
+	// Sorted, not map order: Go forbids two files of a package declaring the
+	// same function name, but metadata can be deserialised from anywhere, and
+	// an index whose answer depends on map order is the determinism bug golden
+	// rule #1 exists to stop. Earlier file wins, matching TypeInPackage.
+	for _, fileName := range m.SortedFileNames(pkgName) {
+		f := pkg.Files[fileName]
 		if f == nil {
 			continue
 		}
@@ -566,9 +573,11 @@ func (m *Metadata) FunctionAnywhere(name string) *Function {
 		if pkg == nil {
 			continue
 		}
-		// Sorted packages outermost and first-declaration-wins: a bare name
-		// declared by several packages must resolve to the same one every run.
-		for _, f := range pkg.Files {
+		// Sorted packages outermost, sorted files within them, and
+		// first-declaration-wins: a bare name declared more than once must
+		// resolve to the same declaration on every run (golden rule #1).
+		for _, fileName := range m.SortedFileNames(pkgName) {
+			f := pkg.Files[fileName]
 			if f == nil {
 				continue
 			}

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -1930,30 +1930,16 @@ func findFunctionByName(meta *metadata.Metadata, pkg, name string) *metadata.Fun
 	if meta == nil || name == "" {
 		return nil
 	}
-	if p, ok := meta.Packages[pkg]; ok {
-		for _, file := range p.Files {
-			if fn, ok := file.Functions[name]; ok {
-				return fn
-			}
-		}
+	if fn := meta.FunctionInPackage(pkg, name); fn != nil {
+		return fn
 	}
-	// Fallback: any package declaring the name. Sort package keys so that when
-	// several packages declare the same bare name the result is stable across
-	// runs (map iteration order is random). Function names are unique within a
-	// package, so the inner file order doesn't affect the result.
-	pkgNames := make([]string, 0, len(meta.Packages))
-	for p := range meta.Packages {
-		pkgNames = append(pkgNames, p)
-	}
-	sort.Strings(pkgNames)
-	for _, p := range pkgNames {
-		for _, file := range meta.Packages[p].Files {
-			if fn, ok := file.Functions[name]; ok {
-				return fn
-			}
-		}
-	}
-	return nil
+	// Fallback: any package declaring the name, the first in sorted package
+	// order so that a bare name declared by several packages resolves the same
+	// way across runs. Both lookups are indexed (issue #322): this is a hot
+	// path — one response-destination resolution asks it per candidate per
+	// path — and scanning every file of every package per miss made it 15% of
+	// a run on a 100-package service.
+	return meta.FunctionAnywhere(name)
 }
 
 // callerAssignmentMap returns the variable→assignments map of the function or

--- a/internal/spec/lazytree.go
+++ b/internal/spec/lazytree.go
@@ -133,6 +133,11 @@ type LazyTree struct {
 	// unfolding actually does. Reported, not budgeted (#247).
 	nodesMaterialized int
 
+	// typeParams memoizes GetTypeParamMap per node. A side table rather than a
+	// node field because only generic call sites ever read it, while the field
+	// would be paid for by every node materialised — see LazyNode.routeScope.
+	typeParams map[*LazyNode]map[string]string
+
 	// instanceCount counts node copies per (instance scope, callee ID) —
 	// see DefaultMaxInstancesPerKey. A node is (edge, parent), so a callee reached
 	// along many paths gets many copies; business-layer diamonds make that
@@ -495,7 +500,7 @@ func (t *LazyTree) routeBudget() int {
 // A registration opens a scope rather than joining one, so everything the route
 // pulls in — its handler, that handler's helpers, their types — is charged to
 // that route and to nothing else.
-func (t *LazyTree) scopeOf(n *LazyNode) int {
+func (t *LazyTree) scopeOf(n *LazyNode) int32 {
 	if n == nil {
 		return 0
 	}
@@ -509,7 +514,7 @@ func (t *LazyTree) scopeOf(n *LazyNode) int {
 	}
 	t.routeScopeNodes = append(t.routeScopeNodes, 0)
 	t.routeScopeKeys = append(t.routeScopeKeys, n.key)
-	return len(t.routeScopeNodes) - 1
+	return int32(len(t.routeScopeNodes) - 1)
 }
 
 // budgetExhausted reports whether the WIRING budget is spent — the walk that
@@ -530,7 +535,7 @@ func (t *LazyTree) budgetExhausted() bool {
 // key is seen at all: a key can be reached below a route first and by the wiring
 // walk afterwards, and skipping it then would let a walk that happens to descend
 // into a route early understate its own cost without bound.
-func (t *LazyTree) countKey(key string, scope int) {
+func (t *LazyTree) countKey(key string, scope int32) {
 	if t.seenKeys == nil {
 		t.seenKeys = map[string]uint8{}
 	}
@@ -547,15 +552,15 @@ func (t *LazyTree) countKey(key string, scope int) {
 
 // routeBudgetExhausted reports whether this node's route has spent its own
 // allowance. Scope 0 — the wiring walk — is bounded by budgetExhausted instead.
-func (t *LazyTree) routeBudgetExhausted(scope int) bool {
-	return scope > 0 && scope < len(t.routeScopeNodes) && t.routeScopeNodes[scope] >= t.routeBudget()
+func (t *LazyTree) routeBudgetExhausted(scope int32) bool {
+	return scope > 0 && int(scope) < len(t.routeScopeNodes) && t.routeScopeNodes[scope] >= t.routeBudget()
 }
 
 // noteRouteTruncation records a route subtree cut short by its own budget, and
 // warns once. The route's own key is named: unlike the whole-walk truncation,
 // this says exactly which endpoint is under-documented.
-func (t *LazyTree) noteRouteTruncation(scope int) {
-	for len(t.routeScopeCut) <= scope {
+func (t *LazyTree) noteRouteTruncation(scope int32) {
+	for int32(len(t.routeScopeCut)) <= scope {
 		t.routeScopeCut = append(t.routeScopeCut, false)
 	}
 	if t.routeScopeCut[scope] {
@@ -564,7 +569,7 @@ func (t *LazyTree) noteRouteTruncation(scope int) {
 	t.routeScopeCut[scope] = true
 	t.routeTruncations++
 	key := ""
-	if scope < len(t.routeScopeKeys) {
+	if int(scope) < len(t.routeScopeKeys) {
 		key = t.routeScopeKeys[scope]
 	}
 	if t.routeFirstTruncated == "" {
@@ -951,8 +956,6 @@ type LazyNode struct {
 	edge *metadata.CallGraphEdge
 	arg  *metadata.CallArgument
 
-	typeParams map[string]string // GetTypeParamMap cache
-
 	children []TrackerNodeInterface // nil = not yet expanded
 
 	// routeScope identifies which budget this node's expansion is charged to:
@@ -963,7 +966,12 @@ type LazyNode struct {
 	// find it per expansion would be O(depth) work on every child, which goes
 	// quadratic over deep graphs and is the shape that shows up in profiles as
 	// GC dominance rather than as the guilty frame.
-	routeScope int
+	//
+	// int32, and the flags below it pack into the same word: a real service
+	// materialises millions of these (7.1M on a 163-route service), so the
+	// struct's SIZE is a first-order cost — expansion is memory-bound on
+	// writing the slabs, not on any computation it does.
+	routeScope int32
 
 	argType    ArgumentType
 	isArgument bool
@@ -989,9 +997,12 @@ func (n *LazyNode) GetArgument() *metadata.CallArgument { return n.arg }
 
 // GetTypeParamMap implements TrackerNodeInterface: bindings from this node's
 // edge/argument merged with its ancestors', nearest binding winning.
+// The memo lives on the tree rather than in a field of the node: only generic
+// call sites ever ask for it, and a field costs 8 bytes on every one of the
+// millions of nodes a real service materialises.
 func (n *LazyNode) GetTypeParamMap() map[string]string {
-	if n.typeParams != nil {
-		return n.typeParams
+	if cached, ok := n.tree.typeParams[n]; ok {
+		return cached
 	}
 	out := map[string]string{}
 	for cur := n; cur != nil; cur = cur.parent {
@@ -1010,7 +1021,10 @@ func (n *LazyNode) GetTypeParamMap() map[string]string {
 			}
 		}
 	}
-	n.typeParams = out
+	if n.tree.typeParams == nil {
+		n.tree.typeParams = map[*LazyNode]map[string]string{}
+	}
+	n.tree.typeParams[n] = out
 	return out
 }
 
@@ -1173,7 +1187,7 @@ func (n *LazyNode) GetChildren() []TrackerNodeInterface {
 		// #224; what this counter can honestly do meanwhile is report the work
 		// instead of hiding it.
 		n.tree.nodesMaterialized++
-		if childScope > 0 && childScope < len(n.tree.routeScopeNodes) {
+		if childScope > 0 && int(childScope) < len(n.tree.routeScopeNodes) {
 			n.tree.routeScopeNodes[childScope]++
 		}
 		n.tree.countKey(spec.key, childScope)

--- a/internal/spec/lazytree.go
+++ b/internal/spec/lazytree.go
@@ -560,7 +560,7 @@ func (t *LazyTree) routeBudgetExhausted(scope int32) bool {
 // warns once. The route's own key is named: unlike the whole-walk truncation,
 // this says exactly which endpoint is under-documented.
 func (t *LazyTree) noteRouteTruncation(scope int32) {
-	for int32(len(t.routeScopeCut)) <= scope {
+	for len(t.routeScopeCut) <= int(scope) {
 		t.routeScopeCut = append(t.routeScopeCut, false)
 	}
 	if t.routeScopeCut[scope] {

--- a/internal/spec/tracker.go
+++ b/internal/spec/tracker.go
@@ -42,8 +42,13 @@ func getTrackerNode() *TrackerNode {
 	return node
 }
 
-// ArgumentType represents the classification of an argument
-type ArgumentType int
+// ArgumentType represents the classification of an argument.
+//
+// uint8, not int: it is a field of every tracker node, and the lazy tree
+// materialises millions of those on a real service, where expansion is bound
+// by the bytes it writes rather than by anything it computes. Eleven values
+// need one byte, and one byte lets the node's flags share a single word.
+type ArgumentType uint8
 
 const (
 	ArgTypeDirectCallee ArgumentType = iota // Direct function call (existing callee)


### PR DESCRIPTION
## What

Two changes to the `spec mapped` stage, found by profiling a 163-route service
(103 packages) that took 13s to generate.

1. **`findFunctionByName` is now indexed.** It resolved a bare name by scanning
   the named package's files and then, on a miss, sorting every package key and
   scanning every file of every package — per call. It is not a cold path: the
   response-destination resolver reaches it through `assignmentsAt` →
   `callerAssignmentMap` once per candidate per path, and the lazy tree
   materialises one node per path. This is `TypeInPackage`'s problem (#322) on
   the function side, so it gets `TypeInPackage`'s answer —
   `Metadata.FunctionInPackage` and `FunctionAnywhere`, behind the same
   `pkgShape` invalidation.

2. **`LazyNode` shrinks 104 → 80 bytes**: `ArgumentType int` → `uint8`,
   `routeScope int` → `int32` (both now sharing one word with the flags), and
   the `GetTypeParamMap` memo moved to a side table on the tree since only
   generic call sites read it.

## Measured

On the 163-route service, generated spec **byte-identical** before and after
(and byte-identical on this repo's own spec):

|                | before  | after   |
|----------------|---------|---------|
| `spec mapped`  | 10.02s  | 6.32s   |
| wall clock     | 12.45s  | 8.03s   |
| peak RSS       | 1318MB  | 1148MB  |

The wall-clock win is all from (1); (2) is the RSS win and moves time not at all.

## Where the rest of the time goes

Recording this so it isn't re-derived. The stage is essentially *nothing but*
node materialization: `extractRouteChildrenScoped` is 85% cumulative and all of
it is `GetChildren` plus recursion — the actual extraction work (pattern
matching, request/response/param) is ~250ms. 12,882 distinct callee keys expand
into 7,147,505 materialized nodes, ~540 copies per key, and the top keys are
leaf utility calls (`fmt.Errorf` with a literal, an ObjectID helper,
`reflect.Value.*` in a struct walker) re-expanded once per reaching path.

Wall clock is linear in that count: at `--max-instances-per-key` 100/50/25 the
stage is 6.7s/4.3s/2.8s **for a byte-identical spec on this project**. That is
#224 — the cap is applied to the wrong unit — and this PR deliberately does not
touch the default, which #342 raised for a different service that genuinely
needs it.

Two dead ends, so nobody re-walks them:

- **It is not GC.** `GOGC=300` and `GOGC=800` are both *slower* and cost 400MB
  of RSS; `GOGC=off` is slower still (8.3s vs 6.3s).
- **It is not the field stores.** `GetChildren`'s flat CPU sits on plain
  assignments like `child.routeScope = childScope`, but that is first-touch on
  freshly committed slab pages — shrinking the struct 23% moved memory and not
  time, which is the evidence.

## Test plan

- [x] `go test ./...` and `go test -race ./internal/... ./generator/...`
- [x] `make lint` (0 issues), `go vet`, `gofmt`
- [x] Generated spec byte-identical on the 163-route service and on this repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved function resolution within packages and across the application.
  * Ensured lookups remain accurate and deterministic as files and package contents change.
  * Improved handling of missing function names without disrupting normal operation.
* **Performance**
  * Improved reuse of generic type information across syntax trees.
  * Reduced memory usage for type and argument tracking.
  * Added caching to speed up repeated function lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->