### PR TITLE
docs: link the README to the documentation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@
 
 **TL;DR**: Point APISpec at your module. Get an OpenAPI spec — plus, optionally, an interactive call-graph diagram and a browser-based config UI.
 
+📖 **Documentation:** [apispec.ehabterra.com](https://apispec.ehabterra.com) — installation,
+CLI reference, configuration, CI drift checking, and per-framework walkthroughs that show the
+spec APISpec actually produces for each router.
+
+Coming from an annotation-based tool? See [APISpec vs swaggo/swag](https://apispec.ehabterra.com/vs/swaggo/),
+or [the wider landscape](https://apispec.ehabterra.com/alternatives/) if you are still choosing.
+
 ## Table of Contents
 
 - [Demo](#demo)
@@ -79,7 +86,8 @@ export PATH=$HOME/go/bin:$PATH
 
 Both tools are published the same way — Homebrew, pre-built binaries for six
 platforms, `go install`, from source, or the install script. See
-[docs/INSTALLATION.md](docs/INSTALLATION.md).
+[docs/INSTALLATION.md](docs/INSTALLATION.md), or the
+[installation guide on the site](https://apispec.ehabterra.com/docs/#install).
 
 ### Generate an OpenAPI spec
 
@@ -263,12 +271,12 @@ See [`cmd/apidiag/README.md`](cmd/apidiag/README.md) for full documentation and 
 
 | Framework         | Routes & methods | Path params | Groups / mounting | Request body | Responses | Auth |
 |-------------------|:----------------:|:-----------:|:-----------------:|:------------:|:---------:|:----:|
-| **Gin**           | ✅               | ✅          | ✅                | ✅           | ✅        | ✅   |
-| **Echo**          | ✅               | ✅          | ✅                | ✅           | ✅        | ✅   |
-| **Chi**           | ✅               | ✅          | ✅ (incl. `render`) | ✅         | ✅        | ✅   |
-| **Fiber**         | ✅               | ✅          | ✅                | ✅           | ✅        | ✅   |
-| **Gorilla Mux**   | ✅               | ✅ (`mux.Vars(r)["id"]`, incl. helper-wrapped & `{id:regex}` → `pattern`) | ✅ (`PathPrefix`, `Subrouter`) | ✅ | ✅ | ✅ |
-| **`net/http`**    | ✅ (`HandleFunc`, `Handle`; Go 1.22 method-aware patterns) | ✅ (`{id}` wildcards + `r.PathValue`) | basic | ✅ | ✅ | ✅ |
+| **[Gin](https://apispec.ehabterra.com/gin-openapi-generator/)**           | ✅               | ✅          | ✅                | ✅           | ✅        | ✅   |
+| **[Echo](https://apispec.ehabterra.com/echo-openapi-generator/)**          | ✅               | ✅          | ✅                | ✅           | ✅        | ✅   |
+| **[Chi](https://apispec.ehabterra.com/chi-openapi-generator/)**           | ✅               | ✅          | ✅ (incl. `render`) | ✅         | ✅        | ✅   |
+| **[Fiber](https://apispec.ehabterra.com/fiber-openapi-generator/)**         | ✅               | ✅          | ✅                | ✅           | ✅        | ✅   |
+| **[Gorilla Mux](https://apispec.ehabterra.com/gorilla-mux-openapi-generator/)**   | ✅               | ✅ (`mux.Vars(r)["id"]`, incl. helper-wrapped & `{id:regex}` → `pattern`) | ✅ (`PathPrefix`, `Subrouter`) | ✅ | ✅ | ✅ |
+| **[`net/http`](https://apispec.ehabterra.com/net-http-openapi-generator/)**    | ✅ (`HandleFunc`, `Handle`; Go 1.22 method-aware patterns) | ✅ (`{id}` wildcards + `r.PathValue`) | basic | ✅ | ✅ | ✅ |
 
 Conditional registration (dynamic routes built at runtime) is generally not supported.
 


### PR DESCRIPTION
Closes #346.

The README contained **zero** links to https://apispec.ehabterra.com. The only connection between this repo and the site was the repository `homepageUrl` field, which renders as a small sidebar link — while the site has grown to 15 pages of installation, CLI reference, configuration, CI guidance and per-framework walkthroughs.

## Three additions

**1. A documentation line under the TL;DR**

```markdown
📖 **Documentation:** [apispec.ehabterra.com](https://apispec.ehabterra.com) — installation,
CLI reference, configuration, CI drift checking, and per-framework walkthroughs…

Coming from an annotation-based tool? See [APISpec vs swaggo/swag](…),
or [the wider landscape](…) if you are still choosing.
```

The swaggo comparison is included because "how is this different from swag?" is the first question most readers arrive with, and the README didn't address it anywhere.

**2. Each framework in the support table links to its guide**

Those pages show the spec APISpec actually produces for that router — generated by running the tool over a sample module, not written by hand.

**3. The install section** offers the hosted guide alongside `docs/INSTALLATION.md`.

## Verification

All ten added URLs checked, all return 200:

```
https://apispec.ehabterra.com                              200
https://apispec.ehabterra.com/alternatives/                200
https://apispec.ehabterra.com/chi-openapi-generator/       200
https://apispec.ehabterra.com/docs/#install                200
https://apispec.ehabterra.com/echo-openapi-generator/      200
https://apispec.ehabterra.com/fiber-openapi-generator/     200
https://apispec.ehabterra.com/gin-openapi-generator/       200
https://apispec.ehabterra.com/gorilla-mux-openapi-generator/ 200
https://apispec.ehabterra.com/net-http-openapi-generator/  200
https://apispec.ehabterra.com/vs/swaggo/                   200
```

Links only — no prose or technical claims were changed.

## Deliberately left out

The two accuracy notes from #346 — the Homebrew runtime-Go prerequisite, and the wording of *"Conditional registration (dynamic routes built at runtime) is generally not supported"*, which undersells what actually happens (those routes **are** documented; unresolved path segments get a synthesized parameter with an `x-warning`). Those change technical claims rather than add links, so they belong in a separate change if you agree with the framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a link to the documentation website.
  * Added comparison and alternatives resources.
  * Expanded installation guidance with a hosted installation guide.
  * Added website links for each supported framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->