### PR TITLE
perf(spec): find a constructor's call edge through the caller index

### DIFF
--- a/internal/spec/branched_status_constructor_test.go
+++ b/internal/spec/branched_status_constructor_test.go
@@ -179,6 +179,9 @@ func TestFindCallEdge(t *testing.T) {
 		}
 	}
 	meta.CallGraph = []metadata.CallGraphEdge{e("pkgA", "pos1"), e("pkgB", "pos2")}
+	// findCallEdge reads the caller index, which generated and loaded metadata
+	// always have; a hand-built call graph has to say so.
+	meta.BuildCallGraphMaps()
 	callerID := caller.ID()
 
 	// Package-agnostic ("" pkg): position match, first-match fallback, no-match.
@@ -409,6 +412,9 @@ func TestStatusesFromConstructorField_EdgeOnlyAssignment(t *testing.T) {
 		Position:    meta.StringPool.Get("callpos"),
 		ParamArgMap: map[string]metadata.CallArgument{"code": *mkIdent(meta, "statusCode", "")},
 	}}
+	// findCallEdge reads the caller index, which generated and loaded metadata
+	// always have; a hand-built call graph has to say so.
+	meta.BuildCallGraphMaps()
 
 	// arg = e.Code
 	arg := metadata.NewCallArgument(meta)

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -3126,8 +3126,18 @@ func calleeNameOf(fun *metadata.CallArgument) string {
 // same-named constructors across packages); "" skips the package check.
 func findCallEdge(impl *ContextProviderImpl, callerID, calleeFunc, calleePkg, valPos string) *metadata.CallGraphEdge {
 	var first *metadata.CallGraphEdge
-	for i := range impl.meta.CallGraph {
-		e := &impl.meta.CallGraph[i]
+	// The caller's own bucket rather than the whole call graph. Measured on a
+	// 163-route service, scanning every edge here — and building each one's
+	// instance ID to compare it — was 13.4% of the run: 660ms of 4.9s, of which
+	// 340ms was Call.ID assembling strings for edges that could not match.
+	//
+	// Buckets are appended in CallGraph order (see BuildCallGraphMaps), so the
+	// first match is the same edge the scan returned. The lookup key is the
+	// BASE id while callerID is the instance id — identical for a caller, whose
+	// position is never recorded, except that a generic caller's instance id
+	// carries its type arguments. Strip to the base to find the bucket, and
+	// keep comparing the full id inside it so that distinction still decides.
+	for _, e := range impl.meta.Callers[metadata.StripToBase(callerID)] {
 		if e.Caller.ID() != callerID || impl.GetString(e.Callee.Name) != calleeFunc {
 			continue
 		}


### PR DESCRIPTION
Found by profiling a 163-route service rather than gitea — the two have very different hot spots, and this one never showed up in gitea's profile.

## Where its time went

```
loaded 103 packages   1.41s   (29%)
metadata generated    0.69s   (14%)
spec mapped           2.78s   (57%)
```

Inside that, the CPU profile:

```
750ms 15.2%  runtime.madvise
340ms  6.9%  metadata.(*Call).InstanceID
310ms  6.3%  spec.findCallEdge          (660ms / 13.4% cumulative)
```

`findCallEdge` scans the **whole call graph** for every lookup, and calls `Caller.ID()` on each edge — which builds a string. Those are the same 660ms twice over: the scan, and the ids it assembles for edges that cannot match.

```go
for i := range impl.meta.CallGraph {
    e := &impl.meta.CallGraph[i]
    if e.Caller.ID() != callerID || … { continue }
```

It is the shape `findFunctionByName` had before #322 indexed it.

## The change

The caller's own bucket answers the same question. `BuildCallGraphMaps` appends buckets in CallGraph order and says so precisely because this substitution is meant to be safe:

> Buckets are appended in CallGraph order, so iterating one yields the matching edges in exactly the order a linear scan would visit them. That is what lets the index replace the scan without changing which edge wins.

One subtlety: the index is keyed by the BASE id, while `callerID` is an instance id. For a caller those are the same — its position is never recorded — **except** that a generic caller's instance id carries its type arguments. So the bucket is found by base and the full id is still compared inside it, which keeps that distinction deciding exactly what it decided before.

## Measured

| | before | after |
|---|---|---|
| the 163-route service | 4.89s | **3.44s (−29.7%)** |
| — its spec-mapping stage | 2.78s | **1.76s** |
| gitea | 1m28.9 / 1m27.5 | 1m31.0 / 1m27.6 (noise) |

Faster in all five interleaved pairs on the service, worst pair −17%, best −35%. **Byte-identical output on both projects.**

gitea is unmoved because its cost is elsewhere: the constructor-field resolution this serves runs far less relative to its 15.7M node materialisations. After the change no apispec function is left in the service's profile top twelve — what remains is allocator and GC, which is #389's territory.

## Tests

Two unit tests built a call graph by hand and never built its index. Generated and loaded metadata always build it (`GenerateMetadata`, `LoadMetadata`), so the tests now do too — rather than the lookup carrying a fallback for a state production never reaches.

Full suite green with a cold cache, `golangci-lint` clean, coverage ratchet at 96.0%.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved call-graph edge resolution for more accurate status analysis.
  * Preserved package and position disambiguation when identifying call relationships.

* **Tests**
  * Updated call-graph test setup to reflect the required caller index.
  * Confirmed existing behavior and assertions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->