### PR TITLE
docs: add an at-a-glance feature list and a forks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,23 @@
 
 **APISpec** analyzes your Go source and generates an OpenAPI 3.1 spec (YAML or JSON). It detects routes for popular frameworks (Gin, Echo, Chi, Fiber, Gorilla Mux, `net/http`), follows the call graph to the real handlers, and infers request/response types from actual code — struct tags, literals, generics, and more.
 
+**At a glance**
+
+- **No annotations, no comments, no code changes** — the spec is derived from your AST and call graph, so it cannot drift out of sync with the implementation.
+- **OpenAPI 3.1** output as YAML or JSON.
+- **Six routers out of the box** — Gin, Echo, Chi, Fiber, Gorilla Mux, and `net/http` (including Go 1.22 `ServeMux` method-aware patterns, `{id}` wildcards and `r.PathValue`), plus mixed multi-framework projects in one binary.
+- **Your own router, detected automatically** — house wrapper types and house contexts (`func (r *Router) Get(...)`, `ctx.JSON/Bind/Query`) need no configuration.
+- **Request bodies** from `json.Decode`/`Unmarshal`, framework binders, custom wrapper helpers, and form / multipart file uploads (`multipart/form-data` vs `x-www-form-urlencoded`).
+- **Responses and status codes** per branch — conditional statuses, envelopes, generic wrappers, map-literal payloads, and interface-typed bodies resolved to the concrete type actually written.
+- **Parameters** in path, query, header, cookie and form position.
+- **Auth and security detection** — bearer/JWT, basic and apiKey schemes, with middleware followed through router-wide `Use`, group closures, per-route chains and handler wrappers.
+- **Type-aware schemas** — generics (including inferred instantiations), aliases, enums from constants, fixed-size arrays, pointers, embedded and inline structs, and external package types.
+- **Validation constraints** from `go-playground/validator` tags — `required`, formats, patterns, and length/value/item bounds routed by field type.
+- **Doc comments** on handlers become the operation `summary` and `description`.
+- **Deterministic output** — regenerating an unchanged project yields a byte-identical file, so the spec can be committed and diffed in CI without false failures.
+- **Debuggable when a route is missed** — call-graph diagram, metadata dump, and an insight report that says *why* a response has no body rather than only that it doesn't.
+- **Extensible without forking** — framework behaviour is regex patterns in YAML; adding a router touches no core logic.
+
 **TL;DR**: Point APISpec at your module. Get an OpenAPI spec — plus, optionally, an interactive call-graph diagram and a browser-based config UI.
 
 📖 **Documentation:** [apispec.ehabterra.com](https://apispec.ehabterra.com) — installation,
@@ -46,6 +63,7 @@ or [the wider landscape](https://apispec.ehabterra.com/alternatives/) if you are
 - [Performance & Limits](#performance--limits)
 - [Development](#development)
 - [Documentation](#documentation)
+- [Forks & derivatives](#forks--derivatives)
 - [License](#license)
 
 ## Demo
@@ -1107,6 +1125,16 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.
 - [cmd/apidiag/README.md](cmd/apidiag/README.md) — diagram server
 - [internal/metadata/README.md](internal/metadata/README.md) — metadata package
 - [internal/spec/README.md](internal/spec/README.md) — spec-generation package
+
+## Forks & derivatives
+
+APISpec is Apache-2.0, so anyone is free to build on it — and someone has:
+
+- **[antst/go-apispec](https://github.com/antst/go-apispec)** — a fork of this project by Anton
+  Starikov, with a substantially reworked analysis pipeline. Credit to him for taking the idea
+  further and spending the time to make it his own; that is exactly what the licence is for.
+
+Building on APISpec yourself? Open an issue or a discussion — downstream projects are welcome here.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 **At a glance**
 
-- **No annotations, no comments, no code changes** — the spec is derived from your AST and call graph, so it cannot drift out of sync with the implementation.
+- **No annotations required** — nothing to add to your code: routes, parameters and bodies come from the AST and the call graph, not from a parallel set of comments you have to keep in sync. (Doc comments you already write are used for `summary`/`description` when they are there.)
 - **OpenAPI 3.1** output as YAML or JSON.
 - **Six routers out of the box** — Gin, Echo, Chi, Fiber, Gorilla Mux, and `net/http` (including Go 1.22 `ServeMux` method-aware patterns, `{id}` wildcards and `r.PathValue`), plus mixed multi-framework projects in one binary.
 - **Your own router, detected automatically** — house wrapper types and house contexts (`func (r *Router) Get(...)`, `ctx.JSON/Bind/Query`) need no configuration.
@@ -1131,8 +1131,9 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.
 APISpec is Apache-2.0, so anyone is free to build on it — and someone has:
 
 - **[antst/go-apispec](https://github.com/antst/go-apispec)** — a fork of this project by Anton
-  Starikov, with a substantially reworked analysis pipeline. Credit to him for taking the idea
-  further and spending the time to make it his own; that is exactly what the licence is for.
+  Starikov, also Apache-2.0, with a substantially reworked analysis pipeline. Credit to him for
+  taking the idea further and spending the time to make it his own; that is exactly what the
+  licence is for.
 
 Building on APISpec yourself? Open an issue or a discussion — downstream projects are welcome here.
 


### PR DESCRIPTION
Two README additions, 28 lines, nothing removed.

## At a glance

The first structured block in the README was the table of contents, so anything summarising the project — a search result, an AI answer, someone skimming the page — had to work from the one-paragraph intro or from the dense prose bullets 300 lines down. This adds a 14-line capability list between the intro and the TL;DR, each line leading with the term people actually type: *no annotations*, *OpenAPI 3.1*, the six routers, *multipart*, *JWT*, *generics*, *validator tags*, *deterministic*, *CI*.

Every claim restates something the README already documents in full further down — no new promises. One is newly accurate rather than newly written: "regenerating an unchanged project yields a byte-identical file" holds on real projects only since #381 closed the last known source of run-to-run variation this morning; before that it was true of fixtures and not of gitea.

`## Why APISpec` is untouched — it answers *why*, the new list answers *what*.

## Forks & derivatives

A short section before `## License` acknowledging [antst/go-apispec](https://github.com/antst/go-apispec), which builds on this project under Apache-2.0, plus a TOC entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an “At a glance” overview of APISpec’s supported capabilities.
  * Documented the `antst/go-apispec` fork and provided guidance for downstream projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->