### PR TITLE
fix: a status write is carried by every body it dominates (#391)

### DIFF
--- a/generator/testdata_branch_status_scope_test.go
+++ b/generator/testdata_branch_status_scope_test.go
@@ -56,11 +56,36 @@ func TestTestdata_BranchStatusScope(t *testing.T) {
 		// honest answer is that it carries neither (golden rule #7). Before the
 		// rule the body took whichever arm the walk saw last.
 		"/arms": {"202": "", "206": "", "200": "Item"},
-		// CHANGE DETECTOR for issue #391, not the behaviour this fixture is
-		// for: the 201 dominates BOTH bodies, but a pending status is consumed
-		// by the first one, so the second falls through to the implicit 200.
-		// When #391 is fixed this becomes {"201": "Item"} alone.
-		"/before": {"201": "Item", "200": "Item"},
+		// The 201 dominates BOTH bodies and is carried by both (#391). They
+		// are the same type, so the response is one schema — nothing to
+		// compose. This used to also document a spurious 200, because a
+		// pending status was consumed by the first body that claimed it.
+		"/before": {"201": "Item"},
+	}
+
+	// One status over two different types: the endpoint can answer 202 with
+	// either, so the response alternates between them rather than keeping
+	// whichever the walk saw last (#391). Asserted apart from the table above,
+	// which describes responses carrying a single schema.
+	alternatives := out.Paths["/alternatives"]
+	if op := opFor(alternatives, "GET"); op == nil {
+		t.Error("GET /alternatives: expected operation, missing")
+	} else if resp, ok := op.Responses["202"]; !ok {
+		t.Errorf("GET /alternatives: response 202 missing; have %v", responseCodesOf(op.Responses))
+	} else {
+		media, ok := resp.Content["application/json"]
+		switch {
+		case !ok || media.Schema == nil:
+			t.Errorf("GET /alternatives 202: no JSON schema, got %v", resp.Content)
+		case len(media.Schema.AnyOf) != 2:
+			t.Errorf("GET /alternatives 202: schema = %+v, want an anyOf of both bodies", media.Schema)
+		default:
+			got := []string{schemaRefName(media.Schema.AnyOf[0]), schemaRefName(media.Schema.AnyOf[1])}
+			sort.Strings(got)
+			if !equalStrings(got, []string{"APIError", "Item"}) {
+				t.Errorf("GET /alternatives 202: anyOf members %v, want [APIError Item]", got)
+			}
+		}
 	}
 
 	for path, wantResponses := range want {
@@ -102,6 +127,15 @@ func TestTestdata_BranchStatusScope(t *testing.T) {
 			}
 		}
 	}
+}
+
+// schemaRefName is the bare component name a schema references.
+func schemaRefName(s *intspec.Schema) string {
+	if s == nil || s.Ref == "" {
+		return ""
+	}
+	name := s.Ref[strings.LastIndexByte(s.Ref, '/')+1:]
+	return name[strings.LastIndexByte(name, '_')+1:]
 }
 
 // schemaNameOf names the schema a response carries: the bare component name for

--- a/internal/metadata/blocks.go
+++ b/internal/metadata/blocks.go
@@ -57,18 +57,48 @@ type blockCollector struct {
 }
 
 // add records one region and returns its 1-based index, for use as a parent.
