### PR TITLE
fix: say so when nothing matched instead of reporting success (#379)

### DIFF
--- a/cmd/apispec/main.go
+++ b/cmd/apispec/main.go
@@ -551,7 +551,14 @@ func writeOutput(openAPISpec interface{}, config *CLIConfig, genEngine *engine.E
 			}
 		}
 
-		fmt.Println("Successfully generated:", outputPath)
+		// "Successfully generated" over a document with no paths is what made an
+		// unmatched router look like a working run (issue #379). The engine has
+		// already said why on stderr; this line must not contradict it.
+		if genEngine.GetRouteDiscovery().Paths == 0 {
+			fmt.Println("Generated (0 paths — nothing matched):", outputPath)
+		} else {
+			fmt.Println("Successfully generated:", outputPath)
+		}
 	}
 	return nil
 }

--- a/cmd/apispecui/assets/js/actions.js
+++ b/cmd/apispecui/assets/js/actions.js
@@ -313,10 +313,16 @@ export async function generate(opts = {}) {
         skipped,
         unresolvedSecurity: res.unresolvedSecurity || [],
         truncated: !!res.truncated,
+        nothingMatched: !!res.nothingMatched,
         nodeLimit: res.nodeLimit || 0,
         genBlocked: false,
       });
-      if (res.truncated) {
+      if (res.nothingMatched) {
+        setStatus(
+          `generated 0 paths · no route registration matched — the router may be unsupported, wired in a style no pattern covers, or excluded by the package filters · ${took}`,
+          "warn",
+        );
+      } else if (res.truncated) {
         setStatus(`generated ${res.pathCount || 0} paths · expansion hit the ${res.nodeLimit}-node limit, so routes are missing · ${took}`, "warn");
       } else if (skipped.length) {
         setStatus(`generated ${res.pathCount || 0} paths · ${skipped.length} package(s) skipped · ${took}`, "warn");

--- a/cmd/apispecui/main.go
+++ b/cmd/apispecui/main.go
@@ -294,6 +294,13 @@ type GenerateResponse struct {
 	// read as a bound that was hit (CodeRabbit, PR #234).
 	Truncated bool `json:"truncated,omitempty"`
 	NodeLimit int  `json:"nodeLimit,omitempty"`
+
+	// NothingMatched reports that the analysis walked a non-empty call graph and
+	// matched no route registration in it — an unsupported router, an unmatched
+	// wiring style, or filters that excluded the routing package. Without it,
+	// "generated 0 paths" reads the same as a project that serves no HTTP
+	// (issue #379).
+	NothingMatched bool `json:"nothingMatched,omitempty"`
 }
 
 // UIServer holds shared state across requests.
@@ -1095,6 +1102,7 @@ func (s *UIServer) handleGenerate(w http.ResponseWriter, r *http.Request) {
 			SkippedPackages:    skipped,
 			UnresolvedSecurity: gen.GetUnresolvedSecurity(),
 			Truncated:          expansion.Truncated,
+			NothingMatched:     gen.GetRouteDiscovery().NothingMatched(),
 		}
 		if expansion.Truncated {
 			resp.NodeLimit = expansion.Limit

--- a/generator/testdata_unmatched_router_test.go
+++ b/generator/testdata_unmatched_router_test.go
@@ -1,0 +1,75 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/engine"
+)
+
+// TestTestdata_UnmatchedRouterIsReported covers issue #379: a project whose
+// router apispec has no patterns for produced an empty spec, exit 0, and no
+// diagnostic — indistinguishable from a project that genuinely serves no HTTP.
+//
+// The fixture is a hand-rolled router (handlers in a map, dispatched by hand),
+// so it needs no third-party dependency and no pattern can be expected to match
+// it. What must hold is that apispec KNOWS it found nothing: it analysed a
+// non-empty call graph and matched no registration in it.
+func TestTestdata_UnmatchedRouterIsReported(t *testing.T) {
+	cfg := engine.DefaultEngineConfig()
+	cfg.InputDir = filepath.Join("..", "testdata", "unmatched_router")
+
+	eng := engine.NewEngine(cfg)
+	out, err := eng.GenerateOpenAPI()
+	if err != nil {
+		t.Fatalf("GenerateOpenAPI: %v", err)
+	}
+	if len(out.Paths) != 0 {
+		t.Fatalf("fixture documents %v; it exists precisely because nothing should match", mapPathKeys(out.Paths))
+	}
+
+	d := eng.GetRouteDiscovery()
+	if !d.NothingMatched() {
+		t.Errorf("an unmatched router must be reported, got %+v", d)
+	}
+	if d.CallEdges == 0 {
+		t.Errorf("the fixture should give the walk something to analyse; got %d call edges", d.CallEdges)
+	}
+	if d.Paths != 0 || d.Packages == 0 || len(d.Frameworks) == 0 {
+		t.Errorf("RouteDiscovery should carry what was analysed and under which patterns, got %+v", d)
+	}
+}
+
+// TestRouteDiscoveryIsQuietWhenRoutesMatch is the other half: the diagnostic
+// must not cry wolf on a project whose routes DO resolve, or it becomes noise
+// everybody learns to ignore.
+func TestRouteDiscoveryIsQuietWhenRoutesMatch(t *testing.T) {
+	for _, fixture := range []string{"chi", "gin", "mux", "servemux"} {
+		t.Run(fixture, func(t *testing.T) {
+			cfg := engine.DefaultEngineConfig()
+			cfg.InputDir = filepath.Join("..", "testdata", fixture)
+
+			eng := engine.NewEngine(cfg)
+			if _, err := eng.GenerateOpenAPI(); err != nil {
+				t.Fatalf("GenerateOpenAPI: %v", err)
+			}
+			if d := eng.GetRouteDiscovery(); d.NothingMatched() {
+				t.Errorf("%s documents routes; the no-routes diagnostic must stay quiet, got %+v", fixture, d)
+			}
+		})
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -292,9 +292,41 @@ type Engine struct {
 	// whose key matches no route placeholder, gathered during the last generation.
 	pathParamMismatches []intspec.PathParamMismatch
 
+	// routeDiscovery records what the route search had to work with and what it
+	// found during the last generation (issue #379).
+	routeDiscovery RouteDiscovery
+
 	// resolvedGraph is the SSA+VTA resolved call graph, built during
 	// GenerateMetadataOnly when config.ResolveCallGraph is set.
 	resolvedGraph *callgraph.Resolved
+}
+
+// RouteDiscovery reports the inputs and the outcome of the route search.
+//
+// It exists because "zero paths" is ambiguous: a library with no HTTP routes
+// legitimately documents nothing, and so does a project whose router apispec
+// does not support, whose wiring style no pattern matched, or whose routing
+// package the include/exclude filters removed. All four used to print
+// "Successfully generated" and exit 0, which made them indistinguishable
+// (issue #379).
+//
+// The signal that separates them is zero paths from a call graph that is NOT
+// empty: there was code to walk, and nothing in it registered a route.
+type RouteDiscovery struct {
+	// CallEdges is the size of the call graph the route search walked.
+	CallEdges int
+	// Packages is how many packages that call graph came from.
+	Packages int
+	// Paths is how many paths the generated document ended up with.
+	Paths int
+	// Frameworks names the pattern sets in effect, primary first.
+	Frameworks []string
+}
+
+// NothingMatched reports the condition worth telling the user about: code was
+// analysed and no route registration in it matched any configured pattern.
+func (d RouteDiscovery) NothingMatched() bool {
+	return d.Paths == 0 && d.CallEdges > 0
 }
 
 // GetResolvedCallGraph returns the resolved call graph from the last
@@ -501,7 +533,8 @@ func (e *Engine) GenerateMetadataOnlyWithLogger(logger *VerboseLogger) (*metadat
 			e.reportPhase("framework-dependency analysis failed", time.Since(tDeps))
 		} else {
 			logger.Printf("Framework dependency analysis completed: %d packages found\n", dependencyTree.TotalPackages)
-			e.reportPhase(fmt.Sprintf("framework dependencies analysed (%d pkgs)", dependencyTree.TotalPackages), time.Since(tDeps))
+			e.reportPhase(fmt.Sprintf("framework dependencies analysed (%d pkgs: %d direct, %d indirect)",
+				dependencyTree.TotalPackages, dependencyTree.DirectPackages, dependencyTree.IndirectPackages), time.Since(tDeps))
 
 			// Auto-include framework packages in IncludePackages if requested
 			if e.config.AutoIncludeFrameworkPackages {
@@ -854,6 +887,14 @@ func (e *Engine) GenerateOpenAPI() (*spec.OpenAPISpec, error) {
 		}
 	}
 	e.reportPhase(fmt.Sprintf("spec mapped (%d paths)", len(openAPISpec.Paths)), time.Since(tSpec))
+
+	e.routeDiscovery = RouteDiscovery{
+		CallEdges:  len(meta.CallGraph),
+		Packages:   len(meta.Packages),
+		Paths:      len(openAPISpec.Paths),
+		Frameworks: frameworks,
+	}
+	e.reportNoRoutes()
 
 	// Handle metadata writing if requested
 	if e.config.WriteMetadata {
@@ -1258,11 +1299,40 @@ func (e *Engine) reportUnresolvedRefs() {
 		len(e.unresolvedRefs), sites, b.String()), 0)
 }
 
+// reportNoRoutes says so when the walk analysed real code and matched no route
+// registration in it — the case that used to print "Successfully generated"
+// over an empty document and exit 0, indistinguishable from a project that
+// genuinely serves no HTTP (issue #379).
+//
+// Written with log rather than reportPhase because it is not a phase: it is the
+// result, and the " in 0s" a phase line appends reads as a timing on something
+// that did not happen.
+func (e *Engine) reportNoRoutes() {
+	d := e.routeDiscovery
+	if !d.NothingMatched() {
+		return
+	}
+	frameworks := strings.Join(d.Frameworks, ", ")
+	if frameworks == "" {
+		frameworks = "no framework"
+	}
+	log.Printf("[engine] no route registrations matched: 0 paths from %d call edges across %d package(s), with %s patterns in effect",
+		d.CallEdges, d.Packages, frameworks)
+	log.Printf("[engine] if this project serves HTTP, then its router is unsupported, is wired in a style no pattern matched, or was excluded by --include-*/--exclude-* filters — docs/DEBUGGING.md walks through telling those apart")
+}
+
 // GetUnresolvedRefs returns the references the most recent generation could not
 // satisfy, after they were repaired. Non-empty means the spec loads but some
 // operation's shape is a placeholder.
 func (e *Engine) GetUnresolvedRefs() []intspec.UnresolvedRef {
 	return e.unresolvedRefs
+}
+
+// GetRouteDiscovery returns what the route search walked and what it found in
+// the most recent generation. NothingMatched() distinguishes "this project has
+// no HTTP routes" from "apispec did not recognise this project's routes".
+func (e *Engine) GetRouteDiscovery() RouteDiscovery {
+	return e.routeDiscovery
 }
 
 // GetPathParamMismatches returns map-key path-variable reads (e.g.

--- a/internal/metadata/dependency_analyzer.go
+++ b/internal/metadata/dependency_analyzer.go
@@ -246,9 +246,11 @@ func (fd *FrameworkDetector) AnalyzeFrameworkDependencies(
 		}
 	}
 
-	fmt.Printf("Found %d framework packages (%d direct, %d indirect)\n",
-		list.TotalPackages, list.DirectPackages, list.IndirectPackages)
-
+	// Deliberately silent: the caller reports these counts (engine's
+	// "framework dependencies analysed" phase line). Printed here, they read as
+	// a result — "Found 1 framework packages" is stated even when detection
+	// produced nothing usable, which is half of why an unmatched router looked
+	// like a success (issue #379).
 	return list, nil
 }
 
@@ -485,8 +487,6 @@ func (fd *FrameworkDetector) findImportedPackages(
 			fd.findImportsRecursively(pkg, availablePackages, importedPackagePaths, processed, &importedPackages)
 		}
 	}
-
-	fmt.Printf("Found %d imported packages by framework packages (including transitive imports)\n", len(importedPackages))
 
 	return importedPackages
 }

