### PR TITLE
feat(metadata): record function end lines and control-flow block ranges (#389)

### DIFF
--- a/internal/metadata/blocks.go
+++ b/internal/metadata/blocks.go
@@ -1,0 +1,234 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"go/ast"
+	"go/token"
+)
+
+// Control-flow block ranges.
+//
+// Metadata records where a call is written (`file:line:col` on the edge) but
+// nothing about the code AROUND it, so the only structural question a consumer
+// could previously ask was "same file?". That is too weak for anything that has
+// to reason about what runs together: a status write in one `if` arm and a body
+// write in the other arm are adjacent in source order and can never both run,
+// and line order alone cannot tell them apart.
+//
+// collectBlocks records each control-flow region of a body as a source range,
+// with two relations on top: PARENT (this region is nested in that one) and
+// GROUP (these regions are arms of one conditional, so at most one runs).
+// Together with Function.EndLine that is enough to place any call edge within
+// its function's control flow using only the position the edge already carries.
+//
+// Nothing here interprets the code — no matcher, no framework knowledge. It
+// records facts, and the spec layer decides what they mean (golden rule #4).
+
+// collectBlocks returns the control-flow regions of a function body in source
+// order. Nil for a declaration without one.
+func collectBlocks(body *ast.BlockStmt, fset *token.FileSet) []Block {
+	if body == nil || fset == nil {
+		return nil
+	}
+	c := &blockCollector{fset: fset}
+	c.stmts(body.List, 0)
+	return c.blocks
+}
+
+// blockCollector accumulates blocks in source order. Indices handed around are
+// 1-based (see Block.Parent), so 0 is "the function body itself".
+type blockCollector struct {
+	fset   *token.FileSet
+	blocks []Block
+	groups int
+}
+
+// add records one region and returns its 1-based index, for use as a parent.
+func (c *blockCollector) add(kind BlockKind, start, end token.Pos, parent, group int) int {
+	sp, ep := c.fset.Position(start), c.fset.Position(end)
+	c.blocks = append(c.blocks, Block{
+		Kind:      kind,
+		StartLine: sp.Line,
+		StartCol:  sp.Column,
+		EndLine:   ep.Line,
+		EndCol:    ep.Column,
+		Parent:    parent,
+		Group:     group,
+	})
+	return len(c.blocks)
+}
+
+// nextGroup mints the id shared by the arms of one conditional.
+func (c *blockCollector) nextGroup() int {
+	c.groups++
+	return c.groups
+}
+
+func (c *blockCollector) stmts(list []ast.Stmt, parent int) {
+	for _, stmt := range list {
+		c.stmt(stmt, parent)
+	}
+}
+
+// stmt records the regions a statement opens, then descends. Statements that
+// open nothing are still scanned for function literals, whose bodies are
+// regions of their own.
+func (c *blockCollector) stmt(stmt ast.Stmt, parent int) {
+	switch s := stmt.(type) {
+	case nil:
+		return
+
+	case *ast.BlockStmt:
+		idx := c.add(BlockPlain, s.Lbrace, s.Rbrace, parent, 0)
+		c.stmts(s.List, idx)
+
+	case *ast.IfStmt:
+		c.ifChain(s, parent)
+
+	case *ast.SwitchStmt:
+		c.stmt(s.Init, parent)
+		c.exprs(parent, s.Tag)
+		c.clauses(s.Body, parent)
+
+	case *ast.TypeSwitchStmt:
+		c.stmt(s.Init, parent)
+		c.stmt(s.Assign, parent)
+		c.clauses(s.Body, parent)
+
+	case *ast.SelectStmt:
+		c.clauses(s.Body, parent)
+
+	case *ast.ForStmt:
+		c.stmt(s.Init, parent)
+		c.exprs(parent, s.Cond)
+		c.stmt(s.Post, parent)
+		idx := c.add(BlockLoop, s.Body.Lbrace, s.Body.Rbrace, parent, 0)
+		c.stmts(s.Body.List, idx)
+
+	case *ast.RangeStmt:
+		c.exprs(parent, s.Key, s.Value, s.X)
+		idx := c.add(BlockLoop, s.Body.Lbrace, s.Body.Rbrace, parent, 0)
+		c.stmts(s.Body.List, idx)
+
+	case *ast.LabeledStmt:
+		c.stmt(s.Stmt, parent)
+
+	default:
+		// Anything else (an expression, an assignment, a return, a defer) opens
+		// no region of its own, but may carry a function literal that does.
+		c.funcLits(stmt, parent)
+	}
+}
+
+// ifChain records every arm of one if/else-if/else chain under a single group.
+// An `else if` is an ALTERNATIVE to the arm before it, not a region nested in
+// it, so walking the chain iteratively here is what keeps the group flat —
+// descending into the else as an ordinary statement would nest each arm inside
+// the previous one and lose the exclusivity relation.
+func (c *blockCollector) ifChain(stmt *ast.IfStmt, parent int) {
+	group := c.nextGroup()
+	for cur := stmt; cur != nil; {
+		// The init and condition run BEFORE the arm is entered and are not part
+		// of it — which is exactly why block ranges carry columns, since on a
+		// one-line `if` they share the arm's lines.
+		c.stmt(cur.Init, parent)
+		c.exprs(parent, cur.Cond)
+
+		idx := c.add(BlockIf, cur.Body.Lbrace, cur.Body.Rbrace, parent, group)
+		c.stmts(cur.Body.List, idx)
+
+		switch alt := cur.Else.(type) {
+		case *ast.IfStmt:
+			cur = alt // `else if`: another arm of this same chain
+		case *ast.BlockStmt:
+			elseIdx := c.add(BlockElse, alt.Lbrace, alt.Rbrace, parent, group)
+			c.stmts(alt.List, elseIdx)
+			cur = nil
+		default:
+			cur = nil
+		}
+	}
+}
+
+// clauses records the arms of a switch, type switch or select. Every arm shares
+// one group, the `default` included: it is as exclusive with the others as any
+// case, and the reason MethodBranch drops it (no verb to name it by) does not
+// apply to a plain control-flow fact.
+func (c *blockCollector) clauses(body *ast.BlockStmt, parent int) {
+	if body == nil {
+		return
+	}
+	group := c.nextGroup()
+	for _, clause := range body.List {
+		switch cl := clause.(type) {
+		case *ast.CaseClause:
+			kind := BlockCase
+			if len(cl.List) == 0 {
+				kind = BlockDefault
+			}
+			c.exprs(parent, cl.List...)
+			// A clause has no braces: its region runs from the colon to the end
+			// of its last statement, so the case expressions stay outside it.
+			idx := c.add(kind, cl.Colon, cl.End(), parent, group)
+			c.stmts(cl.Body, idx)
+		case *ast.CommClause:
+			kind := BlockCase
+			if cl.Comm == nil {
+				kind = BlockDefault
+			}
+			c.stmt(cl.Comm, parent)
+			idx := c.add(kind, cl.Colon, cl.End(), parent, group)
+			c.stmts(cl.Body, idx)
+		}
+	}
+}
+
+// exprs descends into expressions for function literals only.
+func (c *blockCollector) exprs(parent int, list ...ast.Expr) {
+	for _, expr := range list {
+		if expr != nil {
+			c.funcLits(expr, parent)
+		}
+	}
+}
+
+// funcLits records the body of every function literal written in a node that
+// opens no region itself. A literal gets no Function record, so this is the
+// only place its extent is recorded — and a literal reached from here is walked
+// with c.stmt, so control flow INSIDE it is recorded too (issue #382's shape: a
+// `switch r.Method` inside a closure handler).
+func (c *blockCollector) funcLits(node ast.Node, parent int) {
+	ast.Inspect(node, func(n ast.Node) bool {
+		lit, ok := n.(*ast.FuncLit)
+		if !ok || lit.Body == nil {
+			return true
+		}
+		idx := c.add(BlockFuncLit, lit.Body.Lbrace, lit.Body.Rbrace, parent, 0)
+		c.stmts(lit.Body.List, idx)
+		return false // this literal's interior is walked by c.stmts, not here
+	})
+}
+
+// bodyEndLine is the line of a declaration's closing brace, or 0 when it has no
+// body. Paired with Function.Position (its opening line) this bounds the
+// declaration, which is what distinguishes "written in this function" from
+// "written in this file".
+func bodyEndLine(fn *ast.FuncDecl, fset *token.FileSet) int {
+	if fn == nil || fn.Body == nil || fset == nil {
+		return 0
+	}
+	return fset.Position(fn.Body.Rbrace).Line
+}

