### PR TITLE
docs: apispec needs the Go toolchain to run, not only to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ or [the wider landscape](https://apispec.ehabterra.com/alternatives/) if you are
 ### Install
 
 ```bash
-# Homebrew (macOS/Linux) — no Go toolchain needed to install
+# Homebrew (macOS/Linux) — nothing to compile; pulls in Go, which apispec needs to run
 brew install ehabterra/tap/apispec      # the CLI
 brew install ehabterra/tap/apispecui    # the web UI
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -15,8 +15,8 @@ second way does not replace the first (see
 
 | | Install | Update | Uninstall |
 |---|---|---|---|
-| **[Homebrew](#1-homebrew-macos-and-linux)** — macOS/Linux, no Go needed | `brew install ehabterra/tap/apispec` | `brew upgrade apispec` | `brew uninstall apispec` |
-| **[Pre-built binary](#2-download-a-pre-built-binary)** — any platform, no Go needed | [copy-paste block](#2-download-a-pre-built-binary) | re-run the same block | `sudo rm /usr/local/bin/apispec` |
+| **[Homebrew](#1-homebrew-macos-and-linux)** — macOS/Linux, nothing to compile | `brew install ehabterra/tap/apispec` | `brew upgrade apispec` | `brew uninstall apispec` |
+| **[Pre-built binary](#2-download-a-pre-built-binary)** — any platform, nothing to compile | [copy-paste block](#2-download-a-pre-built-binary) | re-run the same block | `sudo rm /usr/local/bin/apispec` |
 | **[Go install](#3-go-install)** — needs Go 1.26+ | `go install github.com/ehabterra/apispec/cmd/apispec@latest` | same command again | `rm "$(go env GOPATH)/bin/apispec"` |
 | **[From source](#4-from-source)** — for development | `make install-local` | `git pull && make install-local` | `make uninstall-local` |
 
@@ -31,11 +31,23 @@ source — see [Development Installation](#development-installation).
 
 ## Prerequisites
 
-**None** for the pre-built binaries below — they are self-contained.
+**Go 1.26 or later, whichever way you install** —
+[Download from golang.org](https://golang.org/doc/install) (the module declares
+`go 1.26.0`).
 
-For the `go install` and from-source methods:
+This one catches people out, because the pre-built binaries are self-contained
+and several methods below compile nothing. apispec still needs the toolchain to
+*run*: it analyses a project by loading its packages through `go/packages`,
+which shells out to `go list`. Without `go` on PATH every run exits with
 
-- **Go 1.26 or later** — [Download from golang.org](https://golang.org/doc/install) (the module declares `go 1.26.0`)
+    failed to load filtered packages: err: go command required, not found
+
+So "nothing to compile" below means exactly that, and never that Go is optional.
+Homebrew reflects this — the formula declares `go` as a runtime dependency and
+installs it for you.
+
+Additionally, for the from-source methods:
+
 - **Git** — for cloning the repository
 
 ## Installation Methods
@@ -57,8 +69,9 @@ Go to *install* them, but you do need it to run them.
 
 ### 2. Download a Pre-built Binary
 
-No Go toolchain and no Homebrew required. **Copy the whole block** — it detects
-your platform, verifies the checksum, and installs `apispec` onto your PATH.
+Nothing to compile and no Homebrew required. **Copy the whole block** — it
+detects your platform, verifies the checksum, and installs `apispec` onto your
+PATH. (Go is still needed to *run* it — see [Prerequisites](#prerequisites).)
 
 **macOS / Linux**
 
@@ -117,7 +130,7 @@ Move-Item -Force $asset "$env:LOCALAPPDATA\Programs\apispec\$tool.exe"
 To pin a version, swap `latest/download` for `download/v0.5.6` (any tag).
 
 **Pros:**
-- No Go toolchain needed
+- Nothing compiles — installs in seconds
 - Exact, reproducible version with a published checksum
 
 **Cons:**
@@ -195,8 +208,9 @@ curl -sSL https://raw.githubusercontent.com/ehabterra/apispec/main/scripts/insta
 
 **Cons:**
 - Requires curl/wget, and downloads and executes a script from the internet
-- **Every mode requires Go** — the script builds from source and does not download
-  a pre-built binary. Use method 1 if you have no Go toolchain.
+- **Every mode compiles from source** — the script does not download a pre-built
+  binary. Use method 1 or 2 to skip the compile; every method still needs Go
+  installed to run apispec, see [Prerequisites](#prerequisites).
 
 ## Platform-Specific Instructions
 

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -1,7 +1,13 @@
 # Homebrew packaging
 
 `brew install ehabterra/tap/apispec` installs the **pre-built release binary**,
-so it needs no Go toolchain and takes seconds.
+so it compiles nothing and takes seconds.
+
+It does pull in Go, as a **runtime** dependency (`depends_on "go"`, not
+`=> :build`). apispec analyses a project by loading its packages through
+`go/packages`, which shells out to `go list`, so without the go binary on PATH
+every run exits with `go command required, not found`. The toolchain is needed
+to *use* the tool, not to install it — nothing is compiled at install time.
 
 ## Files here
 

--- a/packaging/homebrew/apispec.rb
+++ b/packaging/homebrew/apispec.rb
@@ -1,5 +1,6 @@
 # Homebrew formula for apispec: installs the pre-built release binary, so
-# `brew install` needs no Go toolchain.
+# `brew install` compiles nothing. Go is still a RUNTIME dependency (below):
+# apispec shells out to `go list` and cannot analyse anything without it.
 #
 # packaging/homebrew/apispec.rb.tmpl is the SOURCE; apispec.rb is it rendered at
 # the current release. .github/workflows/release.yml renders the template with

--- a/packaging/homebrew/apispec.rb.tmpl
+++ b/packaging/homebrew/apispec.rb.tmpl
@@ -1,5 +1,6 @@
 # Homebrew formula for apispec: installs the pre-built release binary, so
-# `brew install` needs no Go toolchain.
+# `brew install` compiles nothing. Go is still a RUNTIME dependency (below):
+# apispec shells out to `go list` and cannot analyse anything without it.
 #
 # packaging/homebrew/apispec.rb.tmpl is the SOURCE; apispec.rb is it rendered at
 # the current release. .github/workflows/release.yml renders the template with

--- a/packaging/homebrew/apispecui.rb.tmpl
+++ b/packaging/homebrew/apispecui.rb.tmpl
@@ -1,5 +1,6 @@
 # Homebrew formula for apispecui: installs the pre-built release binary, so
-# `brew install` needs no Go toolchain to install it.
+# `brew install` compiles nothing. Go is still a RUNTIME dependency (below):
+# the UI runs the same analysis, which shells out to `go list`.
 #
 # packaging/homebrew/apispecui.rb.tmpl is the SOURCE; apispecui.rb is it
 # rendered at the current release. .github/workflows/release.yml renders the


### PR DESCRIPTION
Surfaced by a review comment on #351, which flagged that the changelog entry ("go is a runtime dependency of the formula") contradicted `packaging/homebrew/README.md` ("needs no Go toolchain"). The changelog is right and the docs were wrong — both formulae already declare `depends_on "go"` as a runtime dependency (#312). Fixing the docs instead.

## The user-visible problem

`docs/INSTALLATION.md` opened Prerequisites with:

> **None** for the pre-built binaries below — they are self-contained.

and sold two of the four methods as "no Go needed". They are self-contained as binaries and compile nothing, but apispec analyses a project by loading its packages through `go/packages`, which shells out to `go list`. Verified against a release build with the toolchain removed:

```console
$ env -i PATH=/usr/bin:/bin apispec --dir . --output out.yaml
failed to load filtered packages: err: go command required, not found
```

So someone without Go who followed the guide got a tool that could not analyse anything — and the guide had steered them there deliberately, because the from-source section ended with:

> Use method 1 if you have no Go toolchain.

which is the one piece of advice guaranteed not to work.

## What changed

Corrected everywhere the claim appears, not only where it was noticed:

- **Prerequisites** now leads with "Go 1.26 or later, whichever way you install", explains why (`go list`), and shows the exact error you get without it — plus the note that Homebrew installs it for you.
- **"no Go needed" → "nothing to compile"** in the at-a-glance table and the pre-built-binary section, which is what was actually meant.
- **The from-source Cons** now say "every mode compiles from source" and point at Prerequisites, instead of recommending a method that does not solve the stated problem.
- **`packaging/homebrew/README.md`** — the contradiction from #351 — now distinguishes install-time from runtime.
- **Formula header comments** (`apispec.rb`, both templates) say which half of the dependency they mean.
- **Main `README.md`** install block, same correction.

## Not changed

No formula behaviour. `depends_on "go"` was already correct; the docs were the thing out of step. `ruby -c` is clean on the rendered formula, and the template and its rendering stay in sync.

Worth having before v0.5.7 goes out, since the install guide is the first thing a new user reads.