### PR TITLE
fix: a status write only claims a body it dominates (#389)

### DIFF
--- a/generator/testdata_branch_status_scope_test.go
+++ b/generator/testdata_branch_status_scope_test.go
@@ -1,0 +1,131 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	intspec "github.com/ehabterra/apispec/internal/spec"
+	"github.com/ehabterra/apispec/spec"
+)
+
+// TestTestdata_BranchStatusScope locks in that a status write only claims a
+// body the write DOMINATES — same function, written first, and inside no region
+// the body escaped.
+//
+// Before the rule, `if bad { WriteHeader(400); return }` above a success body
+// gave that body the 400: the endpoint documented its error status carrying its
+// success schema, and had no success response at all. Measured on this fixture,
+// /guard was `400(Item)` and became `200(Item) 400(no content)`.
+//
+// Statuses are asserted together with whether each carries a body, because the
+// defect was never a missing status — it was the wrong status carrying the
+// schema.
+func TestTestdata_BranchStatusScope(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "branch_status_scope", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+
+	// status -> the schema name it carries, "" for a bodyless response.
+	want := map[string]map[string]string{
+		// The guard's 400 is bodyless and the success body is an implicit 200.
+		"/guard/{id}": {"400": "", "200": "Item"},
+		// Control: the body written INSIDE the arm that set the status does
+		// carry it, and the success body below is unaffected.
+		"/paired/{id}": {"400": "APIError", "200": "Item"},
+		// Nesting is not escaping: a body deeper inside the same arm is still
+		// dominated by the status write.
+		"/nested/{id}": {"400": "APIError", "200": "Item"},
+		// A loop may run zero times, so the status does not dominate what
+		// follows it.
+		"/loop": {"202": "", "200": "array"},
+		// Neither arm's status dominates the body below the branch, so the
+		// honest answer is that it carries neither (golden rule #7). Before the
+		// rule the body took whichever arm the walk saw last.
+		"/arms": {"202": "", "206": "", "200": "Item"},
+		// CHANGE DETECTOR for issue #391, not the behaviour this fixture is
+		// for: the 201 dominates BOTH bodies, but a pending status is consumed
+		// by the first one, so the second falls through to the implicit 200.
+		// When #391 is fixed this becomes {"201": "Item"} alone.
+		"/before": {"201": "Item", "200": "Item"},
+	}
+
+	for path, wantResponses := range want {
+		item, ok := out.Paths[path]
+		if !ok {
+			t.Errorf("path %q missing; have %v", path, mapPathKeys(out.Paths))
+			continue
+		}
+		op := opFor(item, "GET")
+		if op == nil {
+			t.Errorf("GET %s: expected operation, missing", path)
+			continue
+		}
+
+		gotStatuses := make([]string, 0, len(op.Responses))
+		for status := range op.Responses {
+			gotStatuses = append(gotStatuses, status)
+		}
+		wantStatuses := make([]string, 0, len(wantResponses))
+		for status := range wantResponses {
+			wantStatuses = append(wantStatuses, status)
+		}
+		sort.Strings(gotStatuses)
+		sort.Strings(wantStatuses)
+		if !equalStrings(gotStatuses, wantStatuses) {
+			t.Errorf("GET %s: responses %v, want %v", path, gotStatuses, wantStatuses)
+			continue
+		}
+
+		for status, wantSchema := range wantResponses {
+			gotSchema := schemaNameOf(op.Responses[status])
+			if gotSchema != wantSchema {
+				what := "a body of " + wantSchema
+				if wantSchema == "" {
+					what = "no body"
+				}
+				t.Errorf("GET %s response %s: carries %q, want %s",
+					path, status, gotSchema, what)
+			}
+		}
+	}
+}
+
+// schemaNameOf names the schema a response carries: the bare component name for
+// a $ref, the type for an inline schema, and "" when there is no content at all.
+// Media types are visited in sorted order so a response with more than one
+// cannot make the assertion depend on map order.
+func schemaNameOf(resp intspec.Response) string {
+	types := make([]string, 0, len(resp.Content))
+	for mediaType := range resp.Content {
+		types = append(types, mediaType)
+	}
+	sort.Strings(types)
+	for _, mediaType := range types {
+		schema := resp.Content[mediaType].Schema
+		if schema == nil {
+			continue
+		}
+		if ref := schema.Ref; ref != "" {
+			name := ref[strings.LastIndexByte(ref, '/')+1:]
+			// Components are named after the fully-qualified type; the fixture
+			// only needs the type itself.
+			return name[strings.LastIndexByte(name, '_')+1:]
+		}
+		return schema.Type
+	}
+	return ""
+}

