### PR TITLE
fix(scripts): compare enum values as a set, not by position

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,13 @@ jobs:
     - name: Run integration tests
       run: go test -v ./cmd/apispec/...
 
+    # The snapshot comparator decides what counts as drift, so its own key
+    # semantics need guarding: keyed positionally, an inserted enum value or
+    # parameter reports everything after it as changed, which hides whether
+    # anything was really dropped.
+    - name: Comparator self-test
+      run: bash scripts/compare-spec.sh --self-test
+
     - name: Generate coverage report
       run: go tool cover -func=coverage.out
 

--- a/scripts/compare-spec-selftest.py
+++ b/scripts/compare-spec-selftest.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# Copyright 2026 Ehab Terra
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Self-test for compare-spec.sh's KEY SEMANTICS.
+
+The comparator's job is to tell drift from the same thing said differently, and
+that judgement lives entirely in how it keys values. Keyed by position, a list
+reports an INSERTION as a change to every member after it — which both invents
+drift and buries whether anything was genuinely dropped, the one thing the tool
+exists to answer.
+
+Each case writes a pair of tiny specs, runs the real comparator over them, and
+asserts the reported counts and the exit status. A regression then surfaces as a
+named failing case here, instead of as noise in a real project comparison months
+later.
+
+Run via: scripts/compare-spec.sh --self-test
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+
+def spec(schema=None, params=None):
+    doc = {"openapi": "3.1.1", "info": {"title": "t", "version": "1"}, "paths": {}}
+    if schema is not None:
+        doc["components"] = {"schemas": {"S": schema}}
+    if params is not None:
+        doc["paths"] = {
+            "/x": {"get": {"parameters": params, "responses": {"200": {"description": "OK"}}}}
+        }
+    return doc
+
+
+def run(script, ref, gen, flags):
+    with tempfile.TemporaryDirectory() as d:
+        a, b = os.path.join(d, "ref.yaml"), os.path.join(d, "gen.yaml")
+        for path, doc in ((a, ref), (b, gen)):
+            with open(path, "w") as f:
+                json.dump(doc, f)  # JSON is valid YAML
+        p = subprocess.run(
+            ["bash", script, "--compare-files", a, b, *flags],
+            capture_output=True,
+            text=True,
+        )
+        return p.returncode, p.stdout + p.stderr
+
+
+def count(out, label):
+    for line in out.splitlines():
+        line = line.strip()
+        if line.startswith(label + " ("):
+            return int(line.split("(", 1)[1].split(")", 1)[0])
+    return -1
+
+
+PATH_ID = {"name": "id", "in": "path", "required": True, "schema": {"type": "string"}}
+HEADER = {"name": "Retry-After", "in": "header", "schema": {"type": "string"}}
+REF_PARAM = {"$ref": "#/components/parameters/Foo"}
+
+ENUM32 = ["v%02d" % i for i in range(28)] + [
+    "unenrolled",
+    "user_requested",
+    "within_maximum",
+    "within_target",
+]
+ENUM35 = sorted(ENUM32 + ["teacher_extended", "teacher_restored", "teacher_withdrew"])
+
+
+def enum_spec(values):
+    return spec({"properties": {"f": {"enum": values}}})
+
+
+# (name, ref, gen, missing, changed, added, should_fail, flags)
+CASES = [
+    # The case this mechanism exists for: three values added to a 32-value enum
+    # reported four CHANGED and failed, when nothing changed and nothing was lost.
+    ("enum: values inserted", enum_spec(sorted(ENUM32)), enum_spec(ENUM35), 0, 0, 3, False, ["--all"]),
+    ("enum: value dropped still fails", enum_spec(["a", "b", "c"]), enum_spec(["a", "c"]), 1, 0, 0, True, []),
+    ("enum: mixed types not conflated", enum_spec([1, "1", True, None]), enum_spec([1, "1", True, None]), 0, 0, 0, False, []),
+    ("enum: int replaced by string is drift", enum_spec([1, 2]), enum_spec(["1", 2]), 1, 0, 1, True, ["--all"]),
+    # OpenAPI allows object and array enum members, so they are set members too
+    # rather than positional paths that cascade on insertion.
+    ("enum: object members inserted", enum_spec([{"k": 1}, {"k": 3}]), enum_spec([{"k": 1}, {"k": 2}, {"k": 3}]), 0, 0, 1, False, ["--all"]),
+    ("enum: object member dropped still fails", enum_spec([{"k": 1}, {"k": 2}]), enum_spec([{"k": 1}]), 1, 0, 0, True, []),
+    # A schema name spelled '.' on one side and '_' on the other canonicalizes to
+    # the same value, so the key derived from that value has to canonicalize too.
+    ("enum: $ref spelling canonicalizes in key and value",
+     enum_spec(["#/components/schemas/Foo.Bar"]), enum_spec(["#/components/schemas/Foo_Bar"]), 0, 0, 0, False, []),
+    # Parameters are identified by (name, in): inserting one must not rename the rest.
+    ("parameters: inserted ahead of an existing one", spec(params=[PATH_ID]), spec(params=[HEADER, PATH_ID]), 0, 0, 3, False, ["--all"]),
+    # Four leaves go with it: name, in, required and schema.type.
+    ("parameters: dropped still fails", spec(params=[HEADER, PATH_ID]), spec(params=[HEADER]), 4, 0, 0, True, []),
+    ("parameters: a changed attribute is still reported", spec(params=[PATH_ID]), spec(params=[{**PATH_ID, "required": False}]), 0, 1, 0, True, []),
+    # Without a usable identity the list stays positional, so precision never
+    # drops below what it was before identity keying.
+    ("parameters: $ref members fall back to positional", spec(params=[REF_PARAM]), spec(params=[REF_PARAM]), 0, 0, 0, False, []),
+]
+
+
+def main():
+    repo = sys.argv[1] if len(sys.argv) > 1 else os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    script = os.path.join(repo, "scripts", "compare-spec.sh")
+
+    failures = 0
+    for name, ref, gen, want_missing, want_changed, want_added, want_fail, flags in CASES:
+        code, out = run(script, ref, gen, flags)
+        got_added = count(out, "ADDED") if "--all" in flags else want_added
+        got = (count(out, "MISSING"), count(out, "CHANGED"), got_added)
+        want = (want_missing, want_changed, want_added)
+        if got == want and bool(code) == want_fail:
+            print(f"  ok   {name}")
+            continue
+        failures += 1
+        print(f"  FAIL {name}")
+        print(f"       want missing/changed/added={want} fails={want_fail}")
+        print(f"       got  missing/changed/added={got} fails={bool(code)}")
+        for line in out.splitlines():
+            print("       | " + line)
+
+    print()
+    if failures:
+        print(f"self-test: {failures} of {len(CASES)} cases FAILED")
+        return 1
+    print(f"self-test: all {len(CASES)} cases passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/compare-spec.sh
+++ b/scripts/compare-spec.sh
@@ -24,6 +24,11 @@
 #                     default: deleted).
 #   -a, --all         Also list ADDED keys (new routes/fields). STATUS CHANGES,
 #                     MISSING and CHANGED are always reported and always fail.
+#       --self-test   Check the comparator's own key semantics against built-in
+#                     cases and exit. Compares nothing and needs no project.
+#       --compare-files REF GEN
+#                     Compare two spec files directly and exit, skipping
+#                     generation. Used by --self-test; also handy by hand.
 #       --strict      Compare keys literally (do NOT canonicalize '.'<->'_' in
 #                     schema names / $refs). Off by default.
 #       --paths FILE  External-projects list file (default: scripts/compare-spec.paths).
@@ -45,6 +50,8 @@ VERSION=""
 KEEP=0
 SHOW_ALL=0
 STRICT=0
+SELF_TEST=0
+CMP_FILES=()
 GENERATE=0
 NO_TESTDATA=0
 APISPEC_BIN=""
@@ -60,6 +67,8 @@ while [[ $# -gt 0 ]]; do
     -k|--keep)      KEEP=1; shift ;;
     -a|--all)       SHOW_ALL=1; shift ;;
     --strict)       STRICT=1; shift ;;
