### PR TITLE
fix: insight and the tracker-tree diagram use the engine's tree (#410)

### DIFF
--- a/internal/diagserver/server.go
+++ b/internal/diagserver/server.go
@@ -342,13 +342,23 @@ func (s *Server) getAllData(diagramType string, includeFullDepth bool) *spec.Cyt
 		if includeFullDepth {
 			maxDepth = 1000
 		}
-		trackerTree := spec.NewTrackerTree(s.metadata, metadata.TrackerLimits{
+		// Lazy, because that is the engine the spec is generated with. The
+		// eager tree this used to build expands differently enough to draw a
+		// materially different picture — on a real service it reaches 194 of
+		// 280 routes — so the diagram was not showing the tree the spec came
+		// from (issue #410).
+		//
+		// No entrypoint or handler-interface options: this server resolves
+		// metadata only (GenerateMetadataOnly) and never a framework config, so
+		// the roots are the default ones — the same roots the eager call here
+		// used, since it passed no options either.
+		trackerTree := spec.NewLazyTree(s.metadata, metadata.TrackerLimits{
 			MaxNodesPerTree:    50000,
 			MaxChildrenPerNode: 500,
 			MaxArgsPerFunction: 100,
 			MaxNestedArgsDepth: 100,
 			MaxRecursionDepth:  maxDepth,
-		}, nil)
+		})
 		data = spec.DrawTrackerTreeCytoscapeWithMetadata(trackerTree.GetRoots(), s.metadata)
 	} else {
 		data = spec.DrawCallGraphCytoscape(s.metadata)

--- a/internal/insight/metrics.go
+++ b/internal/insight/metrics.go
@@ -275,7 +275,7 @@ func analyzeAdjacency(meta *metadata.Metadata, root string, callersOf func(strin
 // route isn't found in the tree (or has no body there) it falls back to the
 // call graph augmented with structural interface resolution.
 func analyzeFromTrackerTree(meta *metadata.Metadata, cfg *spec.APISpecConfig, method, path, fallbackRoot string) (Metrics, TraceGraph, bool) {
-	if tree := cachedTrackerTreeLocked(meta); tree != nil && cfg != nil {
+	if tree := cachedTrackerTreeLocked(meta, cfg); tree != nil && cfg != nil {
 		for _, r := range spec.NewExtractor(tree, cfg).ExtractRoutes() {
 			if r == nil || r.Node == nil || !strings.EqualFold(r.Method, method) || r.OpenAPIPath() != path {
 				continue
@@ -648,8 +648,9 @@ var analysisMu sync.Mutex
 // cachedTrackerTree builds and memoizes the tracker tree for a metadata,
 // rebuilding only when the metadata pointer changes (after a regenerate).
 var (
-	treeKey *metadata.Metadata
-	treeVal spec.TrackerTreeInterface
+	treeKey    *metadata.Metadata
+	treeCfgKey *spec.APISpecConfig
+	treeVal    spec.TrackerTreeInterface
 )
 
 // cachedTrackerTreeLocked returns the memoized tree. The caller MUST hold
@@ -657,15 +658,34 @@ var (
 // which is the part a self-locking accessor could not express: handing back a
 // mutable shared tree from under a lock is what made this racy in the first
 // place.
-func cachedTrackerTreeLocked(meta *metadata.Metadata) spec.TrackerTreeInterface {
+//
+// The tree is built the way the ENGINE builds the one the spec came from —
+// lazy, with the same entrypoint and handler-interface options. Insight used to
+// build an eager tree here instead, so its metrics described a different tree
+// than the spec they were reported against; on a real service the eager tree
+// finds 194 of 280 routes, which is a difference big enough to make the panel
+// misleading rather than merely approximate (issue #410).
+//
+// cfg is part of the memo key because it selects the entrypoint patterns and
+// the route matcher: a tree built for one framework config does not answer for
+// another.
+func cachedTrackerTreeLocked(meta *metadata.Metadata, cfg *spec.APISpecConfig) spec.TrackerTreeInterface {
 	if meta == nil {
 		return nil
 	}
-	if treeKey == meta && treeVal != nil {
+	if treeKey == meta && treeCfgKey == cfg && treeVal != nil {
 		return treeVal
 	}
-	treeVal = spec.NewTrackerTree(meta, trackerLimits(), nil)
-	treeKey = meta
+	opts := []spec.LazyTreeOption{}
+	if cfg != nil {
+		opts = append(opts,
+			spec.WithHandlerInterfaceMethods(cfg.Framework.HandlerInterfaceMethods),
+			spec.WithEntrypoints(cfg.Framework.EntrypointPatterns,
+				spec.RouteRegistrationMatcher(cfg, meta), nil),
+			spec.WithTerminalRouteMatcher(spec.TerminalRouteMatcher(cfg, meta)))
+	}
+	treeVal = spec.NewLazyTree(meta, trackerLimits(), opts...)
+	treeKey, treeCfgKey = meta, cfg
 	return treeVal
 }
 

--- a/internal/insight/metrics_sweep_test.go
+++ b/internal/insight/metrics_sweep_test.go
@@ -382,7 +382,7 @@ func TestAnalyzeTrackerSubtree(t *testing.T) {
 func TestCachedTrackerTree_NilMeta(t *testing.T) {
 	analysisMu.Lock()
 	defer analysisMu.Unlock()
-	if cachedTrackerTreeLocked(nil) != nil {
+	if cachedTrackerTreeLocked(nil, nil) != nil {
 		t.Error("nil metadata must yield a nil tree")
 	}
 }

--- a/internal/insight/tracker_tree_engine_test.go
+++ b/internal/insight/tracker_tree_engine_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package insight
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+	"github.com/ehabterra/apispec/internal/spec"
+)
+
+// TestCachedTrackerTreeUsesTheEngineTree pins issue #410: insight must analyse
+// the same kind of tree the spec was generated from.
+//
+// It built an EAGER tree here while the engine has generated with the lazy one
+// by default for several releases. The two do not merely differ in speed — on a
+// real service the eager tree reaches 194 of 280 routes — so every metric and
+// trace the panel reported was measured against a tree the spec never saw.
+//
+// A type assertion is the point rather than a proxy for it: there is no output
+// difference to assert on a synthetic fixture (both engines agree at this size),
+// and the defect was precisely that the wrong constructor was called.
+func TestCachedTrackerTreeUsesTheEngineTree(t *testing.T) {
+	analysisMu.Lock()
+	defer analysisMu.Unlock()
+
+	meta := &metadata.Metadata{
+		StringPool: metadata.NewStringPool(),
+		Callers:    map[string][]*metadata.CallGraphEdge{},
+		Packages:   map[string]*metadata.Package{},
+	}
+
+	tree := cachedTrackerTreeLocked(meta, nil)
+	if tree == nil {
+		t.Fatal("no tree built")
+	}
+	if _, ok := tree.(*spec.LazyTree); !ok {
+		t.Fatalf("insight built a %T; the engine generates the spec with *spec.LazyTree, "+
+			"so the panel would describe a tree the spec never used (#410)", tree)
+	}
+}
+
+// TestCachedTrackerTreeRekeysOnConfig covers the memo key.
+//
+// The config selects the entrypoint patterns and the route matcher the tree is
+// rooted with, so a tree built under one framework config does not answer for
+// another. Keyed on the metadata alone — which is how it was keyed while the
+// config was not a parameter at all — the first caller's framework would be
+// served to every later one.
+func TestCachedTrackerTreeRekeysOnConfig(t *testing.T) {
+	analysisMu.Lock()
+	defer analysisMu.Unlock()
+
+	meta := &metadata.Metadata{
+		StringPool: metadata.NewStringPool(),
+		Callers:    map[string][]*metadata.CallGraphEdge{},
+		Packages:   map[string]*metadata.Package{},
+	}
+
+	gin, chi := spec.DefaultGinConfig(), spec.DefaultChiConfig()
+
+	first := cachedTrackerTreeLocked(meta, gin)
+	if again := cachedTrackerTreeLocked(meta, gin); again != first {
+		t.Error("same metadata and config rebuilt the tree — the memo is not working")
+	}
+	if other := cachedTrackerTreeLocked(meta, chi); other == first {
+		t.Error("a different framework config reused the previous tree, so it is rooted for the wrong framework")
+	}
+	// And back again: the key must not be a one-way latch.
+	if back := cachedTrackerTreeLocked(meta, gin); back == nil {
+		t.Error("no tree built after switching config back")
+	}
+}


### PR DESCRIPTION
Step 1 of #410, and a live bug worth fixing regardless of the deprecation.

`internal/insight/metrics.go` and `internal/diagserver/server.go` both called `spec.NewTrackerTree(...)` unconditionally, while the engine has generated the spec with the **lazy** tree by default for several releases. The Insight panel's metrics and traces, and the tracker-tree diagram, therefore described a tree the spec was never built from.

That is not a cosmetic difference. On a real ~280-route service the eager tree reaches **194 routes** — so the diagram was rendering a tree missing a third of the API while the spec beside it had all of it.

### Two call sites, two different fixes

**Insight** has the framework config at its single call site, so its tree is now built with the same `WithHandlerInterfaceMethods` / `WithEntrypoints` / `WithTerminalRouteMatcher` options the engine passes — not just the same engine.

The config also joins the memo key. That is a real bug avoided rather than a precaution: the config selects the entrypoint patterns and route matcher the tree is *rooted* with, so keyed on metadata alone the first caller's framework would be served to every later one. `TestCachedTrackerTreeRekeysOnConfig` fails if the key is narrowed back.

**diagserver** resolves metadata only (`GenerateMetadataOnly`) and never resolves a framework config, so it swaps the engine and nothing else. That is apples-to-apples: the eager call it replaces passed **no options either**, so the roots are unchanged and only the expansion engine differs. Plumbing a framework config into the diagram server is a larger change and is not smuggled in here.

### Result

The engine's own `--legacy-tracker` branch is now the **last non-test caller** of `NewTrackerTree`:

```console
$ grep -rn "NewTrackerTree" --include="*.go" . | grep -v "_test.go"
internal/spec/tracker.go:450:func NewTrackerTree(...)          # the definition
internal/engine/engine.go:835:  tree = intspec.NewTrackerTree(  # the --legacy-tracker branch
```

which is exactly what #410 removes.

### Tests

- `TestCachedTrackerTreeUsesTheEngineTree` — asserts the constructed type. A type assertion is the point rather than a proxy for it: both engines agree on a synthetic fixture, so there is no output difference to assert at that size, and the defect *was* that the wrong constructor was called. The comment says so.
- `TestCachedTrackerTreeRekeysOnConfig` — memoises per (metadata, config), and is not a one-way latch.

Both mutation-verified (reverting either change fails its test with the intended message). Full suite + `-race` + lint clean; coverage holds at 96.0%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved tracker-tree generation through lazy loading, reducing unnecessary upfront work.
  * Enhanced caching to account for framework configuration changes, improving analysis accuracy.
* **Bug Fixes**
  * Ensured tracker-tree analysis uses framework-specific routing and handler settings.
  * Prevented cached trees from being incorrectly reused across different configurations.
* **Tests**
  * Added coverage for lazy tree usage and configuration-aware cache behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->