### PR TITLE
fix: a literal nil response body is documented as null (#404)

### DIFF
--- a/generator/testdata_nil_response_body_test.go
+++ b/generator/testdata_nil_response_body_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/spec"
+)
+
+// TestTestdata_NilResponseBody locks in issue #404: a handler that answers with
+// a literal nil sends `null`, and the spec says `type: "null"` rather than the
+// empty schema.
+//
+// `{}` is not a vaguer version of the same answer — it says the response may be
+// an object, an array or a string, which is the one thing this endpoint never
+// sends. The value is stated at the call site and was being thrown away.
+func TestTestdata_NilResponseBody(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "nil_response_body", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+	noNullSchemas(t, out)
+
+	// The error branch answers nil…
+	if s := responseSchemaOf(t, out, "/items/{id}", "GET", "404"); s.Type != "null" {
+		t.Errorf("GET /items/{id} 404: schema = %+v, want type null", s)
+	}
+	// …and so does a success path, which must read the same way.
+	if s := responseSchemaOf(t, out, "/items/{id}", "DELETE", "200"); s.Type != "null" {
+		t.Errorf("DELETE /items/{id} 200: schema = %+v, want type null", s)
+	}
+	// The real body beside them is untouched.
+	if s := responseSchemaOf(t, out, "/items/{id}", "GET", "200"); s.Ref == "" {
+		t.Errorf("GET /items/{id} 200: schema = %+v, want a $ref to Item", s)
+	}
+}

