### PR TITLE
fix: a middleware wrapped at the registration site no longer replaces the handler (#364)

### DIFF
--- a/generator/testdata_auth_test.go
+++ b/generator/testdata_auth_test.go
@@ -15,6 +15,7 @@
 package generator
 
 import (
+	"strings"
 	"testing"
 
 	intspec "github.com/ehabterra/apispec/internal/spec"
@@ -79,42 +80,56 @@ func TestTestdata_AuthPresets(t *testing.T) {
 		cfg       func() *spec.APISpecConfig
 		protected struct{ method, path string }
 		open      struct{ method, path string }
+		// handler is the function the protected operation must be attributed to.
+		handler string
 	}{
 		{
 			name:      "auth_chi_with",
 			cfg:       spec.DefaultChiConfig,
 			protected: struct{ method, path string }{"GET", "/users/{id}"},
 			open:      struct{ method, path string }{"GET", "/health"},
+			handler:   "getUser",
 		},
 		{
 			name:      "auth_echo_group",
 			cfg:       spec.DefaultEchoConfig,
 			protected: struct{ method, path string }{"GET", "/api/me"},
 			open:      struct{ method, path string }{"GET", "/health"},
+			handler:   "me",
 		},
 		{
 			name:      "auth_fiber_group",
 			cfg:       spec.DefaultFiberConfig,
 			protected: struct{ method, path string }{"GET", "/api/me"},
 			open:      struct{ method, path string }{"GET", "/health"},
+			handler:   "me",
 		},
 		{
 			name:      "auth_gin_perroute",
 			cfg:       spec.DefaultGinConfig,
 			protected: struct{ method, path string }{"GET", "/users/{id}"},
 			open:      struct{ method, path string }{"GET", "/health"},
+			// KNOWN WRONG, pinned as a change detector: gin takes its handler
+			// chain variadically (`r.GET(path, mw, h)`), so the configured
+			// handler position holds the MIDDLEWARE and the operation is
+			// attributed to it. A sibling-argument chain, not the wrapped-call
+			// shape #364 fixes — tracked as #386; flip this to "getUser"
+			// when it lands.
+			handler: "jwtAuth",
 		},
 		{
 			name:      "auth_mux_subrouter",
 			cfg:       spec.DefaultMuxConfig,
 			protected: struct{ method, path string }{"POST", "/api/me"},
 			open:      struct{ method, path string }{"POST", "/health"},
+			handler:   "getUser",
 		},
 		{
 			name:      "auth_nethttp_wrap",
 			cfg:       spec.DefaultHTTPConfig,
 			protected: struct{ method, path string }{"GET", "/users/{id}"},
 			open:      struct{ method, path string }{"GET", "/health"},
+			handler:   "getUser",
 		},
 	}
 
@@ -149,6 +164,21 @@ func TestTestdata_AuthPresets(t *testing.T) {
 			if oOp.Security != nil {
 				t.Errorf("%s %s: expected no security (sibling of guarded route), got %v",
 					tc.open.method, tc.open.path, *oOp.Security)
+			}
+
+			// The guarded operation must still be the HANDLER's, not the
+			// middleware's. Asserted here because auth_nethttp_wrap wires the
+			// guard as `mux.Handle(p, jwtAuth(http.HandlerFunc(getUser)))` — the
+			// exact shape that used to document jwtAuth as the operation, with
+			// the handler's response missing. Security passing while the
+			// operation is wrong is precisely what this fixture missed (#364).
+			if len(pOp.Responses) == 0 {
+				t.Errorf("%s %s: the handler's response is missing — the operation may have been attributed to the middleware (operationId %q)",
+					tc.protected.method, tc.protected.path, pOp.OperationID)
+			}
+			if !strings.HasSuffix(pOp.OperationID, "."+tc.handler) {
+				t.Errorf("%s %s: operationId %q should be attributed to %s",
+					tc.protected.method, tc.protected.path, pOp.OperationID, tc.handler)
 			}
 
 			// The bearerAuth scheme must be catalogued in components.

--- a/generator/testdata_handler_wrapper_test.go
+++ b/generator/testdata_handler_wrapper_test.go
@@ -83,22 +83,46 @@ func TestTestdata_HandlerWrapperAttribution(t *testing.T) {
 					t.Errorf("%s %s: summary %q, want the handler's %q",
 						pair.method, pair.wrapped, wrapped.Summary, direct.Summary)
 				}
-				if (wrapped.RequestBody == nil) != (direct.RequestBody == nil) {
-					t.Errorf("%s %s: request body presence differs from the direct registration (wrapped=%v direct=%v)",
-						pair.method, pair.wrapped, wrapped.RequestBody != nil, direct.RequestBody != nil)
+				// The body must be the same SCHEMA, not merely present: a
+				// wrapper that resolved to a generic object would pass a
+				// presence check while documenting nothing useful.
+				if got, want := bodySchemaRef(wrapped), bodySchemaRef(direct); got != want {
+					t.Errorf("%s %s: request body schema %q, want the handler's %q",
+						pair.method, pair.wrapped, got, want)
 				}
 				if got, want := sortedStatusKeys(wrapped), sortedStatusKeys(direct); !sameStrings(got, want) {
 					t.Errorf("%s %s: responses %v, want the handler's %v",
 						pair.method, pair.wrapped, got, want)
 				}
+				for _, status := range sortedStatusKeys(direct) {
+					if got, want := responseSchemaRef(wrapped, status), responseSchemaRef(direct, status); got != want {
+						t.Errorf("%s %s: response %s schema %q, want the handler's %q",
+							pair.method, pair.wrapped, status, got, want)
+					}
+				}
 				// The path parameter the handler reads must be found through the
 				// wrapper too — it used to be flagged "present in the path but
-				// not found in the code".
-				for _, p := range wrapped.Parameters {
-					if p.In == "path" && p.Extensions != nil {
-						if _, warned := p.Extensions["x-warning"]; warned {
+				// not found in the code" — and must describe the same thing the
+				// direct registration describes.
+				for _, want := range direct.Parameters {
+					if want.In != "path" {
+						continue
+					}
+					got := paramNamed(wrapped, want.Name, want.In)
+					if got == nil {
+						t.Errorf("%s %s: path parameter %q missing; the direct registration has it",
+							pair.method, pair.wrapped, want.Name)
+						continue
+					}
+					if got.Required != want.Required || schemaType(got.Schema) != schemaType(want.Schema) {
+						t.Errorf("%s %s: path parameter %q is %s/required=%v, want %s/required=%v",
+							pair.method, pair.wrapped, want.Name,
+							schemaType(got.Schema), got.Required, schemaType(want.Schema), want.Required)
+					}
+					if got.Extensions != nil {
+						if _, warned := got.Extensions["x-warning"]; warned {
 							t.Errorf("%s %s: path parameter %q is flagged as not found in the code",
-								pair.method, pair.wrapped, p.Name)
+								pair.method, pair.wrapped, want.Name)
 						}
 					}
 				}
@@ -130,4 +154,65 @@ func sortedStatusKeys(op *intspec.Operation) []string {
 
 func sameStrings(a, b []string) bool {
 	return strings.Join(a, ",") == strings.Join(b, ",")
+}
+
+// bodySchemaRef renders an operation's request-body schema identity.
+func bodySchemaRef(op *intspec.Operation) string {
+	if op.RequestBody == nil {
+		return ""
+	}
+	return wrapperContentSchema(op.RequestBody.Content)
+}
+
+func responseSchemaRef(op *intspec.Operation, status string) string {
+	resp, ok := op.Responses[status]
+	if !ok {
+		return "<missing>"
+	}
+	return wrapperContentSchema(resp.Content)
+}
+
+// wrapperContentSchema renders every media type's schema identity, so two
+// operations' bodies compare by what they describe. Named apart from
+// contentSchemaRef, which answers a narrower question (the first $ref).
+func wrapperContentSchema(content map[string]intspec.MediaType) string {
+	types := make([]string, 0, len(content))
+	for mediaType := range content {
+		types = append(types, mediaType)
+	}
+	sort.Strings(types)
+	parts := make([]string, 0, len(types))
+	for _, mediaType := range types {
+		schema := content[mediaType].Schema
+		switch {
+		case schema == nil:
+			parts = append(parts, mediaType+"=<none>")
+		case schema.Ref != "":
+			parts = append(parts, mediaType+"="+schema.Ref)
+		case schema.Items != nil && schema.Items.Ref != "":
+			parts = append(parts, mediaType+"=[]"+schema.Items.Ref)
+		default:
+			parts = append(parts, mediaType+"="+schema.Type)
+		}
+	}
+	return strings.Join(parts, ",")
+}
+
+func paramNamed(op *intspec.Operation, name, in string) *intspec.Parameter {
+	for i := range op.Parameters {
+		if op.Parameters[i].Name == name && op.Parameters[i].In == in {
+			return &op.Parameters[i]
+		}
+	}
+	return nil
+}
+
+func schemaType(s *intspec.Schema) string {
+	if s == nil {
+		return "<none>"
+	}
+	if s.Ref != "" {
+		return s.Ref
+	}
+	return s.Type
 }

--- a/generator/testdata_handler_wrapper_test.go
+++ b/generator/testdata_handler_wrapper_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	intspec "github.com/ehabterra/apispec/internal/spec"
+	"github.com/ehabterra/apispec/spec"
+)
+
+// TestTestdata_HandlerWrapperAttribution covers issue #364: a middleware applied
+// at the registration site (`mux.Handle(p, withLogging(http.HandlerFunc(h)))`)
+// replaced the handler — the operation was built from the MIDDLEWARE, so it
+// carried the wrapper's name and doc comment, the wrapper's header reads as
+// parameters, and none of the handler's request body or responses.
+//
+// The fixture registers the same handlers wrapped and directly, so the two are
+// compared against each other rather than against a snapshot: whatever the
+// direct route documents, the wrapped one must document too.
+func TestTestdata_HandlerWrapperAttribution(t *testing.T) {
+	for _, tc := range []struct {
+		fixture string
+		cfg     *spec.APISpecConfig
+		pairs   []struct{ wrapped, direct, method string }
+	}{
+		{
+			fixture: "handler_wrapper_attribution",
+			cfg:     spec.DefaultHTTPConfig(),
+			pairs: []struct{ wrapped, direct, method string }{
+				{"/wrapped/items/{id}", "/direct/items/{id}", "GET"},
+				{"/wrapped/items", "/direct/items", "POST"},
+				// Nested wrappers resolve to the innermost handler.
+				{"/chained/items/{id}", "/direct/items/{id}", "GET"},
+				// The HandlerFunc-shaped wrapper, whose argument is a plain ident.
+				{"/timed/items/{id}", "/direct/items/{id}", "GET"},
+			},
+		},
+		{
+			// Same wiring in a second framework — the defect is not net/http's
+			// (golden rule #5).
+			fixture: "handler_wrapper_attribution_chi",
+			cfg:     spec.DefaultChiConfig(),
+			pairs: []struct{ wrapped, direct, method string }{
+				{"/wrapped/items/{id}", "/direct/items/{id}", "GET"},
+				{"/wrapped/items", "/direct/items", "POST"},
+			},
+		},
+	} {
+		t.Run(tc.fixture, func(t *testing.T) {
+			out := loadTestdataWithFixtureConfig(t, tc.fixture, tc.cfg)
+			noDanglingRefs(t, out)
+
+			for _, pair := range tc.pairs {
+				wrapped := opFor(out.Paths[pair.wrapped], pair.method)
+				direct := opFor(out.Paths[pair.direct], pair.method)
+				if wrapped == nil || direct == nil {
+					t.Fatalf("%s %s / %s: missing operation(s); have %v",
+						pair.method, pair.wrapped, pair.direct, mapPathKeys(out.Paths))
+				}
+
+				// Same handler ⇒ same operationId, modulo the path it was
+				// registered at (operationIds carry the handler, not the route).
+				if wrapped.OperationID != direct.OperationID {
+					t.Errorf("%s %s: operationId %q, but the same handler registered directly is %q — the wrapper replaced it",
+						pair.method, pair.wrapped, wrapped.OperationID, direct.OperationID)
+				}
+				if wrapped.Summary != direct.Summary {
+					t.Errorf("%s %s: summary %q, want the handler's %q",
+						pair.method, pair.wrapped, wrapped.Summary, direct.Summary)
+				}
+				if (wrapped.RequestBody == nil) != (direct.RequestBody == nil) {
+					t.Errorf("%s %s: request body presence differs from the direct registration (wrapped=%v direct=%v)",
+						pair.method, pair.wrapped, wrapped.RequestBody != nil, direct.RequestBody != nil)
+				}
+				if got, want := sortedStatusKeys(wrapped), sortedStatusKeys(direct); !sameStrings(got, want) {
+					t.Errorf("%s %s: responses %v, want the handler's %v",
+						pair.method, pair.wrapped, got, want)
+				}
+				// The path parameter the handler reads must be found through the
+				// wrapper too — it used to be flagged "present in the path but
+				// not found in the code".
+				for _, p := range wrapped.Parameters {
+					if p.In == "path" && p.Extensions != nil {
+						if _, warned := p.Extensions["x-warning"]; warned {
+							t.Errorf("%s %s: path parameter %q is flagged as not found in the code",
+								pair.method, pair.wrapped, p.Name)
+						}
+					}
+				}
+			}
+
+			// Two different handlers behind the same wrapper stay distinct.
+			ids := map[string]string{}
+			for path, item := range out.Paths {
+				for _, method := range []string{"GET", "POST"} {
+					if op := opFor(item, method); op != nil {
+						ids[method+" "+path] = op.OperationID
+					}
+				}
+			}
+			if a, b := ids["GET /wrapped/items/{id}"], ids["POST /wrapped/items"]; a != "" && a == b {
+				t.Errorf("two handlers behind the same wrapper collapsed onto one operationId %q", a)
+			}
+		})
+	}
+}
+
+// sortedStatusKeys is statusKeys with a stable order, so two operations'
+// response sets compare.
+func sortedStatusKeys(op *intspec.Operation) []string {
+	keys := statusKeys(op)
+	sort.Strings(keys)
+	return keys
+}
+
+func sameStrings(a, b []string) bool {
+	return strings.Join(a, ",") == strings.Join(b, ",")
+}

--- a/internal/spec/handler_wrapper_test.go
+++ b/internal/spec/handler_wrapper_test.go
@@ -1,0 +1,339 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// wrapperMeta declares the functions the peel has to reason about: two
+// middlewares (same type in and out), an adapter that takes a function but is
+// NOT middleware-shaped, and the handlers themselves.
+func wrapperMeta(t *testing.T) *metadata.Metadata {
+	t.Helper()
+	pool := metadata.NewStringPool()
+	meta := &metadata.Metadata{StringPool: pool}
+
+	const pkg = "app"
+	fn := func(name, paramType, returnType string) *metadata.Function {
+		f := &metadata.Function{Name: pool.Get(name), Pkg: pool.Get(pkg)}
+		f.Signature = *metadata.NewCallArgument(meta)
+		param := metadata.NewCallArgument(meta)
+		param.SetKind(metadata.KindIdent)
+		param.SetName("next")
+		if paramType != "" {
+			param.Type = pool.Get(paramType)
+		}
+		f.Signature.Args = []*metadata.CallArgument{param}
+		if returnType != "" {
+			f.Signature.ResolvedType = pool.Get(returnType)
+		}
+		return f
+	}
+	meta.Packages = map[string]*metadata.Package{
+		pkg: {Files: map[string]*metadata.File{
+			"main.go": {Functions: map[string]*metadata.Function{
+				// func(http.Handler) http.Handler
+				"withLogging": fn("withLogging", "Handler", "http.Handler"),
+				// func(http.HandlerFunc) http.HandlerFunc
+				"withTiming": fn("withTiming", "HandlerFunc", "http.HandlerFunc"),
+				// func(func(Req) (Resp, error)) http.HandlerFunc — an adapter,
+				// not a middleware: what goes in is not what comes out.
+				"HandleRequest": fn("HandleRequest", "func(Req) (Resp, error)", "http.HandlerFunc"),
+				"getItem":       {Name: pool.Get("getItem"), Pkg: pool.Get(pkg)},
+				"createItem":    {Name: pool.Get("createItem"), Pkg: pool.Get(pkg)},
+				"handleCreate":  {Name: pool.Get("handleCreate"), Pkg: pool.Get(pkg)},
+			}},
+		}},
+	}
+	return meta
+}
+
+func wrapperIdent(meta *metadata.Metadata, name string) *metadata.CallArgument {
+	a := metadata.NewCallArgument(meta)
+	a.SetKind(metadata.KindIdent)
+	a.SetName(name)
+	a.Pkg = meta.StringPool.Get("app")
+	return a
+}
+
+func wrapperConversion(meta *metadata.Metadata, inner *metadata.CallArgument) *metadata.CallArgument {
+	a := metadata.NewCallArgument(meta)
+	a.SetKind(metadata.KindTypeConversion)
+	a.Args = []*metadata.CallArgument{inner}
+	return a
+}
+
+func wrapperCall(meta *metadata.Metadata, callee string, args ...*metadata.CallArgument) *metadata.CallArgument {
+	a := metadata.NewCallArgument(meta)
+	a.SetKind(metadata.KindCall)
+	a.Fun = wrapperIdent(meta, callee)
+	a.Args = args
+	return a
+}
+
+// TestHandlerArgValuePeelsWrappers pins what the handler position resolves to
+// for each wiring style (issue #364). The rule has to separate a middleware
+// wrapping the handler from an adapter that merely takes a function, because
+// peeling the latter would rename operations that are correct today.
+func TestHandlerArgValuePeelsWrappers(t *testing.T) {
+	meta := wrapperMeta(t)
+
+	tests := []struct {
+		name string
+		arg  *metadata.CallArgument
+		want string // resolved handler name, "" for "unchanged"
+	}{
+		{
+			name: "conversion of a handler",
+			arg:  wrapperConversion(meta, wrapperIdent(meta, "getItem")),
+			want: "getItem",
+		},
+		{
+			name: "middleware wrapping a converted handler",
+			arg:  wrapperCall(meta, "withLogging", wrapperConversion(meta, wrapperIdent(meta, "getItem"))),
+			want: "getItem",
+		},
+		{
+			name: "middleware taking the handler as a plain ident",
+			arg:  wrapperCall(meta, "withTiming", wrapperIdent(meta, "createItem")),
+			want: "createItem",
+		},
+		{
+			name: "nested middlewares peel to the innermost handler",
+			arg: wrapperCall(meta, "withTiming",
+				wrapperCall(meta, "withLogging", wrapperConversion(meta, wrapperIdent(meta, "getItem")))),
+			want: "getItem",
+		},
+		{
+			name: "an adapter that is not middleware-shaped is left alone",
+			arg:  wrapperCall(meta, "HandleRequest", wrapperIdent(meta, "handleCreate")),
+			want: "", // the adapter instantiation stays the operation (#367)
+		},
+		{
+			name: "a handler factory has nothing to peel",
+			arg:  wrapperCall(meta, "withLogging"),
+			want: "",
+		},
+		{
+			name: "two handler-shaped arguments are ambiguous",
+			arg: wrapperCall(meta, "withLogging",
+				wrapperConversion(meta, wrapperIdent(meta, "getItem")),
+				wrapperConversion(meta, wrapperIdent(meta, "createItem"))),
+			want: "",
+		},
+		{
+			name: "a conversion of a value is not a handler",
+			arg:  wrapperConversion(meta, wrapperIdent(meta, "payload")),
+			want: "payload", // the conversion peels; the value simply isn't a function
+		},
+		{
+			name: "a middleware given a value, not a function",
+			arg:  wrapperCall(meta, "withLogging", wrapperIdent(meta, "payload")),
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := handlerArgValue(tc.arg)
+			if tc.want == "" {
+				if got != tc.arg {
+					t.Errorf("expected the argument to stay as it is, got %q (kind %v)", got.GetName(), got.GetKind())
+				}
+				return
+			}
+			if got.GetName() != tc.want {
+				t.Errorf("resolved to %q, want %q", got.GetName(), tc.want)
+			}
+		})
+	}
+}
+
+// TestWrappedHandlerResolvesMethodValuesAndEdges covers the two resolution paths
+// the fixture wiring does not reach: a handler passed as a METHOD value
+// (`withLogging(h.GetItem)`), and a wrapper call the call graph recorded an edge
+// for, where the callee is read from the edge rather than from the call's Fun.
+func TestWrappedHandlerResolvesMethodValuesAndEdges(t *testing.T) {
+	meta := wrapperMeta(t)
+	pool := meta.StringPool
+
+	// A method value: app.Handler.GetItem.
+	pkg := meta.Packages["app"]
+	pkg.Files["main.go"].Types = map[string]*metadata.Type{
+		"Handler": {Methods: []metadata.Method{{Name: pool.Get("GetItem"), Receiver: pool.Get("*Handler")}}},
+	}
+
+	sel := metadata.NewCallArgument(meta)
+	sel.SetKind(metadata.KindSelector)
+	sel.X = wrapperIdent(meta, "h")
+	sel.X.Type = pool.Get("*app.Handler")
+	sel.Sel = wrapperIdent(meta, "GetItem")
+
+	if got := handlerArgValue(wrapperCall(meta, "withLogging", sel)); got != sel {
+		t.Errorf("a wrapped method value should resolve to the method, got %q", got.GetName())
+	}
+
+	// The same wrapper, but resolved through the recorded call edge.
+	viaEdge := metadata.NewCallArgument(meta)
+	viaEdge.SetKind(metadata.KindCall)
+	viaEdge.Args = []*metadata.CallArgument{wrapperIdent(meta, "getItem")}
+	viaEdge.Edge = &metadata.CallGraphEdge{
+		Caller: metadata.Call{Meta: meta, Name: pool.Get("main"), Pkg: pool.Get("app"), RecvType: -1},
+		Callee: metadata.Call{Meta: meta, Name: pool.Get("withLogging"), Pkg: pool.Get("app"), RecvType: -1},
+	}
+	if got := handlerArgValue(viaEdge); got.GetName() != "getItem" {
+		t.Errorf("a wrapper resolved through its edge should peel to the handler, got %q", got.GetName())
+	}
+
+	// No metadata to consult: nothing is known to be a function, so nothing is
+	// peeled — the honest answer rather than a guess.
+	bare := wrapperCall(meta, "withLogging", wrapperIdent(meta, "getItem"))
+	bare.Meta = nil
+	for _, a := range bare.Args {
+		a.Meta = nil
+	}
+	if got := handlerArgValue(bare); got != bare {
+		t.Error("without metadata the wrapper must stay as it is")
+	}
+}
+
+// TestWrapperHelperGuards exercises the refusals directly: every one of them is
+// a place where peeling would be a guess, so "returns nothing" is the behaviour
+// under test, not an incidental nil.
+func TestWrapperHelperGuards(t *testing.T) {
+	meta := wrapperMeta(t)
+
+	t.Run("convertedHandler", func(t *testing.T) {
+		if convertedHandler(nil) != nil {
+			t.Error("nil argument")
+		}
+		twoArgs := wrapperConversion(meta, wrapperIdent(meta, "getItem"))
+		twoArgs.Args = append(twoArgs.Args, wrapperIdent(meta, "createItem"))
+		if convertedHandler(twoArgs) != nil {
+			t.Error("a conversion has exactly one operand; anything else is not one")
+		}
+		lit := metadata.NewCallArgument(meta)
+		lit.SetKind(metadata.KindLiteral)
+		if convertedHandler(wrapperConversion(meta, lit)) != nil {
+			t.Error("a converted literal is not a handler")
+		}
+	})
+
+	t.Run("wrappedHandler", func(t *testing.T) {
+		if wrappedHandler(nil) != nil {
+			t.Error("nil call")
+		}
+		// A conversion of something that is not a function contributes no
+		// candidate, so the wrapper has nothing to give.
+		lit := metadata.NewCallArgument(meta)
+		lit.SetKind(metadata.KindLiteral)
+		if wrappedHandler(wrapperCall(meta, "withLogging", wrapperConversion(meta, lit))) != nil {
+			t.Error("a converted literal must not be taken for the handler")
+		}
+		// A nested call that wraps nothing is not a candidate either.
+		if wrappedHandler(wrapperCall(meta, "withLogging", wrapperCall(meta, "withLogging"))) != nil {
+			t.Error("a nested call that wraps no handler must not be taken for one")
+		}
+	})
+
+	t.Run("middlewareShaped", func(t *testing.T) {
+		if middlewareShaped(wrapperCall(meta, "unknownFunc", wrapperIdent(meta, "getItem"))) {
+			t.Error("a callee apispec cannot resolve has no known shape")
+		}
+		noMeta := wrapperCall(meta, "withLogging", wrapperIdent(meta, "getItem"))
+		noMeta.Meta = nil
+		if middlewareShaped(noMeta) {
+			t.Error("without metadata there is no signature to compare")
+		}
+	})
+
+	t.Run("calleeFunctionOf", func(t *testing.T) {
+		if calleeFunctionOf(nil) != nil {
+			t.Error("nil call")
+		}
+		noFun := metadata.NewCallArgument(meta)
+		noFun.SetKind(metadata.KindCall)
+		if calleeFunctionOf(noFun) != nil {
+			t.Error("a call with neither an edge nor a Fun names nothing")
+		}
+		// Through a selector Fun: pkg.withLogging(...).
+		sel := metadata.NewCallArgument(meta)
+		sel.SetKind(metadata.KindSelector)
+		sel.X = wrapperIdent(meta, "app")
+		sel.Sel = wrapperIdent(meta, "withLogging")
+		viaSel := metadata.NewCallArgument(meta)
+		viaSel.SetKind(metadata.KindCall)
+		viaSel.Fun = sel
+		if calleeFunctionOf(viaSel) == nil {
+			t.Error("a qualified wrapper call should resolve through its selector")
+		}
+	})
+
+	t.Run("namesAFunction", func(t *testing.T) {
+		if namesAFunction(nil) {
+			t.Error("nil argument")
+		}
+		lit := metadata.NewCallArgument(meta)
+		lit.SetKind(metadata.KindFuncLit)
+		if !namesAFunction(lit) {
+			t.Error("a function literal is a function")
+		}
+		noMeta := wrapperIdent(meta, "getItem")
+		noMeta.Meta = nil
+		if namesAFunction(noMeta) {
+			t.Error("without metadata nothing is known to be a function")
+		}
+		bareSel := metadata.NewCallArgument(meta)
+		bareSel.SetKind(metadata.KindSelector)
+		if namesAFunction(bareSel) {
+			t.Error("a selector with no Sel names nothing")
+		}
+		if namesAFunction(wrapperIdent(meta, "payload")) {
+			t.Error("an ident naming a value is not a function")
+		}
+	})
+}
+
+// TestConvertedValueKeys covers the tracker side of the same shape: expansion
+// has to follow what a conversion converts (`http.HandlerFunc(getItem)`),
+// because the conversion itself names a type and a type has no body.
+func TestConvertedValueKeys(t *testing.T) {
+	meta := wrapperMeta(t)
+	node := func(arg *metadata.CallArgument, isArg bool) *LazyNode {
+		return &LazyNode{tree: &LazyTree{meta: meta}, arg: arg, isArgument: isArg}
+	}
+
+	conv := wrapperConversion(meta, wrapperIdent(meta, "getItem"))
+	if keys := node(conv, true).convertedValueKeys(); len(keys) != 1 {
+		t.Errorf("a converted function should yield its own key, got %v", keys)
+	}
+	if keys := node(conv, false).convertedValueKeys(); keys != nil {
+		t.Errorf("only an argument node converts anything, got %v", keys)
+	}
+	if keys := node(wrapperIdent(meta, "getItem"), true).convertedValueKeys(); keys != nil {
+		t.Errorf("a plain ident is not a conversion, got %v", keys)
+	}
+	lit := metadata.NewCallArgument(meta)
+	lit.SetKind(metadata.KindLiteral)
+	if keys := node(wrapperConversion(meta, lit), true).convertedValueKeys(); keys != nil {
+		t.Errorf("a converted literal has no body to expand, got %v", keys)
+	}
+	if keys := node(wrapperConversion(meta, nil), true).convertedValueKeys(); keys != nil {
+		t.Errorf("a conversion of nothing yields nothing, got %v", keys)
+	}
+}

--- a/internal/spec/handler_wrapper_test.go
+++ b/internal/spec/handler_wrapper_test.go
@@ -262,6 +262,36 @@ func TestWrapperHelperGuards(t *testing.T) {
 		}
 	})
 
+	t.Run("a wrapper reached as a method", func(t *testing.T) {
+		// `chain.Then(getItem)` — alice's shape: the wrapper is a METHOD, and
+		// with no recorded call edge only the method table can say it is
+		// middleware-shaped.
+		pool := meta.StringPool
+		sig := *metadata.NewCallArgument(meta)
+		param := metadata.NewCallArgument(meta)
+		param.SetKind(metadata.KindIdent)
+		param.Type = pool.Get("Handler")
+		sig.Args = []*metadata.CallArgument{param}
+		sig.ResolvedType = pool.Get("http.Handler")
+		meta.Packages["app"].Files["main.go"].Types = map[string]*metadata.Type{
+			"Chain": {Methods: []metadata.Method{{Name: pool.Get("Then"), Receiver: pool.Get("Chain"), Signature: sig}}},
+		}
+
+		fun := metadata.NewCallArgument(meta)
+		fun.SetKind(metadata.KindSelector)
+		fun.X = wrapperIdent(meta, "chain")
+		fun.X.Type = pool.Get("app.Chain")
+		fun.Sel = wrapperIdent(meta, "Then")
+		call := metadata.NewCallArgument(meta)
+		call.SetKind(metadata.KindCall)
+		call.Fun = fun
+		call.Args = []*metadata.CallArgument{wrapperIdent(meta, "getItem")}
+
+		if got := handlerArgValue(call); got.GetName() != "getItem" {
+			t.Errorf("a method wrapper should peel to the handler it is given, got %q", got.GetName())
+		}
+	})
+
 	t.Run("calleeFunctionOf", func(t *testing.T) {
 		if calleeFunctionOf(nil) != nil {
 			t.Error("nil call")

--- a/internal/spec/lazytree.go
+++ b/internal/spec/lazytree.go
@@ -1373,6 +1373,15 @@ func (t *LazyTree) buildPlan(n *LazyNode) []childSpec {
 	for _, methodKey := range n.methodBaseKeys() {
 		expandKey(methodKey)
 	}
+	// Converted function (`http.HandlerFunc(getItem)`): the conversion names a
+	// TYPE, which has no body, so without this the function it converts is a dead
+	// end — its parameters, request body and responses never reach the route.
+	// Invisible on a direct registration, where the route's own argument node
+	// carries the function; it bites when the conversion sits inside another call,
+	// which is exactly the middleware shape `mw(http.HandlerFunc(h))` (issue #364).
+	for _, key := range n.convertedValueKeys() {
+		expandKey(key)
+	}
 	// Handler *value* (r.Method(GET, "/health", deps.Health) / mux.Handle("/x", h)):
 	// the argument names no method at all, so the framework's handler-interface
 	// method supplies it — otherwise the handler body is unreachable (issue #204).
@@ -1446,6 +1455,36 @@ func (n *LazyNode) methodBaseKeys() []string {
 	// the eager build's ImplementedBy attachment.
 	keys = append(keys, n.tree.implementerKeys(pkg, recv, selName)...)
 	return keys
+}
+
+// convertedValueKeys resolves a type-conversion argument to the base ID of what
+// it converts, when that is something with a body to expand.
+//
+// `http.HandlerFunc(getItem)` is a conversion: its own key names the TYPE, and a
+// type has no calls, so expansion stops there. What the tracker should follow is
+// getItem. Only an ident, a selector or a function literal is unwrapped — the
+// same shapes handlerArgValue peels for the route's identity — and the key is
+// used exactly like any other: a conversion of a non-function (`[]byte(payload)`)
+// yields a key with no edges, so it expands to nothing rather than to something
+// wrong.
+func (n *LazyNode) convertedValueKeys() []string {
+	if !n.isArgument || n.arg == nil || n.arg.GetKind() != metadata.KindTypeConversion || len(n.arg.Args) != 1 {
+		return nil
+	}
+	inner := n.arg.Args[0]
+	if inner == nil {
+		return nil
+	}
+	switch inner.GetKind() {
+	case metadata.KindIdent, metadata.KindSelector, metadata.KindFuncLit:
+	default:
+		return nil
+	}
+	id := strings.TrimPrefix(inner.ID(), "*")
+	if id == "" {
+		return nil
+	}
+	return []string{metadata.StripToBase(id)}
 }
 
 // handlerValueKeys resolves an argument that is a handler *value* — a variable

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -1490,13 +1490,223 @@ func (r *RoutePatternMatcherImpl) verbsFromArg(arg *metadata.CallArgument) []str
 // stays as it is, since for a non-handler argument the conversion's own type is
 // usually the answer (a `[]byte(body)` request body, for instance).
 func handlerArgValue(arg *metadata.CallArgument) *metadata.CallArgument {
-	if arg == nil || arg.GetKind() != metadata.KindTypeConversion || len(arg.Args) != 1 {
-		return arg
+	// Bounded because the peel is driven by the code's own nesting: a chain
+	// deeper than this is not a wiring style, and a bound keeps a cyclic or
+	// pathological argument tree from spinning here.
+	for i := 0; i < maxHandlerUnwraps && arg != nil; i++ {
+		switch arg.GetKind() {
+		case metadata.KindTypeConversion:
+			inner := convertedHandler(arg)
+			if inner == nil {
+				return arg
+			}
+			arg = inner
+		case metadata.KindCall:
+			inner := wrappedHandler(arg)
+			if inner == nil {
+				return arg
+			}
+			arg = inner
+		default:
+			return arg
+		}
+	}
+	return arg
+}
+
+// maxHandlerUnwraps bounds how many wrapper layers handlerArgValue peels.
+const maxHandlerUnwraps = 8
+
+// convertedHandler returns what a type conversion converts, when that is
+// something that can BE a handler. Anything else stays as it is, since for a
+// non-handler argument the conversion's own type is usually the answer (a
+// `[]byte(body)` request body, for instance).
+func convertedHandler(arg *metadata.CallArgument) *metadata.CallArgument {
+	if arg == nil || len(arg.Args) != 1 {
+		return nil
 	}
 	switch inner := arg.Args[0]; inner.GetKind() {
 	case metadata.KindIdent, metadata.KindSelector, metadata.KindFuncLit:
 		return inner
 	default:
-		return arg
+		return nil
 	}
+}
+
+// wrappedHandler returns the handler a middleware call wraps, or nil when the
+// call is not wrapping one (issue #364).
+//
+// `mux.Handle(p, withLogging(http.HandlerFunc(getItem)))` passes a CALL at the
+// handler position, and taking it at face value documents the operation as the
+// MIDDLEWARE: its name becomes the operationId, its doc comment the summary, its
+// header reads the parameters, and the handler's own request body and responses
+// are missing entirely.
+//
+// What identifies a wrapper is the shape at this position, not the framework: a
+// call one of whose arguments is itself a handler — an ident or selector naming a
+// function apispec knows, a function literal, or a conversion of one. That covers
+// `func(http.Handler) http.Handler`, `func(http.HandlerFunc) http.HandlerFunc` and
+// every framework's equivalent, plus adapters (`gin.WrapH(mw(h))`), because the
+// caller peels repeatedly.
+//
+// Two shapes deliberately do not peel:
+//
+//   - a handler FACTORY (`h.Create()`) — no argument is a handler, so the call
+//     itself remains the answer, which is what issue #221's factory support needs;
+//   - a call with SEVERAL handler-shaped arguments — which of them serves the
+//     route is genuinely ambiguous, and today's behaviour with a warning-free
+//     wrong answer is better than a guess (golden rule #7).
+func wrappedHandler(call *metadata.CallArgument) *metadata.CallArgument {
+	return wrappedHandlerDepth(call, 0)
+}
+
+func wrappedHandlerDepth(call *metadata.CallArgument, depth int) *metadata.CallArgument {
+	if call == nil || len(call.Args) == 0 || depth >= maxHandlerUnwraps {
+		return nil
+	}
+	// The callee's own shape settles the plain-ident case: `withTiming(getItem)`
+	// carries no conversion to say which argument is the handler, so the wrapper
+	// has to identify itself — a function that takes and returns the same type is
+	// a middleware in any framework.
+	shaped := middlewareShaped(call)
+	var found *metadata.CallArgument
+	for _, arg := range call.Args {
+		candidate := arg
+		switch arg.GetKind() {
+		case metadata.KindTypeConversion:
+			// A conversion of a function AT the handler position is the handler,
+			// whatever the enclosing call is — `http.HandlerFunc(h)` says so
+			// outright. This is what carries the adapters whose own signature is
+			// not middleware-shaped (`gin.WrapH`, `echo.WrapHandler`).
+			inner := convertedHandler(arg)
+			if inner == nil || !namesAFunction(inner) {
+				continue
+			}
+			candidate = inner
+		case metadata.KindCall:
+			// A nested wrapper (`withAuth(withLogging(http.HandlerFunc(h)))`):
+			// the argument is itself wrapping a handler, so it is the handler for
+			// this level. The caller peels it on the next pass.
+			if wrappedHandlerDepth(arg, depth+1) == nil {
+				continue
+			}
+		default:
+			if !shaped || !namesAFunction(candidate) {
+				continue
+			}
+		}
+		if found != nil {
+			return nil // ambiguous: more than one handler-shaped argument
+		}
+		found = candidate
+	}
+	return found
+}
+
+// middlewareShaped reports whether a call's callee takes and returns the same
+// type — the middleware shape in every framework (`func(http.Handler)
+// http.Handler`, `func(echo.HandlerFunc) echo.HandlerFunc`, and a
+// `Chain.Then(http.Handler) http.Handler` helper alike).
+//
+// It exists to tell a middleware from an ADAPTER that also takes a function:
+// `HandleRequest(handleCreateUser)` turns a `func(Req) (Resp, error)` into an
+// http.HandlerFunc, so the function it is given is business logic reached
+// through the adapter, not the HTTP handler the route registers — and the
+// operation is the adapter instantiation, which is what apispec documents today
+// (testdata/generic). Peeling it would rename those operations, which is a
+// separate decision from this one (issue #367).
+//
+// Compared on type NAMES, not on the rendered signature: a parameter records its
+// type unqualified ("Handler") while the result records it qualified
+// ("http.Handler"), so the qualification is trimmed off both — the same naming
+// comparison the argument renderer makes, not a type parse (golden rule #2/#3).
+func middlewareShaped(call *metadata.CallArgument) bool {
+	fn := calleeFunctionOf(call)
+	if fn == nil || len(fn.Signature.Args) != 1 {
+		return false
+	}
+	meta := call.Meta
+	if meta == nil {
+		return false
+	}
+	param := baseTypeName(fn.Signature.Args[0].GetType())
+	result := baseTypeName(meta.StringPool.GetString(fn.Signature.ResolvedType))
+	return param != "" && param == result
+}
+
+// calleeFunctionOf resolves the function a call invokes, by its own edge when the
+// call graph recorded one, else by the name its Fun carries.
+func calleeFunctionOf(call *metadata.CallArgument) *metadata.Function {
+	if call == nil || call.Meta == nil {
+		return nil
+	}
+	meta := call.Meta
+	if call.Edge != nil {
+		pkg := meta.StringPool.GetString(call.Edge.Callee.Pkg)
+		name := meta.StringPool.GetString(call.Edge.Callee.Name)
+		recv := strings.TrimPrefix(meta.StringPool.GetString(call.Edge.Callee.RecvType), "*")
+		recv = strings.TrimPrefix(recv, pkg+".")
+		if fn := findFunctionByName(meta, pkg, name); fn != nil {
+			return fn
+		}
+		if m := findMethodByName(meta, pkg, recv, name); m != nil {
+			return &metadata.Function{Name: m.Name, Signature: m.Signature}
+		}
+		return nil
+	}
+	fun := call.Fun
+	if fun == nil {
+		return nil
+	}
+	if fun.GetKind() == metadata.KindSelector && fun.Sel != nil {
+		fun = fun.Sel
+	}
+	return findFunctionByName(meta, fun.GetPkg(), fun.GetName())
+}
+
+// baseTypeName strips a pointer marker and a package qualification from a type
+// name, so an unqualified parameter type and a qualified result type compare.
+func baseTypeName(typ string) string {
+	typ = strings.TrimPrefix(typ, "*")
+	if dot := strings.LastIndex(typ, "."); dot >= 0 {
+		typ = typ[dot+1:]
+	}
+	return typ
+}
+
+// namesAFunction reports whether an argument refers to a function body — a
+// function literal, or an ident/selector that resolves to a declared function or
+// method. It is what keeps wrappedHandler from peeling an ordinary argument: in
+// `h.Create(db)` the `db` ident names a value, not a function, so the factory
+// call stays the handler.
+func namesAFunction(arg *metadata.CallArgument) bool {
+	if arg == nil {
+		return false
+	}
+	if arg.GetKind() == metadata.KindFuncLit {
+		return true
+	}
+	meta := arg.Meta
+	if meta == nil {
+		return false
+	}
+	switch arg.GetKind() {
+	case metadata.KindIdent:
+		return findFunctionByName(meta, arg.GetPkg(), arg.GetName()) != nil
+	case metadata.KindSelector:
+		if arg.Sel == nil {
+			return false
+		}
+		pkg, name := arg.Sel.GetPkg(), arg.Sel.GetName()
+		if findFunctionByName(meta, pkg, name) != nil {
+			return true
+		}
+		recv := ""
+		if arg.X != nil {
+			recv = strings.TrimPrefix(arg.X.GetType(), "*")
+			recv = strings.TrimPrefix(recv, pkg+".")
+		}
+		return findMethodByName(meta, pkg, recv, name) != nil
+	}
+	return false
 }

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -1616,22 +1616,34 @@ func wrappedHandlerDepth(call *metadata.CallArgument, depth int) *metadata.CallA
 // (testdata/generic). Peeling it would rename those operations, which is a
 // separate decision from this one (issue #367).
 //
-// Compared on type NAMES, not on the rendered signature: a parameter records its
-// type unqualified ("Handler") while the result records it qualified
-// ("http.Handler"), so the qualification is trimmed off both — the same naming
-// comparison the argument renderer makes, not a type parse (golden rule #2/#3).
+// Compared as structured type refs, not as rendered strings (golden rule #2):
+// the parameter records its type as WRITTEN (`Handler`) while the result records
+// it RESOLVED (`http.Handler`), so the names are what must match, and a package
+// is compared only when both refs carry one.
 func middlewareShaped(call *metadata.CallArgument) bool {
 	fn := calleeFunctionOf(call)
-	if fn == nil || len(fn.Signature.Args) != 1 {
+	if fn == nil || len(fn.Signature.Args) != 1 || call.Meta == nil {
 		return false
 	}
 	meta := call.Meta
-	if meta == nil {
+	param := baseTypeRef(meta.TypeRefOf(fn.Signature.Args[0].Type))
+	result := baseTypeRef(meta.TypeRefOf(fn.Signature.ResolvedType))
+	if param == nil || result == nil || param.Name == "" {
 		return false
 	}
-	param := baseTypeName(fn.Signature.Args[0].GetType())
-	result := baseTypeName(meta.StringPool.GetString(fn.Signature.ResolvedType))
-	return param != "" && param == result
+	if param.Pkg != "" && result.Pkg != "" && param.Pkg != result.Pkg {
+		return false
+	}
+	return param.Name == result.Name
+}
+
+// baseTypeRef unwraps pointers, so a `*Handler` parameter and a `Handler` result
+// are the same type for this comparison.
+func baseTypeRef(ref *typemodel.TypeRef) *typemodel.TypeRef {
+	for ref != nil && ref.Kind == typemodel.KindPointer && ref.Elem != nil {
+		ref = ref.Elem
+	}
+	return ref
 }
 
 // calleeFunctionOf resolves the function a call invokes, by its own edge when the
@@ -1658,20 +1670,25 @@ func calleeFunctionOf(call *metadata.CallArgument) *metadata.Function {
 	if fun == nil {
 		return nil
 	}
+	recv := ""
 	if fun.GetKind() == metadata.KindSelector && fun.Sel != nil {
+		if fun.X != nil {
+			recv = strings.TrimPrefix(fun.X.GetType(), "*")
+		}
 		fun = fun.Sel
 	}
-	return findFunctionByName(meta, fun.GetPkg(), fun.GetName())
-}
-
-// baseTypeName strips a pointer marker and a package qualification from a type
-// name, so an unqualified parameter type and a qualified result type compare.
-func baseTypeName(typ string) string {
-	typ = strings.TrimPrefix(typ, "*")
-	if dot := strings.LastIndex(typ, "."); dot >= 0 {
-		typ = typ[dot+1:]
+	pkg, name := fun.GetPkg(), fun.GetName()
+	if f := findFunctionByName(meta, pkg, name); f != nil {
+		return f
 	}
-	return typ
+	// A wrapper reached as a METHOD with no recorded edge — `chain.Then(h)`,
+	// the alice-style helper. Without this it resolves to nothing, so its
+	// middleware shape is unknown and a plain-ident handler is not peeled.
+	recv = strings.TrimPrefix(recv, pkg+".")
+	if m := findMethodByName(meta, pkg, recv, name); m != nil {
+		return &metadata.Function{Name: m.Name, Signature: m.Signature}
+	}
+	return nil
 }
 
 // namesAFunction reports whether an argument refers to a function body — a

--- a/internal/spec/request_provenance.go
+++ b/internal/spec/request_provenance.go
@@ -64,8 +64,22 @@ func (e *Extractor) followsControlFlow(parent, child TrackerNodeInterface, depth
 	// registration, though: deeper down, an argument node is an ordinary value,
 	// and the producer relation hangs every writer of that value underneath it —
 	// which is the lateral jump this gate exists to stop.
-	if parent.GetArgument() != nil {
-		return depth <= handlerArgDepth
+	if parentArg := parent.GetArgument(); parentArg != nil {
+		if depth <= handlerArgDepth {
+			return true
+		}
+		// A handler wrapped at the registration site sits deeper than one hop:
+		// `mux.Handle(p, mw(http.HandlerFunc(h)))` puts it behind a call and a
+		// conversion, and refusing those hops loses the handler's request body
+		// (issue #364). Only those two kinds are transparent, which keeps this
+		// gate's own case blocked: the lateral producer relation attaches to
+		// VARIABLE and SELECTOR arguments (see argProducerIDs), so every writer
+		// of a value still stops here.
+		switch parentArg.GetKind() {
+		case metadata.KindCall, metadata.KindTypeConversion:
+			return true
+		}
+		return false
 	}
 	// Arguments belong to the frame that is already in scope.
 	if child.GetArgument() != nil {

--- a/internal/spec/request_provenance_test.go
+++ b/internal/spec/request_provenance_test.go
@@ -98,6 +98,36 @@ func TestFollowsControlFlow_ProvenanceGate(t *testing.T) {
 		}
 	})
 
+	t.Run("a wrapper hop beyond the handler argument stays on the route's own path", func(t *testing.T) {
+		// `mux.Handle(p, withLogging(http.HandlerFunc(h)))` puts the handler two
+		// argument hops down — a call, then a conversion — and refusing those
+		// hops lost the handler's request body (issue #364).
+		for _, kind := range []string{metadata.KindCall, metadata.KindTypeConversion} {
+			arg := metadata.NewCallArgument(meta)
+			arg.SetKind(kind)
+			parent := &provNode{edge: provEdge(meta, "app", "routes", "net/http", "Handle"), arg: arg}
+			child := &provNode{edge: provEdge(meta, "app", "getItem", "json", "Decode")}
+			if !e.followsControlFlow(parent, child, handlerArgDepth+2) {
+				t.Errorf("a %s argument is the handler itself; its body must stay reachable", kind)
+			}
+		}
+	})
+
+	t.Run("a value hop beyond the handler argument does not", func(t *testing.T) {
+		// The distinction that keeps #269 closed: the lateral producer relation
+		// hangs every writer of a value under VARIABLE and SELECTOR arguments,
+		// never under a call or a conversion.
+		for _, kind := range []string{metadata.KindIdent, metadata.KindSelector} {
+			arg := metadata.NewCallArgument(meta)
+			arg.SetKind(kind)
+			parent := &provNode{edge: provEdge(meta, "app", "ToView", "app", "estimateView"), arg: arg}
+			child := &provNode{edge: provEdge(meta, "app", "FuncLit:sibling.go:28:9", "httpx", "DecodeJSON")}
+			if e.followsControlFlow(parent, child, handlerArgDepth+2) {
+				t.Errorf("a %s argument deep in the body must not open a sibling handler", kind)
+			}
+		}
+	})
+
 	t.Run("value argument deep in the body does NOT open a sibling handler", func(t *testing.T) {
 		// This is #269: a response converter passes a shared domain field,
 		// producer resolution answers with the sibling handler that writes that

--- a/testdata/auth_nethttp_wrap/main.go
+++ b/testdata/auth_nethttp_wrap/main.go
@@ -3,10 +3,25 @@
 package main
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"github.com/golang-jwt/jwt/v5"
 )
+
+// User is what the protected handler answers with. The handlers below carry a
+// real body and status on purpose: with empty bodies, an operation attributed to
+// the MIDDLEWARE instead of the handler looked identical to a correct one, so
+// this fixture could not catch that regression (issue #364).
+type User struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// Status is the open endpoint's answer.
+type Status struct {
+	OK bool `json:"ok"`
+}
 
 // jwtAuth is a custom middleware whose returned closure validates a JWT via
 // golang-jwt. apispec looks through it to jwt.Parse and marks wrapped routes as
@@ -20,8 +35,16 @@ func jwtAuth(next http.Handler) http.Handler {
 	})
 }
 
-func getUser(w http.ResponseWriter, r *http.Request) {}
-func health(w http.ResponseWriter, r *http.Request)  {}
+// getUser answers with the requested user.
+func getUser(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(User{ID: r.PathValue("id")})
+}
+
+// health answers with the service status.
+func health(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode(Status{OK: true})
+}
 
 func main() {
 	mux := http.NewServeMux()

--- a/testdata/handler_wrapper_attribution/go.mod
+++ b/testdata/handler_wrapper_attribution/go.mod
@@ -1,0 +1,3 @@
+module testdata/handler_wrapper_attribution
+
+go 1.22

--- a/testdata/handler_wrapper_attribution/main.go
+++ b/testdata/handler_wrapper_attribution/main.go
@@ -1,0 +1,78 @@
+// Package main registers the same handlers wrapped in middleware at the
+// registration site and directly, so the two operations can be compared: a
+// wrapper must not replace the handler it wraps (issue #364).
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type Item struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type CreateItem struct {
+	Name string `json:"name"`
+}
+
+// withLogging is the standard func(http.Handler) http.Handler middleware shape.
+func withLogging(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.Header.Get("X-Request-Id")
+		next.ServeHTTP(w, r)
+	})
+}
+
+// withAuth is a second wrapper, so a chain can be nested.
+func withAuth(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.Header.Get("Authorization")
+		next.ServeHTTP(w, r)
+	})
+}
+
+// withTiming is the HandlerFunc-shaped middleware: it takes and returns
+// http.HandlerFunc, so the handler it wraps is a plain ident rather than a
+// conversion.
+func withTiming(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		next(w, r)
+	}
+}
+
+// getItem returns one item.
+func getItem(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(Item{ID: r.PathValue("id")})
+}
+
+// createItem decodes a CreateItem body and returns 201 with an Item.
+func createItem(w http.ResponseWriter, r *http.Request) {
+	var in CreateItem
+	_ = json.NewDecoder(r.Body).Decode(&in)
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(Item{Name: in.Name})
+}
+
+func main() {
+	mux := http.NewServeMux()
+
+	// Wrapped at the registration site — the operation must still be the
+	// handler's, not the middleware's.
+	mux.Handle("GET /wrapped/items/{id}", withLogging(http.HandlerFunc(getItem)))
+	mux.Handle("POST /wrapped/items", withLogging(http.HandlerFunc(createItem)))
+
+	// Nested wrappers: the innermost handler is still the answer.
+	mux.Handle("GET /chained/items/{id}", withAuth(withLogging(http.HandlerFunc(getItem))))
+
+	// The HandlerFunc-shaped wrapper: same requirement, plain-ident argument.
+	mux.HandleFunc("GET /timed/items/{id}", withTiming(getItem))
+
+	// Controls: the same handlers registered directly.
+	mux.HandleFunc("GET /direct/items/{id}", getItem)
+	mux.HandleFunc("POST /direct/items", createItem)
+
+	_ = http.ListenAndServe(":8080", mux)
+}

--- a/testdata/handler_wrapper_attribution_chi/go.mod
+++ b/testdata/handler_wrapper_attribution_chi/go.mod
@@ -1,0 +1,5 @@
+module github.com/ehabterra/apispec/testdata/handler_wrapper_attribution_chi
+
+go 1.24.3
+
+require github.com/go-chi/chi/v5 v5.2.2

--- a/testdata/handler_wrapper_attribution_chi/go.sum
+++ b/testdata/handler_wrapper_attribution_chi/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=
+github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=

--- a/testdata/handler_wrapper_attribution_chi/main.go
+++ b/testdata/handler_wrapper_attribution_chi/main.go
@@ -1,0 +1,56 @@
+// Package main is the chi half of the handler-wrapper attribution fixture: the
+// defect is not net/http's, so the same wiring has to resolve here too
+// (issue #364, golden rule #5).
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type Item struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type CreateItem struct {
+	Name string `json:"name"`
+}
+
+// withLogging is the standard func(http.Handler) http.Handler middleware.
+func withLogging(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.Header.Get("X-Request-Id")
+		next.ServeHTTP(w, r)
+	})
+}
+
+// getItem returns one item.
+func getItem(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(Item{ID: chi.URLParam(r, "id")})
+}
+
+// createItem decodes a CreateItem body and returns 201 with an Item.
+func createItem(w http.ResponseWriter, r *http.Request) {
+	var in CreateItem
+	_ = json.NewDecoder(r.Body).Decode(&in)
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(Item{Name: in.Name})
+}
+
+func main() {
+	r := chi.NewRouter()
+
+	// Wrapped at the registration site.
+	r.Method("GET", "/wrapped/items/{id}", withLogging(http.HandlerFunc(getItem)))
+	r.Method("POST", "/wrapped/items", withLogging(http.HandlerFunc(createItem)))
+
+	// Controls: the same handlers registered directly.
+	r.Get("/direct/items/{id}", getItem)
+	r.Post("/direct/items", createItem)
+
+	_ = http.ListenAndServe(":8080", r)
+}


### PR DESCRIPTION
Fixes #364.

## The bug

`mux.Handle(p, withLogging(http.HandlerFunc(getItem)))` documented the **middleware**. Not under-documented — documented as something else:

| | before | after |
|---|---|---|
| operationId | `…withLogging` | `…getItem` |
| summary | the wrapper's doc comment | the handler's |
| parameters | the wrapper's header reads; `{id}` flagged *"present in the path but not found in the code"* | the handler's, `{id}` resolved |
| request body | missing | the handler's |
| responses | `default` | the handler's `200`/`201` |

## Three independent causes

1. **Identity.** `handlerArgValue` peeled exactly one shape — a type conversion (#221). It now also peels a wrapper **call**, repeatedly, so nested chains (`withAuth(withLogging(http.HandlerFunc(h)))`) resolve to the innermost handler.

2. **Expansion.** A conversion names a *type*, and a type has no body, so `http.HandlerFunc(getItem)` was a dead end anywhere it was not the route's own argument — which is exactly where a wrapper puts it. The tracker now expands what a conversion converts (`LazyNode.convertedValueKeys`). Self-limiting: a conversion of a non-function yields a key with no edges, so `[]byte(payload)` expands to nothing rather than to something wrong.

3. **Provenance.** #269's gate lets a route reach its own code through the handler **argument**, one hop from the registration. A wrapped handler sits two hops down, so the request body was refused. Call and conversion argument hops are now transparent; **variable and selector hops are not** — and since the lateral producer relation attaches only to those two kinds (`argProducerIDs`), #269's own case stays blocked by construction.

## What counts as a wrapper

The shape at the handler position, not the framework:

- a call whose callee **takes and returns the same type** — middleware in any framework, including a `Chain.Then(http.Handler) http.Handler` helper;
- **or** any call handed a **conversion of a function**, which carries the adapters whose own signature is not middleware-shaped (`gin.WrapH(mw(h))`, `echo.WrapHandler(mw(h))`).

Deliberately **not** peeled:

- a handler **factory** (`h.Create()`) — no argument is a handler, which is what #221's factory support needs;
- a call with **several** handler-shaped arguments — which one serves the route is genuinely ambiguous (golden rule #7);
- an **adapter** that takes a function without being middleware-shaped. `HandleRequest(handleCreateUser)` in `testdata/generic` turns a `func(Req) (Resp, error)` into an `http.HandlerFunc`; peeling it would rename those operations, which is #367's question and not this PR's. I checked: an earlier, broader rule did rename them, and this narrowing is what keeps that fixture byte-identical.

## Tests

- `testdata/handler_wrapper_attribution` (net/http) and `testdata/handler_wrapper_attribution_chi` register the **same handlers wrapped and directly**, so the test compares the two rather than a snapshot: whatever the direct route documents — operationId, summary, request body, response set, an unflagged path parameter — the wrapped one must document too. Two frameworks per golden rule #5. Covers the plain-ident wrapper (`func(http.HandlerFunc) http.HandlerFunc`) and the nested chain.
- `testdata/auth_nethttp_wrap`'s handlers gained a real body and status. With empty bodies an operation built from the middleware looked identical to a correct one, which is exactly why that fixture never caught this.
- `TestTestdata_AuthPresets` now asserts **which** handler each guarded operation is attributed to, not just that the security requirement resolved.
- Unit tests at the layer that changed: every peel and every refusal (`handlerArgValue`, `wrappedHandler`, `middlewareShaped`, `calleeFunctionOf`, `namesAFunction`, `convertedValueKeys`), including method values and edge-resolved callees.

## Found on the way

**#386** — gin takes its handler chain variadically (`r.GET(path, mw, h)`), so the configured handler position holds the middleware and the operation is built from it. Same symptom, different wiring: sibling arguments, nothing wrapped, so this PR's peel does not apply. The new auth assertion surfaced it; the expected value is pinned as a change detector with a comment pointing at #386.

Full suite, goldens and lint pass; coverage 96.0% (floor 96). The only fixture output that moves is `auth_nethttp_wrap` (operationId `jwtAuth` → `getUser`, plus the responses its new handler bodies produce) and `wrapper_router`'s `/api/items/count`, whose handler content now resolves through the conversion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved API specification generation for handlers wrapped in middleware, adapters, and type conversions.
  - Preserved accurate handler attribution and distinct operation IDs for wrapped and multiple handlers.
  - Maintained request-body, response, summary, and path-parameter details when handlers are wrapped.
  - Improved support for method values and nested wrapper patterns while safely ignoring ambiguous cases.

- **Tests**
  - Added comprehensive regression coverage across supported routing frameworks and wrapper scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->