--- a/internal/metadata/blocks_test.go
+++ b/internal/metadata/blocks_test.go
@@ -1,0 +1,305 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// parseBody parses a function body snippet and returns the blocks collected
+// from it, plus the fileset, so a test can also assert positions.
+func parseBody(t *testing.T, body string) ([]Block, *token.FileSet, *ast.FuncDecl) {
+	t.Helper()
+	src := "package p\n\nfunc h() {\n" + body + "\n}\n"
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "h.go", src, 0)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	for _, decl := range file.Decls {
+		if fn, ok := decl.(*ast.FuncDecl); ok && fn.Name.Name == "h" {
+			return collectBlocks(fn.Body, fset), fset, fn
+		}
+	}
+	t.Fatal("function h not found")
+	return nil, nil, nil
+}
+
+// shape renders the blocks as "kind:parent:group" in order, which is the whole
+// structure this file is about and reads far better than field-by-field asserts.
+func shape(blocks []Block) string {
+	parts := make([]string, 0, len(blocks))
+	for _, b := range blocks {
+		parts = append(parts, string(b.Kind)+":"+itoa(b.Parent)+":"+itoa(b.Group))
+	}
+	return strings.Join(parts, " ")
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "-"
+	}
+	return string(rune('0' + n))
+}
+
+func TestCollectBlocksShapes(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "if without else",
+			body: "if x() {\n  a()\n}",
+			want: "if:-:1",
+		},
+		{
+			// The whole chain is ONE group: every arm is an alternative, and
+			// none is nested in another. This is the relation the collector
+			// exists for.
+			name: "if else-if else chain",
+			body: "if x() {\n a()\n} else if y() {\n b()\n} else {\n c()\n}",
+			want: "if:-:1 if:-:1 else:-:1",
+		},
+		{
+			name: "two independent ifs get distinct groups",
+			body: "if x() {\n a()\n}\nif y() {\n b()\n}",
+			want: "if:-:1 if:-:2",
+		},
+		{
+			// A nested if is a region INSIDE the outer arm (parent 1) and its
+			// own conditional (group 2) — nesting and exclusivity are separate.
+			name: "nested if",
+			body: "if x() {\n if y() {\n  a()\n }\n}",
+			want: "if:-:1 if:1:2",
+		},
+		{
+			name: "switch cases share a group, default included",
+			body: "switch v() {\ncase 1:\n a()\ncase 2:\n b()\ndefault:\n c()\n}",
+			want: "case:-:1 case:-:1 default:-:1",
+		},
+		{
+			name: "type switch",
+			body: "switch v().(type) {\ncase int:\n a()\ndefault:\n b()\n}",
+			want: "case:-:1 default:-:1",
+		},
+		{
+			name: "select",
+			body: "select {\ncase <-ch():\n a()\ndefault:\n b()\n}",
+			want: "case:-:1 default:-:1",
+		},
+		{
+			// A loop body is exclusive with nothing, so it carries no group.
+			name: "for and range bodies carry no group",
+			body: "for i := 0; i < 3; i++ {\n a()\n}\nfor range s() {\n b()\n}",
+			want: "loop:-:- loop:-:-",
+		},
+		{
+			name: "bare block",
+			body: "{\n a()\n}",
+			want: "block:-:-",
+		},
+		{
+			name: "function literal body is a region",
+			body: "f(func() {\n a()\n})",
+			want: "func:-:-",
+		},
+		{
+			// The shape behind issue #382: control flow inside a closure is
+			// recorded, parented to the closure's body.
+			name: "conditional inside a function literal",
+			body: "f(func() {\n if x() {\n  a()\n } else {\n  b()\n }\n})",
+			want: "func:-:- if:1:1 else:1:1",
+		},
+		{
+			name: "literal in an if arm is parented to the arm",
+			body: "if x() {\n f(func() {\n  a()\n })\n}",
+			want: "if:-:1 func:1:-",
+		},
+		{
+			name: "labeled statement is transparent",
+			body: "loop:\nfor {\n a()\n}",
+			want: "loop:-:-",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			blocks, _, _ := parseBody(t, tc.body)
+			if got := shape(blocks); got != tc.want {
+				t.Errorf("blocks =\n  %q\nwant\n  %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCollectBlocksRangesAreColumnPrecise pins the reason ranges carry columns:
+// on a one-line `if`, the arm and the code around it share every line, so a
+// line-only range cannot answer containment. Written as a containment assertion
+// rather than as literal numbers so it states the property, not the layout.
+func TestCollectBlocksRangesAreColumnPrecise(t *testing.T) {
+	// The call in the init runs before the arm; the call in the body is inside
+	// it. Both sit on the same line.
+	src := "if err := before(); err != nil { inside() }"
+	blocks, fset, fn := parseBody(t, src)
+	if len(blocks) != 1 {
+		t.Fatalf("want 1 block, got %d (%s)", len(blocks), shape(blocks))
+	}
+	arm := blocks[0]
+	if arm.StartLine != arm.EndLine {
+		t.Fatalf("this fixture is meant to be one line, got %d..%d", arm.StartLine, arm.EndLine)
+	}
+
+	var before, inside token.Position
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if ident, ok := call.Fun.(*ast.Ident); ok {
+			switch ident.Name {
+			case "before":
+				before = fset.Position(ident.Pos())
+			case "inside":
+				inside = fset.Position(ident.Pos())
+			}
+		}
+		return true
+	})
+	if before.Line == 0 || inside.Line == 0 {
+		t.Fatal("did not find both calls")
+	}
+	if contains(arm, before) {
+		t.Errorf("call in the if's init reported as inside the arm (line-only ranges would say this)")
+	}
+	if !contains(arm, inside) {
+		t.Errorf("call in the if's body reported as outside the arm")
+	}
+}
+
+// contains is the containment test a consumer of Block would write.
+func contains(b Block, pos token.Position) bool {
+	afterStart := pos.Line > b.StartLine || (pos.Line == b.StartLine && pos.Column >= b.StartCol)
+	beforeEnd := pos.Line < b.EndLine || (pos.Line == b.EndLine && pos.Column <= b.EndCol)
+	return afterStart && beforeEnd
+}
+
+// TestCollectBlocksExclusivity demonstrates the question the group answers: two
+// statements that cannot both run, though they are adjacent in source order.
+func TestCollectBlocksExclusivity(t *testing.T) {
+	blocks, _, _ := parseBody(t, "if x() {\n a()\n} else {\n b()\n}\nif y() {\n c()\n}")
+	if len(blocks) != 3 {
+		t.Fatalf("want 3 blocks, got %d (%s)", len(blocks), shape(blocks))
+	}
+	ifArm, elseArm, other := blocks[0], blocks[1], blocks[2]
+	if ifArm.Group != elseArm.Group {
+		t.Errorf("if and else arms must share a group: %d vs %d", ifArm.Group, elseArm.Group)
+	}
+	if other.Group == ifArm.Group {
+		t.Errorf("an unrelated if must not share the first chain's group")
+	}
+	if ifArm.Group == 0 || other.Group == 0 {
+		t.Errorf("conditional arms must carry a group, got %d and %d", ifArm.Group, other.Group)
+	}
+}
+
+func TestCollectBlocksNilSafety(t *testing.T) {
+	if got := collectBlocks(nil, token.NewFileSet()); got != nil {
+		t.Errorf("nil body: want nil, got %v", got)
+	}
+	if got := collectBlocks(&ast.BlockStmt{}, nil); got != nil {
+		t.Errorf("nil fileset: want nil, got %v", got)
+	}
+	if got := collectBlocks(&ast.BlockStmt{}, token.NewFileSet()); got != nil {
+		t.Errorf("empty body: want nil, got %v", got)
+	}
+	// A synthesized switch with no clause list: the parser never produces one,
+	// but metadata is also built over nodes this package synthesizes, and a
+	// collector that panicked there would take a whole run down.
+	synthetic := &ast.BlockStmt{List: []ast.Stmt{
+		&ast.SwitchStmt{},
+		&ast.SelectStmt{},
+	}}
+	if got := collectBlocks(synthetic, token.NewFileSet()); got != nil {
+		t.Errorf("switch/select without a body: want nil, got %v", got)
+	}
+}
+
+// TestBlockSurvivesYAMLRoundTrip guards the 1-BASED encoding of Parent and
+// Group. Metadata is written and read back (LoadMetadata), and these fields are
+// omitempty, so a plain 0-based index would serialize "the first block" and
+// "no parent" identically — reading back a nesting relation that was never
+// written. The zero value has to mean "none" for that reason, and this test
+// fails if anyone re-bases the indices.
+func TestBlockSurvivesYAMLRoundTrip(t *testing.T) {
+	blocks, _, _ := parseBody(t, "if x() {\n if y() {\n  a()\n } else {\n  b()\n }\n}")
+	if got := shape(blocks); got != "if:-:1 if:1:2 else:1:2" {
+		t.Fatalf("fixture shape changed: %q", got)
+	}
+
+	data, err := yaml.Marshal(blocks)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back []Block
+	if err := yaml.Unmarshal(data, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got := shape(back); got != shape(blocks) {
+		t.Errorf("round trip changed the structure:\n got %q\nwant %q\nyaml:\n%s",
+			shape(back), shape(blocks), data)
+	}
+	// The outermost arm has no parent, so its field must be absent rather than
+	// written as an index some reader would resolve to a block.
+	if strings.Contains(strings.SplitN(string(data), "- kind: if", 2)[1][:60], "parent:") {
+		t.Errorf("a parentless block serialized a parent field:\n%s", data)
+	}
+}
+
+func TestBodyEndLine(t *testing.T) {
+	src := "package p\n\nfunc h() {\n a()\n}\n\nfunc noBody()\n"
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "h.go", src, 0)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var withBody, without *ast.FuncDecl
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		if fn.Name.Name == "h" {
+			withBody = fn
+		} else {
+			without = fn
+		}
+	}
+	if got := bodyEndLine(withBody, fset); got != 5 {
+		t.Errorf("bodyEndLine = %d, want 5 (the closing brace)", got)
+	}
+	if got := bodyEndLine(without, fset); got != 0 {
+		t.Errorf("declaration without a body: bodyEndLine = %d, want 0", got)
+	}
+	if got := bodyEndLine(nil, fset); got != 0 {
+		t.Errorf("nil declaration: bodyEndLine = %d, want 0", got)
+	}
+}

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -1200,6 +1200,8 @@ func processFunctions(file *ast.File, info *types.Info, pkgName string, fset *to
 			Returns:        allReturns,
 			AssignmentMap:  assignmentsInFunc,
 			MethodDispatch: detectMethodDispatch(fn.Body, info, fset),
+			EndLine:        bodyEndLine(fn, fset),
+			Blocks:         collectBlocks(fn.Body, fset),
 		}
 
 		f.Functions[fn.Name.Name].SignatureStr = metadata.StringPool.Get(CallArgToString(&f.Functions[fn.Name.Name].Signature))