-func (c *blockCollector) add(kind BlockKind, start, end token.Pos, parent, group int) int {
+func (c *blockCollector) add(kind BlockKind, start, end token.Pos, parent, group int, body []ast.Stmt) int {
 	sp, ep := c.fset.Position(start), c.fset.Position(end)
 	c.blocks = append(c.blocks, Block{
-		Kind:      kind,
-		StartLine: sp.Line,
-		StartCol:  sp.Column,
-		EndLine:   ep.Line,
-		EndCol:    ep.Column,
-		Parent:    parent,
-		Group:     group,
+		Kind:       kind,
+		StartLine:  sp.Line,
+		StartCol:   sp.Column,
+		EndLine:    ep.Line,
+		EndCol:     ep.Column,
+		Parent:     parent,
+		Group:      group,
+		Terminates: terminates(body),
 	})
 	return len(c.blocks)
+}
+
+// terminates reports whether a statement list ends in a way that stops control
+// reaching the code after its conditional.
+//
+// Syntactic certainty only: a `return`, a `panic(...)`, or a branch statement.
+// A call that never returns by convention (os.Exit, log.Fatal) is NOT counted —
+// deciding that needs the type checker and the answer would be a guess for any
+// project-local wrapper, and a wrong "terminates" turns sequential statements
+// into alternatives (golden rule #7).
+func terminates(body []ast.Stmt) bool {
+	if len(body) == 0 {
+		return false
+	}
+	switch last := body[len(body)-1].(type) {
+	case *ast.ReturnStmt, *ast.BranchStmt:
+		return true
+	case *ast.ExprStmt:
+		call, ok := last.X.(*ast.CallExpr)
+		if !ok {
+			return false
+		}
+		ident, ok := call.Fun.(*ast.Ident)
+		return ok && ident.Name == "panic"
+	case *ast.LabeledStmt:
+		return terminates([]ast.Stmt{last.Stmt})
+	default:
+		return false
+	}
 }
 
 // nextGroup mints the id shared by the arms of one conditional.
@@ -92,7 +122,7 @@ func (c *blockCollector) stmt(stmt ast.Stmt, parent int) {
 		return
 
 	case *ast.BlockStmt:
-		idx := c.add(BlockPlain, s.Lbrace, s.Rbrace, parent, 0)
+		idx := c.add(BlockPlain, s.Lbrace, s.Rbrace, parent, 0, s.List)
 		c.stmts(s.List, idx)
 
 	case *ast.IfStmt:
@@ -115,12 +145,12 @@ func (c *blockCollector) stmt(stmt ast.Stmt, parent int) {
 		c.stmt(s.Init, parent)
 		c.exprs(parent, s.Cond)
 		c.stmt(s.Post, parent)
-		idx := c.add(BlockLoop, s.Body.Lbrace, s.Body.Rbrace, parent, 0)
+		idx := c.add(BlockLoop, s.Body.Lbrace, s.Body.Rbrace, parent, 0, s.Body.List)
 		c.stmts(s.Body.List, idx)
 
 	case *ast.RangeStmt:
 		c.exprs(parent, s.Key, s.Value, s.X)
-		idx := c.add(BlockLoop, s.Body.Lbrace, s.Body.Rbrace, parent, 0)
+		idx := c.add(BlockLoop, s.Body.Lbrace, s.Body.Rbrace, parent, 0, s.Body.List)
 		c.stmts(s.Body.List, idx)
 
 	case *ast.LabeledStmt:
@@ -147,14 +177,14 @@ func (c *blockCollector) ifChain(stmt *ast.IfStmt, parent int) {
 		c.stmt(cur.Init, parent)
 		c.exprs(parent, cur.Cond)
 
-		idx := c.add(BlockIf, cur.Body.Lbrace, cur.Body.Rbrace, parent, group)
+		idx := c.add(BlockIf, cur.Body.Lbrace, cur.Body.Rbrace, parent, group, cur.Body.List)
 		c.stmts(cur.Body.List, idx)
 
 		switch alt := cur.Else.(type) {
 		case *ast.IfStmt:
 			cur = alt // `else if`: another arm of this same chain
 		case *ast.BlockStmt:
-			elseIdx := c.add(BlockElse, alt.Lbrace, alt.Rbrace, parent, group)
+			elseIdx := c.add(BlockElse, alt.Lbrace, alt.Rbrace, parent, group, alt.List)
 			c.stmts(alt.List, elseIdx)
 			cur = nil
 		default:
@@ -182,7 +212,7 @@ func (c *blockCollector) clauses(body *ast.BlockStmt, parent int) {
 			c.exprs(parent, cl.List...)
 			// A clause has no braces: its region runs from the colon to the end
 			// of its last statement, so the case expressions stay outside it.
-			idx := c.add(kind, cl.Colon, cl.End(), parent, group)
+			idx := c.add(kind, cl.Colon, cl.End(), parent, group, cl.Body)
 			c.stmts(cl.Body, idx)
 		case *ast.CommClause:
 			kind := BlockCase
@@ -190,7 +220,7 @@ func (c *blockCollector) clauses(body *ast.BlockStmt, parent int) {
 				kind = BlockDefault
 			}
 			c.stmt(cl.Comm, parent)
-			idx := c.add(kind, cl.Colon, cl.End(), parent, group)
+			idx := c.add(kind, cl.Colon, cl.End(), parent, group, cl.Body)
 			c.stmts(cl.Body, idx)
 		}
 	}
@@ -216,7 +246,7 @@ func (c *blockCollector) funcLits(node ast.Node, parent int) {
 		if !ok || lit.Body == nil {
 			return true
 		}
-		idx := c.add(BlockFuncLit, lit.Body.Lbrace, lit.Body.Rbrace, parent, 0)
+		idx := c.add(BlockFuncLit, lit.Body.Lbrace, lit.Body.Rbrace, parent, 0, lit.Body.List)
 		c.stmts(lit.Body.List, idx)
 		return false // this literal's interior is walked by c.stmts, not here
 	})

--- a/internal/metadata/blocks.go
+++ b/internal/metadata/blocks.go
@@ -75,17 +75,24 @@ func (c *blockCollector) add(kind BlockKind, start, end token.Pos, parent, group
 // terminates reports whether a statement list ends in a way that stops control
 // reaching the code after its conditional.
 //
-// Syntactic certainty only: a `return`, a `panic(...)`, or a branch statement.
-// A call that never returns by convention (os.Exit, log.Fatal) is NOT counted —
-// deciding that needs the type checker and the answer would be a guess for any
-// project-local wrapper, and a wrong "terminates" turns sequential statements
-// into alternatives (golden rule #7).
+// Only `return` and a direct `panic(...)` qualify. A BRANCH statement does not,
+// even though it leaves the region: `break` leaves a switch and lands on the
+// statement after it, `fallthrough` deliberately continues into the next
+// clause, `continue` starts another iteration, and `goto` goes somewhere this
+// cannot know. Counting them would make a body written after a switch an
+// "alternative" of a break-terminated case, which is the opposite of true.
+//
+// A call that never returns by convention (os.Exit, log.Fatal) is not counted
+// either — deciding that needs the type checker and the answer would be a guess
+// for any project-local wrapper. A wrong "terminates" turns sequential
+// statements into alternatives (golden rule #7), so the bar is syntactic
+// certainty.
 func terminates(body []ast.Stmt) bool {
 	if len(body) == 0 {
 		return false
 	}
 	switch last := body[len(body)-1].(type) {
-	case *ast.ReturnStmt, *ast.BranchStmt:
+	case *ast.ReturnStmt:
 		return true
 	case *ast.ExprStmt:
 		call, ok := last.X.(*ast.CallExpr)

--- a/internal/metadata/blocks_test.go
+++ b/internal/metadata/blocks_test.go
@@ -240,8 +240,13 @@ func TestCollectBlocksTerminates(t *testing.T) {
 		{"panic ends an arm", "if x() {\n panic(\"no\")\n}", []bool{true}},
 		{"a call that merely looks final does not", "if x() {\n exit()\n}", []bool{false}},
 		{"else returns, if does not", "if x() {\n a()\n} else {\n return\n}", []bool{false, true}},
-		{"break ends a case", "switch v() {\ncase 1:\n a()\n break\ncase 2:\n b()\n}", []bool{true, false}},
-		{"continue ends a loop body", "for x() {\n continue\n}", []bool{true}},
+		// A branch statement leaves the region without ending the path: after a
+		// `break` the statement following the switch runs, which is exactly
+		// what "terminates" must not claim.
+		{"break does not end a case", "switch v() {\ncase 1:\n a()\n break\ncase 2:\n b()\n}", []bool{false, false}},
+		{"fallthrough does not", "switch v() {\ncase 1:\n a()\n fallthrough\ncase 2:\n b()\n}", []bool{false, false}},
+		{"continue does not end a loop body", "for x() {\n continue\n}", []bool{false}},
+		{"return inside a case does", "switch v() {\ncase 1:\n return\ncase 2:\n b()\n}", []bool{true, false}},
 		{"empty arm", "if x() {\n}", []bool{false}},
 	}
 

--- a/internal/metadata/blocks_test.go
+++ b/internal/metadata/blocks_test.go
@@ -221,6 +221,46 @@ func TestCollectBlocksExclusivity(t *testing.T) {
 	}
 }
 
+// TestCollectBlocksTerminates pins the fact that makes Go's dominant idiom
+// legible: an arm that exits means nothing after its conditional runs when the
+// arm did, so the two are alternatives even though only one is inside an arm.
+//
+// Only syntactic certainty counts. A call that never returns by convention
+// (os.Exit, log.Fatal) is not one — deciding that needs the type checker, the
+// answer would be a guess for any project-local wrapper, and a wrong
+// "terminates" turns sequential statements into alternatives.
+func TestCollectBlocksTerminates(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want []bool // per block, in source order
+	}{
+		{"arm ending in return", "if x() {\n a()\n return\n}", []bool{true}},
+		{"arm falling through", "if x() {\n a()\n}", []bool{false}},
+		{"panic ends an arm", "if x() {\n panic(\"no\")\n}", []bool{true}},
+		{"a call that merely looks final does not", "if x() {\n exit()\n}", []bool{false}},
+		{"else returns, if does not", "if x() {\n a()\n} else {\n return\n}", []bool{false, true}},
+		{"break ends a case", "switch v() {\ncase 1:\n a()\n break\ncase 2:\n b()\n}", []bool{true, false}},
+		{"continue ends a loop body", "for x() {\n continue\n}", []bool{true}},
+		{"empty arm", "if x() {\n}", []bool{false}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			blocks, _, _ := parseBody(t, tc.body)
+			if len(blocks) != len(tc.want) {
+				t.Fatalf("got %d blocks (%s), want %d", len(blocks), shape(blocks), len(tc.want))
+			}
+			for i, want := range tc.want {
+				if blocks[i].Terminates != want {
+					t.Errorf("block %d (%s): Terminates = %v, want %v",
+						i, blocks[i].Kind, blocks[i].Terminates, want)
+				}
+			}
+		})
+	}
+}
+
 func TestCollectBlocksNilSafety(t *testing.T) {
 	if got := collectBlocks(nil, token.NewFileSet()); got != nil {
 		t.Errorf("nil body: want nil, got %v", got)

--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -991,6 +991,21 @@ type Block struct {
 	// metadata; a plain index could not distinguish "block 0" from "none".
 	Parent int `yaml:"parent,omitempty"`
 
+	// Terminates records that control cannot fall out of this region into the
+	// statement after its conditional — the region ends in a `return`, a
+	// `panic`, or a branch statement.
+	//
+	// It is what makes Go's dominant idiom legible. In
+	// `if bad { …; return }` followed by the success path, the two are
+	// alternatives even though only one of them is written inside an arm: the
+	// arm exits, so nothing after the `if` runs when it did. Without this the
+	// only alternatives visible are sibling arms of an if/else, and the
+	// early-return form — far more common — reads as sequential code.
+	//
+	// False whenever the answer is not syntactically certain, so a consumer
+	// never treats sequential statements as alternatives on a guess.
+	Terminates bool `yaml:"terminates,omitempty"`
+
 	// Group ties together the arms of ONE conditional — every arm of an
 	// if/else-if/else chain, or every case of one switch or select — with a
 	// 1-based id unique within the function. Two blocks sharing a group are

--- a/internal/spec/control_flow.go
+++ b/internal/spec/control_flow.go
@@ -155,11 +155,48 @@ func (idx *blockIndex) dominates(earlier, later codePos) bool {
 	return true
 }
 
-// Mutual exclusion — two positions in arms of one conditional, which
-// Block.Group records — is the other question these facts answer, and the one a
-// summary of a function's responses needs when it merges the arms of a branch.
-// Dominance already rejects every pair the pairing rule cares about, so no
-// exclusivity query is written here until that summary needs one.
+// exclusive reports whether two positions sit in arms of one conditional and so
+// can never both run.
+//
+// It is what tells `if full { A } else { B }` — two bodies under one status
+// write, of which exactly one is sent — apart from `A; …; B`, two bodies on the
+// same path where the second is a different response entirely. Both are
+// dominated by the write; only the first pair are alternatives (issue #391).
+//
+// Conservative in the direction that preserves behaviour: unknown positions or
+// an unindexed file answer false, so nothing is treated as an alternative on
+// missing facts.
+func (idx *blockIndex) exclusive(a, b codePos) bool {
+	if idx == nil || !a.valid() || !b.valid() || a.file != b.file {
+		return false
+	}
+	blocks := idx.byFile[a.file]
+	for i, armA := range blocks {
+		if armA.Group == 0 || !blockContains(armA, a) || blockContains(armA, b) {
+			continue
+		}
+		// a is in an arm b is outside of. Two ways that makes them exclusive:
+		for j, armB := range blocks {
+			// b is in a sibling arm of the same conditional.
+			if i != j && armB.Group == armA.Group && blockContains(armB, b) {
+				return true
+			}
+		}
+		// Or a's arm exits, so nothing after that conditional runs when a did.
+		// This is the early-return idiom — `if bad { …; return }` above the
+		// success path — which is how most Go handlers are written and would
+		// otherwise read as sequential code.
+		if armA.Terminates && afterBlock(armA, b) {
+			return true
+		}
+	}
+	return false
+}
+
+// afterBlock reports whether a position lies beyond a block's end.
+func afterBlock(b metadata.Block, pos codePos) bool {
+	return pos.line > b.EndLine || (pos.line == b.EndLine && pos.col > b.EndCol)
+}
 
 // controlFlow returns the extractor's block index, built on first use.
 func (e *Extractor) controlFlow() *blockIndex {

--- a/internal/spec/control_flow_test.go
+++ b/internal/spec/control_flow_test.go
@@ -184,6 +184,53 @@ func TestDominatesColumnsSeparateAOneLineArm(t *testing.T) {
 // step the hand-built indexes above skip: bucketing each function's blocks
 // under the FILE its position names, which is what lets a position be resolved
 // without knowing which declaration (or which function literal) it sits in.
+// TestExclusive covers the question that decides whether one status write can
+// be carried by two bodies: can both of them run?
+func TestExclusive(t *testing.T) {
+	// if (10..13, returns) / else (14..17), and code after at line 20.
+	ifArm := meta.Block{Kind: meta.BlockIf, StartLine: 10, StartCol: 1, EndLine: 13, EndCol: 80, Group: 1, Terminates: true}
+	elseArm := meta.Block{Kind: meta.BlockElse, StartLine: 14, StartCol: 1, EndLine: 17, EndCol: 80, Group: 1}
+	loop := meta.Block{Kind: meta.BlockLoop, StartLine: 30, StartCol: 1, EndLine: 33, EndCol: 80}
+	idx := indexOf(ifArm, elseArm, loop)
+
+	cases := []struct {
+		name string
+		a, b codePos
+		want bool
+	}{
+		{"sibling arms of one conditional", at(11, 3), at(15, 3), true},
+		{"the same arm", at(11, 3), at(12, 3), false},
+		{"an arm that returns, and code after the conditional", at(11, 3), at(20, 2), true},
+		{"code after the conditional, and the arm", at(20, 2), at(11, 3), false},
+		{"a loop body carries no group and exits nothing", at(31, 3), at(35, 2), false},
+		{"neither is in a region", at(20, 2), at(21, 2), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := idx.exclusive(tc.a, tc.b); got != tc.want {
+				t.Errorf("exclusive(%v, %v) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+
+	// An arm that does NOT exit leaves the code after it reachable on the same
+	// run, so they are not alternatives — the case a terminator fact is needed
+	// to tell apart, and the one a guess would get wrong.
+	falls := meta.Block{Kind: meta.BlockIf, StartLine: 10, StartCol: 1, EndLine: 13, EndCol: 80, Group: 1}
+	if indexOf(falls).exclusive(at(11, 3), at(20, 2)) {
+		t.Error("an arm that falls through must not make what follows an alternative")
+	}
+
+	// Missing facts answer false: nothing is an alternative on a guess.
+	if idx.exclusive(codePos{}, at(15, 3)) || idx.exclusive(at(11, 3), codePos{}) {
+		t.Error("unknown positions must not be reported as exclusive")
+	}
+	var nilIdx *blockIndex
+	if nilIdx.exclusive(at(11, 3), at(15, 3)) {
+		t.Error("a nil index must not report exclusivity")
+	}
+}
+
 func TestNewBlockIndexFromMetadata(t *testing.T) {
 	src := `package main
 

--- a/internal/spec/control_flow_test.go
+++ b/internal/spec/control_flow_test.go
@@ -221,6 +221,14 @@ func TestExclusive(t *testing.T) {
 		t.Error("an arm that falls through must not make what follows an alternative")
 	}
 
+	// A switch case that ends in `break` leaves the switch and lands on the
+	// statement after it, so the two are not alternatives. This is why only
+	// `return` and `panic` set Terminates — see terminates() in metadata.
+	caseArm := meta.Block{Kind: meta.BlockCase, StartLine: 40, StartCol: 1, EndLine: 43, EndCol: 80, Group: 2}
+	if indexOf(caseArm).exclusive(at(41, 3), at(50, 2)) {
+		t.Error("a case that breaks must not make the code after the switch an alternative")
+	}
+
 	// Missing facts answer false: nothing is an alternative on a guess.
 	if idx.exclusive(codePos{}, at(15, 3)) || idx.exclusive(at(11, 3), codePos{}) {
 		t.Error("unknown positions must not be reported as exclusive")

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -1472,6 +1472,11 @@ func (e *Extractor) pairAndFillResponses(route *RouteInfo, candidates []response
 			pendingStatus[f.chain] = status
 			pendingAt[f.chain] = codePos{file: f.file, line: f.line, col: f.col}
 			pendingInFrame[f.chain] = f.resp.StatusInFrame
+			// A new status starts a fresh conversation: the bodies that claimed
+			// the PREVIOUS one are not claimants of this one, and leaving them
+			// here would make the next body prove itself exclusive with a
+			// status it has nothing to do with.
+			delete(claimedAt, f.chain)
 		case known:
 			store(f.resp, f.resp.StatusInFrame)
 		case f.resp.StatusUnresolved:

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -180,6 +180,19 @@ type ResponseInfo struct {
 	// Zero means "leave it undetermined", which is what lands under "default".
 	ImplicitStatus int
 
+	// StatusInFrame marks a status resolved from the call site's own argument —
+	// a literal or constant written right there — rather than traced through a
+	// parameter or a struct field several frames up.
+	//
+	// Only an in-frame status has an identity the pairing can trust for more
+	// than one body. A shared responder (`func (ctx *Context) JSON(status int,
+	// obj any)`) writes ONE `WriteHeader(status)` statement for every call in
+	// the program, and which status that is depends on the invocation — a
+	// distinction the tracker cannot make reliably (issue #389). Treating those
+	// as one status carrying several bodies documented an LFS list endpoint's
+	// 200 with the error type, measured on gitea.
+	StatusInFrame bool
+
 	// StatusUnresolved marks a status WRITE whose value could not be read
 	// (`w.WriteHeader(computeStatus())`). It documents nothing itself — no status,
 	// no body — and is never stored; it exists so pairing knows the handler does
@@ -1394,9 +1407,17 @@ func (e *Extractor) pairAndFillResponses(route *RouteInfo, candidates []response
 		return frags[i].col < frags[j].col
 	})
 
-	store := func(resp *ResponseInfo) {
+	// A slot whose status the handler STATED — written explicitly, or claimed
+	// from a write that dominates the body. Only those compose: two bodies that
+	// merely defaulted to the framework's implicit status are not evidence that
+	// one status carries both, and alternating them advertises an error type on
+	// a success response.
+	stated := map[string]bool{}
+	store := func(resp *ResponseInfo, statusStated bool) {
 		slot := fmt.Sprintf("%d", resp.StatusCode)
 		existing := route.Response[slot]
+		wasStated := stated[slot]
+		stated[slot] = wasStated || statusStated
 		switch {
 		case existing == nil:
 			route.Response[slot] = resp
@@ -1404,6 +1425,11 @@ func (e *Extractor) pairAndFillResponses(route *RouteInfo, candidates []response
 			route.Response[slot] = resp
 		case existing.BodyType != "" && resp.BodyType == "":
 			// keep the informative one
+		case statusStated && wasStated && alternativeBodies(existing, resp):
+			// One status, two genuinely different bodies: the endpoint really
+			// can send either, so the response alternates between them rather
+			// than keeping whichever the walk saw last.
+			route.Response[slot] = mergeResponseAlternatives(existing, resp)
 		default:
 			route.Response[slot] = preferResponseInfo(existing, resp)
 		}
@@ -1417,6 +1443,17 @@ func (e *Extractor) pairAndFillResponses(route *RouteInfo, candidates []response
 	// followed by the success body is the shape this rejects — source order
 	// alone hands that body a 400 it can never carry (see control_flow.go).
 	pendingAt := map[string]codePos{}
+	// chain -> the bodies that have already claimed that pending status. A
+	// second body claims it only when it cannot run alongside the first: arms
+	// of one conditional are alternatives under a single status write, while
+	// two bodies on the same path are two different responses and the later one
+	// is not what that write was for (issue #391).
+	claimedAt := map[string][]codePos{}
+	// chain -> whether that pending status was resolved without leaving the
+	// frame. A status traced in from a caller belongs to one invocation, and
+	// the walk cannot tell invocations of a shared responder apart, so such a
+	// status is claimed once as before.
+	pendingInFrame := map[string]bool{}
 	// chain -> a status write on it did NOT resolve. The handler states a
 	// status; we just could not read it. A body written after that is emphatically
 	// NOT the framework's implicit status — the server sends whatever that call
@@ -1430,12 +1467,13 @@ func (e *Extractor) pairAndFillResponses(route *RouteInfo, candidates []response
 		known := status >= 100 && status < 600
 		switch {
 		case known && body == "":
-			store(f.resp)
+			store(f.resp, f.resp.StatusInFrame)
 			pending[f.chain] = true
 			pendingStatus[f.chain] = status
 			pendingAt[f.chain] = codePos{file: f.file, line: f.line, col: f.col}
+			pendingInFrame[f.chain] = f.resp.StatusInFrame
 		case known:
-			store(f.resp)
+			store(f.resp, f.resp.StatusInFrame)
 		case f.resp.StatusUnresolved:
 			// A status write whose value did not resolve: nothing to store (no
 			// status, no body), but it disqualifies this chain's later bodies
@@ -1446,12 +1484,22 @@ func (e *Extractor) pairAndFillResponses(route *RouteInfo, candidates []response
 				f.resp.ImplicitStatus = 0
 			}
 			bodyAt := codePos{file: f.file, line: f.line, col: f.col}
-			if pending[f.chain] && e.controlFlow().dominates(pendingAt[f.chain], bodyAt) {
+			claimable := len(claimedAt[f.chain]) == 0 ||
+				(pendingInFrame[f.chain] && e.exclusiveWithClaimants(claimedAt[f.chain], bodyAt))
+			if pending[f.chain] && claimable && e.controlFlow().dominates(pendingAt[f.chain], bodyAt) {
+				// The status is NOT consumed by the body that claims it: a
+				// write that dominates two bodies is carried by both, and
+				// `WriteHeader(201)` above an if/else sends 201 down either
+				// branch (issue #391). Only a later status write on this chain
+				// supersedes it, by overwriting the pending entries above.
+				//
+				// Consuming it was load-bearing before dominance existed — it
+				// was the only thing stopping a status from leaking onto every
+				// later body in the function, including bodies in branches it
+				// could never reach. The dominance test does that job now.
 				f.resp.StatusCode = pendingStatus[f.chain]
-				delete(pending, f.chain)
-				delete(pendingStatus, f.chain)
-				delete(pendingAt, f.chain)
-				store(f.resp)
+				claimedAt[f.chain] = append(claimedAt[f.chain], bodyAt)
+				store(f.resp, pendingInFrame[f.chain])
 			} else {
 				unpaired = append(unpaired, f)
 			}
@@ -1491,12 +1539,12 @@ func (e *Extractor) pairAndFillResponses(route *RouteInfo, candidates []response
 			// undetermined.
 			if f.resp.ImplicitStatus > 0 {
 				f.resp.StatusCode = f.resp.ImplicitStatus
-				store(f.resp)
+				store(f.resp, false)
 				continue
 			}
 			unknown++
 			f.resp.StatusCode = -unknown
-			store(f.resp)
+			store(f.resp, false)
 		}
 	}
 }
@@ -1605,7 +1653,11 @@ func requestIsConcrete(r *RequestInfo) bool {
 		return false
 	}
 	s := r.Schema
-	return s.Ref != "" || len(s.Properties) > 0 || len(s.AllOf) > 0 || s.Items != nil
+	// A composed body (anyOf/oneOf) is as resolved as its members. Without
+	// these two, a composition is judged unresolved and the next store for that
+	// status discards it for whichever single body arrived last.
+	return s.Ref != "" || len(s.Properties) > 0 || len(s.AllOf) > 0 ||
+		len(s.AnyOf) > 0 || len(s.OneOf) > 0 || s.Items != nil
 }
 
 // preferResponseInfo deterministically picks between two responses competing
@@ -1633,6 +1685,96 @@ func requestIsConcrete(r *RequestInfo) bool {
 // time, so the name test decided nothing on any measured code. It was a trap
 // waiting for the first project whose handler writes two differently-named
 // bodies, not a working heuristic.
+// exclusiveWithClaimants reports whether a body may claim a status that earlier
+// bodies already claimed: only when it cannot run alongside any of them.
+//
+// The first claimant always may. After that, a body on the same path is a
+// different response — and letting it in is how a 200 ended up documenting an
+// error type on a large real project, because such a body would otherwise be
+// weighed by call depth in the unpaired pass.
+func (e *Extractor) exclusiveWithClaimants(claimed []codePos, bodyAt codePos) bool {
+	flow := e.controlFlow()
+	for _, prior := range claimed {
+		if !flow.exclusive(prior, bodyAt) {
+			return false
+		}
+	}
+	return true
+}
+
+// alternativeBodies reports whether two responses for one status describe
+// genuinely different payloads, which is the only case worth composing.
+//
+// Both must be CONCRETE and must RENDER differently. Measured on a large real
+// project, composing every collision instead produced 261 alternations of which
+// the overwhelming majority said nothing — `anyOf: [string, string]` (two Go
+// types that render identically), or `anyOf: [integer, string]` from writes
+// whose type resolution differs by path rather than by branch. An alternation
+// of noise is worse than picking one: it claims the endpoint can answer in
+// shapes it never does (golden rule #7).
+func alternativeBodies(cur, next *ResponseInfo) bool {
+	if cur == nil || next == nil {
+		return false
+	}
+	if cur.BodyType == next.BodyType {
+		return false
+	}
+	if !responseIsConcrete(cur) || !responseIsConcrete(next) {
+		return false
+	}
+	return !sameRenderedBody(cur.Schema, next.Schema)
+}
+
+// mergeResponseAlternatives composes the bodies a single status can carry into
+// one `anyOf`, accumulating as later fragments arrive.
+//
+// anyOf rather than oneOf: the alternatives are not claimed to be mutually
+// exclusive, only to be what this status may carry. A payload that happens to
+// validate against two of them is still a valid response, which oneOf would
+// call invalid.
+//
+// A member that constrains nothing is not added — an `anyOf` containing the
+// empty schema matches anything, which says LESS than its other members
+// (issue #395's rule, same reasoning as oneOfSchemaFor).
+func mergeResponseAlternatives(cur, next *ResponseInfo) *ResponseInfo {
+	if cur == nil {
+		return next
+	}
+	if next == nil || next.Schema == nil || isEmptySchema(next.Schema) {
+		return cur
+	}
+	if cur.Schema == nil || isEmptySchema(cur.Schema) {
+		return next
+	}
+
+	members, types := alternativesOf(cur)
+	for _, known := range types {
+		if known == next.BodyType {
+			// Already represented; nothing to add.
+			return cur
+		}
+	}
+	nextMembers, nextTypes := alternativesOf(next)
+	members = append(members, nextMembers...)
+	types = append(types, nextTypes...)
+
+	merged := *cur
+	merged.Schema = &Schema{AnyOf: members}
+	// OneOfTypes is what component collection reads to register every type a
+	// composed body can resolve to; it is not tied to the oneOf keyword.
+	merged.OneOfTypes = types
+	return &merged
+}
+
+// alternativesOf unpacks a response into the schemas and type names it already
+// represents, so merging is accumulative rather than nested.
+func alternativesOf(r *ResponseInfo) ([]*Schema, []string) {
+	if len(r.Schema.AnyOf) > 0 && len(r.OneOfTypes) == len(r.Schema.AnyOf) {
+		return append([]*Schema{}, r.Schema.AnyOf...), append([]string{}, r.OneOfTypes...)
+	}
+	return []*Schema{r.Schema}, []string{r.BodyType}
+}
+
 func preferResponseInfo(cur, next *ResponseInfo) *ResponseInfo {
 	if cur == nil {
 		return next
@@ -1660,7 +1802,11 @@ func responseIsConcrete(r *ResponseInfo) bool {
 		return false
 	}
 	s := r.Schema
-	return s.Ref != "" || len(s.Properties) > 0 || len(s.AllOf) > 0 || s.Items != nil
+	// A composed body (anyOf/oneOf) is as resolved as its members. Without
+	// these two, a composition is judged unresolved and the next store for that
+	// status discards it for whichever single body arrived last.
+	return s.Ref != "" || len(s.Properties) > 0 || len(s.AllOf) > 0 ||
+		len(s.AnyOf) > 0 || len(s.OneOf) > 0 || s.Items != nil
 }
 
 // extractRequestFromNode extracts request information from a node
@@ -2488,6 +2634,7 @@ func (r *ResponsePatternMatcherImpl) ExtractResponse(node TrackerNodeInterface, 
 		statusStr := r.contextProvider.GetArgumentInfo(statusArg)
 		if status, ok := r.schemaMapper.MapStatusCode(statusStr); ok {
 			statusResolved = true
+			respInfo.StatusInFrame = true
 			respInfo.StatusCode = status
 		} else if callerArg, _ := resolveArgThroughParams(statusArg, node); callerArg != statusArg {
 			// The status arg is a parameter threaded through one or more
@@ -2517,6 +2664,9 @@ func (r *ResponsePatternMatcherImpl) ExtractResponse(node TrackerNodeInterface, 
 	if !statusResolved && r.pattern.DefaultStatus > 0 {
 		respInfo.StatusCode = r.pattern.DefaultStatus
 		statusResolved = true
+		// A pattern's own default is a property of the call, not of who called
+		// it, so it is as frame-local as a literal.
+		respInfo.StatusInFrame = true
 	}
 
 	// A body write that names no status at all takes the framework's implicit

--- a/internal/spec/tests/generic.yaml
+++ b/internal/spec/tests/generic.yaml
@@ -682,6 +682,7 @@ packages:
                 start_col: 21
                 end_line: 23
                 end_col: 2
+                terminates: true
                 group: 1
           main:
             name: 76

--- a/testdata/branch_status_scope/main.go
+++ b/testdata/branch_status_scope/main.go
@@ -34,6 +34,7 @@ func main() {
 	mux.HandleFunc("GET /loop", statusInLoop)
 	mux.HandleFunc("GET /arms", statusInEveryArm)
 	mux.HandleFunc("GET /before", statusBeforeBranch)
+	mux.HandleFunc("GET /alternatives", statusOverTwoTypes)
 
 	http.ListenAndServe(":8080", mux)
 }
@@ -98,15 +99,22 @@ func statusInEveryArm(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(Item{ID: "1"})
 }
 
+// statusOverTwoTypes writes one status above a branch whose arms send
+// DIFFERENT types. The endpoint really can answer 202 with either, so the
+// response is the alternation of them rather than whichever the walk saw last.
+func statusOverTwoTypes(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusAccepted)
+	if r.URL.Query().Get("detail") != "" {
+		_ = json.NewEncoder(w).Encode(Item{ID: "1", Name: "detailed"})
+		return
+	}
+	_ = json.NewEncoder(w).Encode(APIError{Message: "queued"})
+}
+
 // statusBeforeBranch writes the status unconditionally, then a body on each
 // side of a branch. Every path to both bodies passed the write, so both are
-// 201s.
-//
-// Only the FIRST of them is: a pending status is consumed by the body that
-// claims it, so the second falls through to the implicit 200 (issue #391).
-// That is a separate defect from the dominance rule this fixture is for — the
-// status here dominates both bodies — so the structural test pins the current
-// answer as a change detector and flips when #391 is fixed.
+// 201s — and both bodies are the same type, so the response is one schema
+// (issue #391).
 func statusBeforeBranch(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusCreated)
 	if r.URL.Query().Get("full") != "" {


### PR DESCRIPTION
Closes #391.

## The defect

A status that dominates several bodies was claimed by the first of them, so the rest fell through to the implicit 200:

```go
w.WriteHeader(http.StatusCreated)          // dominates BOTH bodies
if r.URL.Query().Get("full") != "" {
	_ = json.NewEncoder(w).Encode(Item{ID: "1", Name: "full"})
	return
}
_ = json.NewEncoder(w).Encode(Item{ID: "1"})
```

Documented as **201 and 200**. The server sends 201 on both paths; there is no path on which it sends 200.

## The fix, and the two guards it needs

The status is no longer consumed by the body that claims it. Getting there took three measured attempts, and the guards are what the measurements bought:

**1. The bodies must be ALTERNATIVES.** Arms of one conditional, or an arm that exits and the code after it. Two bodies on the same path are two different responses — letting the later one claim the status put `APIError` on the 200 of 44 gitea operations in the first version of this change.

That needs a fact metadata did not record: **`Block.Terminates`**, whether an arm ends in a `return`, a `panic` or a branch statement. Without it the only visible alternatives are the arms of an if/else, and Go's dominant idiom — `if bad { …; return }` above the success path, which is exactly the issue's own example — reads as sequential code. Syntactic certainty only: a call that never returns by convention (`os.Exit`, `log.Fatal`) is not counted, since deciding that needs the type checker and would be a guess for any project-local wrapper.

**2. The status must have been resolved IN FRAME** — a literal or constant at the write itself, not traced in through a parameter. A shared responder has one `WriteHeader(status)` statement serving every call in the program:

```go
func (ctx *Context) JSON(status int, obj any) {
	ctx.Resp.WriteHeader(status)
	_ = json.NewEncoder(ctx.Resp).Encode(obj)
}
```

Which status that statement writes depends on the invocation, and the tracker cannot tell invocations of a shared helper apart — that is #389's open problem, measured there three separate ways. Without this guard gitea's LFS list endpoint documented its 200 with `LFSLockError`, the error type. With it, the relaxation applies exactly where the status's identity is not in doubt.

## anyOf, per the issue discussion

Where one status ends up carrying more than one body TYPE, the response alternates between them; same-typed bodies are one schema and compose nothing.

```yaml
"202":
  content:
    application/json:
      schema:
        anyOf:
          - $ref: '#/components/schemas/…_Item'
          - $ref: '#/components/schemas/…_APIError'
```

anyOf rather than oneOf: the alternatives are not claimed to be mutually exclusive, only to be what this status may carry — a payload validating against two of them is still a valid response, which oneOf would call invalid.

Two things had to be fixed for a composition to survive:

- **`responseIsConcrete` did not recognise `anyOf`/`oneOf`**, so a composed body was judged unresolved and the next store for that status discarded it for whichever single body came last. That is a latent bug for #201's oneOf compositions too.
- **Composition is limited to bodies whose status was STATED.** Two bodies that merely defaulted to the framework's implicit status are not evidence that one status carries both; composing those advertised error types on success responses across 252 gitea operations.

## Measured

**Zero drift on both real projects**: gitea unchanged at 1,109 operations / 2,351 responses, and a 163-route private service unchanged at 239 responses. The fixture is what moves.

For context on why the guards are drawn where they are, the looser versions measured on gitea before them:

| version | wrong/noisy responses |
|---|---|
| claim relaxation, no exclusivity guard | 44 operations documenting an error type on 200 |
| compose every same-status collision | 261 alternations, mostly `anyOf: [string, string]` and `[integer, string]` |
| compose implicit-status bodies too | 252 operations changed |
| **this PR** | **0** |

## Coverage

- `testdata/branch_status_scope`: `/before` flips from its change-detector answer to `{"201": "Item"}`, and `/alternatives` covers one status over two branches sending different types.
- `TestCollectBlocksTerminates` over the statement shapes that do and do not exit, including a call that merely looks final.
- `TestExclusive` over sibling arms, an arm that exits versus one that falls through, and the missing-fact cases that must answer false rather than guess.

Full suite green with a cold cache, `go vet` and `golangci-lint` clean, coverage ratchet holding at 96.0%. The metadata goldens gained the new field.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved API response analysis for conditional control flows.
  * Responses from mutually exclusive branches can now be represented as alternative schemas.
  * Enhanced recognition of combined request and response schemas.

* **Bug Fixes**
  * Corrected branch-status expectations and response mappings.
  * Improved handling of terminating branches, loops, and fall-through paths to avoid incorrect status combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->