--- a/testdata/unmatched_router/go.mod
+++ b/testdata/unmatched_router/go.mod
@@ -1,0 +1,3 @@
+module testdata/unmatched_router
+
+go 1.22

--- a/testdata/unmatched_router/main.go
+++ b/testdata/unmatched_router/main.go
@@ -1,0 +1,58 @@
+// Package main is a router apispec has no patterns for: handlers are stored in
+// a map and dispatched by hand, so there is no registration call to match.
+//
+// The point of the fixture is not the router — it is that analysing it produces
+// an empty spec, and that apispec says so (issue #379) instead of reporting
+// success over a document with no paths.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type Item struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// Router is a house router: routes live in a map keyed by "METHOD path", which
+// no configured pattern can read.
+type Router struct {
+	routes map[string]http.HandlerFunc
+}
+
+func NewRouter() *Router {
+	return &Router{routes: map[string]http.HandlerFunc{}}
+}
+
+func (rt *Router) Add(key string, h http.HandlerFunc) {
+	rt.routes[key] = h
+}
+
+func (rt *Router) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if h, ok := rt.routes[r.Method+" "+r.URL.Path]; ok {
+		h(w, r)
+		return
+	}
+	w.WriteHeader(http.StatusNotFound)
+}
+
+func main() {
+	rt := NewRouter()
+	rt.Add("GET /items", listItems)
+	rt.Add("POST /items", createItem)
+
+	_ = http.ListenAndServe(":8080", rt)
+}
+
+func listItems(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode([]Item{{ID: "1", Name: "first"}})
+}
+
+func createItem(w http.ResponseWriter, r *http.Request) {
+	var in Item
+	_ = json.NewDecoder(r.Body).Decode(&in)
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(in)
+}


