### PR TITLE
test: give each slab node its own value, and pin the carve frontier

### DIFF
--- a/internal/spec/lazytree_budget_test.go
+++ b/internal/spec/lazytree_budget_test.go
@@ -16,6 +16,7 @@ package spec
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -132,9 +133,10 @@ func TestInstanceBudgetCapsTraversal(t *testing.T) {
 }
 
 // TestNewNodeSlabHandsOutStablePointers pins the property the slab must keep: a
-// node's address never moves. Nodes reference their parent, so a slab that grew
-// in place (append) would copy the backing array and leave every pointer already
-// handed out pointing at a stale copy.
+// node's address never moves, and no later carve writes over a node already
+// handed out. Nodes reference their parent, so a slab that grew in place
+// (append) would copy the backing array and leave every pointer already handed
+// out pointing at a stale copy.
 func TestNewNodeSlabHandsOutStablePointers(t *testing.T) {
 	tree := &LazyTree{}
 
@@ -143,7 +145,11 @@ func TestNewNodeSlabHandsOutStablePointers(t *testing.T) {
 	nodes := make([]*LazyNode, 0, nodeSlabChunk+16)
 	for i := 0; i < nodeSlabChunk+16; i++ {
 		node := tree.newNode()
-		node.key = "node"
+		// A DISTINCT value per node, not one shared string: identical values
+		// would read back correctly even from memory a later carve had reused,
+		// so the check would pass on an allocator that hands out overlapping
+		// slots.
+		node.key = strconv.Itoa(i)
 		nodes = append(nodes, node)
 	}
 
@@ -153,8 +159,21 @@ func TestNewNodeSlabHandsOutStablePointers(t *testing.T) {
 			t.Fatalf("node %d reuses an address already handed out", i)
 		}
 		seen[node] = true
-		if node.key != "node" {
-			t.Fatalf("node %d was mutated after being handed out: key=%q", i, node.key)
+		if node.key != strconv.Itoa(i) {
+			t.Fatalf("node %d was written over after being handed out: key=%q, want %q",
+				i, node.key, strconv.Itoa(i))
+		}
+	}
+
+	// The slab the tree is carving from must not contain a node it already
+	// handed out: newNode advances past each slot, so the next free slot is
+	// beyond every live node. (A "compare nodes[0] with tree.nodeSlab[0]" check
+	// would assert the opposite and fail on correct code — after any hand-out
+	// nodeSlab[0] is the NEXT slot, never the first one returned.)
+	if len(tree.nodeSlab) > 0 {
+		next := &tree.nodeSlab[0]
+		if seen[next] {
+			t.Error("the next free slot is a node already handed out")
 		}
 	}
 


### PR DESCRIPTION
From a CodeRabbit finding on #250. The test it names lives on main, so it is fixed here rather than on that branch.

## What the test was proving, and what it wasn't

`TestNewNodeSlabHandsOutStablePointers` wrote **one shared string** to every node and then checked the string came back:

```go
node.key = "node"
...
if node.key != "node" { … }
```

Identical values read back correctly even from memory a later carve had reused, so that check carried almost no information. Each node now carries its own index, and the failure message names the node that was written over.

## The suggested assertion would fail on correct code

The review proposed comparing the first handed-out pointer with the slab's first slot:

```go
if got := &tree.nodeSlab[0]; got != nodes[0] { … }
```

`newNode` carves by advancing the slice:

```go
node := &t.nodeSlab[0]
t.nodeSlab = t.nodeSlab[1:]
```

so after any hand-out `nodeSlab[0]` is the **next free slot**, never the first node returned — the assertion asserts the opposite of the invariant and fails on a correct allocator. The frontier property worth pinning is the one that is actually true: the slot about to be carved is not a node already handed out. That is in the test now, with a comment recording why the obvious version is wrong, since the next reader will think of it too.

## Checked, not assumed

Against an allocator that stops advancing once the slab is down to its last slot:

```
node 4095 was written over after being handed out: key="4111", want "4095"
```

The `append`-reallocation the original comment worries about is not reachable here — `newNode` never appends; when the slab is spent it is **replaced**, and the old array stays alive through the pointers already handed out. That is worth knowing rather than guarding against, so the test does not pretend to cover it.

Full suite green, `golangci-lint` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for node allocation stability during slab growth.
  - Added checks to ensure allocated nodes retain their unique keys.
  - Added validation preventing previously returned nodes from being incorrectly reused as free slots.
  - Documented potential pointer-stability and stale-slot failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->