+    --self-test)    SELF_TEST=1; shift ;;
+    --compare-files) CMP_FILES=("$2" "$3"); shift 3 ;;
     --paths)        PATHS_FILE="$2"; shift 2 ;;
     --no-testdata)  NO_TESTDATA=1; shift ;;
     --bin)          APISPEC_BIN="$2"; shift 2 ;;
@@ -68,6 +77,231 @@ while [[ $# -gt 0 ]]; do
     *)              PATHS+=("$1"); shift ;;
   esac
 done
+
+# self_test checks the comparator's KEY SEMANTICS -- which differences it treats
+# as drift, and which as the same thing said differently -- against built-in
+# cases. See scripts/compare-spec-selftest.py for what each case pins and why.
+self_test() {
+  python3 "$REPO_ROOT/scripts/compare-spec-selftest.py" "$REPO_ROOT"
+}
+
+compare_py() {
+python3 - "$1" "$2" "$SHOW_ALL" "$STRICT" <<'PY'
+import json, sys, yaml
+
+ref_file, gen_file = sys.argv[1], sys.argv[2]
+show_added = sys.argv[3] == "1"
+strict     = sys.argv[4] == "1"
+
+HTTP_METHODS = {"get", "put", "post", "delete", "options", "head", "patch", "trace"}
+
+# Lists whose meaning is membership, not order, and which are therefore keyed by
+# VALUE rather than by index. Sorting (below) already stops a reorder looking like
+# a change, but it does not help an INSERTION: keyed positionally, adding one
+# value to a 32-value enum reports every later value as CHANGED, which both
+# invents drift and buries whether anything was genuinely dropped.
+#
+# `required` and `tags` have the same set-like shape; add them here if their
+# insert-cascade becomes noisy too. They are left out for now because only enum
+# has actually produced false drift in practice.
+SET_VALUED_KEYS = {"enum"}
+
+# Lists of OBJECTS whose members have a stable identity, keyed by that identity
+# rather than by index for the same reason. A parameter is identified by
+# (name, in) per the OpenAPI spec, so inserting a header parameter ahead of a
+# path parameter should report one added parameter — not rename every one after
+# it. Falls back to positional keying when the identity is not usable (a $ref'd
+# parameter has no name, and duplicates would collide), so the comparison is
+# never made less precise than it was.
+IDENTITY_KEYED_LISTS = {"parameters": ("name", "in")}
+
+def member_token(v):
+    # Stable, type-aware identity for a whole set member. json rather than repr:
+    # it gives object and array members a canonical form (sorted keys), which
+    # repr does not, and it still keeps 1, 1.0, "1", true and null apart.
+    return json.dumps(v, sort_keys=True, default=str)
+
+def identity_tokens(obj, fields):
+    # Tokens for an identity-keyed list, or None when they cannot be trusted.
+    if not all(isinstance(v, dict) for v in obj):
+        return None
+    tokens = []
+    for v in obj:
+        if not all(v.get(f) is not None for f in fields):
+            return None  # a $ref'd or malformed member has no identity
+        tokens.append(",".join(str(v[f]) for f in fields))
+    if len(set(tokens)) != len(tokens):
+        return None  # duplicates would collapse; keep them positional instead
+    return tokens
+
+def flatten(obj, prefix=()):
+    out = {}
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            out.update(flatten(v, prefix + (str(k),)))
+    elif isinstance(obj, list):
+        parent = prefix[-1] if prefix else None
+        if obj and parent in SET_VALUED_KEYS:
+            # A member is identified by WHAT IT IS, so one added value is one
+            # ADDED entry and one removed value is one MISSING entry. Whole
+            # members, including object and array ones, which OpenAPI allows.
+            for v in obj:
+                out[prefix + (f"[={member_token(v)}]",)] = v
+            return out
+        if obj and parent in IDENTITY_KEYED_LISTS:
+            tokens = identity_tokens(obj, IDENTITY_KEYED_LISTS[parent])
+            if tokens is not None:
+                for token, v in zip(tokens, obj):
+                    out.update(flatten(v, prefix + (f"[{token}]",)))
+                return out
+        if obj and all(not isinstance(v, (dict, list)) for v in obj):
+            # Sort the remaining all-scalar lists (required, tags, security
+            # scopes, ...) so a cosmetic reorder does not masquerade as CHANGED.
+            obj = sorted(obj, key=lambda x: (str(type(x)), str(x)))
+        for i, v in enumerate(obj):
+            out.update(flatten(v, prefix + (f"[{i}]",)))
+    else:
+        out[prefix] = obj
+    return out
+
+def canon_seg(seg):
+    # Canonicalize a single path segment: treat '.' and '_' as the same separator
+    # in schema component identifiers (the sanitizer changed '.' -> '_').
+    return seg.replace(".", "_")
+
+def canon_key(key):
+    # Only canonicalize the schema-name segment (child of components.schemas.*).
+    if len(key) >= 3 and key[0] == "components" and key[1] == "schemas":
+        return key[:2] + (canon_seg(key[2]),) + key[3:]
+    return key
+
+def canon_val(v):
+    if isinstance(v, str) and v.startswith("#/components/schemas/"):
+        head, name = v.rsplit("/", 1)
+        return head + "/" + canon_seg(name)
+    if isinstance(v, list):
+        return [canon_val(x) for x in v]
+    if isinstance(v, dict):
+        return {k: canon_val(x) for k, x in v.items()}
+    return v
+
+def canon_entry(key, value):
+    # Canonicalize key and value TOGETHER. A set member's key is derived from its
+    # value, so canonicalizing only the value would leave two spellings of the
+    # same $ref keyed differently and report one MISSING plus one ADDED where
+    # there is no drift at all.
+    cvalue = canon_val(value)
+    if key and key[-1].startswith("[=") and cvalue != value:
+        key = key[:-1] + (f"[={member_token(cvalue)}]",)
+    return canon_key(key), cvalue
+
+def show(key):
+    # Human-readable path for display.
+    out = ""
+    for seg in key:
+        if seg.startswith("["):
+            out += seg
+        else:
+            out += ("." if out else "") + seg
+    return out
+
+def op_statuses(doc):
+    # {(path, METHOD): set(response status keys)} for every operation.
+    out = {}
+    for p, item in ((doc or {}).get("paths", {}) or {}).items():
+        if not isinstance(item, dict):
+            continue
+        for m, op in item.items():
+            if m.lower() not in HTTP_METHODS or not isinstance(op, dict):
+                continue
+            resps = op.get("responses", {}) or {}
+            out[(p, m.upper())] = {str(k) for k in resps}
+    return out
+
+with open(ref_file) as f: ref_doc = yaml.safe_load(f) or {}
+with open(gen_file) as f: gen_doc = yaml.safe_load(f) or {}
+
+# Say which file is not a spec, rather than failing inside the walk with an
+# AttributeError. Reachable by hand now that --compare-files takes any two paths.
+for label, path, doc in (("snapshot", ref_file, ref_doc), ("generated", gen_file, gen_doc)):
+    if not isinstance(doc, dict):
+        print(f"  error: {label} {path} is not an OpenAPI document "
+              f"(parsed as {type(doc).__name__})")
+        sys.exit(2)
+
+ref_raw = flatten(ref_doc)
+gen_raw = flatten(gen_doc)
+
+if strict:
+    ref, gen = ref_raw, gen_raw
+else:
+    ref = dict(canon_entry(k, v) for k, v in ref_raw.items())
+    gen = dict(canon_entry(k, v) for k, v in gen_raw.items())
+
+missing = sorted((k for k in ref if k not in gen), key=show)
+changed = sorted((k for k in ref if k in gen and ref[k] != gen[k]), key=show)
+added   = sorted((k for k in gen if k not in ref), key=show)
+
+# Per-operation response-status-set diffs (order-independent).
+ref_st, gen_st = op_statuses(ref_doc), op_statuses(gen_doc)
+status_diffs = []
+for opkey in sorted(set(ref_st) | set(gen_st)):
+    lost = sorted(ref_st.get(opkey, set()) - gen_st.get(opkey, set()))
+    gained = sorted(gen_st.get(opkey, set()) - ref_st.get(opkey, set()))
+    if lost or gained:
+        status_diffs.append((opkey, lost, gained))
+
+# Note the schema-rename normalization if it actually merged anything.
+if not strict:
+    renamed = sum(1 for k in ref_raw if canon_key(k) != k)
+    if renamed:
+        print(f"  (note: schema names canonicalized '.'<->'_'; {renamed} keys "
+              f"normalized — pass --strict to compare literally)")
+
+if status_diffs:
+    print(f"  STATUS CHANGES ({len(status_diffs)}) — response status set differs:")
+    for (p, m), lost, gained in status_diffs:
+        parts = []
+        if lost:   parts.append("lost "   + ",".join(lost))
+        if gained: parts.append("gained " + ",".join(gained))
+        print(f"    ! {m} {p}: {'; '.join(parts)}")
+else:
+    print("  STATUS CHANGES (0) — response status sets unchanged.")
+
+if missing:
+    print(f"  MISSING ({len(missing)}) — in snapshot, absent from generated:")
+    for k in missing:
+        print(f"    - {show(k)} = {ref[k]!r}")
+else:
+    print("  MISSING (0) — nothing from the snapshot was dropped.")
+
+if changed:
+    print(f"  CHANGED ({len(changed)}) — same key, different value:")
+    for k in changed:
+        print(f"    ~ {show(k)}: {ref[k]!r} -> {gen[k]!r}")
+else:
+    print("  CHANGED (0) — no in-place value changes.")
+
+if show_added and added:
+    print(f"  ADDED ({len(added)}) — new in generated:")
+    for k in added:
+        print(f"    + {show(k)} = {gen[k]!r}")
+
+# Fail on any drift that removes or alters documented behaviour: a status
+# gained/lost, a dropped key, or an in-place value change.
+sys.exit(1 if (status_diffs or missing or changed) else 0)
+PY
+}
+
+# Early-exit modes, dispatched here because they need the comparator above and
+# nothing below: neither resolves a project set, so neither should be made to
+# discover one first.
+if [[ $SELF_TEST -eq 1 ]]; then
+  self_test; exit $?
+fi
+if [[ ${#CMP_FILES[@]} -gt 0 ]]; then
+  compare_py "${CMP_FILES[0]}" "${CMP_FILES[1]}"; exit $?
+fi
 
 # Resolve a path token to an absolute path: absolute tokens as-is, otherwise
 # relative to the repo root (so the script works from any CWD).
@@ -206,156 +440,6 @@ run_apispec() {
 # entries for everything after it.
 # ADDED keys (new routes/fields) are informational and shown only with --all,
 # except added statuses, which the STATUS section always reports and fails on.
-compare_py() {
-python3 - "$1" "$2" "$SHOW_ALL" "$STRICT" <<'PY'
-import sys, yaml
-
-ref_file, gen_file = sys.argv[1], sys.argv[2]
-show_added = sys.argv[3] == "1"
-strict     = sys.argv[4] == "1"
-
-HTTP_METHODS = {"get", "put", "post", "delete", "options", "head", "patch", "trace"}
-
-# Lists whose meaning is membership, not order, and which are therefore keyed by
-# VALUE rather than by index. Sorting (below) already stops a reorder looking like
-# a change, but it does not help an INSERTION: keyed positionally, adding one
-# value to a 32-value enum reports every later value as CHANGED, which both
-# invents drift and buries whether anything was genuinely dropped.
-#
-# `required` and `tags` have the same set-like shape; add them here if their
-# insert-cascade becomes noisy too. They are left out for now because only enum
-# has actually produced false drift in practice.
-SET_VALUED_KEYS = {"enum"}
-
-def flatten(obj, prefix=()):
-    out = {}
-    if isinstance(obj, dict):
-        for k, v in obj.items():
-            out.update(flatten(v, prefix + (str(k),)))
-    elif isinstance(obj, list):
-        if obj and all(not isinstance(v, (dict, list)) for v in obj):
-            if prefix and prefix[-1] in SET_VALUED_KEYS:
-                # Keyed by value: one added value is one ADDED entry, one removed
-                # value is one MISSING entry, and nothing else moves. repr() keeps
-                # 1 and "1" distinct in a mixed-type enum.
-                for v in obj:
-                    out[prefix + (f"[={v!r}]",)] = v
-                return out
-            # Sort the remaining all-scalar lists (required, tags, security
-            # scopes, ...) so a cosmetic reorder does not masquerade as CHANGED.
-            obj = sorted(obj, key=lambda x: (str(type(x)), str(x)))
-        for i, v in enumerate(obj):
-            out.update(flatten(v, prefix + (f"[{i}]",)))
-    else:
-        out[prefix] = obj
-    return out
-
-def canon_seg(seg):
-    # Canonicalize a single path segment: treat '.' and '_' as the same separator
-    # in schema component identifiers (the sanitizer changed '.' -> '_').
-    return seg.replace(".", "_")
-
-def canon_key(key):
-    # Only canonicalize the schema-name segment (child of components.schemas.*).
-    if len(key) >= 3 and key[0] == "components" and key[1] == "schemas":
-        return key[:2] + (canon_seg(key[2]),) + key[3:]
-    return key
-
-def canon_val(v):
-    if isinstance(v, str) and v.startswith("#/components/schemas/"):
-        head, name = v.rsplit("/", 1)
-        return head + "/" + canon_seg(name)
-    return v
-
-def show(key):
-    # Human-readable path for display.
-    out = ""
-    for seg in key:
-        if seg.startswith("["):
-            out += seg
-        else:
-            out += ("." if out else "") + seg
-    return out
-
-def op_statuses(doc):
-    # {(path, METHOD): set(response status keys)} for every operation.
-    out = {}
-    for p, item in ((doc or {}).get("paths", {}) or {}).items():
-        if not isinstance(item, dict):
-            continue
-        for m, op in item.items():
-            if m.lower() not in HTTP_METHODS or not isinstance(op, dict):
-                continue
-            resps = op.get("responses", {}) or {}
-            out[(p, m.upper())] = {str(k) for k in resps}
-    return out
-
-with open(ref_file) as f: ref_doc = yaml.safe_load(f) or {}
-with open(gen_file) as f: gen_doc = yaml.safe_load(f) or {}
-
-ref_raw = flatten(ref_doc)
-gen_raw = flatten(gen_doc)
-
-if strict:
-    ref, gen = ref_raw, gen_raw
-else:
-    ref = {canon_key(k): canon_val(v) for k, v in ref_raw.items()}
-    gen = {canon_key(k): canon_val(v) for k, v in gen_raw.items()}
-
-missing = sorted((k for k in ref if k not in gen), key=show)
-changed = sorted((k for k in ref if k in gen and ref[k] != gen[k]), key=show)
-added   = sorted((k for k in gen if k not in ref), key=show)
-
-# Per-operation response-status-set diffs (order-independent).
-ref_st, gen_st = op_statuses(ref_doc), op_statuses(gen_doc)
-status_diffs = []
-for opkey in sorted(set(ref_st) | set(gen_st)):
-    lost = sorted(ref_st.get(opkey, set()) - gen_st.get(opkey, set()))
-    gained = sorted(gen_st.get(opkey, set()) - ref_st.get(opkey, set()))
-    if lost or gained:
-        status_diffs.append((opkey, lost, gained))
-
-# Note the schema-rename normalization if it actually merged anything.
-if not strict:
-    renamed = sum(1 for k in ref_raw if canon_key(k) != k)
-    if renamed:
-        print(f"  (note: schema names canonicalized '.'<->'_'; {renamed} keys "
-              f"normalized — pass --strict to compare literally)")
-
-if status_diffs:
-    print(f"  STATUS CHANGES ({len(status_diffs)}) — response status set differs:")
-    for (p, m), lost, gained in status_diffs:
-        parts = []
-        if lost:   parts.append("lost "   + ",".join(lost))
-        if gained: parts.append("gained " + ",".join(gained))
-        print(f"    ! {m} {p}: {'; '.join(parts)}")
-else:
-    print("  STATUS CHANGES (0) — response status sets unchanged.")
-
-if missing:
-    print(f"  MISSING ({len(missing)}) — in snapshot, absent from generated:")
-    for k in missing:
-        print(f"    - {show(k)} = {ref[k]!r}")
-else:
-    print("  MISSING (0) — nothing from the snapshot was dropped.")
-
-if changed:
-    print(f"  CHANGED ({len(changed)}) — same key, different value:")
-    for k in changed:
-        print(f"    ~ {show(k)}: {ref[k]!r} -> {gen[k]!r}")
-else:
-    print("  CHANGED (0) — no in-place value changes.")
-
-if show_added and added:
-    print(f"  ADDED ({len(added)}) — new in generated:")
-    for k in added:
-        print(f"    + {show(k)} = {gen[k]!r}")
-
-# Fail on any drift that removes or alters documented behaviour: a status
-# gained/lost, a dropped key, or an in-place value change.
-sys.exit(1 if (status_diffs or missing or changed) else 0)
-PY
-}
 
 OVERALL=0
 echo

--- a/scripts/compare-spec.sh
+++ b/scripts/compare-spec.sh
@@ -201,6 +201,9 @@ run_apispec() {
 #   * MISSING — a key present in the snapshot is absent from the generated spec.
 #   * CHANGED — a key present in both has a different value (a $ref retargeted, a
 #     schema type flipped in place, a `required`/format changed).
+# Enum values are compared as SETS (keyed by value, not position), so adding or
+# removing one reports exactly that one value rather than a cascade of CHANGED
+# entries for everything after it.
 # ADDED keys (new routes/fields) are informational and shown only with --all,
 # except added statuses, which the STATUS section always reports and fails on.
 compare_py() {
@@ -213,15 +216,33 @@ strict     = sys.argv[4] == "1"
 
 HTTP_METHODS = {"get", "put", "post", "delete", "options", "head", "patch", "trace"}
 
+# Lists whose meaning is membership, not order, and which are therefore keyed by
+# VALUE rather than by index. Sorting (below) already stops a reorder looking like
+# a change, but it does not help an INSERTION: keyed positionally, adding one
+# value to a 32-value enum reports every later value as CHANGED, which both
+# invents drift and buries whether anything was genuinely dropped.
+#
+# `required` and `tags` have the same set-like shape; add them here if their
+# insert-cascade becomes noisy too. They are left out for now because only enum
+# has actually produced false drift in practice.
+SET_VALUED_KEYS = {"enum"}
+
 def flatten(obj, prefix=()):
     out = {}
     if isinstance(obj, dict):
         for k, v in obj.items():
             out.update(flatten(v, prefix + (str(k),)))
     elif isinstance(obj, list):
-        # Sort all-scalar lists (required, enum, tags, security scopes, ...) so a
-        # cosmetic reorder does not masquerade as a CHANGED value.
         if obj and all(not isinstance(v, (dict, list)) for v in obj):
+            if prefix and prefix[-1] in SET_VALUED_KEYS:
+                # Keyed by value: one added value is one ADDED entry, one removed
+                # value is one MISSING entry, and nothing else moves. repr() keeps
+                # 1 and "1" distinct in a mixed-type enum.
+                for v in obj:
+                    out[prefix + (f"[={v!r}]",)] = v
+                return out
+            # Sort the remaining all-scalar lists (required, tags, security
+            # scopes, ...) so a cosmetic reorder does not masquerade as CHANGED.
             obj = sorted(obj, key=lambda x: (str(type(x)), str(x)))
         for i, v in enumerate(obj):
             out.update(flatten(v, prefix + (f"[{i}]",)))


### PR DESCRIPTION
An enum is a set: membership is its whole meaning and position carries none. `compare-spec.sh` flattened it positionally, so **inserting** a value reported every later value as `CHANGED`. Sorting all-scalar lists (which the script already did) fixes a reorder, but not an insertion.

## The damage

On a real snapshot comparison where three values were added to a 32-value enum declared by two schemas:

```
CHANGED (10)  ->  CHANGED (2)
```

The eight that disappeared looked like this, and every one was an artifact:

```
~ ...Candidate.properties.reason.enum[28]: 'unenrolled' -> 'teacher_extended'
~ ...Candidate.properties.reason.enum[29]: 'user_requested' -> 'teacher_restored'
~ ...Candidate.properties.reason.enum[30]: 'within_maximum' -> 'teacher_withdrew'
~ ...Candidate.properties.reason.enum[31]: 'within_target' -> 'unenrolled'
```

Nothing changed and nothing was dropped — three values were added and the rest shifted down one. The two survivors are genuine (operationIds whose line numbers moved).

This matters beyond tidiness. For a tool whose job is catching regressions, it both invents drift **and** buries whether anything was actually lost, under noise proportional to how far up the list the insertion landed.

## The fix

Enum entries are keyed by value instead of index, so an added value is one `ADDED` entry, a removed value is one `MISSING` entry, and nothing else moves. `repr()` is used in the key so a mixed-type enum keeps `1` and `"1"` distinct.

## Verified

| case | before | after |
|---|---|---|
| 3 values inserted into a 32-value enum | 4 spurious `CHANGED`, exit 1 | 3 `ADDED`, exit 0 |
| a value genuinely dropped | reported, exit 1 | reported by name, exit 1 |
| identical mixed-type enum (`1`, `"1"`, `true`, `null`) | exit 0 | exit 0 |
| int `1` replaced by string `"1"` | exit 1 | `MISSING 1` + `ADDED '1'`, exit 1 |

Re-run against the real snapshot that prompted this: `CHANGED` 10 -> 2, `MISSING` unchanged at 13 (all genuine), `STATUS CHANGES` unchanged at 3 (all genuine).

## Deliberately not included

`required` and `tags` are the same set-like shape and have the same insert-cascade. They are named in the `SET_VALUED_KEYS` comment but left positional, because only `enum` has actually produced false drift in practice — adding them is a one-word change when it does.

Parameter arrays have the same problem for a different reason (they are objects, not scalars, so they are keyed positionally): inserting a header parameter at index 0 reports the path parameter after it as renamed. Fixing that needs keying by `(name, in)` rather than a set, so it is out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved specification comparisons for enum lists.
  * Added clear individual results when enum values are added or removed.
  * Prevented false change reports caused by shifts in enum ordering.
  * Preserved positional comparison behavior for other scalar lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->