### PR TITLE
fix: document a body written without WriteHeader as 200, not default (#369)

### DIFF
--- a/cmd/apispecui/assets/js/config.js
+++ b/cmd/apispecui/assets/js/config.js
@@ -645,14 +645,24 @@ function RequestContextEditor({ rc, onChange }) {
   `;
 }
 
-// ResponseContextEditor edits the writer-type lists only. Body transforms
-// (envelope unwrapping) are nested per-transform structures; those are edited in
-// YAML mode rather than duplicated here, and they round-trip untouched.
+// ResponseContextEditor edits the writer-type lists and the implicit status.
+// Body transforms (envelope unwrapping) are nested per-transform structures;
+// those are edited in YAML mode rather than duplicated here, and they round-trip
+// untouched.
 function ResponseContextEditor({ rc, onChange }) {
   const set = (k, v) => onChange({ ...(rc || {}), [k]: v });
   return html`
     ${area("Writer type regexes (one per line)", lines(rc?.writerTypeRegexes), (e) => set("writerTypeRegexes", toLines(e.target.value)), "^net/http\\.ResponseWriter$")}
     ${area("Writer-compatible type regexes (one per line)", lines(rc?.writerCompatibleTypeRegexes), (e) => set("writerCompatibleTypeRegexes", toLines(e.target.value)), "^io\\.Writer$")}
+    <div class="field">
+      <label class="row" style="gap:6px">
+        <span>Implicit status</span>
+        <${Info} text="Status the framework sends when a handler writes a body without stating one — 200 for net/http, whose first Write implies it. Leave empty for frameworks whose renderers always carry the status." />
+      </label>
+      <input class="input" type="number" value=${rc?.implicitStatus ?? ""}
+        placeholder="200"
+        onInput=${(e) => set("implicitStatus", e.target.value === "" ? 0 : parseInt(e.target.value, 10) || 0)} />
+    </div>
   `;
 }
 

--- a/cmd/apispecui/assets/js/config.js
+++ b/cmd/apispecui/assets/js/config.js
@@ -659,7 +659,7 @@ function ResponseContextEditor({ rc, onChange }) {
         <span>Implicit status</span>
         <${Info} text="Status the framework sends when a handler writes a body without stating one — 200 for net/http, whose first Write implies it. Leave empty for frameworks whose renderers always carry the status." />
       </label>
-      <input class="input" type="number" value=${rc?.implicitStatus ?? ""}
+      <input class="input" type="number" min="100" max="599" step="1" value=${rc?.implicitStatus ?? ""}
         placeholder="200"
         onInput=${(e) => set("implicitStatus", e.target.value === "" ? 0 : parseInt(e.target.value, 10) || 0)} />
     </div>

--- a/generator/testdata_implicit_status_test.go
+++ b/generator/testdata_implicit_status_test.go
@@ -1,0 +1,156 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/ehabterra/apispec/spec"
+)
+
+// TestTestdata_ImplicitStatus locks in issue #369: a net/http handler that
+// writes a body without calling WriteHeader sends 200, so that is what the spec
+// must say. Documenting it under "default" gave the endpoint no success
+// response at all — client generators map "default" to the error branch.
+//
+// The fixture covers the three shapes the fix has to keep apart: the status is
+// implied, the status is stated, and one branch states it while the other does
+// not.
+func TestTestdata_ImplicitStatus(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "implicit_status", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+
+	want := map[string]map[string][]string{
+		"/items/{id}":      {"GET": {"200"}, "DELETE": {"204"}},
+		"/items":           {"GET": {"200", "400"}, "POST": {"201"}},
+		"/items/{id}/raw":  {"GET": {"200"}},
+		"/items/{id}/etag": {"GET": {"default"}},
+	}
+	for path, byMethod := range want {
+		item, ok := out.Paths[path]
+		if !ok {
+			t.Errorf("path %q missing; have %v", path, mapPathKeys(out.Paths))
+			continue
+		}
+		for method, wantStatuses := range byMethod {
+			op := opFor(item, method)
+			if op == nil {
+				t.Errorf("%s %s: expected operation, missing", method, path)
+				continue
+			}
+			got := make([]string, 0, len(op.Responses))
+			for status := range op.Responses {
+				got = append(got, status)
+			}
+			sort.Strings(got)
+			if !equalStrings(got, wantStatuses) {
+				t.Errorf("%s %s: responses %v, want %v", method, path, got, wantStatuses)
+			}
+		}
+	}
+
+	// The implied 200 is a real response, not an empty slot: it carries the
+	// body the handler encodes.
+	if op := opFor(out.Paths["/items/{id}"], "GET"); op != nil {
+		if resp, ok := op.Responses["200"]; !ok || !namesAComponent(resp.Content) {
+			t.Errorf("GET /items/{id}: the implied 200 should carry the Item schema, got %+v", op.Responses)
+		}
+	}
+	// A stated status still wins over the implied one — the encode that follows
+	// WriteHeader(201) must not also produce a 200.
+	if op := opFor(out.Paths["/items"], "POST"); op != nil {
+		if _, ok := op.Responses["200"]; ok {
+			t.Errorf("POST /items states 201 before the body; it must not also document 200: %+v", op.Responses)
+		}
+	}
+	// The other half of the rule: a handler that DOES state a status apispec
+	// cannot read keeps "default". Saying 200 there would be a guess — the
+	// server sends whatever that WriteHeader was given (golden rule #7).
+	if op := opFor(out.Paths["/items/{id}/etag"], "GET"); op != nil {
+		if _, ok := op.Responses["200"]; ok {
+			t.Errorf("GET /items/{id}/etag writes an unreadable status; its body must not be claimed as an implicit 200: %+v",
+				op.Responses)
+		}
+	}
+	// Every other operation resolves, so nothing else may land under "default".
+	for path, item := range out.Paths {
+		if path == "/items/{id}/etag" {
+			continue
+		}
+		for _, method := range []string{"GET", "POST", "PUT", "DELETE"} {
+			op := opFor(item, method)
+			if op == nil {
+				continue
+			}
+			if _, ok := op.Responses["default"]; ok {
+				t.Errorf("%s %s: the status here is determinable, but a default response was emitted: %+v",
+					method, path, op.Responses)
+			}
+		}
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestTestdata_NetHTTPSuccessStatusesAreExplicit is the regression half of
+// issue #369 on the fixtures that showed it worst: every success response in
+// the net/http-family fixtures used to sit under "default" (8 of them in chi
+// alone) because their handlers encode without calling WriteHeader. None of
+// these fixtures has a genuinely undeterminable status, so a "default" here
+// means the implied 200 stopped being resolved.
+func TestTestdata_NetHTTPSuccessStatusesAreExplicit(t *testing.T) {
+	for _, tc := range []struct {
+		fixture string
+		cfg     *spec.APISpecConfig
+	}{
+		{"chi", spec.DefaultChiConfig()},
+		{"mux", spec.DefaultMuxConfig()},
+		{"servemux", spec.DefaultHTTPConfig()},
+	} {
+		t.Run(tc.fixture, func(t *testing.T) {
+			out := loadTestdataWithFixtureConfig(t, tc.fixture, tc.cfg)
+			okCount := 0
+			for path, item := range out.Paths {
+				for _, method := range []string{"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD"} {
+					op := opFor(item, method)
+					if op == nil {
+						continue
+					}
+					if _, bad := op.Responses["default"]; bad {
+						t.Errorf("%s %s: success body documented under \"default\" instead of the implied 200 (#369): %+v",
+							method, path, op.Responses)
+					}
+					if _, ok := op.Responses["200"]; ok {
+						okCount++
+					}
+				}
+			}
+			if okCount == 0 {
+				t.Errorf("%s documents no 200 at all, so this fixture no longer covers the implied-status path", tc.fixture)
+			}
+		})
+	}
+}

--- a/internal/spec/config.go
+++ b/internal/spec/config.go
@@ -167,6 +167,23 @@ type ResponseContextConfig struct {
 	// never reaches a sink (a downstream client's outbound request) is simply
 	// never a response.
 	BodyTransforms []BodyTransform `yaml:"bodyTransforms,omitempty" json:"bodyTransforms,omitempty"`
+
+	// ImplicitStatus is the status the framework sends when a handler writes a
+	// body without stating one — net/http's first Write sends 200. It fills
+	// exactly that gap: a body write whose pattern carries no status source at
+	// all (`json.NewEncoder(w).Encode(v)`, `w.Write(b)`) and that no explicit
+	// status write on its own call chain claims.
+	//
+	// This is not a guess standing in for an unresolved status, and must not
+	// become one: a pattern that HAS a status argument which failed to resolve
+	// keeps landing under "default", because there the status genuinely could
+	// not be determined (golden rule #7). Zero disables it, which is right for
+	// frameworks whose renderers always carry the status (`c.JSON(200, v)`).
+	//
+	// See issue #369: without it the most common Go handler shape documents its
+	// success body under "default", which client generators map to the ERROR
+	// branch — so the endpoint gets no typed success return.
+	ImplicitStatus int `yaml:"implicitStatus,omitempty" json:"implicitStatus,omitempty"`
 }
 
 // BodyTransform matches a serialization call (by callee function name and

--- a/internal/spec/config_fiber.go
+++ b/internal/spec/config_fiber.go
@@ -76,6 +76,12 @@ func DefaultFiberConfig() *APISpecConfig {
 				},
 			},
 			RequestContext: fiberRequestContext,
+			// c.JSON(v) and c.SendString(v) carry no status: fiber sends the
+			// context's status, which is 200 unless c.Status(...) set one — and
+			// that call pairs with the body through the ^Status$ pattern above
+			// (issue #369). Declared here rather than inherited from the stdlib
+			// layer so an explicit fiber config behaves the same.
+			ResponseContext: ResponseContextConfig{ImplicitStatus: http.StatusOK},
 			RequestBodyPatterns: []RequestBodyPattern{
 				{
 					CallRegex:     `^BodyParser$`,

--- a/internal/spec/config_http.go
+++ b/internal/spec/config_http.go
@@ -51,6 +51,9 @@ var netHTTPResponseContext = ResponseContextConfig{
 		{CallRegex: `^Marshal$`, PkgRegex: `^encoding/json$`, ArgIndex: 0},
 		{CallRegex: `^MarshalIndent$`, PkgRegex: `^encoding/json$`, ArgIndex: 0},
 	},
+	// net/http: "If WriteHeader is not called explicitly, the first call to
+	// Write will trigger an implicit WriteHeader(http.StatusOK)".
+	ImplicitStatus: http.StatusOK,
 }
 
 // DefaultHTTPConfig returns a default configuration for net/http.

--- a/internal/spec/config_merge.go
+++ b/internal/spec/config_merge.go
@@ -14,7 +14,10 @@
 
 package spec
 
-import "strings"
+import (
+	"net/http"
+	"strings"
+)
 
 // HTTPSecondaryConfig is the merge-safe subset of the net/http default config,
 // meant to be layered UNDER another framework's config for mixed projects (a
@@ -75,6 +78,11 @@ func HTTPSecondaryConfig() *APISpecConfig {
 			},
 			SecurityPatterns: httpSecurityPatterns(),
 			RequestContext:   netHTTPRequestContext,
+			// A handler reached through the stdlib surface writes to an
+			// http.ResponseWriter, so a body it writes without stating a status
+			// is sent as 200 (issue #369). Only the implicit status is layered;
+			// see SecondaryView on why the writer types are not.
+			ResponseContext: ResponseContextConfig{ImplicitStatus: http.StatusOK},
 			RequestBodyPatterns: []RequestBodyPattern{
 				jsonDecodeRequestPattern(".*json(iter)?\\.\\*Decoder"),
 				jsonUnmarshalRequestPattern("json"),
@@ -149,6 +157,13 @@ func SecondaryView(cfg *APISpecConfig) *APISpecConfig {
 	}
 	out := &APISpecConfig{Framework: FrameworkConfig{
 		RequestContext: cfg.Framework.RequestContext,
+		// Only the implicit status travels from the response context: it
+		// describes what the SERVER sends when a handler states no status, so it
+		// is true of a secondary framework's handlers too. The writer-type
+		// regexes deliberately do not travel — they GATE which encodes count as
+		// responses, and one framework's writer types would drop the other's
+		// (issue #369, keeping #212's "secondary costs nothing" rule).
+		ResponseContext: ResponseContextConfig{ImplicitStatus: cfg.Framework.ResponseContext.ImplicitStatus},
 	}}
 	// Copied rather than aliased so an append by a later caller cannot reach
 	// the source config's backing array.
@@ -281,6 +296,14 @@ func MergeFrameworkConfigs(primary *APISpecConfig, secondaries ...*APISpecConfig
 			primary.Framework.RequestContext.TypeRegexes, sec.Framework.RequestContext.TypeRegexes...)
 		primary.Framework.RequestContext.BodyAccessors = appendUniqueStrings(
 			primary.Framework.RequestContext.BodyAccessors, sec.Framework.RequestContext.BodyAccessors...)
+		// The implicit status is a property of HTTP, not of the framework that
+		// happened to sort first: a chi handler writing a body without stating a
+		// status still sends 200 when gin is primary. Only the ABSENCE is filled
+		// — a primary that declares one keeps it (issue #369, under #212's rule
+		// that being secondary costs a framework nothing).
+		if primary.Framework.ResponseContext.ImplicitStatus == 0 {
+			primary.Framework.ResponseContext.ImplicitStatus = sec.Framework.ResponseContext.ImplicitStatus
+		}
 	}
 	return primary
 }

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -173,6 +173,19 @@ type ResponseInfo struct {
 	Line int
 
 	StatusCode int
+
+	// ImplicitStatus is the status this body takes if no explicit status write
+	// claims it during pairing — the framework's ImplicitStatus, stamped only on
+	// bodies whose pattern carries no status source (see ResponseContextConfig).
+	// Zero means "leave it undetermined", which is what lands under "default".
+	ImplicitStatus int
+
+	// StatusUnresolved marks a status WRITE whose value could not be read
+	// (`w.WriteHeader(computeStatus())`). It documents nothing itself — no status,
+	// no body — and is never stored; it exists so pairing knows the handler does
+	// set a status on this chain, which stops a body written afterwards from
+	// claiming the framework's implicit status (issue #369).
+	StatusUnresolved bool
 }
 
 // Extractor provides a cleaner, more modular approach to extraction
@@ -1347,7 +1360,7 @@ func (e *Extractor) pairAndFillResponses(route *RouteInfo, candidates []response
 		siteID := cand.node.GetEdge().Callee.ID()
 		caller := cand.node.GetEdge().Caller.BaseID()
 		for _, resp := range resps {
-			if resp == nil || (resp.BodyType == "" && resp.StatusCode < 100) {
+			if resp == nil || (resp.BodyType == "" && resp.StatusCode < 100 && !resp.StatusUnresolved) {
 				continue // nothing resolved
 			}
 			status := resp.StatusCode
@@ -1395,6 +1408,12 @@ func (e *Extractor) pairAndFillResponses(route *RouteInfo, candidates []response
 
 	pending := map[string]bool{} // chain -> a bodyless status awaits its body
 	pendingStatus := map[string]int{}
+	// chain -> a status write on it did NOT resolve. The handler states a
+	// status; we just could not read it. A body written after that is emphatically
+	// NOT the framework's implicit status — the server sends whatever that call
+	// set — so such a body keeps its undetermined status rather than claiming 200
+	// (issue #369, golden rule #7).
+	statusUnresolved := map[string]bool{}
 	var unpaired []*fragment
 	for i := range frags {
 		f := &frags[i]
@@ -1407,7 +1426,15 @@ func (e *Extractor) pairAndFillResponses(route *RouteInfo, candidates []response
 			pendingStatus[f.chain] = status
 		case known:
 			store(f.resp)
+		case f.resp.StatusUnresolved:
+			// A status write whose value did not resolve: nothing to store (no
+			// status, no body), but it disqualifies this chain's later bodies
+			// from the implicit status.
+			statusUnresolved[f.chain] = true
 		case body != "":
+			if statusUnresolved[f.chain] {
+				f.resp.ImplicitStatus = 0
+			}
 			if pending[f.chain] {
 				f.resp.StatusCode = pendingStatus[f.chain]
 				delete(pending, f.chain)
@@ -1444,6 +1471,15 @@ func (e *Extractor) pairAndFillResponses(route *RouteInfo, candidates []response
 		unknown := 0
 		for _, f := range unpaired {
 			if depthOf(f) != minDepth {
+				continue
+			}
+			// No status write claimed this body, so the framework's implicit
+			// status is what the server actually sends (issue #369). Only a body
+			// whose pattern named no status carries one; the rest stay
+			// undetermined.
+			if f.resp.ImplicitStatus > 0 {
+				f.resp.StatusCode = f.resp.ImplicitStatus
+				store(f.resp)
 				continue
 			}
 			unknown++
@@ -2471,6 +2507,16 @@ func (r *ResponsePatternMatcherImpl) ExtractResponse(node TrackerNodeInterface, 
 		statusResolved = true
 	}
 
+	// A body write that names no status at all takes the framework's implicit
+	// one — net/http's first Write sends 200 (issue #369). Stamped, not applied:
+	// pairing runs first, so `w.WriteHeader(201)` before the encode still claims
+	// the body (pairAndFillResponses). Patterns that DO carry a status argument
+	// are excluded even when it fails to resolve — that is a status which could
+	// not be determined, and saying 200 there would be a guess.
+	if !statusResolved && !r.pattern.StatusFromArg {
+		respInfo.ImplicitStatus = r.cfg.Framework.ResponseContext.ImplicitStatus
+	}
+
 	if r.pattern.TypeFromArg && len(edge.Args) > r.pattern.TypeArgIndex {
 		// If status code is not from argument, attach this body to an existing
 		// response that has no body yet. route.Response is a map, so iterating it
@@ -2611,6 +2657,13 @@ func (r *ResponsePatternMatcherImpl) ExtractResponse(node TrackerNodeInterface, 
 	}
 
 	if !statusResolved && respInfo.BodyType == "" {
+		// Nothing to document. But a pattern that READS a status argument and
+		// failed is evidence that the handler states one — pass that on so a
+		// later body does not take the implicit status (issue #369).
+		if r.pattern.StatusFromArg {
+			respInfo.StatusUnresolved = true
+			return []*ResponseInfo{respInfo}
+		}
 		return nil
 	}
 

--- a/internal/spec/implicit_status_test.go
+++ b/internal/spec/implicit_status_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestImplicitStatusIsDeclaredWhereItApplies pins which frameworks imply a
+// status (issue #369). net/http states it outright — the first Write sends 200 —
+// and fiber's c.JSON(v) sends the context's status, which is 200 unless
+// c.Status() set one. gin and echo declare none because their renderers always
+// carry the status (c.JSON(200, v)), so there is no absent case to fill.
+func TestImplicitStatusIsDeclaredWhereItApplies(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  *APISpecConfig
+		want int
+	}{
+		{"net/http", DefaultHTTPConfig(), http.StatusOK},
+		{"chi", DefaultChiConfig(), http.StatusOK},
+		{"mux", DefaultMuxConfig(), http.StatusOK},
+		{"fiber", DefaultFiberConfig(), http.StatusOK},
+		{"gin", DefaultGinConfig(), 0},
+		{"echo", DefaultEchoConfig(), 0},
+	} {
+		if got := tc.cfg.Framework.ResponseContext.ImplicitStatus; got != tc.want {
+			t.Errorf("%s: ImplicitStatus = %d, want %d", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestImplicitStatusSurvivesBeingSecondary keeps issue #212's rule: which
+// framework the detector happens to meet first must not change the spec. The
+// implicit status is a property of HTTP, so a chi handler still writes 200 when
+// gin is primary — but the writer TYPE regexes must not travel with it, since
+// they gate which encodes count as responses and one framework's writer types
+// would drop the other's.
+func TestImplicitStatusSurvivesBeingSecondary(t *testing.T) {
+	secondary := SecondaryView(DefaultChiConfig())
+	if got := secondary.Framework.ResponseContext.ImplicitStatus; got != http.StatusOK {
+		t.Errorf("SecondaryView dropped the implicit status: got %d, want %d", got, http.StatusOK)
+	}
+	if regexes := secondary.Framework.ResponseContext.WriterTypeRegexes; len(regexes) != 0 {
+		t.Errorf("SecondaryView carried writer type regexes %v; they gate another framework's encodes", regexes)
+	}
+
+	// A primary without one adopts the secondary's...
+	primary := MergeFrameworkConfigs(DefaultGinConfig(), secondary)
+	if got := primary.Framework.ResponseContext.ImplicitStatus; got != http.StatusOK {
+		t.Errorf("merged config: ImplicitStatus = %d, want %d", got, http.StatusOK)
+	}
+
+	// ...and one that declares its own keeps it.
+	own := &APISpecConfig{Framework: FrameworkConfig{
+		ResponseContext: ResponseContextConfig{ImplicitStatus: http.StatusCreated},
+	}}
+	merged := MergeFrameworkConfigs(own, secondary)
+	if got := merged.Framework.ResponseContext.ImplicitStatus; got != http.StatusCreated {
+		t.Errorf("a secondary overrode the primary's implicit status: got %d, want %d", got, http.StatusCreated)
+	}
+}
+
+// TestHTTPSecondaryConfigCarriesTheImplicitStatus covers the other merge path:
+// the stdlib surface is layered under every non-stdlib framework, so a plain
+// ServeMux handler in a gin project implies 200 too.
+func TestHTTPSecondaryConfigCarriesTheImplicitStatus(t *testing.T) {
+	if got := HTTPSecondaryConfig().Framework.ResponseContext.ImplicitStatus; got != http.StatusOK {
+		t.Errorf("HTTPSecondaryConfig: ImplicitStatus = %d, want %d", got, http.StatusOK)
+	}
+}

--- a/internal/spec/implicit_status_test.go
+++ b/internal/spec/implicit_status_test.go
@@ -16,6 +16,7 @@ package spec
 
 import (
 	"net/http"
+	"sort"
 	"testing"
 )
 
@@ -81,4 +82,98 @@ func TestHTTPSecondaryConfigCarriesTheImplicitStatus(t *testing.T) {
 	if got := HTTPSecondaryConfig().Framework.ResponseContext.ImplicitStatus; got != http.StatusOK {
 		t.Errorf("HTTPSecondaryConfig: ImplicitStatus = %d, want %d", got, http.StatusOK)
 	}
+}
+
+// stubResponseMatcher returns pre-programmed responses per node, so the pairing
+// logic can be exercised without a tracker tree or real patterns.
+type stubResponseMatcher struct {
+	byNode map[TrackerNodeInterface][]*ResponseInfo
+}
+
+func (s *stubResponseMatcher) MatchNode(node TrackerNodeInterface) bool {
+	_, ok := s.byNode[node]
+	return ok
+}
+func (s *stubResponseMatcher) GetPattern() interface{} { return nil }
+func (s *stubResponseMatcher) GetPriority() int        { return 0 }
+func (s *stubResponseMatcher) ExtractResponse(node TrackerNodeInterface, _ *RouteInfo) []*ResponseInfo {
+	return s.byNode[node]
+}
+
+// TestPairAndFillResponsesImplicitStatus covers the pairing states the implicit
+// status introduces (issue #369), at the layer that decides them: the body is
+// unclaimed, the body is claimed by a stated status, and the body follows a
+// status write whose value could not be read.
+func TestPairAndFillResponsesImplicitStatus(t *testing.T) {
+	// One fragment per call site, positioned so source order is unambiguous —
+	// pairing walks fragments in that order.
+	build := func(resps ...[]*ResponseInfo) (*Extractor, []responseCandidate, *RouteInfo) {
+		meta := exSweepMeta()
+		stub := &stubResponseMatcher{byNode: map[TrackerNodeInterface][]*ResponseInfo{}}
+		candidates := make([]responseCandidate, 0, len(resps))
+		for i, r := range resps {
+			pos := "h.go:" + string(rune('1'+i)) + ":1"
+			node := &fakeNode{edge: sweepEdge(meta, "handler", "app", "write", "app", "", pos)}
+			stub.byNode[node] = r
+			candidates = append(candidates, responseCandidate{node: node, chain: "chain"})
+		}
+		e := &Extractor{responseMatchers: []ResponsePatternMatcher{stub}}
+		return e, candidates, &RouteInfo{Metadata: meta, Response: map[string]*ResponseInfo{}}
+	}
+	body := func(implicit int) *ResponseInfo {
+		return &ResponseInfo{StatusCode: -1, ContentType: "application/json", BodyType: "Item", ImplicitStatus: implicit}
+	}
+
+	t.Run("an unclaimed body takes the implicit status", func(t *testing.T) {
+		e, candidates, route := build([]*ResponseInfo{body(200)})
+		e.pairAndFillResponses(route, candidates)
+		if resp, ok := route.Response["200"]; !ok || resp.BodyType != "Item" {
+			t.Errorf("body should be documented as 200, got %v", statusKeysOf(route))
+		}
+	})
+
+	t.Run("a stated status claims the body instead", func(t *testing.T) {
+		e, candidates, route := build(
+			[]*ResponseInfo{{StatusCode: 201, ContentType: "application/json"}},
+			[]*ResponseInfo{body(200)},
+		)
+		e.pairAndFillResponses(route, candidates)
+		if resp, ok := route.Response["201"]; !ok || resp.BodyType != "Item" {
+			t.Errorf("the stated 201 should claim the body, got %v", statusKeysOf(route))
+		}
+		if _, ok := route.Response["200"]; ok {
+			t.Errorf("the implicit status must not also be emitted, got %v", statusKeysOf(route))
+		}
+	})
+
+	t.Run("a body after an unreadable status write stays undetermined", func(t *testing.T) {
+		e, candidates, route := build(
+			[]*ResponseInfo{{StatusCode: -1, ContentType: "application/json", StatusUnresolved: true}},
+			[]*ResponseInfo{body(200)},
+		)
+		e.pairAndFillResponses(route, candidates)
+		if _, ok := route.Response["200"]; ok {
+			t.Errorf("the handler states a status we cannot read; 200 would be a guess, got %v", statusKeysOf(route))
+		}
+		if resp, ok := route.Response["-1"]; !ok || resp.BodyType != "Item" {
+			t.Errorf("the body should keep an undetermined status, got %v", statusKeysOf(route))
+		}
+	})
+
+	t.Run("a body with no implicit status stays undetermined", func(t *testing.T) {
+		e, candidates, route := build([]*ResponseInfo{body(0)})
+		e.pairAndFillResponses(route, candidates)
+		if _, ok := route.Response["-1"]; !ok {
+			t.Errorf("a framework declaring no implicit status leaves the body undetermined, got %v", statusKeysOf(route))
+		}
+	})
+}
+
+func statusKeysOf(route *RouteInfo) []string {
+	keys := make([]string, 0, len(route.Response))
+	for k := range route.Response {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/testdata/implicit_status/go.mod
+++ b/testdata/implicit_status/go.mod
@@ -1,0 +1,3 @@
+module testdata/implicit_status
+
+go 1.22

--- a/testdata/implicit_status/main.go
+++ b/testdata/implicit_status/main.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type Item struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type CreateItem struct {
+	Name string `json:"name"`
+}
+
+type APIError struct {
+	Message string `json:"message"`
+}
+
+func main() {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("GET /items/{id}", getItem)       // implicit 200: encode only
+	mux.HandleFunc("POST /items", createItem)        // explicit 201 before the body
+	mux.HandleFunc("GET /items", listItems)          // branch: explicit 400, implicit 200
+	mux.HandleFunc("GET /items/{id}/raw", rawItem)   // implicit 200 through w.Write
+	mux.HandleFunc("DELETE /items/{id}", dropItem)   // explicit 204, no body
+	mux.HandleFunc("GET /items/{id}/etag", etagItem) // status written but unreadable
+
+	http.ListenAndServe(":8080", mux)
+}
+
+// getItem writes a body without ever calling WriteHeader: net/http sends 200
+// with the first Write.
+func getItem(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode(Item{ID: r.PathValue("id")})
+}
+
+// createItem states its status, so nothing is implied.
+func createItem(w http.ResponseWriter, r *http.Request) {
+	var in CreateItem
+	_ = json.NewDecoder(r.Body).Decode(&in)
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(Item{Name: in.Name})
+}
+
+// listItems states the status on one branch and not on the other, so both the
+// explicit 400 and the implicit 200 are real responses.
+func listItems(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Query().Get("q") == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(APIError{Message: "q is required"})
+		return
+	}
+	_ = json.NewEncoder(w).Encode([]Item{{ID: "1"}})
+}
+
+// rawItem writes pre-marshalled bytes: still an implicit 200.
+func rawItem(w http.ResponseWriter, r *http.Request) {
+	b, _ := json.Marshal(Item{ID: r.PathValue("id")})
+	_, _ = w.Write(b)
+}
+
+// etagItem states a status apispec cannot read (a map lookup), then writes a
+// body. The status IS stated, so the implicit 200 must not be claimed here —
+// this response is genuinely undetermined.
+func etagItem(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(statusOverride[r.URL.Path])
+	_ = json.NewEncoder(w).Encode(Item{ID: r.PathValue("id")})
+}
+
+// statusOverride stands in for any runtime-computed status.
+var statusOverride = map[string]int{}
+
+// dropItem states a bodyless status.
+func dropItem(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNoContent)
+}


### PR DESCRIPTION
Fixes #369.

## The bug

`net/http` states it outright: *"If WriteHeader is not called explicitly, the first call to Write will trigger an implicit `WriteHeader(http.StatusOK)`"*. apispec documented that body under `default` — "Status code could not be determined" — so the most common Go handler shape produced a spec with **no success response at all**.

That is not cosmetic. In OpenAPI `default` is the catch-all that client generators map to the **error** branch, so `openapi-generator` and `oapi-codegen` gave those endpoints a typed 400 and no typed success return.

It was apispec's own fixtures: `testdata/chi` had 8 responses under `default` against 2 real statuses (its two `http.Error` calls); `testdata/mux` had 4.

## The fix

`ResponseContext.ImplicitStatus` — config, not a hardcoded 200 — says what the framework sends when a handler writes a body without stating one:

| framework | implicit status | why |
|---|---|---|
| net/http, chi, mux | 200 | the first `Write` implies it |
| fiber | 200 | `c.JSON(v)` sends the context's status; `c.Status()` pairs with the body through the existing `^Status$` pattern |
| gin, echo | none | their renderers always carry the status (`c.JSON(200, v)`), so there is no absent case to fill |

Applied **at pairing, not at extraction**, so the existing precedence is untouched: `w.WriteHeader(201)` before the encode still claims the body, and only a body that no status write claimed takes the implicit one. A handler that states a status on one branch and not on the other keeps both responses.

### What still lands under `default`, deliberately

- **A pattern that has a status argument which failed to resolve.** The handler states a status; we just cannot read it, and answering 200 there would be a guess (golden rule #7). A status write that resolves to nothing now emits a marker fragment — no status, no body, never stored — purely so pairing knows this chain sets a status and refuses the implicit one for the body that follows.
- A body whose write destination never resolved at all.

### Config merging

Carried through merging under #212's rule that being secondary costs a framework nothing: the implicit status is a property of HTTP, so a chi handler still implies 200 when gin sorts first. **Only that field travels** — the writer *type* regexes must not, since they gate which encodes count as responses and one framework's writer types would drop the other's. `TestPrimaryFrameworkOrderInvariance` caught this on the first run.

## Effect

42 fixtures move, every one in the same direction — `default` → `200`, or `[400 default]` → `[200 400]`. A few worth calling out:

```
chi          8 × default          -> 200          (plus its 2 × 400 untouched)
mux/servemux 4 × default          -> 200
fiber        default              -> 200          (c.JSON with no status)
response_writer_provenance        -> 200          the leak-* handlers' real
                                                   response is w.Write([]byte("ok"));
                                                   the leaked Secret stays undocumented
```

`enum_validation` gains a 200 next to its 201 on `POST /users`, which is a pre-existing attribution bug becoming visible rather than a new one: a `switch r.Method` inside a **closure** handler is never split, so all branches' responses pile onto one operation. That was already true before this change (the GET branch's body sat under `default` and was dropped only because it happened to duplicate the 201's body). Filed as **#382** with a minimal reproduction.

## Tests

- `testdata/implicit_status` — the four shapes: implied 200, stated 201, a branch that states 400 and one that does not, a raw `w.Write` of marshalled bytes, and a handler that writes an unreadable status (which must stay `default`).
- `TestTestdata_ImplicitStatus` asserts the exact status set per operation.
- `TestTestdata_NetHTTPSuccessStatusesAreExplicit` asserts no success response under `default` in chi/mux/servemux, and fails if a fixture stops covering the path.
- `internal/spec` unit tests pin which frameworks declare an implicit status, and that it survives being secondary while the writer regexes do not.

Full suite, metadata goldens and lint pass; coverage 96.0% (floor 96).

## Out of scope

Issue point 4 (stdlib helpers mapping through a status table): `http.Redirect` → 302 and `http.NotFound` → 404 already resolve. The one gap left is `http.ServeFile`, which produces no response at all — documenting it needs a content type this change cannot honestly supply, which is #354's territory. Noted on the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration for implicit HTTP response status codes when handlers write response bodies without explicitly setting a status.
  * Added an editable implicit response status field to the response context editor.
* **Bug Fixes**
  * Generated API specifications now correctly document implicit `200 OK` responses across supported frameworks.
  * Explicit, unresolved, and default response statuses are now represented more accurately.
* **Tests**
  * Added regression coverage for implicit success statuses, status precedence, and framework-specific response behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->