### PR TITLE
fix: a response with no body carries no content block (#393)

### DIFF
--- a/generator/testdata_status_without_body_test.go
+++ b/generator/testdata_status_without_body_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"sort"
+	"testing"
+
+	intspec "github.com/ehabterra/apispec/internal/spec"
+	"github.com/ehabterra/apispec/spec"
+)
+
+// responseCodesOf lists an operation's status codes, sorted, for failure
+// messages that have to say what WAS emitted.
+func responseCodesOf(responses map[string]intspec.Response) []string {
+	codes := make([]string, 0, len(responses))
+	for code := range responses {
+		codes = append(codes, code)
+	}
+	sort.Strings(codes)
+	return codes
+}
+
+// TestTestdata_StatusWithoutBody locks in issue #393: a status the handler
+// writes without a body carries no `content` block.
+//
+// It used to be emitted as `content: {application/json: {}}`, which is not "no
+// body" — an empty media-type object says there IS a body of that type whose
+// shape could not be described. On gitea that was half of all responses.
+//
+// The statuses here are ordinary ones (403, 418), deliberately not the RFC
+// bodyless codes #169 already handles: the rule is about the handler writing no
+// body, not about the code forbidding one.
+func TestTestdata_StatusWithoutBody(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "status_without_body", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+
+	for path, status := range map[string]string{
+		"/forbidden": "403",
+		"/teapot":    "418",
+	} {
+		item, ok := out.Paths[path]
+		if !ok {
+			t.Errorf("path %q missing; have %v", path, mapPathKeys(out.Paths))
+			continue
+		}
+		op := opFor(item, "GET")
+		if op == nil {
+			t.Errorf("GET %s: expected operation, missing", path)
+			continue
+		}
+		resp, ok := op.Responses[status]
+		if !ok {
+			t.Errorf("GET %s: response %s missing; have %v", path, status, responseCodesOf(op.Responses))
+			continue
+		}
+		if len(resp.Content) != 0 {
+			t.Errorf("GET %s response %s: has content %v, want none — the handler writes no body",
+				path, status, resp.Content)
+		}
+		if resp.Description == "" {
+			t.Errorf("GET %s response %s: lost its description", path, status)
+		}
+	}
+
+	// The control: a handler that does write a body keeps its schema, so the
+	// rule cannot be satisfied by dropping every content block.
+	item, ok := out.Paths["/item"]
+	if !ok {
+		t.Fatalf("path /item missing; have %v", mapPathKeys(out.Paths))
+	}
+	op := opFor(item, "GET")
+	if op == nil {
+		t.Fatal("GET /item: expected operation, missing")
+	}
+	resp, ok := op.Responses["200"]
+	if !ok {
+		t.Fatalf("GET /item: response 200 missing; have %v", responseCodesOf(op.Responses))
+	}
+	media, ok := resp.Content["application/json"]
+	if !ok {
+		t.Fatalf("GET /item 200: expected a JSON body, got content %v", resp.Content)
+	}
+	if media.Schema == nil || media.Schema.Ref == "" {
+		t.Errorf("GET /item 200: want a $ref to the Item schema, got %+v", media.Schema)
+	}
+}

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -856,6 +856,20 @@ func buildResponses(respInfo map[string]*ResponseInfo) map[string]Response {
 			continue
 		}
 
