### PR TITLE
perf(spec): bound the scan for a statement's enclosing frame (#389)

### DIFF
--- a/internal/spec/enclosing_frame_test.go
+++ b/internal/spec/enclosing_frame_test.go
@@ -20,10 +20,14 @@ import (
 	"github.com/ehabterra/apispec/internal/metadata"
 )
 
-// frameChain builds a node whose ancestors are `depth` frames deep, with the
-// frame that CALLS `enclosing` sitting at `at` (1 = the immediate parent).
-// Frames carry parameter bindings unless their index is in `noParams`.
-func frameChain(t *testing.T, depth, at int, noParams map[int]bool) (TrackerNodeInterface, string) {
+// frameChain builds a statement whose ancestors are `depth` frames deep, with a
+// frame that calls `enclosing` at each depth in `targets` (1 = the immediate
+// parent). A depth listed in `noParams` carries no parameter bindings.
+//
+// It returns the frames by depth so a test can assert WHICH one was chosen:
+// with a single matching frame, "the nearest wins" and "a bindingless frame is
+// skipped" are both unfalsifiable.
+func frameChain(t *testing.T, depth int, targets map[int]bool, noParams map[int]bool) (TrackerNodeInterface, string, []*TrackerNode) {
 	t.Helper()
 	pool := metadata.NewStringPool()
 	meta := &metadata.Metadata{StringPool: pool}
@@ -34,30 +38,29 @@ func frameChain(t *testing.T, depth, at int, noParams map[int]bool) (TrackerNode
 	target := callee("target")
 	enclosing := target.BaseID()
 
-	var node TrackerNodeInterface
+	byDepth := make([]*TrackerNode, depth+1) // 1-based: byDepth[1] is the parent
+	var node *TrackerNode
 	for i := depth; i >= 1; i-- {
 		name := "filler"
-		var params map[string]metadata.CallArgument
-		if i == at {
+		if targets[i] {
 			name = "target"
 		}
+		var params map[string]metadata.CallArgument
 		if !noParams[i] {
 			params = map[string]metadata.CallArgument{"v": {}}
 		}
 		frame := &TrackerNode{
 			CallGraphEdge: &metadata.CallGraphEdge{Callee: callee(name), ParamArgMap: params},
+			Parent:        node,
 		}
-		if node != nil {
-			frame.Parent = node.(*TrackerNode)
-		}
+		byDepth[i] = frame
 		node = frame
 	}
-	// The statement itself hangs below the innermost frame.
 	stmt := &TrackerNode{
 		CallGraphEdge: &metadata.CallGraphEdge{Caller: callee("target")},
-		Parent:        node.(*TrackerNode),
+		Parent:        node,
 	}
-	return stmt, enclosing
+	return stmt, enclosing, byDepth
 }
 
 // TestEnclosingFrameIsBounded pins the limit and the reason it is safe: it sits
@@ -66,27 +69,24 @@ func frameChain(t *testing.T, depth, at int, noParams map[int]bool) (TrackerNode
 // that reaching the root already gives.
 func TestEnclosingFrameIsBounded(t *testing.T) {
 	// Inside the bound: found.
-	node, enclosing := frameChain(t, enclosingFrameLimit+8, enclosingFrameLimit, nil)
-	if got := enclosingFrame(node, enclosing, false); got == nil {
-		t.Errorf("frame at depth %d was not found, and the limit is %d",
-			enclosingFrameLimit, enclosingFrameLimit)
+	node, enclosing, frames := frameChain(t, enclosingFrameLimit+8, map[int]bool{enclosingFrameLimit: true}, nil)
+	if got := enclosingFrame(node, enclosing, false); got != frames[enclosingFrameLimit] {
+		t.Errorf("frame at the limit (%d) was not the one returned: got %v",
+			enclosingFrameLimit, got)
 	}
 
 	// Past the bound: not found, rather than walked to the root.
-	node, enclosing = frameChain(t, enclosingFrameLimit+8, enclosingFrameLimit+4, nil)
+	node, enclosing, _ = frameChain(t, enclosingFrameLimit+8, map[int]bool{enclosingFrameLimit + 4: true}, nil)
 	if got := enclosingFrame(node, enclosing, false); got != nil {
 		t.Errorf("frame beyond the limit of %d was returned; the scan is unbounded again",
 			enclosingFrameLimit)
 	}
 
-	// The nearest frame wins when several match.
-	node, enclosing = frameChain(t, 6, 2, nil)
-	got := enclosingFrame(node, enclosing, false)
-	if got == nil {
-		t.Fatal("no frame found in a chain that contains one")
-	}
-	if got.GetParent() == nil {
-		t.Error("returned the outermost frame, want the nearest matching one")
+	// The NEAREST frame wins when several match — asserted against a chain that
+	// contains two, so returning the farther one fails.
+	node, enclosing, frames = frameChain(t, 8, map[int]bool{2: true, 5: true}, nil)
+	if got := enclosingFrame(node, enclosing, false); got != frames[2] {
+		t.Errorf("with matching frames at depths 2 and 5, got %v, want the one at 2", got)
 	}
 }
 
@@ -94,16 +94,16 @@ func TestEnclosingFrameIsBounded(t *testing.T) {
 // depend on: one stops at the first matching frame whatever it carries, the
 // other keeps looking for a frame that can actually bind the parameter.
 func TestEnclosingFrameParamRequirement(t *testing.T) {
-	// The nearest matching frame carries no bindings; a further one does.
-	node, enclosing := frameChain(t, 8, 2, map[int]bool{2: true})
+	// The nearest matching frame carries no bindings; a farther one does. Both
+	// are needed: with only the near one, "skips it" and "stops at it" look the
+	// same.
+	node, enclosing, frames := frameChain(t, 8, map[int]bool{2: true, 5: true}, map[int]bool{2: true})
 
-	if got := enclosingFrame(node, enclosing, false); got == nil {
-		t.Error("without requireParams the first matching frame must be returned, bindings or not")
+	if got := enclosingFrame(node, enclosing, false); got != frames[2] {
+		t.Errorf("without requireParams the nearest matching frame must be returned whatever it carries: got %v", got)
 	}
-	// With requireParams the bindingless frame is skipped — and since this
-	// fixture has only one matching frame, nothing is found.
-	if got := enclosingFrame(node, enclosing, true); got != nil {
-		t.Error("with requireParams a frame carrying no bindings must be skipped")
+	if got := enclosingFrame(node, enclosing, true); got != frames[5] {
+		t.Errorf("with requireParams the bindingless frame at 2 must be skipped for the bound one at 5: got %v", got)
 	}
 }
 
@@ -111,7 +111,7 @@ func TestEnclosingFrameNilSafety(t *testing.T) {
 	if got := enclosingFrame(nil, "pkg.target", false); got != nil {
 		t.Error("a nil node must yield no frame")
 	}
-	node, _ := frameChain(t, 4, 2, nil)
+	node, _, _ := frameChain(t, 4, map[int]bool{2: true}, nil)
 	if got := enclosingFrame(node, "", false); got != nil {
 		t.Error("an empty enclosing name must yield no frame")
 	}

--- a/internal/spec/enclosing_frame_test.go
+++ b/internal/spec/enclosing_frame_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// frameChain builds a node whose ancestors are `depth` frames deep, with the
+// frame that CALLS `enclosing` sitting at `at` (1 = the immediate parent).
+// Frames carry parameter bindings unless their index is in `noParams`.
+func frameChain(t *testing.T, depth, at int, noParams map[int]bool) (TrackerNodeInterface, string) {
+	t.Helper()
+	pool := metadata.NewStringPool()
+	meta := &metadata.Metadata{StringPool: pool}
+
+	callee := func(name string) metadata.Call {
+		return metadata.Call{Meta: meta, Pkg: pool.Get("pkg"), Name: pool.Get(name)}
+	}
+	target := callee("target")
+	enclosing := target.BaseID()
+
+	var node TrackerNodeInterface
+	for i := depth; i >= 1; i-- {
+		name := "filler"
+		var params map[string]metadata.CallArgument
+		if i == at {
+			name = "target"
+		}
+		if !noParams[i] {
+			params = map[string]metadata.CallArgument{"v": {}}
+		}
+		frame := &TrackerNode{
+			CallGraphEdge: &metadata.CallGraphEdge{Callee: callee(name), ParamArgMap: params},
+		}
+		if node != nil {
+			frame.Parent = node.(*TrackerNode)
+		}
+		node = frame
+	}
+	// The statement itself hangs below the innermost frame.
+	stmt := &TrackerNode{
+		CallGraphEdge: &metadata.CallGraphEdge{Caller: callee("target")},
+		Parent:        node.(*TrackerNode),
+	}
+	return stmt, enclosing
+}
+
+// TestEnclosingFrameIsBounded pins the limit and the reason it is safe: it sits
+// above the deepest scan either measured project needs (10 ancestors on gitea,
+// 2 on a 163-route service), and past it the answer is the same "not resolved"
+// that reaching the root already gives.
+func TestEnclosingFrameIsBounded(t *testing.T) {
+	// Inside the bound: found.
+	node, enclosing := frameChain(t, enclosingFrameLimit+8, enclosingFrameLimit, nil)
+	if got := enclosingFrame(node, enclosing, false); got == nil {
+		t.Errorf("frame at depth %d was not found, and the limit is %d",
+			enclosingFrameLimit, enclosingFrameLimit)
+	}
+
+	// Past the bound: not found, rather than walked to the root.
+	node, enclosing = frameChain(t, enclosingFrameLimit+8, enclosingFrameLimit+4, nil)
+	if got := enclosingFrame(node, enclosing, false); got != nil {
+		t.Errorf("frame beyond the limit of %d was returned; the scan is unbounded again",
+			enclosingFrameLimit)
+	}
+
+	// The nearest frame wins when several match.
+	node, enclosing = frameChain(t, 6, 2, nil)
+	got := enclosingFrame(node, enclosing, false)
+	if got == nil {
+		t.Fatal("no frame found in a chain that contains one")
+	}
+	if got.GetParent() == nil {
+		t.Error("returned the outermost frame, want the nearest matching one")
+	}
+}
+
+// TestEnclosingFrameParamRequirement covers the difference the three callers
+// depend on: one stops at the first matching frame whatever it carries, the
+// other keeps looking for a frame that can actually bind the parameter.
+func TestEnclosingFrameParamRequirement(t *testing.T) {
+	// The nearest matching frame carries no bindings; a further one does.
+	node, enclosing := frameChain(t, 8, 2, map[int]bool{2: true})
+
+	if got := enclosingFrame(node, enclosing, false); got == nil {
+		t.Error("without requireParams the first matching frame must be returned, bindings or not")
+	}
+	// With requireParams the bindingless frame is skipped — and since this
+	// fixture has only one matching frame, nothing is found.
+	if got := enclosingFrame(node, enclosing, true); got != nil {
+		t.Error("with requireParams a frame carrying no bindings must be skipped")
+	}
+}
+
+func TestEnclosingFrameNilSafety(t *testing.T) {
+	if got := enclosingFrame(nil, "pkg.target", false); got != nil {
+		t.Error("a nil node must yield no frame")
+	}
+	node, _ := frameChain(t, 4, 2, nil)
+	if got := enclosingFrame(node, "", false); got != nil {
+		t.Error("an empty enclosing name must yield no frame")
+	}
+}

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -2862,6 +2862,51 @@ func (r *ResponsePatternMatcherImpl) traceArgViaParent(arg *metadata.CallArgumen
 	return resolved, resolvedNode
 }
 
+// enclosingFrameLimit bounds how far up the ancestor chain a resolver may look
+// for the frame that called the function a statement is written in.
+//
+// The three scans that look for it are identical and were unbounded, so a scan
+// that found nothing walked to the root. Measured, the frame is always near:
+//
+//	                       deepest successful scan   scans that found nothing
+//	gitea (374 packages)          10 ancestors        57,818 of 118,178 (49%)
+//	a 163-route service            2 ancestors        47,147 of 197,678 (24%)
+//
+// 95% of gitea's successful scans finish within 8 and every one within 10, while
+// the fruitless ones ran 24 to 128 ancestors before giving up. The bound is set
+// above the deepest observed hit with room to spare; past it the answer is the
+// same "not resolved" a scan that reaches the root already gives, so the failure
+// mode is unchanged and only its cost is.
+//
+// It also makes the ancestry a resolver reads FINITE, which is what any attempt
+// to memoize the walk needs and has never had (issue #389).
+const enclosingFrameLimit = 16
+
+// enclosingFrame returns the nearest ancestor whose callee is the named
+// function — the call that entered the frame a statement is written in — or nil
+// when there is none within enclosingFrameLimit ancestors.
+//
+// requireParams skips a frame that carries no parameter bindings instead of
+// stopping at it. The two behaviours differ and both are load-bearing: a
+// resolver that stops treats the first matching frame as the answer, and one
+// that skips keeps looking for a frame that can actually bind the parameter.
+func enclosingFrame(node TrackerNodeInterface, enclosing string, requireParams bool) TrackerNodeInterface {
+	if node == nil || enclosing == "" {
+		return nil
+	}
+	for p, steps := node.GetParent(), 0; p != nil && steps < enclosingFrameLimit; p, steps = p.GetParent(), steps+1 {
+		pe := p.GetEdge()
+		if pe == nil || pe.Callee.BaseID() != enclosing {
+			continue
+		}
+		if requireParams && pe.ParamArgMap == nil {
+			continue
+		}
+		return p
+	}
+	return nil
+}
+
 // argViaParent recovers the caller-site value of a parameter ident by finding
 // the call into the function the matched call lives in and reading that edge's
 // ParamArgMap (callee parameter name → caller argument). Returns nil when the
@@ -2900,18 +2945,16 @@ func argViaParent(arg *metadata.CallArgument, node TrackerNodeInterface) (*metad
 	if enclosing == "" {
 		return nil, nil
 	}
-	for p := node.GetParent(); p != nil; p = p.GetParent() {
-		pe := p.GetEdge()
-		if pe == nil || pe.Callee.BaseID() != enclosing {
-			continue
-		}
-		if pe.ParamArgMap == nil {
-			return nil, nil
-		}
-		if callerArg, ok := pe.ParamArgMap[arg.GetName()]; ok {
-			return &callerArg, p
-		}
+	p := enclosingFrame(node, enclosing, false)
+	if p == nil {
 		return nil, nil
+	}
+	pe := p.GetEdge()
+	if pe.ParamArgMap == nil {
+		return nil, nil
+	}
+	if callerArg, ok := pe.ParamArgMap[arg.GetName()]; ok {
+		return &callerArg, p
 	}
 	return nil, nil
 }
@@ -3451,22 +3494,19 @@ func (r *BasePatternMatcher) concreteFromParamBinding(arg *metadata.CallArgument
 	if enclosing == "" {
 		return ""
 	}
-	for p := node.GetParent(); p != nil; p = p.GetParent() {
-		pe := p.GetEdge()
-		if pe == nil || pe.Callee.BaseID() != enclosing {
-			continue
-		}
-		callerArg, ok := pe.ParamArgMap[arg.GetName()]
-		if !ok {
-			return ""
-		}
-		ct := r.contextProvider.GetArgumentInfo(&callerArg)
-		if ct == "" || isInterfaceTypeName(ct, meta) {
-			return ""
-		}
-		return ct
+	p := enclosingFrame(node, enclosing, false)
+	if p == nil {
+		return ""
 	}
-	return ""
+	callerArg, ok := p.GetEdge().ParamArgMap[arg.GetName()]
+	if !ok {
+		return ""
+	}
+	ct := r.contextProvider.GetArgumentInfo(&callerArg)
+	if ct == "" || isInterfaceTypeName(ct, meta) {
+		return ""
+	}
+	return ct
 }
 
 // concreteFromCalleeReturn resolves an interface-typed call result used as a

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -331,15 +331,12 @@ func paramArgOfEnclosingFunc(arg *metadata.CallArgument, node TrackerNodeInterfa
 	if enclosing == "" {
 		return nil, false
 	}
-	for p := node.GetParent(); p != nil; p = p.GetParent() {
-		pe := p.GetEdge()
-		if pe == nil || pe.Callee.BaseID() != enclosing || pe.ParamArgMap == nil {
-			continue
-		}
-		if callerArg, ok := pe.ParamArgMap[arg.GetName()]; ok {
-			return &callerArg, true
-		}
+	p := enclosingFrame(node, enclosing, true)
+	if p == nil {
 		return nil, false
+	}
+	if callerArg, ok := p.GetEdge().ParamArgMap[arg.GetName()]; ok {
+		return &callerArg, true
 	}
 	return nil, false
 }


### PR DESCRIPTION
Part of #389 — the prerequisite the three failed memo attempts were missing.

## What was unbounded

Three resolvers look for the frame that called the function a statement is written in, each by the same loop: walk ancestors until one's callee matches. Unbounded, so a scan that found nothing walked to the root.

Instrumenting them says the frame is always near, and the fruitless scans are the long ones:

|  | deepest successful scan | scans that found nothing |
|---|---|---|
| gitea (374 packages) | **10 ancestors** | 57,818 of 118,178 (49%) |
| a 163-route service | **2 ancestors** | 47,147 of 197,678 (24%) |

95% of gitea's successful scans finish within 8 and every one within 10, while the fruitless ones ran **24 to 128** ancestors before giving up.

## The change

The three loops become one helper, bounded at **16** — above the deepest observed hit with room to spare. Past the bound the answer is the same *not resolved* that reaching the root already gives, so the failure mode is unchanged and only its cost is.

`requireParams` keeps the one difference between the callers: two stop at the first matching frame whatever it carries, the third skips a frame with no parameter bindings and keeps looking. Both behaviours are load-bearing, so the helper takes the flag rather than picking one.

## Why it matters beyond the pointer chases

The saved work is small — ~118K walks, not 15.7M nodes. The point is the invariant: **the ancestry a resolver may read is now finite and stated.**

Every attempt to collapse the extraction walk has died on the same thing, recorded on #389: a memo key must model everything resolution reads, and "everything" was an unbounded walk up the tree that nobody had enumerated. The third attempt passed every fixture and the eager/lazy parity test, then dropped 609 of gitea's responses because it missed a resolver. With the reads bounded and named, a bounded key can be sound by construction rather than by hope.

## Verification

Byte-identical output on gitea (900 paths, 2,351 responses) and on a 163-route private service. Full suite green with a cold cache, `go vet` and `golangci-lint` clean, coverage ratchet at 96.0%. Unit tests pin the bound, the nearest-frame-wins rule, and the skip/stop distinction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of nested parameter and argument lookups.
  - Added safeguards for missing, empty, or incomplete binding information.
  - Prevented ancestor searches from continuing indefinitely in deeply nested structures.

- **Tests**
  - Added coverage for bounded frame lookup, nearest matching frames, parameter-binding requirements, and nil or empty inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->