### PR TITLE
perf: skip subtrees no matcher can accept (#318)

### DIFF
--- a/generator/testdata_barren_subtree_test.go
+++ b/generator/testdata_barren_subtree_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestTestdata_BarrenSubtree guards the barren-subtree prune (issue #318): the
+// expansion skips subtrees no matcher family can accept, which is 97.6% of the
+// nodes on a real service.
+//
+// The fixture wraps two ordinary routes around a dense, mutually recursive
+// utility layer that matches nothing. What must survive the prune is everything
+// the routes actually declare — the paths, the request body, the status-coded
+// response and the array response — because each of those hangs off a node the
+// prune has to prove reachable. A prune that is too aggressive does not fail
+// loudly; it drops one of these quietly, which is what this asserts against.
+func TestTestdata_BarrenSubtree(t *testing.T) {
+	out := loadTestdata(t, "barren_subtree", nil)
+
+	item, ok := out.Paths["/orders"]
+	if !ok {
+		t.Fatalf("/orders missing; have %v", mapPathKeys(out.Paths))
+	}
+	if item.Post == nil {
+		t.Fatal("POST /orders missing — the route is behind the barren helper layer")
+	}
+	if item.Get == nil {
+		t.Fatal("GET /orders missing — it shares the barren helpers with POST")
+	}
+
+	// Request body: reached through the handler, which also calls into the
+	// barren layer.
+	if item.Post.RequestBody == nil {
+		t.Fatal("POST /orders: request body dropped")
+	}
+	body, ok := item.Post.RequestBody.Content["application/json"]
+	if !ok || body.Schema == nil {
+		t.Fatalf("POST /orders: want an application/json body schema, got %+v", item.Post.RequestBody.Content)
+	}
+	if !strings.Contains(body.Schema.Ref, "CreateOrderRequest") {
+		t.Errorf("POST /orders: want a $ref to CreateOrderRequest, got ref=%q type=%q", body.Schema.Ref, body.Schema.Type)
+	}
+
+	// Response: the status comes from WriteHeader and the schema from the
+	// Encode argument, both below the same handler.
+	created, ok := item.Post.Responses["201"]
+	if !ok {
+		codes := make([]string, 0, len(item.Post.Responses))
+		for code := range item.Post.Responses {
+			codes = append(codes, code)
+		}
+		sort.Strings(codes)
+		t.Fatalf("POST /orders: want a 201 response, have %v", codes)
+	}
+	resp, ok := created.Content["application/json"]
+	if !ok || resp.Schema == nil {
+		t.Fatalf("POST /orders 201: want an application/json schema, got %+v", created.Content)
+	}
+	if !strings.Contains(resp.Schema.Ref, "Order") {
+		t.Errorf("POST /orders 201: want a $ref to Order, got ref=%q type=%q", resp.Schema.Ref, resp.Schema.Type)
+	}
+
+	// The array response on the sibling route, which reaches the same helpers
+	// along different paths — the diamond the unfolding duplicates.
+	var listSchemaOK bool
+	for _, r := range item.Get.Responses {
+		c, ok := r.Content["application/json"]
+		if !ok || c.Schema == nil {
+			continue
+		}
+		if c.Schema.Type == "array" && c.Schema.Items != nil && strings.Contains(c.Schema.Items.Ref, "Order") {
+			listSchemaOK = true
+		}
+	}
+	if !listSchemaOK {
+		t.Error("GET /orders: want an array-of-Order response; the sibling route's schema was dropped")
+	}
+}

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -308,6 +308,11 @@ func (e *Extractor) initializePatternMatchers() {
 
 // ExtractRoutes extracts all routes from the tracker tree
 func (e *Extractor) ExtractRoutes() []*RouteInfo {
+	// Installed before the first expansion, not at tree construction, because
+	// the matcher families belong to the extractor. The tree expands nothing
+	// until walked, so this is in time (issue #318, prune.go).
+	e.enableBarrenPruning()
+
 	routes := make([]*RouteInfo, 0)
 	for _, root := range e.tree.GetRoots() {
 		e.traverseForRoutes(root, "", nil, nil, nil, &routes)

--- a/internal/spec/lazytree.go
+++ b/internal/spec/lazytree.go
@@ -158,6 +158,18 @@ type LazyTree struct {
 	// routeMatch gates which entrypoints earn a root: only those whose subtree
 	// can reach a route registration.
 	routeMatch func(*metadata.CallGraphEdge) bool
+	// edgeMatches reports whether any configured matcher family accepts an edge
+	// — the base case of the barren-subtree prune (issue #318, see prune.go).
+	// Nil is the off switch, and the default: a consumer that wants the full
+	// unfolding (the diagram server builds its own tree and never runs the
+	// extractor) simply never installs one.
+	edgeMatches func(*metadata.CallGraphEdge) bool
+	// reach is the memoized per-identity answer; nil until built, and nil
+	// forever when pruning is off. reachIdentities is its size, reported.
+	reach           map[planKey]bool
+	reachBuilt      bool
+	reachIdentities int
+
 	// terminalRouteMatch matches only the calls that register ONE route. It is
 	// what opens a budget scope; routeMatch (which also matches mounts and
 	// groups) must not, or every route inside a group shares one allowance —
@@ -825,6 +837,19 @@ func WithTerminalRouteMatcher(match func(*metadata.CallGraphEdge) bool) LazyTree
 	return func(t *LazyTree) { t.terminalRouteMatch = match }
 }
 
+// SetEdgeMatcher supplies the predicate deciding whether an edge is one some
+// matcher family accepts, enabling the barren-subtree prune. Set by the
+// extractor before it walks, because the matcher families are its own; the tree
+// is constructed earlier and expands nothing until walked, so installing it here
+// is not late.
+func (t *LazyTree) SetEdgeMatcher(match func(*metadata.CallGraphEdge) bool) {
+	if t == nil {
+		return
+	}
+	t.edgeMatches = match
+	t.reach, t.reachBuilt = nil, false
+}
+
 // addEntrypointRoots appends a root per qualifying entrypoint. Called from
 // buildRelations (which every expansion path already goes through) rather than
 // from the constructor, because the candidate set comes out of the same walk that
@@ -1144,6 +1169,13 @@ func (n *LazyNode) GetChildren() []TrackerNodeInterface {
 		}
 		if n.onPath(spec.key) {
 			continue // cycle: this call is already on the current path
+		}
+		if !n.tree.canReachMatch(spec) {
+			// Nothing below this child can match any pattern, on any path, so
+			// the whole subtree would be built only to be walked and discarded
+			// (issue #318). Skipped rather than built-and-ignored: it is 97.6%
+			// of the nodes on a real service.
+			continue
 		}
 		if scopeCounts[spec.key] >= n.tree.instanceBudget() {
 			// Diamond inside this scope: stop materializing further copies.

--- a/internal/spec/lazytree.go
+++ b/internal/spec/lazytree.go
@@ -165,10 +165,9 @@ type LazyTree struct {
 	// extractor) simply never installs one.
 	edgeMatches func(*metadata.CallGraphEdge) bool
 	// reach is the memoized per-identity answer; nil until built, and nil
-	// forever when pruning is off. reachIdentities is its size, reported.
-	reach           map[planKey]bool
-	reachBuilt      bool
-	reachIdentities int
+	// forever when pruning is off.
+	reach      map[planKey]bool
+	reachBuilt bool
 
 	// terminalRouteMatch matches only the calls that register ONE route. It is
 	// what opens a budget scope; routeMatch (which also matches mounts and

--- a/internal/spec/prune.go
+++ b/internal/spec/prune.go
@@ -147,7 +147,6 @@ func (t *LazyTree) buildReachIndex() {
 	}
 
 	t.reach = computeReach(roots, childrenOf, matches)
-	t.reachIdentities = len(specOf)
 }
 
 // computeReach returns the identities with a path to one that matches.

--- a/internal/spec/prune.go
+++ b/internal/spec/prune.go
@@ -110,24 +110,22 @@ func (t *LazyTree) buildReachIndex() {
 	specOf := map[planKey]childSpec{}
 	roots := make([]planKey, 0, len(t.roots))
 	for _, r := range t.roots {
+		// buildRelations creates every root as a bare-key node, so a root is
+		// never an argument and the identity is the key alone.
 		root, ok := r.(*LazyNode)
 		if !ok {
 			continue
 		}
 		spec := childSpec{key: root.key, edge: root.edge, arg: root.arg, argType: root.argType}
-		if root.isArgument {
-			spec.argEdge = root.edge
-		}
 		id := specIdentity(spec)
 		specOf[id] = spec
 		roots = append(roots, id)
 	}
 
 	childrenOf := func(id planKey) []planKey {
-		spec, ok := specOf[id]
-		if !ok {
-			return nil
-		}
+		// Every id computeReach can ask about was registered here or as a root
+		// before it was handed back, so the lookup always finds its spec.
+		spec := specOf[id]
 		// planFor memoizes, so the plans built here are the same objects the
 		// expansion will use — this warms the memo rather than duplicating it.
 		plan := t.planFor(t.specNode(spec))

--- a/internal/spec/prune.go
+++ b/internal/spec/prune.go
@@ -1,0 +1,283 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import "github.com/ehabterra/apispec/internal/metadata"
+
+// Barren-subtree pruning (issue #318).
+//
+// The lazy tree materializes one node per PATH, so a callee reached along many
+// paths is rebuilt once per path: measured on a 163-route service, 12,882
+// distinct callee keys unfold into 7,147,505 nodes. Of those, 6,930,424 (97.6%)
+// sit in subtrees that match no pattern at all — the walk builds 7.1M nodes to
+// consult 104K.
+//
+// Those subtrees can be skipped outright, and soundly rather than heuristically,
+// because of a property the extractor already documents and relies on for its
+// per-edge matcher memos: every matcher family's MatchNode is a pure function of
+// the CALL EDGE, and only extraction depends on a node's ancestry. So "does this
+// subtree contain anything a matcher would accept" is a property of content
+// identity, not of path — which is exactly what a per-path unfolding cannot
+// exploit on its own.
+//
+// The answer is therefore computed once over the PLAN graph (content identities,
+// of which there are thousands) instead of over the unfolded tree (millions).
+// A node that can reach a match is still built, so provenance resolution walking
+// UP from a matching node is unaffected: nothing it can reach is ever pruned.
+
+// specIdentity returns the plan-memo key the node built from this spec would
+// have. It must agree with planFor's key exactly, or the reachability answer
+// would be recorded against an identity the expansion never asks about.
+func specIdentity(spec childSpec) planKey {
+	if spec.arg != nil {
+		return planKey{key: spec.key, edge: spec.argEdge, arg: spec.arg, isArg: true}
+	}
+	return planKey{key: spec.key, edge: spec.edge, isArg: false}
+}
+
+// specEdge is the edge the node built from this spec would carry — the argument's
+// own edge for an argument child, the callee edge otherwise, mirroring the
+// assignments GetChildren makes.
+func specEdge(spec childSpec) *metadata.CallGraphEdge {
+	if spec.arg != nil {
+		return spec.argEdge
+	}
+	return spec.edge
+}
+
+// specNode builds the throwaway node an identity's plan is computed from. It has
+// no parent, which is safe by buildPlan's own contract: "Nothing here may depend
+// on the node's parent — per-path concerns live in GetChildren."
+func (t *LazyTree) specNode(spec childSpec) *LazyNode {
+	n := &LazyNode{tree: t, key: spec.key}
+	if spec.arg != nil {
+		n.edge, n.arg, n.argType, n.isArgument = spec.argEdge, spec.arg, spec.argType, true
+		return n
+	}
+	n.edge = spec.edge
+	return n
+}
+
+// canReachMatch reports whether the subtree of the node this spec would create
+// can contain any node a matcher accepts. False means the subtree is provably
+// empty of anything the spec generation reads, so it need not be built.
+//
+// Answers true when pruning is not in force, so the guard is inert unless a
+// predicate has been supplied.
+func (t *LazyTree) canReachMatch(spec childSpec) bool {
+	if t.edgeMatches == nil {
+		return true
+	}
+	if !t.reachBuilt {
+		t.buildReachIndex()
+	}
+	return t.reach[specIdentity(spec)]
+}
+
+// buildReachIndex computes, for every content identity reachable from the roots,
+// whether its subtree can reach a matcher-accepted edge.
+//
+// Two passes, both linear:
+//
+//  1. Enumerate the identities and record REVERSE edges (child -> parents),
+//     seeding the identities whose own edge matches.
+//  2. Propagate backwards from the seeds. Reachability is a least fixpoint over
+//     an OR, and running it backwards from the matches reaches exactly the
+//     identities with a path to one — with no special handling for cycles, which
+//     a forward DFS with memoization would get wrong (a node whose only route to
+//     a match runs through a back edge would cache a premature false).
+func (t *LazyTree) buildReachIndex() {
+	if t.reachBuilt || t.edgeMatches == nil {
+		return
+	}
+	t.reachBuilt = true
+	t.buildRelations()
+
+	// Roots are identities too: one that cannot reach a match is not worth
+	// expanding either.
+	specOf := map[planKey]childSpec{}
+	roots := make([]planKey, 0, len(t.roots))
+	for _, r := range t.roots {
+		root, ok := r.(*LazyNode)
+		if !ok {
+			continue
+		}
+		spec := childSpec{key: root.key, edge: root.edge, arg: root.arg, argType: root.argType}
+		if root.isArgument {
+			spec.argEdge = root.edge
+		}
+		id := specIdentity(spec)
+		specOf[id] = spec
+		roots = append(roots, id)
+	}
+
+	childrenOf := func(id planKey) []planKey {
+		spec, ok := specOf[id]
+		if !ok {
+			return nil
+		}
+		// planFor memoizes, so the plans built here are the same objects the
+		// expansion will use — this warms the memo rather than duplicating it.
+		plan := t.planFor(t.specNode(spec))
+		out := make([]planKey, 0, len(plan))
+		for _, child := range plan {
+			childID := specIdentity(child)
+			if _, seen := specOf[childID]; !seen {
+				specOf[childID] = child
+			}
+			out = append(out, childID)
+		}
+		return out
+	}
+	matches := func(id planKey) bool {
+		spec, ok := specOf[id]
+		return ok && t.edgeMatches(specEdge(spec))
+	}
+
+	t.reach = computeReach(roots, childrenOf, matches)
+	t.reachIdentities = len(specOf)
+}
+
+// computeReach returns the identities with a path to one that matches.
+//
+// Enumerate forwards recording REVERSE edges, then propagate backwards from the
+// matches. Backwards is what makes cycles a non-issue: a forward DFS with
+// memoization caches a premature false for a node whose only route to a match
+// runs through a back edge that was still in progress (X -> Y -> X with X -> M
+// wrongly answers false for Y), so it would need SCC condensation or repeated
+// passes to be correct. Propagating from the matches needs neither.
+func computeReach(roots []planKey, childrenOf func(planKey) []planKey, matches func(planKey) bool) map[planKey]bool {
+	reach := map[planKey]bool{}
+	rev := map[planKey][]planKey{}
+	seen := map[planKey]bool{}
+	var seeds, frontier []planKey
+
+	visit := func(id planKey) {
+		if seen[id] {
+			return
+		}
+		seen[id] = true
+		frontier = append(frontier, id)
+		if matches(id) && !reach[id] {
+			reach[id] = true
+			seeds = append(seeds, id)
+		}
+	}
+	for _, id := range roots {
+		visit(id)
+	}
+	for len(frontier) > 0 {
+		id := frontier[len(frontier)-1]
+		frontier = frontier[:len(frontier)-1]
+		for _, child := range childrenOf(id) {
+			rev[child] = append(rev[child], id)
+			visit(child)
+		}
+	}
+	for len(seeds) > 0 {
+		id := seeds[len(seeds)-1]
+		seeds = seeds[:len(seeds)-1]
+		for _, parent := range rev[id] {
+			if !reach[parent] {
+				reach[parent] = true
+				seeds = append(seeds, parent)
+			}
+		}
+	}
+	return reach
+}
+
+// edgeOnlyNode presents a bare call edge as a TrackerNodeInterface, so a
+// matcher family can be evaluated for an edge before any node exists for it.
+//
+// Sound because of the property this whole mechanism rests on, stated at the
+// extractor's per-edge matcher memos: every MatchNode implementation reads only
+// GetEdge(). The remaining methods answer as an unparented, childless node, so a
+// matcher that started consulting ancestry would see "no ancestry" and — since
+// every such check is a further condition to satisfy — match no MORE than the
+// real node would. The prune stays an over-approximation either way.
+type edgeOnlyNode struct{ edge *metadata.CallGraphEdge }
+
+func (n edgeOnlyNode) GetKey() string                      { return "" }
+func (n edgeOnlyNode) GetParent() TrackerNodeInterface     { return nil }
+func (n edgeOnlyNode) GetChildren() []TrackerNodeInterface { return nil }
+func (n edgeOnlyNode) GetEdge() *metadata.CallGraphEdge    { return n.edge }
+func (n edgeOnlyNode) GetArgument() *metadata.CallArgument { return nil }
+func (n edgeOnlyNode) GetTypeParamMap() map[string]string  { return nil }
+
+// edgeMatchesAnyFamily reports whether any configured matcher accepts the edge.
+// It is the base case of the barren-subtree prune: an edge no family accepts
+// contributes nothing to the spec, and a subtree of only such edges contributes
+// nothing at all.
+//
+// EVERY family that the extraction walk consults has to be represented here. A
+// family left out would make the prune drop subtrees that family would have
+// matched — routes going quietly missing, which is the failure mode this guards.
+func (e *Extractor) edgeMatchesAnyFamily(edge *metadata.CallGraphEdge) bool {
+	if edge == nil {
+		return false
+	}
+	node := edgeOnlyNode{edge: edge}
+	for _, m := range e.routeMatchers {
+		if m.MatchNode(node) {
+			return true
+		}
+	}
+	for _, m := range e.mountMatchers {
+		if m.MatchNode(node) {
+			return true
+		}
+	}
+	for _, m := range e.securityMatchers {
+		if m.MatchNode(node) {
+			return true
+		}
+	}
+	for _, m := range e.requestMatchers {
+		if m.MatchNode(node) {
+			return true
+		}
+	}
+	for _, m := range e.responseMatchers {
+		if m.MatchNode(node) {
+			return true
+		}
+	}
+	for _, m := range e.paramMatchers {
+		if m.MatchNode(node) {
+			return true
+		}
+	}
+	return false
+}
+
+// enableBarrenPruning hands the tree the matcher-derived predicate, memoized per
+// edge because the reachability build asks once per identity and edges repeat
+// across them. A tree that does not support pruning ignores this.
+func (e *Extractor) enableBarrenPruning() {
+	lazy, ok := e.tree.(*LazyTree)
+	if !ok {
+		return
+	}
+	memo := map[*metadata.CallGraphEdge]bool{}
+	lazy.SetEdgeMatcher(func(edge *metadata.CallGraphEdge) bool {
+		if v, ok := memo[edge]; ok {
+			return v
+		}
+		v := e.edgeMatchesAnyFamily(edge)
+		memo[edge] = v
+		return v
+	})
+}

--- a/internal/spec/prune_test.go
+++ b/internal/spec/prune_test.go
@@ -193,3 +193,64 @@ func TestSpecIdentityMatchesPlanKey(t *testing.T) {
 		t.Errorf("call child: specEdge = %p, want the callee edge %p", got, calleeEdge)
 	}
 }
+
+// TestEdgeOnlyNodeAnswersAsUnparented pins the half of the prune's soundness
+// argument that lives in this type rather than in the fixpoint.
+//
+// edgeOnlyNode lets a matcher family be evaluated for an edge before any node
+// exists for it. That is sound because every MatchNode implementation reads only
+// GetEdge() — but the argument does not stop there: should one start consulting
+// ancestry, it must see NOTHING rather than something borrowed, since every such
+// check is a further condition to satisfy. Answering empty keeps the prune an
+// over-approximation, which is the direction that can only keep subtrees the
+// real node would have kept, never drop one it would have matched.
+func TestEdgeOnlyNodeAnswersAsUnparented(t *testing.T) {
+	edge := &metadata.CallGraphEdge{}
+	node := edgeOnlyNode{edge: edge}
+
+	if node.GetEdge() != edge {
+		t.Errorf("GetEdge = %p, want the edge under test %p", node.GetEdge(), edge)
+	}
+	if got := node.GetKey(); got != "" {
+		t.Errorf("GetKey = %q, want empty: an edge has no node key yet", got)
+	}
+	if got := node.GetParent(); got != nil {
+		t.Errorf("GetParent = %v, want nil: a matcher consulting ancestry must see none, not a borrowed one", got)
+	}
+	if got := node.GetChildren(); got != nil {
+		t.Errorf("GetChildren = %v, want nil", got)
+	}
+	if got := node.GetArgument(); got != nil {
+		t.Errorf("GetArgument = %v, want nil: the edge form carries no argument", got)
+	}
+	if got := node.GetTypeParamMap(); got != nil {
+		t.Errorf("GetTypeParamMap = %v, want nil", got)
+	}
+
+	// It has to actually satisfy the interface the matchers take, which is the
+	// whole point of the type.
+	var _ TrackerNodeInterface = node
+}
+
+// TestCanReachMatchIsInertWithoutAPredicate covers the off switch: no predicate
+// installed means no pruning, which is how every consumer other than the
+// extractor sees the tree (the diagram server builds its own and never installs
+// one). A tree that pruned by default would silently change what they read.
+func TestCanReachMatchIsInertWithoutAPredicate(t *testing.T) {
+	tree := &LazyTree{}
+	spec := childSpec{key: "pkg.Anything"}
+
+	if !tree.canReachMatch(spec) {
+		t.Error("with no edge matcher installed every child must be kept; pruning must be opt-in")
+	}
+	if tree.reachBuilt {
+		t.Error("no index should be built when pruning is off")
+	}
+
+	// buildReachIndex is likewise a no-op, so a consumer that never installs a
+	// predicate pays nothing for the machinery.
+	tree.buildReachIndex()
+	if tree.reach != nil || tree.reachBuilt {
+		t.Errorf("buildReachIndex built an index with no predicate: reach=%v built=%v", tree.reach, tree.reachBuilt)
+	}
+}

--- a/internal/spec/prune_test.go
+++ b/internal/spec/prune_test.go
@@ -147,17 +147,32 @@ func TestComputeReachJoinsDiamond(t *testing.T) {
 func TestSpecIdentityMatchesPlanKey(t *testing.T) {
 	tree := &LazyTree{}
 
-	callSpec := childSpec{key: "pkg.Callee"}
+	// Distinct, non-nil edges throughout: an argument child carries argEdge and
+	// a call child carries edge, so leaving either nil would let the test pass
+	// even if specIdentity read the wrong one.
+	calleeEdge := &metadata.CallGraphEdge{}
+	argOwnEdge := &metadata.CallGraphEdge{}
+	parentEdge := &metadata.CallGraphEdge{}
+
+	callSpec := childSpec{key: "pkg.Callee", edge: calleeEdge}
 	callNode := tree.specNode(callSpec)
 	wantCall := planKey{key: callNode.key, edge: callNode.edge, arg: callNode.arg, isArg: callNode.isArgument}
 	if got := specIdentity(callSpec); got != wantCall {
 		t.Errorf("call child: specIdentity = %+v, planFor would use %+v", got, wantCall)
 	}
+	if callNode.edge != calleeEdge {
+		t.Errorf("call child: node carries edge %p, want the spec's callee edge %p", callNode.edge, calleeEdge)
+	}
 
-	argSpec := childSpec{key: "pkg.Arg", argType: ArgTypeLiteral}
-	// A non-nil arg is what makes it an argument child; the pointer identity is
-	// all that matters to the key.
-	argSpec.arg = &metadata.CallArgument{}
+	// An argument child carries its OWN edge, not the parent edge it holds for
+	// context — the distinction GetChildren makes and the identity must follow.
+	argSpec := childSpec{
+		key:     "pkg.Arg",
+		edge:    parentEdge,
+		argEdge: argOwnEdge,
+		arg:     &metadata.CallArgument{},
+		argType: ArgTypeLiteral,
+	}
 	argNode := tree.specNode(argSpec)
 	wantArg := planKey{key: argNode.key, edge: argNode.edge, arg: argNode.arg, isArg: argNode.isArgument}
 	if got := specIdentity(argSpec); got != wantArg {
@@ -165,5 +180,16 @@ func TestSpecIdentityMatchesPlanKey(t *testing.T) {
 	}
 	if !argNode.isArgument {
 		t.Error("a spec carrying an argument must build an argument node")
+	}
+	if argNode.edge != argOwnEdge {
+		t.Errorf("argument child: node carries edge %p, want the argument's own edge %p (not the parent edge %p)",
+			argNode.edge, argOwnEdge, parentEdge)
+	}
+	if got := specEdge(argSpec); got != argOwnEdge {
+		t.Errorf("argument child: specEdge = %p, want the argument's own edge %p — the prune would test the wrong edge for a match",
+			got, argOwnEdge)
+	}
+	if got := specEdge(callSpec); got != calleeEdge {
+		t.Errorf("call child: specEdge = %p, want the callee edge %p", got, calleeEdge)
 	}
 }

--- a/internal/spec/prune_test.go
+++ b/internal/spec/prune_test.go
@@ -1,0 +1,169 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// reachCase drives computeReach over a named graph, so the tests read as the
+// graph shapes they are about rather than as planKey literals.
+func reachCase(t *testing.T, graph map[string][]string, matching []string, roots ...string) map[string]bool {
+	t.Helper()
+	id := func(name string) planKey { return planKey{key: name} }
+	rootIDs := make([]planKey, 0, len(roots))
+	for _, r := range roots {
+		rootIDs = append(rootIDs, id(r))
+	}
+	childrenOf := func(k planKey) []planKey {
+		out := make([]planKey, 0, len(graph[k.key]))
+		for _, c := range graph[k.key] {
+			out = append(out, id(c))
+		}
+		return out
+	}
+	matches := func(k planKey) bool { return slices.Contains(matching, k.key) }
+
+	got := computeReach(rootIDs, childrenOf, matches)
+	byName := map[string]bool{}
+	for k, v := range got {
+		byName[k.key] = v
+	}
+	return byName
+}
+
+func assertReach(t *testing.T, got map[string]bool, want map[string]bool) {
+	t.Helper()
+	for name, expect := range want {
+		if got[name] != expect {
+			t.Errorf("reach[%s] = %v, want %v", name, got[name], expect)
+		}
+	}
+}
+
+// TestComputeReachMarksThePathToAMatch covers the base case the prune rests on:
+// a node is kept when something below it matches, and dropped when nothing does.
+func TestComputeReachMarksThePathToAMatch(t *testing.T) {
+	// root -> a -> b -> match, and root -> dead -> alsoDead
+	got := reachCase(t,
+		map[string][]string{
+			"root": {"a", "dead"},
+			"a":    {"b"},
+			"b":    {"match"},
+			"dead": {"alsoDead"},
+		},
+		[]string{"match"},
+		"root")
+
+	assertReach(t, got, map[string]bool{
+		"root": true, "a": true, "b": true, "match": true,
+		"dead": false, "alsoDead": false,
+	})
+}
+
+// TestComputeReachHandlesCycleToAMatch is the case a forward DFS with
+// memoization gets WRONG, and the reason the fixpoint runs backwards from the
+// matches instead.
+//
+// x -> y -> x, and x -> match. A forward DFS entering x marks it in progress,
+// descends into y, sees x is in progress, treats that edge as contributing
+// nothing, and caches y = false — before it ever reaches match through x's other
+// child. y really can reach the match, via x.
+func TestComputeReachHandlesCycleToAMatch(t *testing.T) {
+	got := reachCase(t,
+		map[string][]string{
+			"x": {"y", "match"},
+			"y": {"x"},
+		},
+		[]string{"match"},
+		"x")
+
+	assertReach(t, got, map[string]bool{"x": true, "match": true})
+	if !got["y"] {
+		t.Error("y reaches the match through x and must be kept; a forward DFS would cache a premature false here")
+	}
+}
+
+// TestComputeReachDropsAMatchlessCycle is the same shape without a match: a
+// cycle must not keep itself alive.
+func TestComputeReachDropsAMatchlessCycle(t *testing.T) {
+	got := reachCase(t,
+		map[string][]string{
+			"root": {"x"},
+			"x":    {"y"},
+			"y":    {"x"},
+		},
+		nil,
+		"root")
+
+	assertReach(t, got, map[string]bool{"root": false, "x": false, "y": false})
+}
+
+// TestComputeReachKeepsAMatchingRoot covers a root that matches on its own,
+// with nothing below it.
+func TestComputeReachKeepsAMatchingRoot(t *testing.T) {
+	got := reachCase(t, map[string][]string{"root": nil}, []string{"root"}, "root")
+	assertReach(t, got, map[string]bool{"root": true})
+}
+
+// TestComputeReachJoinsDiamond covers a node reached along two paths, only one
+// of which leads to a match — the shared-helper shape the tree unfolds per path.
+func TestComputeReachJoinsDiamond(t *testing.T) {
+	got := reachCase(t,
+		map[string][]string{
+			"root":   {"left", "right"},
+			"left":   {"shared"},
+			"right":  {"shared"},
+			"shared": {"match", "dead"},
+		},
+		[]string{"match"},
+		"root")
+
+	assertReach(t, got, map[string]bool{
+		"root": true, "left": true, "right": true, "shared": true, "match": true,
+		"dead": false,
+	})
+}
+
+// TestSpecIdentityMatchesPlanKey pins the correspondence the whole mechanism
+// depends on: the identity a reachability answer is recorded against must be the
+// key planFor looks the plan up by, for both child shapes. If these drift, the
+// prune silently answers about a different node than the one being expanded.
+func TestSpecIdentityMatchesPlanKey(t *testing.T) {
+	tree := &LazyTree{}
+
+	callSpec := childSpec{key: "pkg.Callee"}
+	callNode := tree.specNode(callSpec)
+	wantCall := planKey{key: callNode.key, edge: callNode.edge, arg: callNode.arg, isArg: callNode.isArgument}
+	if got := specIdentity(callSpec); got != wantCall {
+		t.Errorf("call child: specIdentity = %+v, planFor would use %+v", got, wantCall)
+	}
+
+	argSpec := childSpec{key: "pkg.Arg", argType: ArgTypeLiteral}
+	// A non-nil arg is what makes it an argument child; the pointer identity is
+	// all that matters to the key.
+	argSpec.arg = &metadata.CallArgument{}
+	argNode := tree.specNode(argSpec)
+	wantArg := planKey{key: argNode.key, edge: argNode.edge, arg: argNode.arg, isArg: argNode.isArgument}
+	if got := specIdentity(argSpec); got != wantArg {
+		t.Errorf("argument child: specIdentity = %+v, planFor would use %+v", got, wantArg)
+	}
+	if !argNode.isArgument {
+		t.Error("a spec carrying an argument must build an argument node")
+	}
+}

--- a/testdata/barren_subtree/go.mod
+++ b/testdata/barren_subtree/go.mod
@@ -1,0 +1,3 @@
+module example.com/barrensubtree
+
+go 1.26

--- a/testdata/barren_subtree/main.go
+++ b/testdata/barren_subtree/main.go
@@ -1,0 +1,125 @@
+// Package main exercises the barren-subtree prune (issue #318): a handler whose
+// real work — decoding a body, writing a response — sits behind a large subtree
+// of calls that match no pattern at all.
+//
+// The utility layer below is deliberately dense and mutually recursive, so the
+// per-path unfolding reaches it along many distinct paths. None of it can
+// contribute to the spec, so the expansion is free to skip it; what this fixture
+// guards is that skipping it does not take the route, its request body or its
+// response with it.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type CreateOrderRequest struct {
+	SKU      string `json:"sku"`
+	Quantity int    `json:"quantity"`
+}
+
+type Order struct {
+	ID    string `json:"id"`
+	SKU   string `json:"sku"`
+	Total int    `json:"total"`
+}
+
+// The barren layer. Nothing here is a route, a body, a param or a response —
+// it is the shape that makes a real project's tree explode.
+
+func normalize(s string) string {
+	if len(s) == 0 {
+		return s
+	}
+	return trim(pad(s))
+}
+
+func pad(s string) string {
+	if len(s) > 4 {
+		return s
+	}
+	return pad(s + "_")
+}
+
+func trim(s string) string {
+	if len(s) < 2 {
+		return s
+	}
+	return classify(s)
+}
+
+func classify(s string) string {
+	switch {
+	case len(s)%3 == 0:
+		return score(s)
+	case len(s)%3 == 1:
+		return weigh(s)
+	default:
+		return s
+	}
+}
+
+func score(s string) string {
+	if len(s) > 32 {
+		return s
+	}
+	return weigh(s + "s")
+}
+
+func weigh(s string) string {
+	if len(s) > 24 {
+		return s
+	}
+	return normalize(s[:len(s)-1])
+}
+
+func total(q int) int {
+	if q <= 0 {
+		return 0
+	}
+	return q*price(q) + surcharge(q)
+}
+
+func price(q int) int {
+	if q > 10 {
+		return 5
+	}
+	return 10 - q
+}
+
+func surcharge(q int) int {
+	if q < 2 {
+		return 0
+	}
+	return price(q) / 2
+}
+
+// createOrder is the route. Its body and response must survive the prune, and
+// every barren helper above is reachable from it.
+func createOrder(w http.ResponseWriter, r *http.Request) {
+	var req CreateOrderRequest
+	_ = json.NewDecoder(r.Body).Decode(&req)
+
+	order := Order{
+		ID:    normalize(req.SKU),
+		SKU:   normalize(req.SKU),
+		Total: total(req.Quantity),
+	}
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(order)
+}
+
+// listOrders shares the same barren helpers, so they are reached along more than
+// one route's paths — the diamond that the per-path unfolding duplicates.
+func listOrders(w http.ResponseWriter, r *http.Request) {
+	_ = normalize("seed")
+	_ = json.NewEncoder(w).Encode([]Order{})
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /orders", createOrder)
+	mux.HandleFunc("GET /orders", listOrders)
+	_ = http.ListenAndServe(":8080", mux)
+}


### PR DESCRIPTION
Closes #318.

## The problem

The lazy tree materializes one node per PATH, so a callee reached along many paths is rebuilt once per path. On a 163-route service, 12,882 distinct callee keys unfold into 7,147,505 nodes. Instrumenting the extraction walk to report, per node, whether it or anything below it matched a pattern:

```
nodes visited                              = 7,103,742
nodes whose ENTIRE subtree matched nothing = 6,930,424   (97.6%)
nodes that ever matched                    =   104,156    (1.5%)
```

The walk builds 7.1M nodes to consult 104K.

## Why skipping them is sound, not a heuristic

The property this rests on is already documented in the code and relied on for the per-edge matcher memos (`extractor.go`):

> The MatchNode implementations of the response/request/param matcher families are **pure functions of the call edge**... Extraction itself stays per-node: it depends on the node's ancestry.

Matching is edge-pure; only *extraction* needs ancestry. So "does this subtree contain anything a matcher would accept" is a property of **content identity, not path** — precisely what a per-path unfolding cannot exploit on its own, and why the same barren subtree is rebuilt hundreds of times.

The answer is computed once over the **plan graph** (content identities, thousands) instead of the unfolded tree (millions), and `GetChildren` skips a child that cannot reach a match. A node that *can* reach one is still built, so provenance resolution walking up from a matching node is untouched — nothing it can reach is ever pruned.

Every matcher family is represented in the predicate — route, mount, security, request, response, param. A family left out would drop subtrees it would have matched, so `edgeMatchesAnyFamily` is the place to look when adding one.

**The fixpoint runs backwards from the matches, not forwards from the roots.** That is what makes cycles a non-issue: a forward DFS with memoization caches a premature `false` for a node whose only route to a match runs through a back edge still in progress (`x -> y -> x` with `x -> match` wrongly answers false for `y`), and would need SCC condensation or repeated passes to be correct. `TestComputeReachHandlesCycleToAMatch` is exactly that graph.

Pruning is enabled by the extractor installing the predicate before it walks, since the matcher families are its own. A nil predicate is the off switch **and the default** — a consumer that wants the full unfolding simply never installs one. (The diagram server builds its own eager tree and never runs the extractor, so diagrams are unaffected; `--diagram` renders from metadata, not the tree.)

## Measured

Mapping stage, minima of three interleaved pairs:

| | before | after |
|---|---|---|
| 163-route service | 6.06s | **2.67s** |
| ↳ nodes materialized | 7,147,505 | **405,490** (−94.3%) |
| ↳ peak RSS | 1145 MB | **522 MB** (−54%) |
| this repo | 6.58s | **0.58s** |

## Output

**Byte-identical** on the 163-route service, and deterministic across three runs.

**On this repo it changes — and only by gaining.** The baseline exhausts the per-route budget on 6 of 36 routes and drops 8,706,027 call copies to the instance cap, so responses were missing; the diff adds `200`/`500` responses with proper `$ref` schemas. Confirmed this is budget and not semantics:

- the pruned output is **converged** — raising both caps 20x changes nothing;
- the same raise on the baseline **does not terminate in ten minutes**.

That is #224's symptom (bodies silently missing at scale) easing as a side effect. The cap is much less load-bearing now: 509,218 copies dropped where it dropped 3,624,817, and the per-route truncation warning disappears entirely on the 163-route service.

## Test plan

- [x] `go test -race ./...`, `make lint`, `go vet`, `gofmt` — all clean
- [x] Metadata goldens unchanged; determinism tests pass
- [x] `testdata/barren_subtree` — two routes wrapped around a dense, mutually recursive utility layer that matches nothing, asserting the paths, request body, status-coded response and array response all survive. **Its output is identical with and without pruning**, so it is a change-detector rather than a test of the optimisation's own arithmetic.
- [x] `internal/spec/prune_test.go` — the fixpoint over named graphs: path-to-a-match, cycle-to-a-match, matchless cycle, matching root, diamond join; plus `TestSpecIdentityMatchesPlanKey`, which pins that the identity a reachability answer is recorded against is the key `planFor` looks the plan up by (if those drift, the prune silently answers about a different node).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved specification processing by pruning branches that cannot produce relevant routes or schemas.
  * Preserved route methods, request-body schemas, status-coded responses, and array responses during pruning.
  * Added handling for cyclic and branching specification structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->