--- a/generator/testdata_wrapper_nil_payload_test.go
+++ b/generator/testdata_wrapper_nil_payload_test.go
@@ -30,23 +30,38 @@ import (
 // is the envelope itself. A real payload still composes an allOf naming the
 // concrete type.
 //
-// The empty-schema fallback for unmappable types (#395) briefly broke the first
-// half: `nil` stopped resolving to a nil schema, so the override fired with a
-// schema that constrains nothing and wrapped the base $ref in an allOf whose
-// second member said nothing. It cost 27 responses on a 163-route service
-// before it was caught by a snapshot comparison.
+// Both halves compose, and what each one composes is the point. A real payload
+// names its type; a nil payload pins `data` to null, which is what the endpoint
+// actually sends.
+//
+// The empty-schema fallback for unmappable types (#395) briefly made the nil
+// case compose NOTHING useful — `data: {}`, an allOf member that constrains
+// nothing — which cost 27 responses on a 163-route service their plain $ref for
+// no gain. #404 replaced that with `type: "null"`, so the composition is worth
+// making again. `isEmptySchema` still guards the case it was written for: an
+// override that genuinely resolves to nothing is still skipped.
 func TestTestdata_WrapperNilPayload(t *testing.T) {
 	out := loadTestdataWithFixtureConfig(t, "wrapper_nil_payload", spec.DefaultHTTPConfig())
 	noDanglingRefs(t, out)
 	noNullSchemas(t, out)
 
-	// No payload: the envelope, plainly. An allOf here is the defect.
+	// No payload: the envelope with data pinned to null, because that is what
+	// the endpoint sends. This composed to noise — `data: {}` — for as long as a
+	// literal nil had no schema of its own; #404 gave it `type: "null"`, which
+	// says something true and narrows the envelope's `Data any`.
 	logout := responseSchemaOf(t, out, "/logout", "GET", "200")
-	if len(logout.AllOf) != 0 {
-		t.Errorf("GET /logout: composed an allOf for a nil payload: %+v", logout.AllOf)
+	if len(logout.AllOf) != 2 {
+		t.Fatalf("GET /logout: want the envelope composed with its null data, got %+v", logout)
 	}
-	if !strings.HasSuffix(logout.Ref, "_Envelope") {
-		t.Errorf("GET /logout: schema = %+v, want a $ref to Envelope", logout)
+	if !strings.HasSuffix(logout.AllOf[0].Ref, "_Envelope") {
+		t.Errorf("GET /logout: first allOf member = %+v, want the Envelope $ref", logout.AllOf[0])
+	}
+	nulled, ok := logout.AllOf[1].Properties["data"]
+	if !ok {
+		t.Fatalf("GET /logout: second allOf member has no data property: %+v", logout.AllOf[1])
+	}
+	if nulled.Type != "null" {
+		t.Errorf("GET /logout: data = %+v, want type null — the endpoint sends `\"data\": null`", nulled)
 	}
 
 	// A real payload: still specialised, naming the concrete type.

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -3221,6 +3221,19 @@ func mapGoTypeToOpenAPISchema(usedTypes map[string]*Schema, goType string, meta 
 		// null}` — not valid OpenAPI, and enough to crash a reader that
 		// dereferences it (issue #395).
 		return &Schema{Type: "object"}, schemas
+	case "nil":
+		// A handler that answers with a literal nil — `ctx.Status(500).JSON(nil)`
+		// — sends exactly `null`, and the call site says so. Without this case
+		// `nil` falls through to the unmapped-primitive path and comes back as
+		// the empty schema, which claims the response may be an object, an
+		// array, a string or anything else (issue #404).
+		//
+		// `type: "null"` is JSON Schema 2020-12, which is what OpenAPI 3.1 is,
+		// and 3.1 is the default target. Under a 3.0 target the equivalent
+		// spelling is `nullable: true` — the type mapper cannot tell the two
+		// apart yet, and #368 needs the same fact for pointer fields, so
+		// whichever lands first should thread the target version down here.
+		return &Schema{Type: "null"}, schemas
 	default:
 		// For custom types, check if it's a struct in metadata
 		if meta != nil {

--- a/testdata/nil_response_body/go.mod
+++ b/testdata/nil_response_body/go.mod
@@ -1,0 +1,3 @@
+module github.com/ehabterra/apispec/testdata/nil_response_body
+
+go 1.22

--- a/testdata/nil_response_body/main.go
+++ b/testdata/nil_response_body/main.go
@@ -1,0 +1,43 @@
+// Fixture: a handler that answers with a literal nil sends `null`, and the spec
+// must say so.
+//
+// `json.NewEncoder(w).Encode(nil)` writes exactly `null`. Documenting it as `{}`
+// — the empty schema — says the response may be an object, an array, a string or
+// anything else, which is the one thing this endpoint never does. The call site
+// states the value; the spec should carry it (issue #404).
+//
+// `type: "null"` is JSON Schema 2020-12, which is what OpenAPI 3.1 is.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type Item struct {
+	ID string `json:"id"`
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /items/{id}", getItem)
+	mux.HandleFunc("DELETE /items/{id}", dropItem)
+	http.ListenAndServe(":8080", mux)
+}
+
+// getItem answers the error branch with a literal nil and the success branch
+// with a real body, so the two renderings sit side by side.
+func getItem(w http.ResponseWriter, r *http.Request) {
+	if r.PathValue("id") == "" {
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(nil)
+		return
+	}
+	_ = json.NewEncoder(w).Encode(Item{ID: r.PathValue("id")})
+}
+
+// dropItem answers nil on the success path: a null body, not an absent one.
+func dropItem(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(nil)
+}


### PR DESCRIPTION
Closes #404.

## The defect

```go
return ctx.Status(500).JSON(nil)          // fiber
_ = json.NewEncoder(w).Encode(nil)        // net/http
```

sends exactly `null`. It was documented as:

```yaml
schema: {}      # any JSON value
```

`nil` sits in metadata's primitive list but had no case in the type switch, so it fell through to the unmapped-primitive path (the one #395 added so an unmappable type renders as `{}` instead of a `null` that crashed readers — right as a floor, wrong when the value is known).

## The fix

```go
case "nil":
    return &Schema{Type: "null"}, schemas
```

`type: "null"` is JSON Schema 2020-12, which is what OpenAPI 3.1 is and what apispec targets by default. Under a 3.0 target the spelling is `nullable: true`, and the type mapper cannot tell the two apart — `OpenAPIVersion` lives on `GeneratorConfig` while the mapper takes `APISpecConfig`. #368 needs exactly the same fact for pointer fields, so whichever lands first should thread it down and the other can use it. Noted in the code rather than left to be rediscovered.

## Knock-on: the wrapper specialisation gets something true to compose

An envelope built from a nil payload now documents what it sends:

```yaml
# GET /logout
allOf:
  - $ref: '#/components/schemas/…_Envelope'
  - type: object
    properties: {data: {type: "null"}}
```

That composition was suppressed while `nil` had no schema — `isEmptySchema` skipped it, correctly, because `data: {}` constrained nothing. `data: {type: "null"}` narrows the envelope's `Data any` to what the endpoint actually answers, so it is worth composing. `isEmptySchema` still guards its original case: an override that genuinely resolves to nothing is still skipped.

`testdata/wrapper_nil_payload` moves with it — the fixture now asserts the composed null rather than the bare $ref.

## Measured

| project | effect |
|---|---|
| 163-route service | 26 operations gain `data: {type: "null"}` — all of them endpoints that answer `{"data": null}` |
| gitea | 1 operation, 1 response now `type: "null"` |
| recipes/hexagonal | 5 responses, all from `ctx.Status(…).JSON(nil)` |

**Heads-up for snapshot comparisons:** on those 26 operations the response `$ref` moves into `allOf[0].$ref`, so a key-level diff reports the old path as missing. Same information, one level deeper.

Full suite green with a cold cache, `golangci-lint` clean, coverage ratchet at 96.0%.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected generated API schemas for responses with no body, representing them explicitly as `null` instead of allowing any JSON value.
  - Updated wrapped responses with nil payloads to accurately describe their `data` field as `null`.
  - Preserved standard response schemas and references for non-nil response bodies.

- **Tests**
  - Added regression coverage for nil response bodies and verified that generated schemas contain no dangling references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->