### PR DESCRIPTION
Fixes #379.

## The bug

A project whose router apispec has no patterns for produced `paths: {}`, exit 0, and no diagnostic — the same output as a project that genuinely serves no HTTP. Two lines actively argued the run had worked:

- **"Found 1 framework packages"** — printed even when detection produced nothing usable.
- **"Successfully generated"** — over a document with no content.

So these four cases were indistinguishable from the output: no HTTP routes; unsupported router; supported router wired in an unmatched style; routing package excluded by filters. Only the first is a success.

## The signal

Not zero paths on its own — a library legitimately has none. It is **zero paths from a call graph that is not empty**: there was code to walk, and nothing in it registered a route. `RouteDiscovery` records what the search had (call edges, packages, the pattern sets in effect) and what it produced; `NothingMatched()` is the condition. Both are exposed via `Engine.GetRouteDiscovery()`, so #297's `--strict` has a typed thing to promote rather than having to re-derive it.

## What changes

```
[engine] no route registrations matched: 0 paths from 13 call edges across 1 package(s), with net/http patterns in effect
[engine] if this project serves HTTP, then its router is unsupported, is wired in a style no pattern matched, or was excluded by --include-*/--exclude-* filters — docs/DEBUGGING.md walks through telling those apart
Generated (0 paths — nothing matched): openapi.yaml
```

