### PR TITLE
fix: make resolution deterministic — sort every first-match file/type scan (#340)

### DIFF
--- a/generator/determinism_test.go
+++ b/generator/determinism_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ehabterra/apispec/internal/engine"
 	"gopkg.in/yaml.v3"
 )
 
@@ -42,6 +43,57 @@ func TestGenerateDeterministic(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestGenerateDeterministicUnderTruncation runs the same fixtures with the
+// budgets forced low enough to truncate, because that is where determinism
+// broke in the field (issue #340): the same command on a large project dropped
+// different responses and header parameters between runs, while every fixture
+// small enough for TestGenerateDeterministic never spent a budget at all.
+//
+// Truncation itself is asserted, so the test cannot quietly stop exercising the
+// path it exists for.
+func TestGenerateDeterministicUnderTruncation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping determinism fixtures in -short mode")
+	}
+	for _, name := range []string{"complex_chi_router", "group_closure_instances", "mixed_gin_mux"} {
+		t.Run(name, func(t *testing.T) {
+			base, truncated := marshalTruncatedSpec(t, name)
+			if !truncated {
+				t.Fatalf("%s did not truncate at the forced budgets, so this fixture no longer covers the truncation path", name)
+			}
+			for run := 1; run < 3; run++ {
+				got, _ := marshalTruncatedSpec(t, name)
+				if string(got) != string(base) {
+					t.Fatalf("spec for %s differs between runs at a truncating budget:\n%s",
+						name, firstDiffLine(string(base), string(got)))
+				}
+			}
+		})
+	}
+}
+
+// marshalTruncatedSpec generates the fixture with both expansion budgets forced
+// to their harshest useful values, and reports whether either one truncated.
+func marshalTruncatedSpec(t *testing.T, fixture string) ([]byte, bool) {
+	t.Helper()
+	cfg := engine.DefaultEngineConfig()
+	cfg.InputDir = filepath.Join("..", "testdata", fixture)
+	cfg.MaxInstancesPerKey = 1
+	cfg.MaxNodesPerRoute = 200
+
+	eng := engine.NewEngine(cfg)
+	out, err := eng.GenerateOpenAPI()
+	if err != nil {
+		t.Fatalf("GenerateOpenAPI(%s): %v", fixture, err)
+	}
+	data, err := yaml.Marshal(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stats := eng.GetExpansionStats()
+	return data, stats.InstanceTruncations > 0 || stats.RouteTruncations > 0
 }
 
 func marshalSpec(t *testing.T, dir string) []byte {

--- a/internal/metadata/analysis.go
+++ b/internal/metadata/analysis.go
@@ -625,7 +625,14 @@ func traceVariableOriginHelper(
 									calleeMethod, exists = metadata.methodLookupCache[methodKey]
 								}
 								if !exists {
-									for _, t := range calleeFile.Types {
+									// Sorted: two types in one file can declare
+									// the same method name, and the first match
+									// wins — and is cached for the whole run.
+									for _, typeName := range metadata.SortedTypeNames(assign.CalleePkg, calleeFileName) {
+										t := calleeFile.Types[typeName]
+										if t == nil {
+											continue
+										}
 										for _, method := range t.Methods {
 											if metadata.StringPool.GetString(method.Name) == assign.CalleeFunc {
 												calleeMethod = &method

--- a/internal/metadata/analysis.go
+++ b/internal/metadata/analysis.go
@@ -558,9 +558,16 @@ func traceVariableOriginHelper(
 		}
 	}
 
-	// Try to find assignment in the same pkg
+	// Try to find assignment in the same pkg. Sorted: the loop returns on the
+	// FIRST file that declares the variable or the function, so map order would
+	// decide which declaration answers — and the answer is cached for the rest
+	// of the run (issue #340).
 	if pkg, ok := metadata.Packages[pkgName]; ok {
-		for _, file := range pkg.Files {
+		for _, fileName := range metadata.SortedFileNames(pkgName) {
+			file := pkg.Files[fileName]
+			if file == nil {
+				continue
+			}
 			if v, ok := file.Variables[varName]; ok {
 				arg := NewCallArgument(metadata)
 				arg.SetKind(KindIdent)
@@ -581,7 +588,11 @@ func traceVariableOriginHelper(
 					if assign.CalleeFunc != "" && assign.CalleePkg != "" {
 						calleePkg, ok := metadata.Packages[assign.CalleePkg]
 						if ok {
-							for _, calleeFile := range calleePkg.Files {
+							for _, calleeFileName := range metadata.SortedFileNames(assign.CalleePkg) {
+								calleeFile := calleePkg.Files[calleeFileName]
+								if calleeFile == nil {
+									continue
+								}
 								if calleeFn, ok := calleeFile.Functions[assign.CalleeFunc]; ok {
 									retIdx := assign.ReturnIndex
 									if retIdx < len(calleeFn.ReturnVars) {

--- a/internal/metadata/analysis.go
+++ b/internal/metadata/analysis.go
@@ -562,123 +562,106 @@ func traceVariableOriginHelper(
 	// FIRST file that declares the variable or the function, so map order would
 	// decide which declaration answers — and the answer is cached for the rest
 	// of the run (issue #340).
-	if pkg, ok := metadata.Packages[pkgName]; ok {
-		for _, fileName := range metadata.SortedFileNames(pkgName) {
-			file := pkg.Files[fileName]
-			if file == nil {
-				continue
-			}
-			if v, ok := file.Variables[varName]; ok {
-				arg := NewCallArgument(metadata)
-				arg.SetKind(KindIdent)
-				arg.Type = v.Type
-				return cacheAndReturn(varName, pkgName, funcName, arg)
-			}
+	for _, file := range metadata.SortedFiles(pkgName) {
+		if v, ok := file.Variables[varName]; ok {
+			arg := NewCallArgument(metadata)
+			arg.SetKind(KindIdent)
+			arg.Type = v.Type
+			return cacheAndReturn(varName, pkgName, funcName, arg)
+		}
 
-			if fn, ok := file.Functions[funcName]; ok {
-				if assigns, ok := fn.AssignmentMap[varName]; ok && len(assigns) > 0 {
-					// Use the most recent assignment (last in slice)
-					assign := assigns[len(assigns)-1]
-					// If the assignment is an alias (Value.Kind == kindIdent), recursively trace the RHS to the base variable
-					if assign.Value.GetKind() == KindIdent && assign.Value.GetName() != varName {
-						baseVar, basePkg, t, f := traceVariableOriginHelper(assign.Value.GetName(), funcName, pkgName, metadata, visited)
-						return baseVar, basePkg, t, f
-					}
-					// If the assignment is from a function call, follow the return value
-					if assign.CalleeFunc != "" && assign.CalleePkg != "" {
-						calleePkg, ok := metadata.Packages[assign.CalleePkg]
-						if ok {
-							for _, calleeFileName := range metadata.SortedFileNames(assign.CalleePkg) {
-								calleeFile := calleePkg.Files[calleeFileName]
-								if calleeFile == nil {
-									continue
-								}
-								if calleeFn, ok := calleeFile.Functions[assign.CalleeFunc]; ok {
-									retIdx := assign.ReturnIndex
-									if retIdx < len(calleeFn.ReturnVars) {
-										retArg := calleeFn.ReturnVars[retIdx]
-									OuterLoop:
-										for retArg.GetKind() != KindIdent {
-											switch retArg.GetKind() {
-											case KindSelector:
-												retArg = *retArg.Sel
-											case KindUnary, KindCompositeLit:
-												retArg = *retArg.X
-											default:
-												break OuterLoop
-											}
-										}
-										if retArg.GetKind() == KindIdent && retArg.Name != -1 {
-											_, _, t, f := traceVariableOriginHelper(retArg.GetName(), assign.CalleeFunc, assign.CalleePkg, metadata, visited)
-											return retArg.GetName(), assign.CalleePkg, t, f
-										}
-										// For literals or other expressions, return as is
-										return retArg.GetName(), assign.CalleePkg, &retArg, funcName
+		if fn, ok := file.Functions[funcName]; ok {
+			if assigns, ok := fn.AssignmentMap[varName]; ok && len(assigns) > 0 {
+				// Use the most recent assignment (last in slice)
+				assign := assigns[len(assigns)-1]
+				// If the assignment is an alias (Value.Kind == kindIdent), recursively trace the RHS to the base variable
+				if assign.Value.GetKind() == KindIdent && assign.Value.GetName() != varName {
+					baseVar, basePkg, t, f := traceVariableOriginHelper(assign.Value.GetName(), funcName, pkgName, metadata, visited)
+					return baseVar, basePkg, t, f
+				}
+				// If the assignment is from a function call, follow the return value
+				if assign.CalleeFunc != "" && assign.CalleePkg != "" {
+					for calleeFileName, calleeFile := range metadata.SortedFiles(assign.CalleePkg) {
+						if calleeFn, ok := calleeFile.Functions[assign.CalleeFunc]; ok {
+							retIdx := assign.ReturnIndex
+							if retIdx < len(calleeFn.ReturnVars) {
+								retArg := calleeFn.ReturnVars[retIdx]
+							OuterLoop:
+								for retArg.GetKind() != KindIdent {
+									switch retArg.GetKind() {
+									case KindSelector:
+										retArg = *retArg.Sel
+									case KindUnary, KindCompositeLit:
+										retArg = *retArg.X
+									default:
+										break OuterLoop
 									}
 								}
-
-								// Looking for methods with caching
-								methodKey := assign.CalleePkg + "." + assign.CalleeFunc
-								var calleeMethod *Method
-								var exists bool
-								if metadata.methodLookupCache != nil {
-									calleeMethod, exists = metadata.methodLookupCache[methodKey]
+								if retArg.GetKind() == KindIdent && retArg.Name != -1 {
+									_, _, t, f := traceVariableOriginHelper(retArg.GetName(), assign.CalleeFunc, assign.CalleePkg, metadata, visited)
+									return retArg.GetName(), assign.CalleePkg, t, f
 								}
-								if !exists {
-									// Sorted: two types in one file can declare
-									// the same method name, and the first match
-									// wins — and is cached for the whole run.
-									for _, typeName := range metadata.SortedTypeNames(assign.CalleePkg, calleeFileName) {
-										t := calleeFile.Types[typeName]
-										if t == nil {
-											continue
+								// For literals or other expressions, return as is
+								return retArg.GetName(), assign.CalleePkg, &retArg, funcName
+							}
+						}
+
+						// Looking for methods with caching
+						methodKey := assign.CalleePkg + "." + assign.CalleeFunc
+						var calleeMethod *Method
+						var exists bool
+						if metadata.methodLookupCache != nil {
+							calleeMethod, exists = metadata.methodLookupCache[methodKey]
+						}
+						if !exists {
+							// Sorted: two types in one file can declare the same
+							// method name, and the first match wins — and is
+							// cached for the whole run.
+							for _, t := range metadata.SortedTypes(assign.CalleePkg, calleeFileName) {
+								for _, method := range t.Methods {
+									if metadata.StringPool.GetString(method.Name) == assign.CalleeFunc {
+										calleeMethod = &method
+										if metadata.methodLookupCache != nil {
+											metadata.methodLookupCache[methodKey] = calleeMethod
 										}
-										for _, method := range t.Methods {
-											if metadata.StringPool.GetString(method.Name) == assign.CalleeFunc {
-												calleeMethod = &method
-												if metadata.methodLookupCache != nil {
-													metadata.methodLookupCache[methodKey] = calleeMethod
-												}
-												break
-											}
-										}
-										if calleeMethod != nil {
-											break
-										}
-									}
-									// Cache nil result to avoid repeated lookups
-									if calleeMethod == nil && metadata.methodLookupCache != nil {
-										metadata.methodLookupCache[methodKey] = nil
+										break
 									}
 								}
 								if calleeMethod != nil {
-									retIdx := assign.ReturnIndex
-									if retIdx < len(calleeMethod.ReturnVars) {
-										retArg := calleeMethod.ReturnVars[retIdx]
-									OuterLoop2:
-										for retArg.GetKind() != KindIdent {
-											switch retArg.GetKind() {
-											case KindSelector:
-												retArg = *retArg.Sel
-											case KindUnary, KindCompositeLit:
-												retArg = *retArg.X
-											default:
-												break OuterLoop2
-											}
-										}
-										if retArg.GetKind() == KindIdent && retArg.Name != -1 {
-											_, _, t, f := traceVariableOriginHelper(retArg.GetName(), assign.CalleeFunc, assign.CalleePkg, metadata, visited)
-											return retArg.GetName(), assign.CalleePkg, t, f
-										}
-										// For literals or other expressions, return as is
-										return retArg.GetName(), assign.CalleePkg, &retArg, funcName
+									break
+								}
+							}
+							// Cache nil result to avoid repeated lookups
+							if calleeMethod == nil && metadata.methodLookupCache != nil {
+								metadata.methodLookupCache[methodKey] = nil
+							}
+						}
+						if calleeMethod != nil {
+							retIdx := assign.ReturnIndex
+							if retIdx < len(calleeMethod.ReturnVars) {
+								retArg := calleeMethod.ReturnVars[retIdx]
+							OuterLoop2:
+								for retArg.GetKind() != KindIdent {
+									switch retArg.GetKind() {
+									case KindSelector:
+										retArg = *retArg.Sel
+									case KindUnary, KindCompositeLit:
+										retArg = *retArg.X
+									default:
+										break OuterLoop2
 									}
 								}
+								if retArg.GetKind() == KindIdent && retArg.Name != -1 {
+									_, _, t, f := traceVariableOriginHelper(retArg.GetName(), assign.CalleeFunc, assign.CalleePkg, metadata, visited)
+									return retArg.GetName(), assign.CalleePkg, t, f
+								}
+								// For literals or other expressions, return as is
+								return retArg.GetName(), assign.CalleePkg, &retArg, funcName
 							}
 						}
 					}
-					return cacheAndReturn(varName, pkgName, funcName, &assign.Value)
 				}
+				return cacheAndReturn(varName, pkgName, funcName, &assign.Value)
 			}
 		}
 	}

--- a/internal/metadata/determinism_test.go
+++ b/internal/metadata/determinism_test.go
@@ -115,6 +115,19 @@ func (u User) Label() string { return u.Name }
 func generateOnce(t *testing.T, cfg *packages.Config) []byte {
 	t.Helper()
 
+	meta := generateMetaOnce(t, cfg)
+	out, err := yaml.Marshal(meta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+// generateMetaOnce is generateOnce without the serialization, for tests that
+// query the metadata itself.
+func generateMetaOnce(t *testing.T, cfg *packages.Config) *metadata.Metadata {
+	t.Helper()
+
 	fset := token.NewFileSet()
 	loadCfg := *cfg
 	loadCfg.Mode = packages.NeedName | packages.NeedFiles | packages.NeedSyntax |
@@ -144,12 +157,7 @@ func generateOnce(t *testing.T, cfg *packages.Config) []byte {
 		}
 	}
 
-	meta := metadata.GenerateMetadata(pkgsMetadata, fileToInfo, importPaths, fset)
-	out, err := yaml.Marshal(meta)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return out
+	return metadata.GenerateMetadata(pkgsMetadata, fileToInfo, importPaths, fset)
 }
 
 // TestGenerateMetadataDeterministic asserts that repeated metadata generation

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -457,32 +457,26 @@ func (m *Metadata) BuildAssignmentRelationships() map[AssignmentKey]*AssignmentL
 
 		// Get root assignments. Sorted: relationships[akey] is last-write-wins,
 		// so two files contributing the same key would resolve by map order.
-		if pkg, ok := m.Packages[callerPkg]; ok {
-			for _, fileName := range m.SortedFileNames(callerPkg) {
-				file := pkg.Files[fileName]
-				if file == nil {
-					continue
-				}
-				if fn, ok := file.Functions[callerName]; ok && callerName == MainFunc {
-					for recvVarName, assigns := range fn.AssignmentMap {
-						assignment := assigns[len(assigns)-1]
+		for _, file := range m.SortedFiles(callerPkg) {
+			if fn, ok := file.Functions[callerName]; ok && callerName == MainFunc {
+				for recvVarName, assigns := range fn.AssignmentMap {
+					assignment := assigns[len(assigns)-1]
 
-						if edge.CalleeRecvVarName != recvVarName {
-							continue
-						}
+					if edge.CalleeRecvVarName != recvVarName {
+						continue
+					}
 
-						akey := AssignmentKey{
-							Name:      recvVarName,
-							Pkg:       callerPkg,
-							Type:      m.StringPool.GetString(assignment.ConcreteType),
-							Container: callerName,
-						}
+					akey := AssignmentKey{
+						Name:      recvVarName,
+						Pkg:       callerPkg,
+						Type:      m.StringPool.GetString(assignment.ConcreteType),
+						Container: callerName,
+					}
 
-						relationships[akey] = &AssignmentLink{
-							AssignmentKey: akey,
-							Assignment:    &assignment,
-							Edge:          edge,
-						}
+					relationships[akey] = &AssignmentLink{
+						AssignmentKey: akey,
+						Assignment:    &assignment,
+						Edge:          edge,
 					}
 				}
 			}

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -455,9 +455,14 @@ func (m *Metadata) BuildAssignmentRelationships() map[AssignmentKey]*AssignmentL
 		callerName := m.StringPool.GetString(edge.Caller.Name)
 		callerPkg := m.StringPool.GetString(edge.Caller.Pkg)
 
-		// Get root assignments
+		// Get root assignments. Sorted: relationships[akey] is last-write-wins,
+		// so two files contributing the same key would resolve by map order.
 		if pkg, ok := m.Packages[callerPkg]; ok {
-			for _, file := range pkg.Files {
+			for _, fileName := range m.SortedFileNames(callerPkg) {
+				file := pkg.Files[fileName]
+				if file == nil {
+					continue
+				}
 				if fn, ok := file.Functions[callerName]; ok && callerName == MainFunc {
 					for recvVarName, assigns := range fn.AssignmentMap {
 						assignment := assigns[len(assigns)-1]

--- a/internal/metadata/sorted_file_scan_test.go
+++ b/internal/metadata/sorted_file_scan_test.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import "testing"
+
+// TestSortedFileScansSkipNilEntries covers the resolution lookups that answer
+// from the first file declaring a name (issue #340 made the order sorted rather
+// than map-random). They now index Files by sorted name, so a nil file entry —
+// which a deserialised metadata.yaml may carry — has to be stepped over instead
+// of dereferenced.
+func TestSortedFileScansSkipNilEntries(t *testing.T) {
+	pool := NewStringPool()
+	const pkg = "example.com/app"
+
+	meta := &Metadata{
+		StringPool: pool,
+		Packages: map[string]*Package{
+			pkg: {
+				Files: map[string]*File{
+					// Sorts first, and is nil: every scan starts here.
+					"a_generated.go": nil,
+					"b_real.go": {
+						Variables: map[string]*Variable{
+							"Registry": {Tok: pool.Get("var"), Type: pool.Get("*Store")},
+						},
+						Functions: map[string]*Function{
+							"Serve": {Name: pool.Get("Serve")},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// traceVariableOriginHelper: the package-level variable is declared in the
+	// file after the nil one.
+	if _, _, typ, _ := TraceVariableOrigin("Registry", "Serve", pkg, meta); typ == nil {
+		t.Error("TraceVariableOrigin skipped the real file after the nil entry")
+	}
+
+	// resolveIdentReturnType: same scan, reading the variable's type.
+	ret := NewCallArgument(meta)
+	ret.SetKind(KindIdent)
+	ret.SetName("Registry")
+	if got := meta.resolveIdentReturnType(ret, pkg, "Serve"); got != "*Store" {
+		t.Errorf("resolveIdentReturnType = %q, want *Store", got)
+	}
+
+	// The iterators themselves: an unknown package and a nil file yield
+	// nothing, and a caller that stops early stops the walk.
+	for range meta.SortedFiles("no/such/pkg") {
+		t.Error("SortedFiles yielded a file for an unknown package")
+	}
+	for range meta.SortedTypes("no/such/pkg", "b_real.go") {
+		t.Error("SortedTypes yielded a type for an unknown package")
+	}
+	for range meta.SortedTypes(pkg, "a_generated.go") {
+		t.Error("SortedTypes yielded a type for a nil file")
+	}
+	files := 0
+	for range meta.SortedFiles(pkg) {
+		files++
+		break
+	}
+	if files != 1 {
+		t.Errorf("SortedFiles kept walking after the caller stopped (%d files)", files)
+	}
+}
+
+// TestSortedTypesStopsEarly covers the iterator's stop path over a file that
+// really has types, which the nil-file cases above cannot reach.
+func TestSortedTypesStopsEarly(t *testing.T) {
+	pool := NewStringPool()
+	const pkg = "example.com/app"
+	meta := &Metadata{
+		StringPool: pool,
+		Packages: map[string]*Package{
+			pkg: {Files: map[string]*File{"a.go": {Types: map[string]*Type{
+				"Alpha": {}, "Beta": {}, "Gamma": nil,
+			}}}},
+		},
+	}
+	var seen []string
+	for name := range meta.SortedTypes(pkg, "a.go") {
+		seen = append(seen, name)
+		if name == "Alpha" {
+			break
+		}
+	}
+	if len(seen) != 1 || seen[0] != "Alpha" {
+		t.Errorf("SortedTypes yielded %v, want [Alpha] (sorted first, then stopped)", seen)
+	}
+	// Without stopping, the nil entry is skipped rather than yielded.
+	seen = nil
+	for name := range meta.SortedTypes(pkg, "a.go") {
+		seen = append(seen, name)
+	}
+	if len(seen) != 2 || seen[0] != "Alpha" || seen[1] != "Beta" {
+		t.Errorf("SortedTypes yielded %v, want [Alpha Beta] (Gamma is nil)", seen)
+	}
+}

--- a/internal/metadata/trace_origin_determinism_test.go
+++ b/internal/metadata/trace_origin_determinism_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata_test
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// traceOriginFixture reproduces the shape that made spec output vary run to run
+// on a large project (issue #340): a builder call whose method lives in ONE file
+// of a multi-file package.
+//
+// Resolving `cmd` follows the assignment into gitcmd-style package `builder`,
+// where the lookup scans the package's files for the method. The scan used to
+// range the Files map, so which file it saw first decided whether the method was
+// found at all — and the answer is memoized for the rest of the run, so one coin
+// flip during loading changed which producers the tracker resolved, which
+// subtrees the barren-subtree prune kept, and therefore which responses and
+// header parameters survived the instance cap.
+var traceOriginFixture = testModule{
+	Name: "traceorigin",
+	Files: map[string]interface{}{
+		"main.go": `package main
+
+import "traceorigin/svc"
+
+func main() { svc.Build() }
+`,
+		"svc/svc.go": `package svc
+
+import "traceorigin/builder"
+
+func Build() {
+	cmd := builder.New().WithArgs("clone")
+	builder.Run(cmd)
+}
+`,
+		// Sorts before command.go, and declares no method at all: the file the
+		// scan reaches first when file names are ordered.
+		"builder/aux.go": `package builder
+
+type Aux struct{ Note string }
+`,
+		"builder/command.go": `package builder
+
+type Command struct{ Args []string }
+
+func New() *Command { return &Command{} }
+
+func (c *Command) WithArgs(args ...string) *Command {
+	c.Args = append(c.Args, args...)
+	return c
+}
+
+func Run(c *Command) error { return nil }
+`,
+	},
+}
+
+// TestTraceVariableOriginDeterministic asserts that tracing the same variable
+// over freshly loaded metadata answers identically every time.
+//
+// Each iteration re-loads the packages, so Go's per-map iteration randomisation
+// differs between them exactly as it does between real runs — an unordered file
+// scan flips the answer here roughly half the time.
+func TestTraceVariableOriginDeterministic(t *testing.T) {
+	cfg := exportModules(t, []testModule{traceOriginFixture})
+
+	type answer struct{ variable, pkg, caller string }
+	// The sorted scan reaches builder/aux.go first, which declares no method,
+	// so the trace stops at the local assignment instead of following the
+	// builder's receiver. Pinned, not just compared run to run: a flip is only
+	// caught here if some run lands on the other order.
+	want := answer{variable: "cmd", pkg: "traceorigin/svc", caller: "Build"}
+	for run := 0; run < 12; run++ {
+		meta := generateMetaOnce(t, cfg)
+		v, p, _, caller := metadata.TraceVariableOrigin("cmd", "Build", "traceorigin/svc", meta)
+		if got := (answer{v, p, caller}); got != want {
+			t.Fatalf("run %d traced `cmd` to %+v, want %+v", run, got, want)
+		}
+	}
+}

--- a/internal/metadata/trace_origin_determinism_test.go
+++ b/internal/metadata/trace_origin_determinism_test.go
@@ -85,6 +85,11 @@ func TestTraceVariableOriginDeterministic(t *testing.T) {
 	// so the trace stops at the local assignment instead of following the
 	// builder's receiver. Pinned, not just compared run to run: a flip is only
 	// caught here if some run lands on the other order.
+	//
+	// That the receiver is NOT followed is issue #380 — the method lookup
+	// caches its miss package-wide after scanning one file — so this value is
+	// also a change detector: when #380 is fixed the answer becomes the
+	// builder's receiver and this expectation moves with it.
 	want := answer{variable: "cmd", pkg: "traceorigin/svc", caller: "Build"}
 	for run := 0; run < 12; run++ {
 		meta := generateMetaOnce(t, cfg)

--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -1800,7 +1800,13 @@ func (m *Metadata) resolveIdentReturnType(returnVar *CallArgument, pkgName, cont
 
 	// First, check if it's a variable in the current package
 	if pkg, exists := m.Packages[pkgName]; exists {
-		for _, file := range pkg.Files {
+		// Sorted: the first file declaring the variable (or the context
+		// function) answers, so map order would decide the type.
+		for _, fileName := range m.SortedFileNames(pkgName) {
+			file := pkg.Files[fileName]
+			if file == nil {
+				continue
+			}
 			// Check variables
 			if variable, exists := file.Variables[varName]; exists {
 				return m.StringPool.GetString(variable.Type)
@@ -1993,7 +1999,12 @@ func (m *Metadata) processFunctionCallReturnType(arg *CallArgument) {
 
 	// Look for the function in metadata
 	if pkg, exists := m.Packages[pkgName]; exists {
-		for _, file := range pkg.Files {
+		// Sorted: the first declaration found answers (golden rule #1).
+		for _, fileName := range m.SortedFileNames(pkgName) {
+			file := pkg.Files[fileName]
+			if file == nil {
+				continue
+			}
 			// Check functions
 			if fn, exists := file.Functions[funcName]; exists {
 				if fn.Signature.ResolvedType != -1 {

--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -2014,8 +2014,13 @@ func (m *Metadata) processFunctionCallReturnType(arg *CallArgument) {
 				return
 			}
 
-			// Check methods
-			for _, typ := range file.Types {
+			// Check methods. Sorted: two types in a file can declare the same
+			// method name, and the first match returns.
+			for _, typeName := range m.SortedTypeNames(pkgName, fileName) {
+				typ := file.Types[typeName]
+				if typ == nil {
+					continue
+				}
 				for _, method := range typ.Methods {
 					if m.StringPool.GetString(method.Name) == funcName {
 						if method.Signature.ResolvedType != -1 {

--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"go/token"
 	"go/types"
+	"iter"
 	"maps"
 	"regexp"
 	"slices"
@@ -375,6 +376,58 @@ func shapeOf(pkg *Package) pkgShape {
 		shape.funcs += len(f.Functions)
 	}
 	return shape
+}
+
+// SortedFiles iterates a package's files in sorted-name order, skipping nil
+// entries.
+//
+// It pairs with SortedFileNames, whose cached list it walks: the lookups that
+// use it answer from the FIRST file declaring what they are after, so the order
+// decides the answer (golden rule #1, issue #340). The nil skip is the
+// convention every reader of Package.Files follows — a deserialised
+// metadata.yaml need not be as well-formed as a generated one — kept here so
+// each call site is a plain loop over real files.
+func (m *Metadata) SortedFiles(pkgName string) iter.Seq2[string, *File] {
+	return func(yield func(string, *File) bool) {
+		pkg, ok := m.Packages[pkgName]
+		if !ok || pkg == nil {
+			return
+		}
+		for _, name := range m.SortedFileNames(pkgName) {
+			file := pkg.Files[name]
+			if file == nil {
+				continue
+			}
+			if !yield(name, file) {
+				return
+			}
+		}
+	}
+}
+
+// SortedTypes iterates a file's types in sorted-name order, skipping nil
+// entries. The SortedFiles rationale applies unchanged: two types in one file
+// can declare the same method name, and the first match answers.
+func (m *Metadata) SortedTypes(pkgName, fileName string) iter.Seq2[string, *Type] {
+	return func(yield func(string, *Type) bool) {
+		pkg, ok := m.Packages[pkgName]
+		if !ok || pkg == nil {
+			return
+		}
+		file := pkg.Files[fileName]
+		if file == nil {
+			return
+		}
+		for _, name := range m.SortedTypeNames(pkgName, fileName) {
+			typ := file.Types[name]
+			if typ == nil {
+				continue
+			}
+			if !yield(name, typ) {
+				return
+			}
+		}
+	}
 }
 
 // SortedTypeNames returns a file's type names in sorted order.
@@ -1799,31 +1852,25 @@ func (m *Metadata) resolveIdentReturnType(returnVar *CallArgument, pkgName, cont
 	varName := returnVar.GetName()
 
 	// First, check if it's a variable in the current package
-	if pkg, exists := m.Packages[pkgName]; exists {
-		// Sorted: the first file declaring the variable (or the context
-		// function) answers, so map order would decide the type.
-		for _, fileName := range m.SortedFileNames(pkgName) {
-			file := pkg.Files[fileName]
-			if file == nil {
-				continue
-			}
-			// Check variables
-			if variable, exists := file.Variables[varName]; exists {
-				return m.StringPool.GetString(variable.Type)
-			}
+	// Sorted: the first file declaring the variable (or the context
+	// function) answers, so map order would decide the type.
+	for _, file := range m.SortedFiles(pkgName) {
+		// Check variables
+		if variable, exists := file.Variables[varName]; exists {
+			return m.StringPool.GetString(variable.Type)
+		}
 
-			// Check function assignments
-			if fn, exists := file.Functions[contextName]; exists {
-				if assignments, exists := fn.AssignmentMap[varName]; exists && len(assignments) > 0 {
-					// Use the most recent assignment
-					assign := assignments[len(assignments)-1]
-					if assign.ConcreteType != -1 {
-						return m.StringPool.GetString(assign.ConcreteType)
-					}
-					// Try to resolve from the assignment value
-					assign.Value.Meta = m
-					return m.determineResolvedTypeFromReturnVar(&assign.Value, pkgName, contextName)
+		// Check function assignments
+		if fn, exists := file.Functions[contextName]; exists {
+			if assignments, exists := fn.AssignmentMap[varName]; exists && len(assignments) > 0 {
+				// Use the most recent assignment
+				assign := assignments[len(assignments)-1]
+				if assign.ConcreteType != -1 {
+					return m.StringPool.GetString(assign.ConcreteType)
 				}
+				// Try to resolve from the assignment value
+				assign.Value.Meta = m
+				return m.determineResolvedTypeFromReturnVar(&assign.Value, pkgName, contextName)
 			}
 		}
 	}
@@ -1998,37 +2045,27 @@ func (m *Metadata) processFunctionCallReturnType(arg *CallArgument) {
 	}
 
 	// Look for the function in metadata
-	if pkg, exists := m.Packages[pkgName]; exists {
-		// Sorted: the first declaration found answers (golden rule #1).
-		for _, fileName := range m.SortedFileNames(pkgName) {
-			file := pkg.Files[fileName]
-			if file == nil {
-				continue
+	// Sorted: the first declaration found answers (golden rule #1).
+	for fileName, file := range m.SortedFiles(pkgName) {
+		// Check functions
+		if fn, exists := file.Functions[funcName]; exists {
+			if fn.Signature.ResolvedType != -1 {
+				arg.SetResolvedType(fn.Signature.GetResolvedType())
+				arg.Fun.SetResolvedType(fn.Signature.GetResolvedType())
 			}
-			// Check functions
-			if fn, exists := file.Functions[funcName]; exists {
-				if fn.Signature.ResolvedType != -1 {
-					arg.SetResolvedType(fn.Signature.GetResolvedType())
-					arg.Fun.SetResolvedType(fn.Signature.GetResolvedType())
-				}
-				return
-			}
+			return
+		}
 
-			// Check methods. Sorted: two types in a file can declare the same
-			// method name, and the first match returns.
-			for _, typeName := range m.SortedTypeNames(pkgName, fileName) {
-				typ := file.Types[typeName]
-				if typ == nil {
-					continue
-				}
-				for _, method := range typ.Methods {
-					if m.StringPool.GetString(method.Name) == funcName {
-						if method.Signature.ResolvedType != -1 {
-							arg.SetResolvedType(method.Signature.GetResolvedType())
-							arg.Fun.SetResolvedType(method.Signature.GetResolvedType())
-						}
-						return
+		// Check methods. Sorted: two types in a file can declare the same
+		// method name, and the first match returns.
+		for _, typ := range m.SortedTypes(pkgName, fileName) {
+			for _, method := range typ.Methods {
+				if m.StringPool.GetString(method.Name) == funcName {
+					if method.Signature.ResolvedType != -1 {
+						arg.SetResolvedType(method.Signature.GetResolvedType())
+						arg.Fun.SetResolvedType(method.Signature.GetResolvedType())
 					}
+					return
 				}
 			}
 		}

--- a/internal/spec/assignment_order.go
+++ b/internal/spec/assignment_order.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"sort"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// sortedAssignmentRelationships returns the metadata's assignment links in a
+// total order, for both trackers to consume.
+//
+// Order is load-bearing, not cosmetic: the consumers write the links into
+// last-write-wins indexes (assignmentIndex/assignIndex[akey] = producer) and
+// append to per-producer child lists, so it decides which producer an
+// ambiguous variable resolves to and in which order a node's children are
+// expanded — and under a truncation budget, expansion order decides what
+// survives. The source is a map, so it is randomised per run.
+//
+// The producing call's instance ID alone does NOT order the list: one edge can
+// be linked to several assignments (`a, b := f()`, an edge whose AssignmentMap
+// holds more than one variable), and sort.Slice is unstable, so those ties were
+// broken by the random map order — 9,284 of 21,735 links on gitea sat in such a
+// tie, which is how the same command produced different specs run to run
+// (issue #340). The link's AssignmentKey is the map key, hence unique, so
+// tie-breaking on its fields is a total order.
+func sortedAssignmentRelationships(meta *metadata.Metadata) []*metadata.AssignmentLink {
+	relationships := meta.GetAssignmentRelationships()
+	rels := make([]*metadata.AssignmentLink, 0, len(relationships))
+	for _, rel := range relationships {
+		rels = append(rels, rel)
+	}
+	sort.Slice(rels, func(i, j int) bool {
+		a, b := rels[i], rels[j]
+		if ai, bi := a.Edge.Callee.ID(), b.Edge.Callee.ID(); ai != bi {
+			return ai < bi
+		}
+		ak, bk := a.AssignmentKey, b.AssignmentKey
+		if ak.Container != bk.Container {
+			return ak.Container < bk.Container
+		}
+		if ak.Pkg != bk.Pkg {
+			return ak.Pkg < bk.Pkg
+		}
+		if ak.Name != bk.Name {
+			return ak.Name < bk.Name
+		}
+		return ak.Type < bk.Type
+	})
+	return rels
+}

--- a/internal/spec/assignment_order.go
+++ b/internal/spec/assignment_order.go
@@ -15,7 +15,8 @@
 package spec
 
 import (
-	"sort"
+	"cmp"
+	"slices"
 
 	"github.com/ehabterra/apispec/internal/metadata"
 )
@@ -32,7 +33,7 @@ import (
 //
 // The producing call's instance ID alone does NOT order the list: one edge can
 // be linked to several assignments (`a, b := f()`, an edge whose AssignmentMap
-// holds more than one variable), and sort.Slice is unstable, so those ties were
+// holds more than one variable), and the sort is unstable, so those ties were
 // broken by the random map order — 9,284 of 21,735 links on gitea sat in such a
 // tie, which is how the same command produced different specs run to run
 // (issue #340). The link's AssignmentKey is the map key, hence unique, so
@@ -43,22 +44,15 @@ func sortedAssignmentRelationships(meta *metadata.Metadata) []*metadata.Assignme
 	for _, rel := range relationships {
 		rels = append(rels, rel)
 	}
-	sort.Slice(rels, func(i, j int) bool {
-		a, b := rels[i], rels[j]
-		if ai, bi := a.Edge.Callee.ID(), b.Edge.Callee.ID(); ai != bi {
-			return ai < bi
-		}
+	slices.SortFunc(rels, func(a, b *metadata.AssignmentLink) int {
 		ak, bk := a.AssignmentKey, b.AssignmentKey
-		if ak.Container != bk.Container {
-			return ak.Container < bk.Container
-		}
-		if ak.Pkg != bk.Pkg {
-			return ak.Pkg < bk.Pkg
-		}
-		if ak.Name != bk.Name {
-			return ak.Name < bk.Name
-		}
-		return ak.Type < bk.Type
+		return cmp.Or(
+			cmp.Compare(a.Edge.Callee.ID(), b.Edge.Callee.ID()),
+			cmp.Compare(ak.Container, bk.Container),
+			cmp.Compare(ak.Pkg, bk.Pkg),
+			cmp.Compare(ak.Name, bk.Name),
+			cmp.Compare(ak.Type, bk.Type),
+		)
 	})
 	return rels
 }

--- a/internal/spec/body_source.go
+++ b/internal/spec/body_source.go
@@ -344,7 +344,13 @@ func findFunction(meta *metadata.Metadata, pkg, name string) *metadata.Function 
 	if !ok {
 		return nil
 	}
-	for _, file := range p.Files {
+	// Sorted: the first file declaring the name answers, so map order would
+	// decide which declaration wins (golden rule #1).
+	for _, fileName := range meta.SortedFileNames(pkg) {
+		file := p.Files[fileName]
+		if file == nil {
+			continue
+		}
 		if fn, ok := file.Functions[name]; ok {
 			return fn
 		}

--- a/internal/spec/body_source.go
+++ b/internal/spec/body_source.go
@@ -340,17 +340,9 @@ func findFunction(meta *metadata.Metadata, pkg, name string) *metadata.Function 
 	if meta == nil {
 		return nil
 	}
-	p, ok := meta.Packages[pkg]
-	if !ok {
-		return nil
-	}
 	// Sorted: the first file declaring the name answers, so map order would
 	// decide which declaration wins (golden rule #1).
-	for _, fileName := range meta.SortedFileNames(pkg) {
-		file := p.Files[fileName]
-		if file == nil {
-			continue
-		}
+	for _, file := range meta.SortedFiles(pkg) {
 		if fn, ok := file.Functions[name]; ok {
 			return fn
 		}

--- a/internal/spec/config_security.go
+++ b/internal/spec/config_security.go
@@ -14,7 +14,11 @@
 
 package spec
 
-import "github.com/ehabterra/apispec/internal/metadata"
+import (
+	"sort"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
 
 // This file holds the auth/security presets. Two pure-data layers keep the
 // engine framework-agnostic:
@@ -316,6 +320,8 @@ func collectImports(meta *metadata.Metadata) []string {
 			}
 		}
 	}
+	// Sorted: the caller ranges the result, and both maps above are unordered.
+	sort.Strings(out)
 	return out
 }
 

--- a/internal/spec/context_provider.go
+++ b/internal/spec/context_provider.go
@@ -178,16 +178,10 @@ func (c *ContextProviderImpl) callArgToString(arg *metadata.CallArgument, sep *s
 
 	case metadata.KindIdent, metadata.KindFuncLit:
 		// Try to resolve as a constant value from metadata
-		if pkg, exists := c.meta.Packages[arg.GetPkg()]; exists {
-			// Sorted: the first file declaring the constant answers.
-			for _, fileName := range c.meta.SortedFileNames(arg.GetPkg()) {
-				file := pkg.Files[fileName]
-				if file == nil {
-					continue
-				}
-				if variable, exists := file.Variables[arg.GetName()]; exists && c.GetString(variable.Tok) == "const" {
-					return strings.Trim(c.GetString(variable.Value), "\"")
-				}
+		// Sorted: the first file declaring the constant answers.
+		for _, file := range c.meta.SortedFiles(arg.GetPkg()) {
+			if variable, exists := file.Variables[arg.GetName()]; exists && c.GetString(variable.Tok) == "const" {
+				return strings.Trim(c.GetString(variable.Value), "\"")
 			}
 		}
 		// If not a function type, build a qualified type string

--- a/internal/spec/context_provider.go
+++ b/internal/spec/context_provider.go
@@ -179,7 +179,12 @@ func (c *ContextProviderImpl) callArgToString(arg *metadata.CallArgument, sep *s
 	case metadata.KindIdent, metadata.KindFuncLit:
 		// Try to resolve as a constant value from metadata
 		if pkg, exists := c.meta.Packages[arg.GetPkg()]; exists {
-			for _, file := range pkg.Files {
+			// Sorted: the first file declaring the constant answers.
+			for _, fileName := range c.meta.SortedFileNames(arg.GetPkg()) {
+				file := pkg.Files[fileName]
+				if file == nil {
+					continue
+				}
 				if variable, exists := file.Variables[arg.GetName()]; exists && c.GetString(variable.Tok) == "const" {
 					return strings.Trim(c.GetString(variable.Value), "\"")
 				}

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -2026,8 +2026,18 @@ func methodAssignmentMap(meta *metadata.Metadata, pkg, recv, name, varName strin
 	if !ok {
 		return nil
 	}
-	for _, file := range p.Files {
-		for _, t := range file.Types {
+	// Sorted: the first method whose assignments hold the variable answers, so
+	// map order would decide which declaration wins (golden rule #1).
+	for _, fileName := range meta.SortedFileNames(pkg) {
+		file := p.Files[fileName]
+		if file == nil {
+			continue
+		}
+		for _, tname := range meta.SortedTypeNames(pkg, fileName) {
+			t := file.Types[tname]
+			if t == nil {
+				continue
+			}
 			for i := range t.Methods {
 				m := &t.Methods[i]
 				if meta.StringPool.GetString(m.Name) != name {

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -2078,7 +2078,13 @@ func findMethodByName(meta *metadata.Metadata, pkg, recv, name string) *metadata
 	}
 	sort.Strings(fileNames)
 	for _, fname := range fileNames {
-		for _, t := range p.Files[fname].Types {
+		// Sorted: with no receiver to filter on, the first same-named method
+		// found answers, so map order would decide which type's method wins.
+		for _, tname := range meta.SortedTypeNames(pkg, fname) {
+			t := p.Files[fname].Types[tname]
+			if t == nil {
+				continue
+			}
 			for i := range t.Methods {
 				m := &t.Methods[i]
 				if meta.StringPool.GetString(m.Name) != name {

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -2022,22 +2022,10 @@ func methodAssignmentMap(meta *metadata.Metadata, pkg, recv, name, varName strin
 	if meta == nil || name == "" {
 		return nil
 	}
-	p, ok := meta.Packages[pkg]
-	if !ok {
-		return nil
-	}
 	// Sorted: the first method whose assignments hold the variable answers, so
 	// map order would decide which declaration wins (golden rule #1).
-	for _, fileName := range meta.SortedFileNames(pkg) {
-		file := p.Files[fileName]
-		if file == nil {
-			continue
-		}
-		for _, tname := range meta.SortedTypeNames(pkg, fileName) {
-			t := file.Types[tname]
-			if t == nil {
-				continue
-			}
+	for fileName := range meta.SortedFiles(pkg) {
+		for _, t := range meta.SortedTypes(pkg, fileName) {
 			for i := range t.Methods {
 				m := &t.Methods[i]
 				if meta.StringPool.GetString(m.Name) != name {
@@ -2065,26 +2053,11 @@ func findMethodByName(meta *metadata.Metadata, pkg, recv, name string) *metadata
 	if meta == nil || name == "" {
 		return nil
 	}
-	p, ok := meta.Packages[pkg]
-	if !ok {
-		return nil
-	}
-	// Sort file keys: a receiver-less lookup can match in several files, and map
-	// iteration order would make the winner (and any doc comment it carries)
-	// vary between runs.
-	fileNames := make([]string, 0, len(p.Files))
-	for f := range p.Files {
-		fileNames = append(fileNames, f)
-	}
-	sort.Strings(fileNames)
-	for _, fname := range fileNames {
-		// Sorted: with no receiver to filter on, the first same-named method
-		// found answers, so map order would decide which type's method wins.
-		for _, tname := range meta.SortedTypeNames(pkg, fname) {
-			t := p.Files[fname].Types[tname]
-			if t == nil {
-				continue
-			}
+	// Sorted: a receiver-less lookup can match in several files (and in several
+	// types within one file), and map iteration order would make the winner —
+	// and any doc comment it carries — vary between runs.
+	for fname := range meta.SortedFiles(pkg) {
+		for _, t := range meta.SortedTypes(pkg, fname) {
 			for i := range t.Methods {
 				m := &t.Methods[i]
 				if meta.StringPool.GetString(m.Name) != name {

--- a/internal/spec/field_resolver.go
+++ b/internal/spec/field_resolver.go
@@ -172,17 +172,9 @@ func constIdentDeclaredType(arg *metadata.CallArgument, cp ContextProvider) stri
 	if !ok || impl.meta == nil {
 		return ""
 	}
-	pkg, ok2 := impl.meta.Packages[arg.GetPkg()]
-	if !ok2 {
-		return ""
-	}
 	name := arg.GetName()
 	// Sorted: the first file declaring the constant answers (golden rule #1).
-	for _, fileName := range impl.meta.SortedFileNames(arg.GetPkg()) {
-		file := pkg.Files[fileName]
-		if file == nil {
-			continue
-		}
+	for _, file := range impl.meta.SortedFiles(arg.GetPkg()) {
 		v, ok := file.Variables[name]
 		if !ok {
 			continue
@@ -215,11 +207,7 @@ func findType(meta *metadata.Metadata, pkg, typeName string) *metadata.Type {
 		return t
 	}
 	// Sorted: the first file declaring the type answers (golden rule #1).
-	for _, fileName := range meta.SortedFileNames(pkg) {
-		file := p.Files[fileName]
-		if file == nil {
-			continue
-		}
+	for _, file := range meta.SortedFiles(pkg) {
 		if t, ok := file.Types[typeName]; ok && t != nil {
 			return t
 		}

--- a/internal/spec/field_resolver.go
+++ b/internal/spec/field_resolver.go
@@ -177,7 +177,12 @@ func constIdentDeclaredType(arg *metadata.CallArgument, cp ContextProvider) stri
 		return ""
 	}
 	name := arg.GetName()
-	for _, file := range pkg.Files {
+	// Sorted: the first file declaring the constant answers (golden rule #1).
+	for _, fileName := range impl.meta.SortedFileNames(arg.GetPkg()) {
+		file := pkg.Files[fileName]
+		if file == nil {
+			continue
+		}
 		v, ok := file.Variables[name]
 		if !ok {
 			continue
@@ -209,7 +214,12 @@ func findType(meta *metadata.Metadata, pkg, typeName string) *metadata.Type {
 	if t, ok := p.Types[typeName]; ok && t != nil {
 		return t
 	}
-	for _, file := range p.Files {
+	// Sorted: the first file declaring the type answers (golden rule #1).
+	for _, fileName := range meta.SortedFileNames(pkg) {
+		file := p.Files[fileName]
+		if file == nil {
+			continue
+		}
 		if t, ok := file.Types[typeName]; ok && t != nil {
 			return t
 		}

--- a/internal/spec/lazytree.go
+++ b/internal/spec/lazytree.go
@@ -673,15 +673,10 @@ func (t *LazyTree) buildRelations() {
 		}
 	}
 
-	// Assignment links: variable <- producing call. Sort by producing callee
-	// ID so the receiverChildren lists are order-independent of the source map.
-	rels := make([]*metadata.AssignmentLink, 0)
-	for _, rel := range meta.GetAssignmentRelationships() {
-		rels = append(rels, rel)
-	}
-	sort.Slice(rels, func(i, j int) bool {
-		return rels[i].Edge.Callee.ID() < rels[j].Edge.Callee.ID()
-	})
+	// Assignment links: variable <- producing call, in a total order so the
+	// receiverChildren lists and assignIndex winners are independent of the
+	// source map's iteration order (see sortedAssignmentRelationships).
+	rels := sortedAssignmentRelationships(meta)
 	producerByVar := map[recvKey]string{}
 	for _, rel := range rels {
 		producerKey := strings.TrimPrefix(rel.Edge.Callee.ID(), "*")

--- a/internal/spec/sorted_lookup_test.go
+++ b/internal/spec/sorted_lookup_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// TestSortedAssignmentRelationshipsIsATotalOrder pins the tie-break that issue
+// #340 turned on: one edge can produce several assignment links, so the
+// producing callee ID alone does not order them, and the consumers write the
+// result into last-write-wins indexes.
+func TestSortedAssignmentRelationshipsIsATotalOrder(t *testing.T) {
+	meta := newTestMeta()
+	pool := meta.StringPool
+
+	// One edge, four variables — every link shares a callee ID, so ordering is
+	// decided entirely by the tie-break, and each pair below differs in exactly
+	// one AssignmentKey field.
+	assign := func(pkg, typ, fn string) []metadata.Assignment {
+		return []metadata.Assignment{{Pkg: pool.Get(pkg), ConcreteType: pool.Get(typ), Func: pool.Get(fn)}}
+	}
+	meta.CallGraph = []metadata.CallGraphEdge{{
+		Caller: metadata.Call{Meta: meta, Name: pool.Get("Setup"), Pkg: pool.Get("app"), RecvType: -1},
+		Callee: metadata.Call{Meta: meta, Name: pool.Get("New"), Pkg: pool.Get("app/router"), RecvType: -1},
+		AssignmentMap: map[string][]metadata.Assignment{
+			"r": assign("app", "*Router", "Setup"),
+			"s": assign("app", "*Router", "Setup"),   // differs by Name
+			"t": assign("app", "*Engine", "Setup"),   // differs by Type
+			"u": assign("app", "*Router", "Startup"), // differs by Container
+			"v": assign("zzz", "*Router", "Setup"),   // differs by Pkg
+		},
+	}}
+
+	want := []string{"Setup|app|r|*Router", "Setup|app|s|*Router", "Setup|app|t|*Engine",
+		"Setup|zzz|v|*Router", "Startup|app|u|*Router"}
+	key := func(l *metadata.AssignmentLink) string {
+		k := l.AssignmentKey
+		return k.Container + "|" + k.Pkg + "|" + k.Name + "|" + k.Type
+	}
+
+	// Repeated because the source is a map: each call sees a different input
+	// order, which is exactly what an unstable sort turned into a different
+	// result.
+	for run := 0; run < 8; run++ {
+		rels := sortedAssignmentRelationships(meta)
+		if len(rels) != len(want) {
+			t.Fatalf("run %d: got %d links, want %d", run, len(rels), len(want))
+		}
+		for i, rel := range rels {
+			if got := key(rel); got != want[i] {
+				t.Fatalf("run %d: link %d is %s, want %s", run, i, got, want[i])
+			}
+		}
+	}
+}
+
+// TestSortedFileScansSkipNilFileEntries covers the lookups that answer from the
+// first file declaring a name. They range the sorted file names, so a nil file
+// entry — which a deserialised metadata.yaml may carry — sits in the middle of
+// the scan and must be stepped over rather than dereferenced.
+func TestSortedFileScansSkipNilFileEntries(t *testing.T) {
+	meta := newTestMeta()
+	pool := meta.StringPool
+
+	const pkg = "example.com/app"
+	handler := &metadata.Type{
+		Methods: []metadata.Method{{
+			Name:     pool.Get("Serve"),
+			Receiver: pool.Get("*Handler"),
+			AssignmentMap: map[string][]metadata.Assignment{
+				"body": {{Pkg: pool.Get(pkg), ConcreteType: pool.Get("Payload")}},
+			},
+		}},
+	}
+	meta.Packages = map[string]*metadata.Package{
+		pkg: {
+			Files: map[string]*metadata.File{
+				// Sorts first, and is nil: every scan below starts here.
+				"a_generated.go": nil,
+				"b_real.go": {
+					Types:     map[string]*metadata.Type{"Handler": handler, "Payload": {}},
+					Functions: map[string]*metadata.Function{"Route": {Name: pool.Get("Route")}},
+					Variables: map[string]*metadata.Variable{
+						"DefaultLimit": {Tok: pool.Get("const"), Type: pool.Get("int")},
+					},
+				},
+			},
+		},
+	}
+
+	if findFunction(meta, pkg, "Route") == nil {
+		t.Error("findFunction skipped the real file after the nil entry")
+	}
+	if findType(meta, pkg, "Payload") == nil {
+		t.Error("findType skipped the real file after the nil entry")
+	}
+	if findMethodByName(meta, pkg, "*Handler", "Serve") == nil {
+		t.Error("findMethodByName skipped the real file after the nil entry")
+	}
+	if methodAssignmentMap(meta, pkg, "*Handler", "Serve", "body") == nil {
+		t.Error("methodAssignmentMap skipped the real file after the nil entry")
+	}
+
+	cp := NewContextProvider(meta)
+	arg := mkIdent(meta, "DefaultLimit", "")
+	arg.Pkg = pool.Get(pkg)
+	if got := constIdentDeclaredType(arg, cp); got != "int" {
+		t.Errorf("constIdentDeclaredType = %q, want int (the nil file must be skipped)", got)
+	}
+}

--- a/internal/spec/tracker.go
+++ b/internal/spec/tracker.go
@@ -1536,17 +1536,11 @@ func NewTrackerNode(tree *TrackerTree, meta *metadata.Metadata, parentID, id str
 			callerName := getStringFromPool(meta, edges[0].Caller.Name)
 			callerPkg := getStringFromPool(meta, edges[0].Caller.Pkg)
 
-			if pkg, ok := meta.Packages[callerPkg]; ok {
-				// Sorted: two files declaring the same name would otherwise
-				// copy in random order, and the later copy wins per variable.
-				for _, fileName := range meta.SortedFileNames(callerPkg) {
-					file := pkg.Files[fileName]
-					if file == nil {
-						continue
-					}
-					if fn, ok := file.Functions[callerName]; ok {
-						maps.Copy(node.RootAssignmentMap, fn.AssignmentMap)
-					}
+			// Sorted: two files declaring the same name would otherwise
+			// copy in random order, and the later copy wins per variable.
+			for _, file := range meta.SortedFiles(callerPkg) {
+				if fn, ok := file.Functions[callerName]; ok {
+					maps.Copy(node.RootAssignmentMap, fn.AssignmentMap)
 				}
 			}
 		}
@@ -1662,51 +1656,39 @@ func NewTrackerNode(tree *TrackerTree, meta *metadata.Metadata, parentID, id str
 		calleePkg := getString(meta, parentEdge.Callee.Pkg)
 		methodName := getString(meta, parentEdge.Callee.Name)
 
-		if pkg, exists := meta.Packages[calleePkg]; exists {
-			// Sorted: the type declaration found first decides the fan-out.
-			for _, fileName := range meta.SortedFileNames(calleePkg) {
-				file := pkg.Files[fileName]
-				if file == nil {
-					continue
-				}
-				if typ, exists := file.Types[recvTypeName]; exists {
-					kindStr := getString(meta, typ.Kind)
-					if kindStr == "interface" && len(typ.ImplementedBy) > 0 {
-						for _, implTypeIdx := range typ.ImplementedBy {
-							implTypeName := getString(meta, implTypeIdx)
-							// ImplementedBy is "import/path.Type"; the import path
-							// itself contains dots (github.com/…), so split on the
-							// LAST dot — not every dot — to separate pkg from type.
-							dot := strings.LastIndex(implTypeName, ".")
-							if dot <= 0 || dot == len(implTypeName)-1 {
-								continue
-							}
-							implPkg, implType := implTypeName[:dot], implTypeName[dot+1:]
+		// Sorted: the type declaration found first decides the fan-out.
+		for _, file := range meta.SortedFiles(calleePkg) {
+			if typ, exists := file.Types[recvTypeName]; exists {
+				kindStr := getString(meta, typ.Kind)
+				if kindStr == "interface" && len(typ.ImplementedBy) > 0 {
+					for _, implTypeIdx := range typ.ImplementedBy {
+						implTypeName := getString(meta, implTypeIdx)
+						// ImplementedBy is "import/path.Type"; the import path
+						// itself contains dots (github.com/…), so split on the
+						// LAST dot — not every dot — to separate pkg from type.
+						dot := strings.LastIndex(implTypeName, ".")
+						if dot <= 0 || dot == len(implTypeName)-1 {
+							continue
+						}
+						implPkg, implType := implTypeName[:dot], implTypeName[dot+1:]
 
-							if implPkgObj, exists := meta.Packages[implPkg]; exists {
-								for _, implFileName := range meta.SortedFileNames(implPkg) {
-									implFile := implPkgObj.Files[implFileName]
-									if implFile == nil {
+						for _, implFile := range meta.SortedFiles(implPkg) {
+							if implTypeObj, exists := implFile.Types[implType]; exists {
+								for _, method := range implTypeObj.Methods {
+									if getString(meta, method.Name) != methodName {
 										continue
 									}
-									if implTypeObj, exists := implFile.Types[implType]; exists {
-										for _, method := range implTypeObj.Methods {
-											if getString(meta, method.Name) != methodName {
+
+									concreteMethodID := implPkg + "." + implType + "." + methodName
+									if concreteEdges, exists := meta.Callers[concreteMethodID]; exists {
+										for _, concreteEdge := range concreteEdges {
+											concreteCalleeID := concreteEdge.Callee.ID()
+											if tree.nodeMap[concreteCalleeID] != nil {
 												continue
 											}
 
-											concreteMethodID := implPkg + "." + implType + "." + methodName
-											if concreteEdges, exists := meta.Callers[concreteMethodID]; exists {
-												for _, concreteEdge := range concreteEdges {
-													concreteCalleeID := concreteEdge.Callee.ID()
-													if tree.nodeMap[concreteCalleeID] != nil {
-														continue
-													}
-
-													if childNode := NewTrackerNode(tree, meta, id, concreteCalleeID, concreteEdge, nil, visited, assignmentIndex, limits); childNode != nil {
-														node.AddChild(childNode)
-													}
-												}
+											if childNode := NewTrackerNode(tree, meta, id, concreteCalleeID, concreteEdge, nil, visited, assignmentIndex, limits); childNode != nil {
+												node.AddChild(childNode)
 											}
 										}
 									}

--- a/internal/spec/tracker.go
+++ b/internal/spec/tracker.go
@@ -477,21 +477,11 @@ func NewTrackerTree(meta *metadata.Metadata, limits metadata.TrackerLimits, logg
 
 	visited := make(map[string]int, 200) // Pre-allocate with estimated capacity
 
-	// Get pre-built relationships from metadata
-	assignmentRelationships := meta.GetAssignmentRelationships()
-
-	// Iterate in a stable order: this is a map, and the assignment below is
-	// last-write-wins (assignmentIndex[akey] = …). When two relationships map to
-	// the same akey, random map order would pick a different winner each run,
-	// flipping variable resolution (and the final spec). Order by the edge's
-	// instance ID (unique, position-based).
-	rels := make([]*metadata.AssignmentLink, 0, len(assignmentRelationships))
-	for _, a := range assignmentRelationships {
-		rels = append(rels, a)
-	}
-	sort.Slice(rels, func(i, j int) bool {
-		return rels[i].Edge.Callee.ID() < rels[j].Edge.Callee.ID()
-	})
+	// Iterate in a stable order: the source is a map, and the assignment below
+	// is last-write-wins (assignmentIndex[akey] = …). When two relationships map
+	// to the same akey, random map order would pick a different winner each run,
+	// flipping variable resolution (and the final spec).
+	rels := sortedAssignmentRelationships(meta)
 
 	for _, assignment := range rels {
 		recvVarName := getString(meta, assignment.Assignment.VariableName)
@@ -1547,7 +1537,13 @@ func NewTrackerNode(tree *TrackerTree, meta *metadata.Metadata, parentID, id str
 			callerPkg := getStringFromPool(meta, edges[0].Caller.Pkg)
 
 			if pkg, ok := meta.Packages[callerPkg]; ok {
-				for _, file := range pkg.Files {
+				// Sorted: two files declaring the same name would otherwise
+				// copy in random order, and the later copy wins per variable.
+				for _, fileName := range meta.SortedFileNames(callerPkg) {
+					file := pkg.Files[fileName]
+					if file == nil {
+						continue
+					}
 					if fn, ok := file.Functions[callerName]; ok {
 						maps.Copy(node.RootAssignmentMap, fn.AssignmentMap)
 					}
@@ -1667,7 +1663,12 @@ func NewTrackerNode(tree *TrackerTree, meta *metadata.Metadata, parentID, id str
 		methodName := getString(meta, parentEdge.Callee.Name)
 
 		if pkg, exists := meta.Packages[calleePkg]; exists {
-			for _, file := range pkg.Files {
+			// Sorted: the type declaration found first decides the fan-out.
+			for _, fileName := range meta.SortedFileNames(calleePkg) {
+				file := pkg.Files[fileName]
+				if file == nil {
+					continue
+				}
 				if typ, exists := file.Types[recvTypeName]; exists {
 					kindStr := getString(meta, typ.Kind)
 					if kindStr == "interface" && len(typ.ImplementedBy) > 0 {
@@ -1683,7 +1684,11 @@ func NewTrackerNode(tree *TrackerTree, meta *metadata.Metadata, parentID, id str
 							implPkg, implType := implTypeName[:dot], implTypeName[dot+1:]
 
 							if implPkgObj, exists := meta.Packages[implPkg]; exists {
-								for _, implFile := range implPkgObj.Files {
+								for _, implFileName := range meta.SortedFileNames(implPkg) {
+									implFile := implPkgObj.Files[implFileName]
+									if implFile == nil {
+										continue
+									}
 									if implTypeObj, exists := implFile.Types[implType]; exists {
 										for _, method := range implTypeObj.Methods {
 											if getString(meta, method.Name) != methodName {

--- a/internal/spec/wrapper_detect.go
+++ b/internal/spec/wrapper_detect.go
@@ -414,22 +414,16 @@ func embeddingRecvRegex(meta *metadata.Metadata, w *wrapperMethod) string {
 
 	// Transitively: a type embedding a type that embeds the declaring one gets
 	// the method too.
-	pkg, ok := meta.Packages[w.pkg]
-	if !ok {
+	if _, ok := meta.Packages[w.pkg]; !ok {
 		return recvTypeRegexForNames(w.pkg, names)
 	}
 	for round := 0; round < wrapperDetectRounds; round++ {
 		grew := false
-		for _, fileName := range meta.SortedFileNames(w.pkg) {
-			file := pkg.Files[fileName]
-			if file == nil {
-				continue
-			}
+		for fileName := range meta.SortedFiles(w.pkg) {
 			// Sorted: names accumulates in scan order and is consumed as a
 			// list, so map order would reach the caller.
-			for _, typeName := range meta.SortedTypeNames(w.pkg, fileName) {
-				typ := file.Types[typeName]
-				if typ == nil || containsName(names, typeName) {
+			for typeName, typ := range meta.SortedTypes(w.pkg, fileName) {
+				if containsName(names, typeName) {
 					continue
 				}
 				for _, embedded := range typ.Embeds {

--- a/internal/spec/wrapper_detect.go
+++ b/internal/spec/wrapper_detect.go
@@ -425,8 +425,11 @@ func embeddingRecvRegex(meta *metadata.Metadata, w *wrapperMethod) string {
 			if file == nil {
 				continue
 			}
-			for typeName, typ := range file.Types {
-				if containsName(names, typeName) {
+			// Sorted: names accumulates in scan order and is consumed as a
+			// list, so map order would reach the caller.
+			for _, typeName := range meta.SortedTypeNames(w.pkg, fileName) {
+				typ := file.Types[typeName]
+				if typ == nil || containsName(names, typeName) {
 					continue
 				}
 				for _, embedded := range typ.Embeds {


### PR DESCRIPTION
Fixes #340.

## The bug

The same command on gitea produced different specs run to run. Re-measured on `main` before touching anything: **3 distinct outputs in 4 runs** at `--max-nodes-per-route 5000 --max-instances-per-key 10`, and **two alternating outputs at the defaults**. The difference is a route silently documenting fewer responses, and header parameters (`X-Forwarded-Proto`, `User-Agent`, …) appearing and vanishing.

## Root cause

Not the truncation tie-break the issue theorised. Found by dumping the tree's full materialization sequence (`parent -> child`, 1.1M lines) for two runs and diffing to the **first** divergent node — everything before it, including every counter, was identical.

Variable-origin resolution scans a package's `Files` **map** and answers from the first file that declares what it is looking for. Which file that is was decided by Go's per-run map randomisation, and the answer is memoized for the rest of the run. On gitea, tracing `cmd` in `modules/git.Clone` either found gitcmd's builder method and followed its receiver, or hit the method lookup's negative cache first and stopped at the local assignment. Those two answers put `HandleGitCmdHTTPRedirection` in or out of the reachable set — 9 identities' reachability flipped with it — which changed which subtrees the barren-subtree prune (#348) kept, and therefore which copies the instance cap dropped.

So the chain is: one map-order coin flip during loading → different producer resolution → different reach index → different truncation victims → a smaller spec, with nothing to say why.

## The fix

1. **Sorted every remaining first-match scan** through the memoized `Metadata.SortedFileNames` / `SortedTypeNames` — the helpers that exist for exactly this (`"Sorting IS the determinism guarantee"`): both loops in `traceVariableOriginHelper`, `resolveIdentReturnType`, the function-signature resolver, `BuildAssignmentRelationships`, and the spec layer's function/type/const/method lookups (`body_source`, `field_resolver`, `context_provider`, `extractor`, `tracker`, `wrapper_detect`). `collectImports` sorts its result for the same reason.

2. **Made the assignment-relationship order a total order.** Both trackers sorted the links by producing callee ID alone, which is not unique — one edge can be linked to several assignments — and `sort.Slice` is unstable, so the ties fell back to the source map's order. **9,284 of 21,735 links on gitea sit in such a tie**, and the consumers are last-write-wins indexes (`assignIndex`) and per-producer child lists. Extracted as `sortedAssignmentRelationships` (`internal/spec/assignment_order.go`), now shared by the eager and lazy trees instead of duplicated.

## Verification

| | before | after |
|---|---|---|
| gitea, issue's flags | 3 distinct outputs / 4 runs | **6/6 identical** |
| gitea, default limits | 2 alternating outputs | **4/4 identical** |

Runtime is unchanged (107s / 102s before vs 93s / 104s after — noise; the sorted lists are cached). Full suite passes unchanged, metadata goldens included: no output drift on any fixture.

## Guards

- `TestTraceVariableOriginDeterministic` (metadata) — a fixture whose builder method lives in one file of a multi-file package; traces the same variable over repeated **fresh** loads and pins the answer. Fails 3/3 without the fix.
- `TestGenerateDeterministicUnderTruncation` (generator) — generates fixtures twice with both budgets forced low, and asserts truncation actually happened so the test cannot quietly stop covering that path. This is the gap the issue identified: every existing determinism fixture is too small to spend a budget.

## Follow-up

#380 — the determinism fix made a precision gap reproducible: the method lookup caches its miss package-wide after scanning one file, so a builder method outside the package's first file is never followed. Deliberately not changed here (this PR changes no resolution results); the new test pins the current answer as a change detector.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when generating API specifications, ensuring repeated runs produce stable results.
  * Reduced variability in metadata, type resolution, relationship processing, imports, and declaration discovery.
  * Improved handling of truncated generation scenarios for more predictable outputs.

* **Tests**
  * Added regression coverage to verify deterministic specification and metadata generation across repeated runs.
  * Added validation for stable variable tracing and expansion-budget truncation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->