--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -952,7 +952,84 @@ type Function struct {
 	// body, so a net/http handler that branches on the verb can be split into
 	// one operation per HTTP method. Empty for handlers that don't dispatch.
 	MethodDispatch []MethodBranch `yaml:"method_dispatch,omitempty"`
+
+	// EndLine is the last line of the declaration (the body's closing brace),
+	// so a statement located by position can be tested for membership in THIS
+	// function rather than merely in the same FILE — which is all Position
+	// alone supports, and is why method-dispatch attribution has to fall back
+	// to a same-file test. Zero for a declaration with no body (an assembly or
+	// cgo stub).
+	EndLine int `yaml:"end_line,omitempty"`
+
+	// Blocks records the body's control-flow regions in source order. See Block:
+	// it is what lets a consumer tell that two statements sit in arms of one
+	// conditional that cannot both run, which line order alone cannot say.
+	Blocks []Block `yaml:"blocks,omitempty"`
 }
+
+// Block is one control-flow region of a function body: an `if` or `else` arm, a
+// `switch`/`select` case, a loop body, a bare block, or a function literal's
+// body. Recorded as a source range rather than as statements, because every
+// consumer of this locates code by the position it already has on a call edge.
+//
+// Ranges carry COLUMNS, not just lines. A one-line `if err != nil { return }`
+// and a call in an `if`'s init statement (`if err := f(); err != nil {`) both
+// share a line with the arm they are not inside, so a line-only range answers
+// containment wrongly for exactly the shapes control flow is being consulted
+// about. MethodBranch predates this and stays line-only; it compares against a
+// case clause, where the distinction does not arise.
+type Block struct {
+	Kind      BlockKind `yaml:"kind,omitempty"`
+	StartLine int       `yaml:"start_line,omitempty"`
+	StartCol  int       `yaml:"start_col,omitempty"`
+	EndLine   int       `yaml:"end_line,omitempty"`
+	EndCol    int       `yaml:"end_col,omitempty"`
+
+	// Parent is the 1-BASED index into Function.Blocks of the enclosing block,
+	// or 0 for a block sitting directly in the function body. One-based so that
+	// "no parent" is the zero value and the field stays out of serialized
+	// metadata; a plain index could not distinguish "block 0" from "none".
+	Parent int `yaml:"parent,omitempty"`
+
+	// Group ties together the arms of ONE conditional — every arm of an
+	// if/else-if/else chain, or every case of one switch or select — with a
+	// 1-based id unique within the function. Two blocks sharing a group are
+	// alternatives: at most one of them runs. Zero for a region whose siblings
+	// are not alternatives (a loop body, a bare block, a function literal).
+	//
+	// This is the fact that line ranges alone cannot supply. Nesting says a
+	// statement is INSIDE a region; only the group says two regions are
+	// mutually exclusive.
+	Group int `yaml:"group,omitempty"`
+}
+
+// BlockKind names what opened a Block. A string rather than a packed enum
+// because these are shared constants (no per-block allocation) and they are
+// read in byte-compared golden metadata, where a number would be unreadable.
+type BlockKind string
+
+const (
+	// BlockIf is the body of an `if` — including each `else if` in a chain,
+	// which is an alternative arm of the same conditional, not a nested one.
+	BlockIf BlockKind = "if"
+	// BlockElse is the final `else` arm of an if chain.
+	BlockElse BlockKind = "else"
+	// BlockCase is one `case` of a switch, type switch, or select.
+	BlockCase BlockKind = "case"
+	// BlockDefault is the `default` arm of a switch or select. It is an
+	// alternative like any case, and unlike MethodBranch — which drops it,
+	// having no verb to name it by — it is recorded here.
+	BlockDefault BlockKind = "default"
+	// BlockLoop is a `for` or `range` body: entered zero or more times, and
+	// exclusive with nothing, so it carries no group.
+	BlockLoop BlockKind = "loop"
+	// BlockPlain is a bare `{ … }` block.
+	BlockPlain BlockKind = "block"
+	// BlockFuncLit is a function literal's body. Recorded inside the enclosing
+	// declaration because a literal gets no Function record of its own, so
+	// without this its extent is invisible.
+	BlockFuncLit BlockKind = "func"
+)
 
 // MethodBranch is one arm of an `r.Method` dispatch: the HTTP method(s) it
 // handles and the source line range of its body, used to attribute each

