### PR TITLE
perf(spec): grow the children slice instead of sizing it from the plan

### DIFF
--- a/internal/spec/lazytree.go
+++ b/internal/spec/lazytree.go
@@ -1153,9 +1153,16 @@ func (n *LazyNode) GetChildren() []TrackerNodeInterface {
 		n.tree.instanceCount[scope] = scopeCounts
 	}
 	plan := n.tree.planFor(n)
-	if cap(n.children) < len(plan) {
-		n.children = make([]TrackerNodeInterface, 0, len(plan))
-	}
+	// The children slice is GROWN, not sized from the plan. Nearly every child a
+	// plan lists is refused before it is built — by the barren-subtree prune,
+	// the cycle guard, the per-scope instance cap — so sizing by len(plan)
+	// reserved room for children that never arrive.
+	//
+	// Measured on gitea: 15,662,493 expansions reserved 143,364,946 slots and
+	// used 15,684,231 of them, wasting 89%. 7,020,413 of those expansions keep
+	// NO children at all, and each was reserving a slice for a whole plan.
+	// Leaving it nil means they allocate nothing; append sizes the rest to what
+	// they actually hold, and 91% of expansions hold two children or fewer.
 	childCount := 0
 	for _, spec := range plan {
 		if spec.arg == nil && childCount >= n.tree.limits.MaxChildrenPerNode {


### PR DESCRIPTION
Part of #389 — not the structural fix, but a measured cost that turned out to be nothing to do with node count.

## What the profile said

`GetChildren` was **40% of all allocation on gitea, 2.21 GB of it flat** — the children slices themselves, twice what the nodes cost. Instrumenting the expansion explains why:

```
expansions                        15,662,493
slots reserved (cap = len(plan))  143,364,946
slots used                         15,684,231   (10.9%)
wasted                            127,680,715   (89.1%)

expansions keeping NO children      7,020,413
expansions keeping <= 2            14,327,220   (91%)
```

Every expansion sized its slice from the PLAN, but nearly every planned child is refused before it is built — by the barren-subtree prune (#318), the cycle guard, the per-scope instance cap. Seven million expansions reserved a slice for a plan they never used a single slot of.

## The change

Leave the slice nil and let `append` grow it. The seven million zero-child expansions now allocate nothing, and the rest are sized to what they actually hold.

```
total allocated       9.70 GB -> 7.99 GB   (-17.6%)
GetChildren, flat     2.21 GB -> 0.44 GB   (-80%)
GetChildren, cum      3.91 GB -> 2.15 GB
peak RSS              4.53 / 4.44 GB -> 3.54 / 3.84 GB
```

Sizing by `min(len(plan), k)` instead was considered and is worse: with 7M zero-child expansions, any non-zero floor pays for all of them.

## Output

**Byte-identical on gitea (900 paths) and on a 163-route private service**, which is the whole claim — this changes how the slice is grown, not what is built. Full suite green with a cold cache, `golangci-lint` clean.

Wall clock is inside the run-to-run noise on a loaded machine (both binaries straddle 2m07–2m26 on gitea), which is what an allocation-only change should look like when the work is unchanged. The win is memory and GC pressure.

## What this does not do

It does not touch the node COUNT, which is what #389 is about: 15.7M nodes for 177K distinct (node, route) pairs. Three attempts at collapsing that are recorded on the issue, all reverted. This is the cost that sat beside it and was never the node count at all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of expanded tree nodes when all potential child entries are rejected.
  * Avoids creating unnecessary empty child collections, improving efficiency and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->