### PR TITLE
fix: a field with no schema mapping is no longer a null property (#395)

### DIFF
--- a/generator/testdata_interface_field_schema_test.go
+++ b/generator/testdata_interface_field_schema_test.go
@@ -60,7 +60,7 @@ func TestTestdata_InterfaceFieldSchema(t *testing.T) {
 	if sample == nil {
 		t.Fatal("Sample component missing")
 	}
-	for _, field := range []string{"ratio", "smaller"} {
+	for _, field := range []string{"ratio", "smaller", "optional"} {
 		s, ok := sample.Properties[field]
 		if !ok {
 			t.Errorf("%s property missing; have %v", field, propertyNames(sample))
@@ -73,5 +73,24 @@ func TestTestdata_InterfaceFieldSchema(t *testing.T) {
 		if s.Type != "" || s.Ref != "" {
 			t.Errorf("%s property = %+v, want the empty schema (any)", field, s)
 		}
+	}
+
+	// A container of an unmappable type: the fallback has to apply where the
+	// schema is BUILT, not only where a property is stored, or the nil is kept
+	// as items/additionalProperties one level up and crashes the same reader.
+	if series := sample.Properties["series"]; series == nil {
+		t.Error("series property missing")
+	} else if series.Items == nil {
+		t.Error("series.items is null — the container form of the same defect")
+	} else if series.Items.Type != "" || series.Items.Ref != "" {
+		t.Errorf("series.items = %+v, want the empty schema", series.Items)
+	}
+
+	if byName := sample.Properties["by_name"]; byName == nil {
+		t.Error("by_name property missing")
+	} else if byName.AdditionalProperties == nil {
+		t.Error("by_name.additionalProperties is null — the map form of the same defect")
+	} else if byName.AdditionalProperties.Type != "" || byName.AdditionalProperties.Ref != "" {
+		t.Errorf("by_name.additionalProperties = %+v, want the empty schema", byName.AdditionalProperties)
 	}
 }

--- a/generator/testdata_interface_field_schema_test.go
+++ b/generator/testdata_interface_field_schema_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/spec"
+)
+
+// TestTestdata_InterfaceFieldSchema locks in issue #395: a struct field whose
+// type has no schema mapping must not be emitted as a null property.
+//
+// `Err error` is the shape that surfaced it. metadata classifies `error` as
+// primitive, so the mapper skipped the $ref branch, found no case for it, and
+// stored the nil it got back — `properties: {err: null}`. A reader that walks
+// properties dereferences that and dies ("Cannot read properties of null
+// (reading '$ref')" in ReDoc 2.5.3).
+func TestTestdata_InterfaceFieldSchema(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "interface_field_schema", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+	noNullSchemas(t, out)
+
+	failure := componentByName(out, "PushFailure")
+	if failure == nil {
+		t.Fatal("PushFailure component missing")
+	}
+	// An error is an interface, so it is documented like `any` — the mapping
+	// the same switch already gives interface{} and any.
+	errProp, ok := failure.Properties["err"]
+	if !ok {
+		t.Fatalf("err property missing; have %v", propertyNames(failure))
+	}
+	if errProp == nil {
+		t.Fatal("err property is null — the defect this fixture is for")
+	}
+	if errProp.Type != "object" {
+		t.Errorf("err property = %+v, want an object like any/interface{}", errProp)
+	}
+	// The ordinary fields beside it are unaffected.
+	if s := failure.Properties["message"]; s == nil || s.Type != "string" {
+		t.Errorf("message property = %+v, want a string", s)
+	}
+
+	// A type nothing can honestly map — encoding/json cannot marshal a complex
+	// number at all — gets the empty schema rather than an invented type.
+	sample := componentByName(out, "Sample")
+	if sample == nil {
+		t.Fatal("Sample component missing")
+	}
+	for _, field := range []string{"ratio", "smaller"} {
+		s, ok := sample.Properties[field]
+		if !ok {
+			t.Errorf("%s property missing; have %v", field, propertyNames(sample))
+			continue
+		}
+		if s == nil {
+			t.Errorf("%s property is null", field)
+			continue
+		}
+		if s.Type != "" || s.Ref != "" {
+			t.Errorf("%s property = %+v, want the empty schema (any)", field, s)
+		}
+	}
+}

--- a/generator/testdata_smoke_test.go
+++ b/generator/testdata_smoke_test.go
@@ -15,7 +15,9 @@
 package generator
 
 import (
+	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -103,6 +105,57 @@ func noUnresolvedPlaceholders(t *testing.T, out *spec.OpenAPISpec) {
 // component. A dangling $ref (e.g. a specialised `data` ref whose
 // payload type was never registered) is the exact failure Redoc reports
 // as "Invalid reference token".
+// noNullSchemas fails when any schema slot in the document is null.
+//
+// A null is not a vaguer description than the empty schema — it is an invalid
+// document, and a reader that walks properties dereferences it and dies (issue
+// #395). noDanglingRefs cannot catch this: its walker returns early on nil, so
+// a null property looks like the end of a branch rather than a defect.
+func noNullSchemas(t *testing.T, out *spec.OpenAPISpec) {
+	t.Helper()
+	if out.Components == nil {
+		return
+	}
+	var walk func(s *intspec.Schema, path string)
+	walk = func(s *intspec.Schema, path string) {
+		if s == nil {
+			t.Errorf("null schema at %s", path)
+			return
+		}
+		for name, c := range s.Properties {
+			walk(c, path+".properties."+name)
+		}
+		if s.Items != nil {
+			walk(s.Items, path+".items")
+		}
+		if s.AdditionalProperties != nil {
+			walk(s.AdditionalProperties, path+".additionalProperties")
+		}
+		for i, c := range s.AllOf {
+			walk(c, fmt.Sprintf("%s.allOf[%d]", path, i))
+		}
+		for i, c := range s.OneOf {
+			walk(c, fmt.Sprintf("%s.oneOf[%d]", path, i))
+		}
+		for i, c := range s.AnyOf {
+			walk(c, fmt.Sprintf("%s.anyOf[%d]", path, i))
+		}
+	}
+	for name, s := range out.Components.Schemas {
+		walk(s, "components.schemas."+name)
+	}
+}
+
+// propertyNames lists a schema's property names for failure messages.
+func propertyNames(s *intspec.Schema) []string {
+	names := make([]string, 0, len(s.Properties))
+	for name := range s.Properties {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
 func noDanglingRefs(t *testing.T, out *spec.OpenAPISpec) {
 	t.Helper()
 	if out.Components == nil {

--- a/generator/testdata_wrapper_nil_payload_test.go
+++ b/generator/testdata_wrapper_nil_payload_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	intspec "github.com/ehabterra/apispec/internal/spec"
+	"github.com/ehabterra/apispec/spec"
+)
+
+// TestTestdata_WrapperNilPayload guards the pair that has to stay apart when a
+// response envelope is specialised per call site.
+//
+// A payload the caller did not supply — `respondJSON(w, nil)`, the shape of
+// every logout and delete endpoint — is nothing to specialise, so the response
+// is the envelope itself. A real payload still composes an allOf naming the
+// concrete type.
+//
+// The empty-schema fallback for unmappable types (#395) briefly broke the first
+// half: `nil` stopped resolving to a nil schema, so the override fired with a
+// schema that constrains nothing and wrapped the base $ref in an allOf whose
+// second member said nothing. It cost 27 responses on a 163-route service
+// before it was caught by a snapshot comparison.
+func TestTestdata_WrapperNilPayload(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "wrapper_nil_payload", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+	noNullSchemas(t, out)
+
+	// No payload: the envelope, plainly. An allOf here is the defect.
+	logout := responseSchemaOf(t, out, "/logout", "GET", "200")
+	if len(logout.AllOf) != 0 {
+		t.Errorf("GET /logout: composed an allOf for a nil payload: %+v", logout.AllOf)
+	}
+	if !strings.HasSuffix(logout.Ref, "_Envelope") {
+		t.Errorf("GET /logout: schema = %+v, want a $ref to Envelope", logout)
+	}
+
+	// A real payload: still specialised, naming the concrete type.
+	profile := responseSchemaOf(t, out, "/profile", "GET", "200")
+	if len(profile.AllOf) != 2 {
+		t.Fatalf("GET /profile: want an allOf of the envelope and its data, got %+v", profile)
+	}
+	if !strings.HasSuffix(profile.AllOf[0].Ref, "_Envelope") {
+		t.Errorf("GET /profile: first allOf member = %+v, want the Envelope $ref", profile.AllOf[0])
+	}
+	data, ok := profile.AllOf[1].Properties["data"]
+	if !ok {
+		t.Fatalf("GET /profile: second allOf member has no data property: %+v", profile.AllOf[1])
+	}
+	if !strings.HasSuffix(data.Ref, "_User") {
+		t.Errorf("GET /profile: data = %+v, want a $ref to User", data)
+	}
+}
+
+// responseSchemaOf returns the JSON schema of one response, failing the test
+// when any step of the path is missing.
+func responseSchemaOf(t *testing.T, out *spec.OpenAPISpec, path, method, status string) *intspec.Schema {
+	t.Helper()
+	item, ok := out.Paths[path]
+	if !ok {
+		t.Fatalf("path %q missing; have %v", path, mapPathKeys(out.Paths))
+	}
+	op := opFor(item, method)
+	if op == nil {
+		t.Fatalf("%s %s: operation missing", method, path)
+	}
+	resp, ok := op.Responses[status]
+	if !ok {
+		t.Fatalf("%s %s: response %s missing; have %v", method, path, status, responseCodesOf(op.Responses))
+	}
+	media, ok := resp.Content["application/json"]
+	if !ok {
+		t.Fatalf("%s %s response %s: no JSON content", method, path, status)
+	}
+	if media.Schema == nil {
+		t.Fatalf("%s %s response %s: null schema", method, path, status)
+	}
+	return media.Schema
+}

--- a/internal/spec/handler_value.go
+++ b/internal/spec/handler_value.go
@@ -74,7 +74,10 @@ func oneOfSchemaFor(usedTypes map[string]*Schema, concretes []string, meta *meta
 	members := make([]*Schema, 0, len(concretes))
 	for _, ct := range concretes {
 		schema := mapGoTypeForRoute(usedTypes, ct, meta, cfg)
-		if schema == nil {
+		if schema == nil || isEmptySchema(schema) {
+			// A member that constrains nothing makes the oneOf say less, not
+			// more: "any of these, or anything at all". Skipped like the nil
+			// this used to receive (issue #395).
 			continue
 		}
 		members = append(members, schema)

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -3239,7 +3239,23 @@ func mapGoTypeToOpenAPISchema(usedTypes map[string]*Schema, goType string, meta 
 			return addRefSchemaForType(goType), schemas
 		}
 
-		return schema, schemas
+		if goType == "" {
+			// No type at all is a different thing from a type that cannot be
+			// mapped: there is nothing to describe, and a caller checking for
+			// nil is asking exactly that. TestMapGoTypeToOpenAPISchema_EdgeCases
+			// pins it.
+			return schema, schemas
+		}
+
+		// A named primitive with no mapping and no $ref of its own —
+		// `complex64`, `complex128`, `nil` — reaches here with nothing
+		// resolved. It must still be a schema: this function is called
+		// RECURSIVELY for a slice's items, a map's values and a pointer's
+		// target, and those callers store what they are given, so a nil here
+		// becomes `items: null` or `additionalProperties: null` one level up
+		// (issue #395). The empty schema says "any JSON value", which is the
+		// honest answer for a type encoding/json cannot marshal at all.
+		return schemaOrAny(schema), schemas
 	}
 }
 

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -883,6 +883,25 @@ func buildResponses(respInfo map[string]*ResponseInfo) map[string]Response {
 	return responses
 }
 
+// schemaOrAny replaces a schema that could not be derived with the empty
+// schema, which is OpenAPI for "any JSON value".
+//
+// A property whose value is null is not a weaker description than `{}` — it is
+// an invalid document. The field is genuinely there and its shape is genuinely
+// unknown, so `{}` says exactly that; null says nothing and breaks every reader
+// that walks the schema (issue #395).
+//
+// The types that reach here are the ones metadata calls primitive but has no
+// mapping for — `complex64`, `complex128`, `nil` — which encoding/json cannot
+// marshal at all. Guessing a type for them would be worse than saying nothing
+// (golden rule #7).
+func schemaOrAny(s *Schema) *Schema {
+	if s == nil {
+		return &Schema{}
+	}
+	return s
+}
+
 // isBodylessStatus reports whether an HTTP status code must not carry a
 // response body per RFC 9110 / the OpenAPI spec: 1xx (informational), 204
 // (No Content), 205 (Reset Content), and 304 (Not Modified). Responses for
@@ -1609,7 +1628,7 @@ func generateStructSchema(usedTypes map[string]*Schema, key string, typ *metadat
 			}
 		}
 
-		schema.Properties[fieldName] = fieldSchema
+		schema.Properties[fieldName] = schemaOrAny(fieldSchema)
 	}
 
 	return schema, schemas
@@ -3174,7 +3193,13 @@ func mapGoTypeToOpenAPISchema(usedTypes map[string]*Schema, goType string, meta 
 		return &Schema{Type: "boolean"}, schemas
 	case "time.Time":
 		return &Schema{Type: "string", Format: "date-time"}, schemas
-	case "interface{}", "struct{}", "any":
+	case "interface{}", "struct{}", "any", "error":
+		// `error` is an interface like the others, and is mapped like them
+		// rather than left unmapped: metadata calls it primitive, so the
+		// $ref branch below is skipped for it, and what came back was a NIL
+		// schema. A nil stored as a property serializes as `properties: {Err:
+		// null}` — not valid OpenAPI, and enough to crash a reader that
+		// dereferences it (issue #395).
 		return &Schema{Type: "object"}, schemas
 	default:
 		// For custom types, check if it's a struct in metadata
@@ -3311,7 +3336,7 @@ func schemaFromAnonStructLiteral(usedTypes map[string]*Schema, goType string, me
 		if schema.Properties == nil {
 			schema.Properties = map[string]*Schema{}
 		}
-		schema.Properties[propName] = fieldSchema
+		schema.Properties[propName] = schemaOrAny(fieldSchema)
 	}
 	return schema, schemas
 }

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -902,6 +902,26 @@ func schemaOrAny(s *Schema) *Schema {
 	return s
 }
 
+// isEmptySchema reports whether a schema constrains nothing at all — the `{}`
+// schemaOrAny produces for a type with no mapping.
+//
+// It exists because several callers used to read a NIL schema as "nothing
+// usable here, skip it", and that nil is now an empty schema (issue #395). The
+// judgement they were making is still the right one: composing an empty schema
+// into a oneOf member or an allOf override adds a term that says nothing, so it
+// is noise rather than detail.
+func isEmptySchema(s *Schema) bool {
+	if s == nil {
+		return false
+	}
+	return s.Type == "" && s.Ref == "" && s.Format == "" &&
+		s.Description == "" && s.Title == "" &&
+		s.Default == nil && s.Example == nil && s.Not == nil &&
+		s.Items == nil && s.AdditionalProperties == nil &&
+		len(s.Properties) == 0 && len(s.AllOf) == 0 &&
+		len(s.OneOf) == 0 && len(s.AnyOf) == 0 && len(s.Enum) == 0
+}
+
 // isBodylessStatus reports whether an HTTP status code must not carry a
 // response body per RFC 9110 / the OpenAPI spec: 1xx (informational), 204
 // (No Content), 205 (Reset Content), and 304 (Not Modified). Responses for

--- a/internal/spec/wrapper_specialisation.go
+++ b/internal/spec/wrapper_specialisation.go
@@ -278,7 +278,14 @@ func specialiseWrapperSchema(baseSchema *Schema, overrides []wrapperFieldOverrid
 			continue
 		}
 		propSchema, discovered := mapGoTypeToOpenAPISchema(usedTypes, override.GoType, meta, cfg, nil)
-		if propSchema == nil {
+		if propSchema == nil || isEmptySchema(propSchema) {
+			// An override that constrains nothing is not a specialisation. It
+			// used to arrive here as a nil and be skipped; unmappable types now
+			// resolve to the empty schema instead (issue #395), and composing
+			// THAT would wrap the base $ref in an allOf whose second member
+			// says nothing — measured as 27 responses on a 163-route service
+			// turning `{$ref: Wrapper}` into
+			// `allOf: [{$ref: Wrapper}, {properties: {data: {}}}]`.
 			continue
 		}
 		// mapGoTypeToOpenAPISchema returns the payload's $ref in

--- a/testdata/interface_field_schema/go.mod
+++ b/testdata/interface_field_schema/go.mod
@@ -1,0 +1,3 @@
+module github.com/ehabterra/apispec/testdata/interface_field_schema
+
+go 1.22

--- a/testdata/interface_field_schema/main.go
+++ b/testdata/interface_field_schema/main.go
@@ -1,0 +1,49 @@
+// Fixture: a struct field whose type has no schema mapping must not serialize
+// as a null property.
+//
+// `Err error` is the shape that surfaced it (gitea's ErrPushRejected). metadata
+// classifies `error` as primitive, so the mapper skipped the $ref branch for
+// it, found no case for it either, and returned a nil schema — which was stored
+// as `properties: {Err: null}`. That is not a vaguer description than `{}`, it
+// is an invalid document: ReDoc dereferences every property and dies with
+// "Cannot read properties of null (reading '$ref')".
+//
+// `error` is an interface, so it is documented like `any`. The complex fields
+// have no honest mapping at all — encoding/json refuses to marshal them — so
+// they get the empty schema rather than an invented type.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// PushFailure mirrors the shape from the wild: an error field beside ordinary
+// ones, all exported and all serialized.
+type PushFailure struct {
+	Message string `json:"message"`
+	StdOut  string `json:"stdout"`
+	Err     error  `json:"err"`
+}
+
+// Sample carries the other types metadata calls primitive but cannot map.
+type Sample struct {
+	Name    string     `json:"name"`
+	Ratio   complex128 `json:"ratio"`
+	Smaller complex64  `json:"smaller"`
+}
+
+func failure(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode(PushFailure{Message: "rejected"})
+}
+
+func sample(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode(Sample{Name: "s"})
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /failure", failure)
+	mux.HandleFunc("GET /sample", sample)
+	http.ListenAndServe(":8080", mux)
+}

--- a/testdata/interface_field_schema/main.go
+++ b/testdata/interface_field_schema/main.go
@@ -26,11 +26,17 @@ type PushFailure struct {
 	Err     error  `json:"err"`
 }
 
-// Sample carries the other types metadata calls primitive but cannot map.
+// Sample carries the other types metadata calls primitive but cannot map,
+// including inside a slice and a map: the fallback has to apply where the
+// schema is BUILT, or a container stores the nil as `items: null` /
+// `additionalProperties: null` one level up.
 type Sample struct {
-	Name    string     `json:"name"`
-	Ratio   complex128 `json:"ratio"`
-	Smaller complex64  `json:"smaller"`
+	Name     string                `json:"name"`
+	Ratio    complex128            `json:"ratio"`
+	Smaller  complex64             `json:"smaller"`
+	Series   []complex64           `json:"series"`
+	ByName   map[string]complex128 `json:"by_name"`
+	Optional *complex64            `json:"optional"`
 }
 
 func failure(w http.ResponseWriter, r *http.Request) {

--- a/testdata/multipart_upload/main.go
+++ b/testdata/multipart_upload/main.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"encoding/json"
+	"mime/multipart"
 	"net/http"
 )
 
@@ -24,7 +25,13 @@ func upload(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	defer file.Close()
+	defer func(file multipart.File) {
+		err := file.Close()
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}(file)
 	_ = header.Filename
 	title := r.FormValue("title")
 	_ = title

--- a/testdata/wrapper_nil_payload/go.mod
+++ b/testdata/wrapper_nil_payload/go.mod
@@ -1,0 +1,3 @@
+module github.com/ehabterra/apispec/testdata/wrapper_nil_payload
+
+go 1.22

--- a/testdata/wrapper_nil_payload/main.go
+++ b/testdata/wrapper_nil_payload/main.go
@@ -1,0 +1,61 @@
+// Fixture: a wrapper whose generic payload is nil must not be "specialised".
+//
+// A response helper that wraps every payload in an envelope is specialised by
+// composing an allOf: the envelope's $ref plus the concrete type of the field
+// the caller bound. When the caller passes no payload at all — `NewEnvelope(nil)`,
+// the shape of every logout and delete endpoint — there is nothing to
+// specialise, and the response is just the envelope.
+//
+// The override for such a field used to resolve to a nil schema and be skipped.
+// Once an unmappable type resolves to the empty schema instead (issue #395),
+// the override fired with a schema that constrains nothing, turning
+// `{$ref: Envelope}` into `allOf: [{$ref: Envelope}, {properties: {data: {}}}]`
+// — the same claim with noise around it. Measured on a 163-route service, it
+// hit 27 responses.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type Envelope struct {
+	Message string `json:"message"`
+	Data    any    `json:"data"`
+}
+
+type User struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// NewEnvelope binds its parameter to the Data field, which is what makes the
+// field specialisable from the call site.
+func NewEnvelope(data any) Envelope {
+	return Envelope{Message: "ok", Data: data}
+}
+
+// respondJSON is the shared writer: it builds the envelope from whatever the
+// caller passed, which is what makes Data specialisable per call site.
+func respondJSON(w http.ResponseWriter, data any) {
+	response := NewEnvelope(data)
+	_ = json.NewEncoder(w).Encode(response)
+}
+
+// logout carries no payload: the response is the envelope itself.
+func logout(w http.ResponseWriter, r *http.Request) {
+	respondJSON(w, nil)
+}
+
+// profile carries one: the envelope specialised with the concrete type, which
+// must keep working.
+func profile(w http.ResponseWriter, r *http.Request) {
+	respondJSON(w, User{ID: "1", Name: "ada"})
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /logout", logout)
+	mux.HandleFunc("GET /profile", profile)
+	http.ListenAndServe(":8080", mux)
+}


### PR DESCRIPTION
Closes #395.

## The crash

```
TypeError: Cannot read properties of null (reading '$ref')
    at Fu.generateExample (redoc.standalone.js:47:104887)
ReDoc 2.5.3
```

from one line of an otherwise healthy document:

```yaml
components:
  schemas:
    gitea_dev_modules_git_ErrPushRejected:
      properties:
        Err: null
```

A null property is not a vaguer description than `{}` — it is an invalid document, and a reader that walks properties dereferences it and renders a stack trace instead of the page.

## Cause

metadata classifies `error`, `complex64`, `complex128` and `nil` as primitive. `mapGoTypeToOpenAPISchema`'s default switch has a case for `interface{}`, `struct{}` and `any` but **not** for those; and because they are primitive, `canAddRefSchemaForType` refuses them too, so the `$ref`-with-placeholder fallback never ran either. The function returned nil, and two of the three places that fill `Properties` stored it unchecked (`mapper.go:1598`, `mapper.go:3300` — the form-param site already guarded).

`error` is the one that bites: any struct with an `Err error` field that reaches a response body. gitea has exactly one, and one is enough.

## Fix

- **`error` is mapped like the other interfaces** (`{type: object}`) — what the same switch already does for `interface{}` and `any`. Not a guess: the field marshals to whatever the concrete error is, and most error types marshal to an object.
- **Anything else with no mapping becomes the empty schema `{}`** — OpenAPI for "any JSON value". `complex64`/`complex128` cannot be marshalled by encoding/json at all, so inventing a type for them would be worse than saying nothing (golden rule #7).

```yaml
PushFailure:
  properties: {err: {type: object}, message: {type: string}, stdout: {type: string}}
Sample:
  properties: {name: {type: string}, ratio: {}, smaller: {}}
```

## Why no test caught it

`noDanglingRefs` walks the schema tree and its walker opens with `if s == nil { return }` — a null property reads as the end of a branch rather than as a defect. `noNullSchemas` now sits beside it and reports the path, so any fixture calling it fails loudly on this class.

## Verification

- `testdata/interface_field_schema` reproduces both shapes; confirmed against a worktree at main that it really did emit `err: null`, `ratio: null`, `smaller: null` before the fix.
- **gitea: nulls in the document 1 → 0**, with operations (1109), responses (2351), component count (273) and every other schema byte-identical — the only change in 1.3 MB of YAML is `Err: null` → `Err: {type: object}`.
- Full suite green with a cold cache, `go vet` and `golangci-lint` clean, coverage ratchet holding at 96.0%.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated API schemas for interface, anonymous struct, and `error` fields.
  * Prevented null property schemas by providing valid empty schemas when types cannot be mapped.
  * Unsupported complex-number fields now produce empty schemas instead of incorrect types.
  * Improved schema validation to detect dangling references and null schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->