--- a/internal/spec/tests/complex.yaml
+++ b/internal/spec/tests/complex.yaml
@@ -796,6 +796,7 @@ packages:
                   position: 80
                   resolved_type: -1
                   generic_type_name: -1
+            end_line: 34
           NewService:
             name: 69
             pkg: 2
@@ -973,6 +974,7 @@ packages:
                   position: 68
                   resolved_type: -1
                   generic_type_name: -1
+            end_line: 30
           main:
             name: 92
             pkg: 2
@@ -1099,6 +1101,7 @@ packages:
                   func: 92
                   callee_func: NewService
                   callee_pkg: complex
+            end_line: 40
         struct_instances:
           - type: 45
             pkg: 2

--- a/internal/spec/tests/constants.yaml
+++ b/internal/spec/tests/constants.yaml
@@ -128,6 +128,7 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   func: 23
+            end_line: 23
           init:
             name: 13
             pkg: 10
@@ -183,6 +184,7 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   func: 13
+            end_line: 16
         variables:
           GlobalVar:
             name: 37

--- a/internal/spec/tests/example.yaml
+++ b/internal/spec/tests/example.yaml
@@ -613,6 +613,7 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   func: 62
+            end_line: 37
           main:
             name: 73
             pkg: 2
@@ -699,6 +700,7 @@ packages:
                   func: 73
                   callee_func: NewUser
                   callee_pkg: example