In `apispecui`, "generated 0 paths" becomes a warning naming the same three causes instead of a neutral result.

The two misleading stdout lines are **removed** rather than reworded. Both were `fmt.Printf` from the dependency analyser — a library package printing analysis chatter to stdout as though it were a result — and the engine's own phase line already reports the same count. It now also carries the direct/indirect split the deleted line had, so no information is lost:

```
[engine] framework dependencies analysed (5 pkgs: 4 direct, 1 indirect) in 1ms
```

**Exit code stays 0.** Promoting quality warnings to a non-zero exit is #297; doing it here would break every pipeline that runs apispec over a module with no routes.

## Tests

`testdata/unmatched_router` — a hand-rolled router (handlers in a `map[string]http.HandlerFunc`, dispatched by hand). It needs no third-party dependency, and there is nothing in it any pattern could be expected to match, which is exactly the point.

Both halves are asserted:

- `TestTestdata_UnmatchedRouterIsReported` — 0 paths, `NothingMatched()` true, and the diagnostic carries what was analysed.
- `TestRouteDiscoveryIsQuietWhenRoutesMatch` — chi, gin, mux and servemux must **not** trip it. A diagnostic that cries wolf is one people learn to ignore.

Full suite, goldens and lint pass; coverage 96.0% (floor 96).