--- a/internal/spec/control_flow.go
+++ b/internal/spec/control_flow.go
@@ -1,0 +1,170 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"sort"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// Control-flow queries over the block ranges metadata records (Function.Blocks).
+//
+// The question this answers is "if execution reached B, must it have passed
+// through A?" — which is what decides whether a status write can claim a body
+// write. Source order alone says only that A is written above B, and that is a
+// different thing:
+//
+//	if err != nil {
+//	    w.WriteHeader(400)          // A
+//	    return
+//	}
+//	json.NewEncoder(w).Encode(user) // B — reached only when A did NOT run
+//
+// A is written first, so an order-based pairing gives B a 400 it can never
+// carry. A cannot dominate B because A sits inside a region B is outside of,
+// which is exactly what block ranges make visible.
+//
+// The rule is deliberately one-directional: it rejects a pairing, never invents
+// one. Where the facts are missing (no block recorded, a position that will not
+// parse) it answers "dominates", leaving the existing behaviour in place —
+// missing facts must not silently change a spec (golden rule #7).
+
+// codePos is a source position: the file plus a (line, column) point in it.
+type codePos struct {
+	file string
+	line int
+	col  int
+}
+
+func (p codePos) valid() bool { return p.file != "" && p.line > 0 }
+
+// beforeOrAt reports whether p is at or ahead of q within the same file.
+func (p codePos) beforeOrAt(q codePos) bool {
+	if p.line != q.line {
+		return p.line < q.line
+	}
+	return p.col <= q.col
+}
+
+// blockIndex holds every recorded control-flow region of a file, from every
+// function declared in it.
+//
+// Keyed by FILE rather than by function on purpose: a function literal has no
+// Function record of its own, so its regions are recorded inside the enclosing
+// declaration, and a caller identified as `pkg.FuncLit:pos` could not look
+// itself up. Positions are absolute, so containment answers the question
+// without needing to know which declaration a statement belongs to.
+type blockIndex struct {
+	byFile map[string][]metadata.Block
+}
+
+// newBlockIndex collects the blocks of every function into per-file buckets.
+func newBlockIndex(meta *metadata.Metadata) *blockIndex {
+	idx := &blockIndex{byFile: map[string][]metadata.Block{}}
+	if meta == nil {
+		return idx
+	}
+	for _, pkgName := range meta.SortedPackageNames() {
+		pkg := meta.Packages[pkgName]
+		if pkg == nil {
+			continue
+		}
+		for _, fileName := range meta.SortedFileNames(pkgName) {
+			file := pkg.Files[fileName]
+			if file == nil {
+				continue
+			}
+			for _, fnName := range sortedFunctionNames(file) {
+				fn := file.Functions[fnName]
+				if fn == nil || len(fn.Blocks) == 0 {
+					continue
+				}
+				at := fileOfPosition(meta.StringPool.GetString(fn.Position))
+				if at == "" {
+					continue
+				}
+				idx.byFile[at] = append(idx.byFile[at], fn.Blocks...)
+			}
+		}
+	}
+	return idx
+}
+
+// sortedFunctionNames orders a file's functions so the index is built the same
+// way on every run. Nothing here reaches the spec by iteration order — the
+// queries are conjunctions over the matching blocks — but a map range that can
+// grow into an output path is the bug golden rule #1 exists for.
+func sortedFunctionNames(file *metadata.File) []string {
+	names := make([]string, 0, len(file.Functions))
+	for name := range file.Functions {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// contains reports whether a block's range covers the position. Columns are
+// compared, not just lines: a one-line `if` shares every line with the code
+// around it, which is the case this exists to get right.
+func blockContains(b metadata.Block, pos codePos) bool {
+	afterStart := pos.line > b.StartLine || (pos.line == b.StartLine && pos.col >= b.StartCol)
+	beforeEnd := pos.line < b.EndLine || (pos.line == b.EndLine && pos.col <= b.EndCol)
+	return afterStart && beforeEnd
+}
+
+// dominates reports whether every execution that reaches later must first have
+// passed through earlier: they are in the same file, earlier is written first,
+// and no region encloses earlier without also enclosing later.
+//
+// Conservative in one direction only. Unknown positions, an unindexed file, or
+// a pair the block facts cannot separate all answer true, so a caller that used
+// to pair them still does.
+func (idx *blockIndex) dominates(earlier, later codePos) bool {
+	if idx == nil || !earlier.valid() || !later.valid() {
+		return true
+	}
+	if earlier.file != later.file {
+		// Different files means different functions, and pairing is per
+		// invocation, so this is not a case the caller can produce. Answer
+		// permissively rather than inventing a rule for it.
+		return true
+	}
+	if !earlier.beforeOrAt(later) {
+		return false
+	}
+	for _, b := range idx.byFile[earlier.file] {
+		if blockContains(b, earlier) && !blockContains(b, later) {
+			// earlier is inside a region later escaped: an `if` arm, a loop, a
+			// switch case. Reaching later does not imply earlier ran.
+			return false
+		}
+	}
+	return true
+}
+
+// Mutual exclusion — two positions in arms of one conditional, which
+// Block.Group records — is the other question these facts answer, and the one a
+// summary of a function's responses needs when it merges the arms of a branch.
+// Dominance already rejects every pair the pairing rule cares about, so no
+// exclusivity query is written here until that summary needs one.
+
+// controlFlow returns the extractor's block index, built on first use.
+func (e *Extractor) controlFlow() *blockIndex {
+	if e.blocks == nil {
+		e.blocks = newBlockIndex(e.metadata())
+	}
+	return e.blocks
+}

--- a/internal/spec/control_flow_test.go
+++ b/internal/spec/control_flow_test.go
@@ -1,0 +1,258 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"sort"
+	"testing"
+
+	meta "github.com/ehabterra/apispec/internal/metadata"
+)
+
+// armAt builds a block standing for a region spanning whole lines, which is
+// what every case here needs except the column test.
+func armAt(startLine, endLine int) meta.Block {
+	return meta.Block{
+		Kind:      meta.BlockIf,
+		StartLine: startLine, StartCol: 1,
+		EndLine: endLine, EndCol: 80,
+		Group: 1,
+	}
+}
+
+func at(line, col int) codePos { return codePos{file: "h.go", line: line, col: col} }
+
+func indexOf(blocks ...meta.Block) *blockIndex {
+	return &blockIndex{byFile: map[string][]meta.Block{"h.go": blocks}}
+}
+
+func TestDominates(t *testing.T) {
+	cases := []struct {
+		name    string
+		idx     *blockIndex
+		earlier codePos
+		later   codePos
+		want    bool
+	}{
+		{
+			// The guard clause: the status is inside an arm the body escaped,
+			// so reaching the body means the status did not run.
+			name:    "status inside an arm the body escapes",
+			idx:     indexOf(armAt(10, 13)),
+			earlier: at(11, 3),
+			later:   at(15, 2),
+			want:    false,
+		},
+		{
+			name:    "both inside the same arm",
+			idx:     indexOf(armAt(10, 13)),
+			earlier: at(11, 3),
+			later:   at(12, 3),
+			want:    true,
+		},
+		{
+			// Nesting is not escaping: the body is deeper in, but every path to
+			// it still passed the status write.
+			name:    "body nested deeper inside the same arm",
+			idx:     indexOf(armAt(10, 16), armAt(12, 14)),
+			earlier: at(11, 3),
+			later:   at(13, 4),
+			want:    true,
+		},
+		{
+			// The rule is about the STATUS escaping, not the body: a status at
+			// top level dominates a body inside a branch below it.
+			name:    "status above the branch, body inside it",
+			idx:     indexOf(armAt(12, 15)),
+			earlier: at(10, 2),
+			later:   at(13, 3),
+			want:    true,
+		},
+		{
+			name:    "neither inside any region",
+			idx:     indexOf(armAt(20, 25)),
+			earlier: at(10, 2),
+			later:   at(11, 2),
+			want:    true,
+		},
+		{
+			name:    "written after the body",
+			idx:     indexOf(),
+			earlier: at(14, 2),
+			later:   at(11, 2),
+			want:    false,
+		},
+		{
+			// Same line: only the column separates them.
+			name:    "same line, earlier column first",
+			idx:     indexOf(),
+			earlier: at(11, 2),
+			later:   at(11, 30),
+			want:    true,
+		},
+		{
+			name:    "same line, earlier column after",
+			idx:     indexOf(),
+			earlier: at(11, 30),
+			later:   at(11, 2),
+			want:    false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.idx.dominates(tc.earlier, tc.later); got != tc.want {
+				t.Errorf("dominates(%v, %v) = %v, want %v", tc.earlier, tc.later, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDominatesIsPermissiveWithoutFacts pins the direction of the conservatism:
+// where the facts are missing the answer is "dominates", so a pairing that
+// happened before still happens. A missing fact must never silently change a
+// spec (golden rule #7).
+func TestDominatesIsPermissiveWithoutFacts(t *testing.T) {
+	idx := indexOf(armAt(10, 13))
+	cases := []struct {
+		name           string
+		earlier, later codePos
+	}{
+		{"no position for the status", codePos{}, at(15, 2)},
+		{"no position for the body", at(11, 3), codePos{}},
+		{"unknown file", codePos{file: "other.go", line: 11, col: 3}, codePos{file: "other.go", line: 15, col: 2}},
+		{"positions in different files", codePos{file: "a.go", line: 11, col: 3}, codePos{file: "b.go", line: 2, col: 2}},
+		{"line zero", codePos{file: "h.go", line: 0, col: 3}, at(15, 2)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !idx.dominates(tc.earlier, tc.later) {
+				t.Errorf("dominates(%v, %v) = false; missing facts must keep the previous pairing",
+					tc.earlier, tc.later)
+			}
+		})
+	}
+	var nilIdx *blockIndex
+	if !nilIdx.dominates(at(11, 3), at(15, 2)) {
+		t.Error("a nil index must answer permissively")
+	}
+}
+
+// TestDominatesColumnsSeparateAOneLineArm is the case line-only ranges get
+// wrong: the init call and the arm share every line, and only the column says
+// the call is outside.
+func TestDominatesColumnsSeparateAOneLineArm(t *testing.T) {
+	// if err := before(); err != nil { inside(); return }
+	// col:   9 (before)              33 (arm start)  35 (inside)   50 (arm end)
+	arm := meta.Block{
+		Kind:      meta.BlockIf,
+		StartLine: 7, StartCol: 33,
+		EndLine: 7, EndCol: 50,
+		Group: 1,
+	}
+	idx := indexOf(arm)
+
+	// A status written in the init dominates a body below the statement: it is
+	// not inside the arm at all.
+	if !idx.dominates(at(7, 9), at(9, 2)) {
+		t.Error("a call in the if's init must not be treated as inside the arm")
+	}
+	// A status written inside the one-line arm does not dominate a body below.
+	if idx.dominates(at(7, 35), at(9, 2)) {
+		t.Error("a call inside the one-line arm must not dominate what follows the statement")
+	}
+}
+
+// TestNewBlockIndexFromMetadata builds the index the way a run does — from
+// generated metadata — and asks it the guard-clause question. It covers the
+// step the hand-built indexes above skip: bucketing each function's blocks
+// under the FILE its position names, which is what lets a position be resolved
+// without knowing which declaration (or which function literal) it sits in.
+func TestNewBlockIndexFromMetadata(t *testing.T) {
+	src := `package main
+
+func guard(bad bool) {
+	if bad {
+		fail()
+		return
+	}
+	succeed()
+}
+
+func fail()    {}
+func succeed() {}
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "guard.go", src, 0)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	info := &types.Info{
+		Types: map[ast.Expr]types.TypeAndValue{},
+		Defs:  map[*ast.Ident]types.Object{},
+		Uses:  map[*ast.Ident]types.Object{},
+	}
+	if _, err := (&types.Config{}).Check("main", fset, []*ast.File{file}, info); err != nil {
+		t.Fatalf("typecheck: %v", err)
+	}
+	pkgs := map[string]map[string]*ast.File{"main": {"guard.go": file}}
+	md := meta.GenerateMetadata(pkgs, map[*ast.File]*types.Info{file: info}, map[string]string{"main": "main"}, fset)
+
+	idx := newBlockIndex(md)
+	blocks := idx.byFile["guard.go"]
+	if len(blocks) != 1 {
+		t.Fatalf("want the one `if` arm indexed under guard.go, got %d blocks (files: %v)",
+			len(blocks), indexedFiles(idx.byFile))
+	}
+	if blocks[0].Kind != meta.BlockIf || blocks[0].Group == 0 {
+		t.Errorf("indexed block = %+v, want an if arm carrying a group", blocks[0])
+	}
+
+	// fail() is inside the arm, succeed() below it: the shape the rule rejects.
+	inArm := codePos{file: "guard.go", line: 5, col: 3}
+	belowArm := codePos{file: "guard.go", line: 8, col: 2}
+	if idx.dominates(inArm, belowArm) {
+		t.Error("a call inside the returning arm must not dominate the call below it")
+	}
+	if !idx.dominates(belowArm, codePos{file: "guard.go", line: 8, col: 20}) {
+		t.Error("two positions outside every region must dominate in source order")
+	}
+}
+
+func indexedFiles(m map[string][]meta.Block) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestNewBlockIndexNilMetadata(t *testing.T) {
+	idx := newBlockIndex(nil)
+	if idx == nil {
+		t.Fatal("newBlockIndex(nil) must return an empty index, not nil")
+	}
+	if len(idx.byFile) != 0 {
+		t.Errorf("want an empty index, got %d files", len(idx.byFile))
+	}
+	if !idx.dominates(at(1, 1), at(2, 1)) {
+		t.Error("an empty index must answer permissively")
+	}
+}

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -229,6 +229,9 @@ type Extractor struct {
 	// is over the whole call graph and pairAndFillResponses runs once per
 	// route extraction context.
 	callDepthsByFn map[string]map[string]int
+	// blocks indexes the recorded control-flow regions of every file, for the
+	// dominance question response pairing asks. Built once, on first use.
+	blocks *blockIndex
 	// extractedRouteIDs marks route identities whose subtree walk has
 	// already run in this extraction. Fragment extraction is pure, so a
 	// re-visit of the same (function, mount, path, method) through another
@@ -1408,6 +1411,12 @@ func (e *Extractor) pairAndFillResponses(route *RouteInfo, candidates []response
 
 	pending := map[string]bool{} // chain -> a bodyless status awaits its body
 	pendingStatus := map[string]int{}
+	// chain -> where that pending status was written. A body may only claim it
+	// if the write DOMINATES the body: same file, written first, and inside no
+	// region the body escaped. `if err != nil { WriteHeader(400); return }`
+	// followed by the success body is the shape this rejects — source order
+	// alone hands that body a 400 it can never carry (see control_flow.go).
+	pendingAt := map[string]codePos{}
 	// chain -> a status write on it did NOT resolve. The handler states a
 	// status; we just could not read it. A body written after that is emphatically
 	// NOT the framework's implicit status — the server sends whatever that call
@@ -1424,6 +1433,7 @@ func (e *Extractor) pairAndFillResponses(route *RouteInfo, candidates []response
 			store(f.resp)
 			pending[f.chain] = true
 			pendingStatus[f.chain] = status
+			pendingAt[f.chain] = codePos{file: f.file, line: f.line, col: f.col}
 		case known:
 			store(f.resp)
 		case f.resp.StatusUnresolved:
@@ -1435,10 +1445,12 @@ func (e *Extractor) pairAndFillResponses(route *RouteInfo, candidates []response
 			if statusUnresolved[f.chain] {
 				f.resp.ImplicitStatus = 0
 			}
-			if pending[f.chain] {
+			bodyAt := codePos{file: f.file, line: f.line, col: f.col}
+			if pending[f.chain] && e.controlFlow().dominates(pendingAt[f.chain], bodyAt) {
 				f.resp.StatusCode = pendingStatus[f.chain]
 				delete(pending, f.chain)
 				delete(pendingStatus, f.chain)
+				delete(pendingAt, f.chain)
 				store(f.resp)
 			} else {
 				unpaired = append(unpaired, f)

--- a/testdata/branch_status_scope/go.mod
+++ b/testdata/branch_status_scope/go.mod
@@ -1,0 +1,3 @@
+module github.com/ehabterra/apispec/testdata/branch_status_scope
+
+go 1.22

--- a/testdata/branch_status_scope/main.go
+++ b/testdata/branch_status_scope/main.go
@@ -1,0 +1,117 @@
+// Fixture: a status write only claims a body the write DOMINATES.
+//
+// Response pairing walks fragments in source order, so a status written above a
+// body used to claim it whatever the control flow between them. A guard clause
+// is the shape that breaks on: `if bad { WriteHeader(400); return }` sits above
+// the success body, but a request that reaches that body is precisely one where
+// the 400 did NOT run. The endpoint ended up documented with its error status
+// carrying its success schema, and with no success response at all.
+//
+// Each handler here isolates one relation between the status write and the body
+// write. See generator/testdata_branch_status_scope_test.go.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type Item struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type APIError struct {
+	Message string `json:"message"`
+}
+
+func main() {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("GET /guard/{id}", guardBodyless)
+	mux.HandleFunc("GET /paired/{id}", pairedInArm)
+	mux.HandleFunc("GET /nested/{id}", nestedInArm)
+	mux.HandleFunc("GET /loop", statusInLoop)
+	mux.HandleFunc("GET /arms", statusInEveryArm)
+	mux.HandleFunc("GET /before", statusBeforeBranch)
+
+	http.ListenAndServe(":8080", mux)
+}
+
+// guardBodyless is the shape this fixture exists for: the 400 is written in a
+// branch that returns, so the body below it is reached only when the 400 did
+// not run. The 400 is bodyless and the success body is an implicit 200.
+func guardBodyless(w http.ResponseWriter, r *http.Request) {
+	if r.PathValue("id") == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	_ = json.NewEncoder(w).Encode(Item{ID: r.PathValue("id")})
+}
+
+// pairedInArm is the control: the body is written INSIDE the arm that set the
+// status, so it does carry it. Nothing about this case may change.
+func pairedInArm(w http.ResponseWriter, r *http.Request) {
+	if r.PathValue("id") == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(APIError{Message: "id is required"})
+		return
+	}
+	_ = json.NewEncoder(w).Encode(Item{ID: r.PathValue("id")})
+}
+
+// nestedInArm writes the body deeper inside the arm that set the status. Every
+// path to the body still passes the status write, so it is paired — nesting is
+// not escaping.
+func nestedInArm(w http.ResponseWriter, r *http.Request) {
+	if r.PathValue("id") == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		if r.URL.Query().Get("verbose") != "" {
+			_ = json.NewEncoder(w).Encode(APIError{Message: "id is required"})
+		}
+		return
+	}
+	_ = json.NewEncoder(w).Encode(Item{ID: r.PathValue("id")})
+}
+
+// statusInLoop writes the status inside a loop, which may run zero times, so
+// the body below it is not dominated by the write.
+func statusInLoop(w http.ResponseWriter, r *http.Request) {
+	for _, v := range r.URL.Query()["reset"] {
+		if v == "1" {
+			w.WriteHeader(http.StatusAccepted)
+		}
+	}
+	_ = json.NewEncoder(w).Encode([]Item{{ID: "1"}})
+}
+
+// statusInEveryArm states a different status on each arm and writes the body
+// below the branch. No single write dominates the body, so which status it
+// carries is genuinely undetermined — the honest answer is neither of them
+// rather than whichever the walk saw last (golden rule #7).
+func statusInEveryArm(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Query().Get("async") != "" {
+		w.WriteHeader(http.StatusAccepted)
+	} else {
+		w.WriteHeader(http.StatusPartialContent)
+	}
+	_ = json.NewEncoder(w).Encode(Item{ID: "1"})
+}
+
+// statusBeforeBranch writes the status unconditionally, then a body on each
+// side of a branch. Every path to both bodies passed the write, so both are
+// 201s.
+//
+// Only the FIRST of them is: a pending status is consumed by the body that
+// claims it, so the second falls through to the implicit 200 (issue #391).
+// That is a separate defect from the dominance rule this fixture is for — the
+// status here dominates both bodies — so the structural test pins the current
+// answer as a change detector and flips when #391 is fixed.
+func statusBeforeBranch(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusCreated)
+	if r.URL.Query().Get("full") != "" {
+		_ = json.NewEncoder(w).Encode(Item{ID: "1", Name: "full"})
+		return
+	}
+	_ = json.NewEncoder(w).Encode(Item{ID: "1"})
+}


### PR DESCRIPTION
Second step of #389, and the first consumer of the block ranges from #390.

## The defect

Response pairing walks fragments in source order, so a status written above a body claimed it whatever the control flow in between. gitea's `/ssh_info`:

```go
func SSHInfo(rw http.ResponseWriter, req *http.Request) {
	if !git.DefaultFeatures().SupportProcReceive {
		rw.WriteHeader(http.StatusNotFound)                        // written first...
		return
	}
	rw.Header().Set("content-type", "text/json;charset=UTF-8")
	_, err := rw.Write([]byte(`{"type":"agit","version":1}`))      // ...claimed this
	...
	rw.WriteHeader(http.StatusOK)
}
```

was documented as

```yaml
"200": { content: { application/json: {} } }          # no schema
"404": { content: { application/json: { schema: { type: string, format: byte } } } }
```

The 404 is bodyless in reality, and the payload belongs to the 200. An error status holding the success schema is worse than a missing response — a client generator believes it.

Source order cannot see this. A request that reaches the body is precisely one where the 404 did *not* run.

## The rule

A body may claim a pending status only if the write **dominates** it: same file, written first, and inside no region the body escaped. Answered from `Function.Blocks`, so an `if` arm, a `switch` case and a loop body all behave the same way with none of them special-cased.

**Conservative in one direction only.** An unknown position, an unindexed file, or a pair the facts cannot separate all answer "dominates", so every pairing that happened before still happens. A missing fact must never silently change a spec (golden rule #7), and `TestDominatesIsPermissiveWithoutFacts` pins that direction.

The index is keyed by FILE, not by function: a function literal has no `Function` record of its own, so its regions are recorded inside the enclosing declaration and a caller identified as `pkg.FuncLit:pos` could not look itself up. Positions are absolute, so containment answers the question without knowing which declaration a statement belongs to.

## Measured

**gitea, 900 paths: exactly one operation changes** — `/ssh_info`, whose body moves off the 404 onto the 200. Operations 1109 → 1109, responses 2351 → 2351, responses carrying a body 2322 → 2322, statuses gained 0, statuses lost 0. Everything else is byte-identical, and no fixture in the suite moved.

The fixture, before and after:

| endpoint | before | after |
|---|---|---|
| `/guard/{id}` | `400(Item)` | `200(Item) 400(no content)` |
| `/loop` | `202(array)` | `200(array) 202(no content)` |
| `/arms` | `202(-) 206(Item)` | `200(Item) 202(-) 206(-)` |
| `/paired/{id}` | `200(Item) 400(APIError)` | unchanged |
| `/nested/{id}` | `200(Item) 400(APIError)` | unchanged |

`/arms` is the honest case: a status on each arm and the body below the branch, so no write dominates it and it carries neither (golden rule #7) rather than whichever arm the walk happened to see last.

## Found on the way: #391

`/before` writes `WriteHeader(201)` unconditionally, then a body on each side of a branch. The 201 dominates both, but a pending status is consumed by the first body that claims it, so the second falls through to the implicit 200. That is a separate defect — deleting the pending entry was load-bearing before this rule existed — so it is filed as #391, and `TestTestdata_BranchStatusScope` pins the current answer as a change detector that flips when it is fixed.

## Verification

Full suite green with a cold cache, `go vet` and `golangci-lint` clean, coverage ratchet holding at 96.0%.

## What is next in #389

Dominance is what makes pairing a property of the FUNCTION rather than of the tracker path. The remaining steps: dedupe response candidates by `(site, bindings)` instead of `(chain, site)`, then let the extraction walk skip a subtree it has already processed for those bindings — which is what stops the tree materialising 15.7M nodes, since `GetChildren` only builds what the walk descends into.

Mutual exclusion (`Block.Group`) is the other question the facts answer, and the one a summary needs when merging the arms of a branch. Dominance already rejects every pair the pairing rule cares about, so no exclusivity query is written until that summary needs one.