+            end_line: 42
         struct_instances:
           - type: 29
             pkg: 2

--- a/internal/spec/tests/generic.yaml
+++ b/internal/spec/tests/generic.yaml
@@ -556,6 +556,7 @@ packages:
                   position: 40
                   resolved_type: -1
                   generic_type_name: -1
+            end_line: 17
           Process:
             name: 58
             pkg: 2
@@ -674,6 +675,14 @@ packages:
                   position: 55
                   resolved_type: -1
                   generic_type_name: -1
+            end_line: 25
+            blocks:
+              - kind: if
+                start_line: 21
+                start_col: 21
+                end_line: 23
+                end_col: 2
+                group: 1
           main:
             name: 76
             pkg: 2
@@ -948,6 +957,7 @@ packages:
                   func: 76
                   callee_func: Get
                   callee_pkg: generic
+            end_line: 35
         struct_instances:
           - type: 95
             pkg: 2

--- a/internal/spec/tests/main.yaml
+++ b/internal/spec/tests/main.yaml
@@ -201,6 +201,7 @@ packages:
                   func: 7
                   callee_func: Sprintf
                   callee_pkg: fmt
+            end_line: 14
         imports:
           16: 16
           27: 27

--- a/internal/spec/tests/multipackage.yaml
+++ b/internal/spec/tests/multipackage.yaml
@@ -426,6 +426,7 @@ packages:
                   func: 19
                   callee_func: NewUser
                   callee_pkg: multipackage/models