+		// No body was found at this status, so say so by omitting `content`
+		// (issue #393). An empty media-type object is not "no body" — it reads
+		// as "there IS a body of this type and I cannot describe its shape",
+		// which a handler that only calls WriteHeader never claims.
+		//
+		// A body that WAS found but could not be typed keeps its content block:
+		// BodyType and Schema are set together in the extractor, so a set
+		// BodyType means a body is really written here, and dropping it would
+		// assert an empty response just as wrongly (golden rule #7).
+		if resp.Schema == nil && resp.BodyType == "" {
+			responses[statusCode] = Response{Description: description}
+			continue
+		}
+
 		responses[statusCode] = Response{
 			Description: description,
 			Content: map[string]MediaType{

--- a/internal/spec/response_bodyless_test.go
+++ b/internal/spec/response_bodyless_test.go
@@ -64,3 +64,53 @@ func TestBuildResponses_BodylessOmitsContent(t *testing.T) {
 		t.Error("status 200 must keep its content block")
 	}
 }
+
+// TestBuildResponses_NoBodyOmitsContent pins issue #393, and the distinction it
+// turns on. An empty media-type object is not "no body" — it reads as "there IS
+// a body of this type whose shape I cannot describe" — so the two cases that
+// both arrive with a nil Schema must render differently:
+//
+//   - no body was found at all (a bare WriteHeader): no content;
+//   - a body was found but could not be typed: content kept, because claiming
+//     an empty response would be wrong in the other direction.
+//
+// BodyType is what separates them: the extractor sets it alongside Schema in
+// its body branch, so a set BodyType means a body really is written there.
+func TestBuildResponses_NoBodyOmitsContent(t *testing.T) {
+	r := buildResponses(map[string]*ResponseInfo{
+		// `w.WriteHeader(http.StatusForbidden)` and nothing else.
+		"403": {StatusCode: 403, ContentType: "application/json"},
+		// A body was found; the type did not map to a schema.
+		"500": {StatusCode: 500, ContentType: "application/json", BodyType: "internal.Opaque"},
+		// A body that mapped, for contrast.
+		"200": {StatusCode: 200, ContentType: "application/json", BodyType: "Widget",
+			Schema: &Schema{Ref: "#/components/schemas/Widget"}},
+	})
+
+	noBody, ok := r["403"]
+	if !ok {
+		t.Fatal("status 403 missing from responses")
+	}
+	if len(noBody.Content) != 0 {
+		t.Errorf("a status written with no body must have no content, got %v", noBody.Content)
+	}
+	if noBody.Description == "" {
+		t.Error("status 403 should retain a description")
+	}
+
+	untyped, ok := r["500"]
+	if !ok {
+		t.Fatal("status 500 missing from responses")
+	}
+	media, ok := untyped.Content["application/json"]
+	if !ok {
+		t.Fatalf("a body that could not be typed must keep its content block, got %v", untyped.Content)
+	}
+	if media.Schema != nil {
+		t.Errorf("no schema was resolvable, so none should be invented: %v", media.Schema)
+	}
+
+	if resp, ok := r["200"]; !ok || resp.Content["application/json"].Schema == nil {
+		t.Error("a resolved body must keep its schema")
+	}
+}

--- a/testdata/status_without_body/go.mod
+++ b/testdata/status_without_body/go.mod
@@ -1,0 +1,3 @@
+module github.com/ehabterra/apispec/testdata/status_without_body
+
+go 1.22

--- a/testdata/status_without_body/main.go
+++ b/testdata/status_without_body/main.go
@@ -1,0 +1,45 @@
+// Fixture: a response with no body must carry no `content` block.
+//
+// A status the handler writes without ever writing a body was still emitted as
+// `content: {application/json: {}}` — an empty media-type object, which says
+// "there IS a JSON body, and I cannot describe it". That is a different claim
+// from "there is no body", and it is the wrong one: a client generator reads it
+// as an unknown-shaped payload and a validator sees a body where none is sent.
+//
+// The distinction the mapper has to keep is between a response with no body at
+// all (here) and one whose body was seen but could not be typed, which keeps
+// its content block. See internal/spec/mapper_test.go.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type Item struct {
+	ID string `json:"id"`
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /forbidden", forbidden)
+	mux.HandleFunc("GET /teapot", teapot)
+	mux.HandleFunc("GET /item", item)
+	http.ListenAndServe(":8080", mux)
+}
+
+// forbidden writes a status and nothing else: no body, so no content.
+func forbidden(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusForbidden)
+}
+
+// teapot is the same shape at another status, to prove nothing is special-cased
+// about the code itself.
+func teapot(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusTeapot)
+}
+
+// item is the control: a real body, which must keep its schema.
+func item(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode(Item{ID: "1"})
+}


### PR DESCRIPTION
Closes #393.

## The problem

A status the handler writes without ever writing a body was emitted as

```yaml
"403":
  description: Forbidden
  content:
    application/json: {}
```

for

```go
func forbidden(w http.ResponseWriter, r *http.Request) {
	w.WriteHeader(http.StatusForbidden)
}
```

`content: {application/json: {}}` is not "no body". An empty media-type object says there IS a JSON body whose shape could not be described: a client generator emits an unknown-shaped payload for it, and a validator expects bytes the server never sends.

**On gitea this was 1,183 of 2,351 responses — 50.3% of the document** making a claim no handler makes.

`isBodylessStatus` already omits content for the codes RFC 9110 forbids a body on (#169, 1xx/204/205/304). It has nothing to say about the ordinary shape this is about: a 400, 403 or 500 guard clause that writes a status and returns.

## The distinction that makes it a two-line fix rather than a one-line one

Two different situations reach the mapper with a nil `Schema`:

1. **No body was found at all** — a bare `WriteHeader`. Emit no content.
2. **A body was found but could not be typed** — the empty content block is the honest answer here: there IS a body, of a shape we cannot describe. Dropping it would assert an empty response, which is the same error in the other direction (golden rule #7).

`ResponseInfo.BodyType` separates them: the extractor assigns it alongside `Schema` in its body branch, so a set `BodyType` means a body really is written there whether or not it mapped.

## Measured on gitea

| | before | after |
|---|---|---|
| responses | 2,351 | 2,351 |
| responses carrying a schema | 1,139 | **1,139** |
| empty content blocks | **1,183** | **37** |
| responses that lost a schema | — | **0** |

The 37 that remain are case 2 — error paths (`ctx.APIErrorInternal(err)` and friends) whose payload type does not resolve. Spot-checked `DELETE /admin/actions/runners/{runner_id}`, which reaches a body write through a shared helper that apispec cannot type; keeping its block is the intended behaviour, not residue.

## Coverage

- `testdata/status_without_body` — 403 and 418 written with no body, plus a real body as the control, so the rule cannot be satisfied by dropping every content block. Ordinary statuses on purpose: the rule is about the handler writing no body, not about the code forbidding one.
- `TestBuildResponses_NoBodyOmitsContent` — the untypeable-body case, as a unit test on `buildResponses`. Building an unresolvable body through the whole pipeline would test the type resolver rather than this distinction.

Full suite green with a cold cache, `go vet` and `golangci-lint` clean, coverage ratchet holding at 96.0%.

## Note on the snapshot artifacts

`scripts/compare-spec.sh` will show a large diff against pre-change snapshots: every bodyless response loses its `content` key. That is the intended change, and the structural tests are unaffected.

Independent of #392 (branched from main, no overlap in the files touched). When both land, a guard-clause status ends up both correctly bodyless *and* free of the empty block — which is how `testdata/multipart_upload`'s 400 stops claiming an `UploadResult`.
