### PR TITLE
fix: report packages that fail to load instead of generating a thin spec (#237)

### DIFF
--- a/cmd/apispecui/main.go
+++ b/cmd/apispecui/main.go
@@ -1081,7 +1081,12 @@ func (s *UIServer) handleGenerate(w http.ResponseWriter, r *http.Request) {
 		skipped := gen.SkippedPackages()
 		msg := ""
 		if len(skipped) > 0 {
-			msg = fmt.Sprintf("%d package(s) skipped because they failed to type-check — the spec may be incomplete. Ensure the project builds (go build ./...).", len(skipped))
+			// Naming the first package and what went wrong with it is the whole
+			// value of the message: a count alone leaves the user to guess
+			// whether the project has a syntax error or a missing dependency
+			// (issue #237).
+			msg = fmt.Sprintf("%d package(s) skipped — the spec is incomplete. %s %s: %s. Ensure the project builds (go build ./...).",
+				len(skipped), skipped[0].Package, skipped[0].Kind, skipped[0].Reason)
 		}
 		if expansion.Truncated {
 			// The failure mode this guards against is a run that LOOKS fine: the

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -335,11 +335,73 @@ func (e *Engine) GetResolvedCallGraph() *callgraph.Resolved {
 	return e.resolvedGraph
 }
 
-// SkippedPackage is a package excluded from analysis due to compile/type
-// errors, with a representative reason.
+// SkippedPackage is a package excluded from analysis because it did not load,
+// with a representative reason.
 type SkippedPackage struct {
 	Package string `json:"package"`
 	Reason  string `json:"reason"`
+	// Kind separates "did not parse" from "did not type-check" because the fix
+	// differs: a syntax error is always in the project's own source, while a
+	// type error is as often a missing generated file or an unresolved private
+	// dependency (issue #237). One of skipParse/skipType/skipLoad.
+	Kind string `json:"kind,omitempty"`
+}
+
+// Why a package was excluded, in the words the report uses.
+const (
+	skipParse = "does not parse"
+	skipType  = "does not type-check"
+	skipLoad  = "could not be loaded"
+)
+
+// classifySkip reduces a package's load errors to one kind and one reason.
+//
+// A package that fails to parse reports SEVERAL errors — go/packages emits the
+// driver's `# pkg` blob (ListError) alongside the parser's own message — so the
+// kind cannot be read off the first one, and neither can a useful reason: the
+// parser's message ("expected declaration, found ','") carries no position
+// while the driver's blob does. So the kind comes from the strongest error
+// present and the reason from the first one that names a file.
+func classifySkip(errs []packages.Error) (kind, reason string) {
+	kind = skipLoad
+	for _, e := range errs {
+		switch {
+		case e.Kind == packages.ParseError:
+			kind = skipParse
+		case e.Kind == packages.TypeError && kind != skipParse:
+			kind = skipType
+		}
+	}
+
+	// Prefer an error that names a file: without a position the reason cannot
+	// be acted on. The driver's blob leads with a "# import/path" line, which
+	// only repeats what the report already prints.
+	for _, e := range errs {
+		if msg := trimDriverHeader(e.Msg); strings.Contains(msg, ".go:") {
+			return kind, msg
+		}
+	}
+	if len(errs) > 0 {
+		return kind, trimDriverHeader(errs[0].Msg)
+	}
+	return kind, ""
+}
+
+// trimDriverHeader drops the leading "# import/path" line the go command puts
+// in front of a build error, and folds the rest onto one line so a report stays
+// one package per line.
+func trimDriverHeader(msg string) string {
+	lines := strings.Split(msg, "\n")
+	if len(lines) > 1 && strings.HasPrefix(lines[0], "# ") {
+		lines = lines[1:]
+	}
+	var kept []string
+	for _, l := range lines {
+		if l = strings.TrimSpace(l); l != "" {
+			kept = append(kept, l)
+		}
+	}
+	return strings.Join(kept, "; ")
 }
 
 // NewEngine creates a new Engine with the given configuration
@@ -464,11 +526,8 @@ func (e *Engine) GenerateMetadataOnlyWithLogger(logger *VerboseLogger) (*metadat
 			// Record (only in-module packages — third-party type errors are
 			// rarely actionable by the user) so the caller can surface them.
 			if mp := e.moduleImportPath(); mp == "" || pkg.PkgPath == mp || strings.HasPrefix(pkg.PkgPath, mp+"/") {
-				reason := ""
-				if len(pkg.Errors) > 0 {
-					reason = pkg.Errors[0].Msg
-				}
-				e.skipped = append(e.skipped, SkippedPackage{Package: pkg.PkgPath, Reason: reason})
+				kind, reason := classifySkip(pkg.Errors)
+				e.skipped = append(e.skipped, SkippedPackage{Package: pkg.PkgPath, Reason: reason, Kind: kind})
 			}
 			continue
 		}
@@ -484,6 +543,7 @@ func (e *Engine) GenerateMetadataOnlyWithLogger(logger *VerboseLogger) (*metadat
 		logger.Printf("Info: Continuing analysis with %d valid packages (%d packages skipped due to errors)\n",
 			len(validPkgs), errorCount)
 	}
+	e.reportSkippedPackages()
 
 	// Use valid packages instead of all filtered packages
 	filteredPkgs = validPkgs
@@ -1321,6 +1381,46 @@ func (e *Engine) reportNoRoutes() {
 	log.Printf("[engine] if this project serves HTTP, then its router is unsupported, is wired in a style no pattern matched, or was excluded by --include-*/--exclude-* filters — docs/DEBUGGING.md walks through telling those apart")
 }
 
+// maxSkippedPackagesReported bounds the per-package detail. One broken package
+// takes every package that imports it down with it, so on a large project the
+// list is a cascade of one root cause and printing all of it buries the line
+// that matters.
+const maxSkippedPackagesReported = 10
+
+// reportSkippedPackages says so when the project's own packages did not load.
+//
+// This is the diagnostic that turns "apispec found nothing" into "your project
+// does not compile". It was recorded and logged already, but only to the
+// verbose logger, so a default run dropped a package's entire route tree and
+// still printed "Successfully generated" over a thin spec (issue #237) — the
+// same silence #379 removed for the no-routes case, and it is written the same
+// way: log rather than reportPhase, because it is a result and not a phase.
+func (e *Engine) reportSkippedPackages() {
+	if len(e.skipped) == 0 {
+		return
+	}
+	log.Printf("[engine] %d in-module package(s) were not analysed, so the spec is incomplete:", len(e.skipped))
+	shown := e.skipped
+	if len(shown) > maxSkippedPackagesReported {
+		shown = shown[:maxSkippedPackagesReported]
+	}
+	parse := false
+	for _, s := range shown {
+		if s.Kind == skipParse {
+			parse = true
+		}
+		log.Printf("[engine]   %s %s: %s", s.Package, s.Kind, s.Reason)
+	}
+	if rest := len(e.skipped) - len(shown); rest > 0 {
+		log.Printf("[engine]   ... and %d more (one broken package takes its importers with it)", rest)
+	}
+	if parse {
+		log.Printf("[engine] a package that does not parse is a syntax error in the project's own source — `go build ./...` reports the same")
+	} else {
+		log.Printf("[engine] check that the project builds (`go build ./...`); generated files and private dependencies are the usual causes")
+	}
+}
+
 // GetUnresolvedRefs returns the references the most recent generation could not
 // satisfy, after they were repaired. Non-empty means the spec loads but some
 // operation's shape is a placeholder.
@@ -1343,8 +1443,9 @@ func (e *Engine) GetPathParamMismatches() []intspec.PathParamMismatch {
 }
 
 // SkippedPackages returns the in-module packages excluded from the most recent
-// analysis because they failed to type-check. A non-empty result means the
-// spec is likely incomplete — usually the project doesn't build (e.g. an
+// analysis because they failed to parse or type-check (Kind says which). A
+// non-empty result means the spec is likely incomplete — usually the project
+// doesn't build (e.g. a syntax error, a missing generated file, or an
 // unresolved/private dependency).
 func (e *Engine) SkippedPackages() []SkippedPackage {
 	return e.skipped

--- a/internal/engine/skipped_packages_test.go
+++ b/internal/engine/skipped_packages_test.go
@@ -1,0 +1,182 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// TestClassifySkip covers the reduction of a package's load errors to one kind
+// and one reason (issue #237).
+//
+// The multi-error case is the reason this function exists rather than reading
+// errs[0]: a package that fails to parse reports the go command's `# pkg` blob
+// AND the parser's own message, and neither one alone is a usable report — the
+// blob leads with a line that only repeats the package name, and the parser's
+// message carries no position.
+func TestClassifySkip(t *testing.T) {
+	cases := []struct {
+		name       string
+		errs       []packages.Error
+		wantKind   string
+		wantReason string
+	}{
+		{
+			name: "parse error, as go/packages really reports it",
+			errs: []packages.Error{
+				{Kind: packages.ListError, Msg: "# example.com/x/broken\nbroken/broken.go:3:1: syntax error: non-declaration statement outside function body"},
+				{Kind: packages.ParseError, Msg: "expected declaration, found ','"},
+			},
+			wantKind: skipParse,
+			// The positioned message, with the driver's header line dropped.
+			wantReason: "broken/broken.go:3:1: syntax error: non-declaration statement outside function body",
+		},
+		{
+			name:       "type error",
+			errs:       []packages.Error{{Kind: packages.TypeError, Msg: "undefined: broken.Helper"}},
+			wantKind:   skipType,
+			wantReason: "undefined: broken.Helper",
+		},
+		{
+			// A parse error anywhere outranks a type error: the type errors are
+			// its consequence, and reporting them sends the user after the wrong
+			// file.
+			name: "parse outranks type regardless of order",
+			errs: []packages.Error{
+				{Kind: packages.TypeError, Msg: "undefined: Foo"},
+				{Kind: packages.ParseError, Msg: "a.go:2:1: expected declaration"},
+			},
+			wantKind:   skipParse,
+			wantReason: "a.go:2:1: expected declaration",
+		},
+		{
+			name:       "list error only",
+			errs:       []packages.Error{{Kind: packages.ListError, Msg: "no Go files in /x"}},
+			wantKind:   skipLoad,
+			wantReason: "no Go files in /x",
+		},
+		{
+			// Nothing names a file, so the first error stands rather than the
+			// report having no reason at all.
+			name: "no positioned message falls back to the first",
+			errs: []packages.Error{
+				{Kind: packages.TypeError, Msg: "could not import x"},
+				{Kind: packages.TypeError, Msg: "undefined: y"},
+			},
+			wantKind:   skipType,
+			wantReason: "could not import x",
+		},
+		{name: "no errors", errs: nil, wantKind: skipLoad, wantReason: ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			kind, reason := classifySkip(tc.errs)
+			if kind != tc.wantKind {
+				t.Errorf("kind = %q, want %q", kind, tc.wantKind)
+			}
+			if reason != tc.wantReason {
+				t.Errorf("reason  = %q\nwant    = %q", reason, tc.wantReason)
+			}
+		})
+	}
+}
+
+// TestSkippedPackagesReportsParseError is the acceptance case for #237: a
+// project with a syntax error must say so.
+//
+// It builds the module in a temp dir rather than under testdata/ on purpose —
+// an unparseable .go file checked into the repo would break gofmt, vet and the
+// fixture suites, which is exactly why this shape had no coverage.
+//
+// The importer is asserted alongside the broken package because that is what
+// made the original report expensive: gitea's router package was two hops from
+// the syntax error, so the whole route tree vanished with nothing naming a
+// cause.
+func TestSkippedPackagesReportsParseError(t *testing.T) {
+	dir := t.TempDir()
+	write := func(rel, content string) {
+		t.Helper()
+		path := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", rel, err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+
+	write("go.mod", "module example.com/parsebug\n\ngo 1.21\n")
+	// A stray comma outside a declaration: the smallest thing the parser
+	// rejects while the file still looks like Go.
+	write("broken/broken.go", "package broken\n\n,\n\nfunc Helper() string { return \"x\" }\n")
+	write("router/router.go", "package router\n\nimport \"example.com/parsebug/broken\"\n\nfunc Name() string { return broken.Helper() }\n")
+	write("main.go", `package main
+
+import (
+	"net/http"
+
+	"example.com/parsebug/router"
+)
+
+func main() {
+	http.HandleFunc("/users", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(router.Name()))
+	})
+	_ = http.ListenAndServe(":8080", nil)
+}
+`)
+
+	e := NewEngine(&EngineConfig{InputDir: dir})
+	if _, err := e.GenerateOpenAPI(); err != nil {
+		// The run must still SUCCEED — the point is that it reports, not that
+		// it refuses to generate what it could read.
+		t.Fatalf("generation failed: %v", err)
+	}
+
+	skipped := e.SkippedPackages()
+	if len(skipped) == 0 {
+		t.Fatal("no packages reported as skipped — a project that does not build generated a thin spec silently (#237)")
+	}
+
+	byPkg := make(map[string]SkippedPackage, len(skipped))
+	for _, s := range skipped {
+		byPkg[s.Package] = s
+	}
+
+	broken, ok := byPkg["example.com/parsebug/broken"]
+	if !ok {
+		t.Fatalf("the unparseable package is not reported; got %v", skipped)
+	}
+	if broken.Kind != skipParse {
+		t.Errorf("kind = %q, want %q — a syntax error must not be reported as a type error", broken.Kind, skipParse)
+	}
+	if !strings.Contains(broken.Reason, "broken.go:") {
+		t.Errorf("reason %q does not name the file and line the parser rejected", broken.Reason)
+	}
+
+	// The cascade: a package is unusable because of a syntax error two hops
+	// away, and must not disappear without a word.
+	if imp, ok := byPkg["example.com/parsebug/router"]; !ok {
+		t.Errorf("the importer of the broken package is not reported; got %v", skipped)
+	} else if imp.Kind != skipType {
+		t.Errorf("importer kind = %q, want %q", imp.Kind, skipType)
+	}
+}


### PR DESCRIPTION
Fixes #237.

A project with a syntax error generated a spec over whatever happened to parse, and exited 0 with no indication anything was wrong.

```console
$ apispec --dir ./parsebug --output openapi.yaml     # before
[engine] loaded 3 packages in 189ms
[engine] spec mapped (1 paths) in 2ms
Successfully generated: openapi.yaml
```

```console
$ apispec --dir ./parsebug --output openapi.yaml     # after
[engine] loaded 3 packages in 217ms
[engine] 2 in-module package(s) were not analysed, so the spec is incomplete:
[engine]   example.com/parsebug/broken does not parse: broken/broken.go:3:1: syntax error: non-declaration statement outside function body
[engine]   example.com/parsebug/router does not type-check: undefined: broken.Helper
[engine] a package that does not parse is a syntax error in the project's own source — `go build ./...` reports the same
```

### The diagnosis in the issue was wrong, and that's the interesting part

The issue guessed the loader either drops the unparseable package or attaches its error elsewhere. Probed directly with the engine's own `packages.Config`, **neither is true** — `go/packages` returns the package and puts the error in `pkg.Errors`, and the engine already recorded and logged it.

The actual gap: that log line goes to the **verbose** logger, and `SkippedPackages()` is consumed **only by the UI**. A default CLI run printed nothing. Same silence #379 removed for the no-routes case, so this is written the same way — `log` rather than `reportPhase`, because it is a result and not a phase.

### Why `classifySkip` exists rather than `pkg.Errors[0]`

A parse failure reports **two** errors, and neither alone is a usable report:

| Kind | Msg |
|---|---|
| `ListError` | `# example.com/parsebug/broken\nbroken/broken.go:3:1: syntax error: …` |
| `ParseError` | `expected declaration, found ','` |

The parser's own message has no position; the driver's blob has the position but leads with a line that just repeats the package name. So the **kind** comes from the strongest error present (a parse error outranks the type errors it causes, which would otherwise send the user to the wrong file) and the **reason** from the first error that names a file, with the driver header stripped.

### Acceptance items

- ✅ the package appears in `SkippedPackages` with the parse error as its reason, and the CLI logs it
- ✅ the reason distinguishes "does not parse" from "does not type-check" — `SkippedPackage.Kind`, which the UI now surfaces too
- ✅ a project that imports a broken package is reported as well — asserted explicitly, since that cascade is what made the original gitea report expensive
- The list is capped at 10, because one broken package takes every importer with it and printing the whole cascade buries the root cause.

### Tests

`t.TempDir()` rather than a `testdata/` fixture on purpose — an unparseable `.go` file checked into the repo would break gofmt, vet and the fixture suites, which is precisely why this shape had no coverage.

- `TestClassifySkip` — 6 cases including the real two-error shape and parse-outranks-type in either order.
- `TestSkippedPackagesReportsParseError` — builds the broken module, asserts generation still **succeeds** (the point is that it reports, not that it refuses), that the parse kind and file position are reported, and that the importer two hops away is reported too.

Mutation-verified (reverting to `errs[0]` fails 3 subtests). Verified no false positives: a healthy real project prints zero skip lines. Full suite + `-race` + lint clean; coverage 96.0% → 96.1%.