+            end_line: 15
         imports:
           7: 7
           21: 21
@@ -970,6 +971,7 @@ packages:
                   position: 79
                   resolved_type: -1
                   generic_type_name: -1
+            end_line: 26
         struct_instances:
           - type: 60
             pkg: 7
@@ -1949,6 +1951,7 @@ packages:
                   position: 123
                   resolved_type: -1
                   generic_type_name: -1
+            end_line: 14
         struct_instances:
           - type: 34
             pkg: 21
@@ -2697,6 +2700,7 @@ packages:
                   position: 139
                   resolved_type: -1
                   generic_type_name: -1
+            end_line: 7
           ValidateAge:
             name: 155
             pkg: 132
@@ -2884,6 +2888,7 @@ packages:
                   position: 147
                   resolved_type: -1
                   generic_type_name: -1
+            end_line: 11
         variables:
           DefaultFormat:
             name: 167


### PR DESCRIPTION
First step of #389. Adds two metadata facts; **nothing consumes them yet**.

## Why

Metadata records where a call is written (`file:line:col` on the edge) and nothing about the code around it, so the only structural question a consumer could ask was *"same file?"*. That is too weak for anything that has to reason about what runs together:

```go
if err != nil {
    ctx.WriteHeader(400)      // a status write
    ctx.JSON(problem)         // ... paired with THIS body
} else {
    ctx.JSON(user)            // never with this one
}
```

Those three statements are adjacent in source order and line order cannot separate them. It is also why `method_dispatch.go`'s `insideHandler` is a same-*file* test: `Function.Position` is `fn.Pos()` and there was no end position, so "written in this function" had no way to be asked.

## What

- **`Function.EndLine`** — the body's closing brace (0 for a bodyless declaration). With `Position` it bounds the declaration.
- **`Function.Blocks`** — the body's control-flow regions in source order. Each `Block` has a kind (`if`, `else`, `case`, `default`, `loop`, `block`, `func`), a source range, and two relations:
  - **Parent** — nesting.
  - **Group** — a 1-based id shared by the arms of *one* conditional. Two blocks in the same group are alternatives: at most one runs.

The group is the part line ranges cannot supply. Nesting says a statement is *inside* a region; only the group says two regions are *mutually exclusive*.

Both are recorded, neither is interpreted — no matcher, no framework knowledge (golden rule #4). `MethodBranch` is untouched.

## Three decisions worth reviewing

**Ranges carry columns.** A one-line `if err := before(); err != nil { inside() }` puts the init call and the arm on the same line, so a line-only range answers containment wrongly for exactly the shapes control flow is consulted about. `TestCollectBlocksRangesAreColumnPrecise` asserts the property (init call outside the arm, body call inside) rather than literal numbers. `MethodBranch` stays line-only: it compares against a case clause, where the distinction does not arise.

**An `else if` is an ARM, not a nested block.** The chain is walked iteratively, so `if / else if / else` is three blocks in one group at one depth. Descending into the `else` as an ordinary statement would nest each arm inside the previous one and lose the exclusivity relation.

**`Parent` and `Group` are 1-BASED.** Metadata is read back through `LoadMetadata`, and both fields are `omitempty` — a plain 0-based index would serialize "the first block" and "no parent" identically, so a reader would resolve a nesting relation that was never written. `TestBlockSurvivesYAMLRoundTrip` fails if anyone re-bases them.

Function literals get their bodies recorded inside the enclosing declaration, with control flow *inside* them recorded too. A literal has no `Function` record of its own, so this is the only place its extent exists — which is also #382's shape.

## Cost

Blocks are collected for every function in every loaded package, so the overhead was measured over gitea's whole source tree:

```
11,907 functions -> 37,592 blocks   (3.2 per function)
collectBlocks over the corpus:  44 ms
retained:                      2.3 MB   (64 B per block)
```

Against a run whose metadata stage is ~20 s and whose peak RSS is in gigabytes, that is noise — it did not resolve against run-to-run variance in the stage timing.

## Verification

- Full suite green with a cold cache; `go vet` and `golangci-lint` clean.
- `TestGenerateMetadataDeterministic` passes; block order is AST walk order and group ids are minted in that order, so nothing here can reach output unsorted.
- Coverage ratchet holds at 96.0%, `blocks.go` at 100% per function.
- The six metadata goldens were regenerated with the documented `-update`: 23 added lines, only `end_line` in most of them — `generic.yaml` is the one fixture with a conditional in it, and it is where `blocks:` shows up.

## What this unblocks

In #389, response body-to-status attribution is defined over enumerated tracker paths (`pending[chain]`), which is why the tree materialises 15.7M nodes on gitea and why bounding the copies costs response bodies. Replacing that with summaries instantiated per binding needs pairing to happen *within* a function, respecting branches — which is what these facts make possible. Measured there: 99.7% of response statements yield one outcome across every chain they are reached through.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Function metadata now includes the ending source line for each function.
  * Added detailed control-flow block metadata, including nesting, conditional branches, loops, switch cases, and function literals.
  * Block locations include precise line and column ranges.

* **Tests**
  * Added comprehensive coverage for block detection, source ranges, nesting, serialization, and edge cases.
  * Updated metadata fixtures with function end-line and control-flow details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->