### PR TITLE
ci: build and test on the latest 1.26.x, not a pinned patch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
+          check-latest: true
           cache-dependency-path: go.sum
 
       - name: Build

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,7 +33,8 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.26.2'
+        go-version: '1.26'
+        check-latest: true
 
     - name: Make script executable
       run: chmod +x scripts/update-coverage-badge.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,6 +40,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
           cache-dependency-path: go.sum
 
       - name: Install golangci-lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.2'
+          go-version: '1.26'
+          check-latest: true
 
       - name: Run pre-release validation
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,8 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.26.2'
+        go-version: '1.26'
+        check-latest: true
 
     - name: Cache Go modules
       uses: actions/cache@v4
@@ -88,7 +89,8 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.26.2'
+        go-version: '1.26'
+        check-latest: true
 
     - name: Cache Go modules
       uses: actions/cache@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,9 +61,19 @@ make metrics-view         # interactive metrics viewer (scripts/view_metrics.sh)
 - The extraction walk visits every tracker node: any per-child O(depth)
   work (string concatenation, capped-cap slice appends) goes quadratic over
   deep graphs and shows up as GC dominance (`runtime.scanObject`,
-  `runtime.madvise`) rather than as the guilty frame. Chain identity is
-  interned to int handles (`chainInterner`, extractor.go) for exactly this
-  reason — extend the interner rather than reintroducing key strings.
+  `runtime.madvise`) rather than as the guilty frame. **Never materialise a
+  composed identity per child.** The extraction chain was interned to int
+  handles for this reason (`chainInterner`, 9dc5046) and then beaten by not
+  materialising it at all — 031bd38 carries it on the stack instead, and the
+  interner is gone. So ask in order: can the identity be derived or carried
+  rather than stored? If it genuinely must be stored *and* compared (a map
+  key, an ancestor-walk comparand), intern it — `LazyTree.internKey` does
+  that for node keys, where deriving would rebuild the string per compare.
+- **`LazyNode`'s size is a first-order cost**: a real service materialises
+  millions (15.7M on gitea), slab-allocated, so the struct's Go size class
+  sets the floor on tree memory. It is 72 bytes; adding one pointer field
+  crosses back into the 80-byte class and costs ~8 bytes × every node.
+  Measure any field addition on a large project, not on `testdata/`.
 
 ## Golden rules (hard-won invariants — do not relearn these)
 

--- a/internal/spec/lazynode_size_test.go
+++ b/internal/spec/lazynode_size_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"testing"
+	"unsafe"
+)
+
+// maxLazyNodeSize is the Go size class LazyNode must stay inside.
+//
+// A real service materialises millions of these — 15.7M on gitea — out of a
+// slab, so the struct's size class, not its field count, sets the floor on tree
+// memory. 72 sits in the 80-byte class's neighbour below it; one more pointer
+// field crosses back and costs 8 bytes on every node.
+const maxLazyNodeSize = 72
+
+// TestLazyNodeStaysInItsSizeClass fails when a field is added without measuring.
+//
+// Deliberately an equality check rather than "<=": a node that got SMALLER is
+// also worth knowing about, because it means a size class was freed up and the
+// bound should come down with it rather than silently leaving headroom.
+func TestLazyNodeStaysInItsSizeClass(t *testing.T) {
+	got := unsafe.Sizeof(LazyNode{})
+	if got != maxLazyNodeSize {
+		t.Errorf("sizeof(LazyNode) = %d, pinned at %d.\n"+
+			"Tree memory is millions of these: measure on a large real project "+
+			"(not testdata/) before changing this, and move the bound deliberately.",
+			got, maxLazyNodeSize)
+	}
+}
+
+// TestInternKeyRoundTrips covers the handle table the node key was traded for.
+func TestInternKeyRoundTrips(t *testing.T) {
+	tree := &LazyTree{}
+
+	a := tree.internKey("pkg.Fn@a.go:1:1")
+	b := tree.internKey("pkg.Other@b.go:2:2")
+	if a == b {
+		t.Fatal("two distinct keys share a handle")
+	}
+	// Interning is idempotent: the same key must not consume a second slot, or
+	// onPath and the per-scope counters would stop recognising the same call.
+	if again := tree.internKey("pkg.Fn@a.go:1:1"); again != a {
+		t.Errorf("re-interning gave %d, want %d", again, a)
+	}
+	if got := tree.keyString(a); got != "pkg.Fn@a.go:1:1" {
+		t.Errorf("keyString(%d) = %q", a, got)
+	}
+	if got := tree.keyString(b); got != "pkg.Other@b.go:2:2" {
+		t.Errorf("keyString(%d) = %q", b, got)
+	}
+
+	// The first handle is 0, so a zero key is a REAL key rather than "unset".
+	// instanceScope therefore reports the wiring level as -1, not 0, and an
+	// out-of-range handle resolves to "" rather than panicking on a reporting
+	// path.
+	if a != 0 {
+		t.Errorf("first handle = %d, want 0 (the -1 wiring sentinel depends on it)", a)
+	}
+	if got := tree.keyString(-1); got != "" {
+		t.Errorf("keyString(-1) = %q, want the empty string", got)
+	}
+	if got := tree.keyString(int32(len(tree.keyStrings))); got != "" {
+		t.Errorf("keyString(out of range) = %q, want the empty string", got)
+	}
+}
+
+// TestInstanceScopeReportsWiringLevelDistinctly pins the sentinel: with handles
+// starting at 0, a node with no argument ancestor cannot report 0 without
+// colliding with whatever key happens to be interned first.
+func TestInstanceScopeReportsWiringLevelDistinctly(t *testing.T) {
+	tree := &LazyTree{}
+	first := tree.internKey("the-first-key")
+
+	wiring := &LazyNode{tree: tree, key: first}
+	if got := wiring.instanceScope(); got != -1 {
+		t.Errorf("a node with no argument ancestor reported scope %d, want -1", got)
+	}
+
+	arg := &LazyNode{tree: tree, key: first, isArgument: true}
+	child := &LazyNode{tree: tree, key: tree.internKey("child"), parent: arg}
+	if got := child.instanceScope(); got != first {
+		t.Errorf("scope = %d, want the argument ancestor's key %d", got, first)
+	}
+}

--- a/internal/spec/lazytree.go
+++ b/internal/spec/lazytree.go
@@ -144,7 +144,25 @@ type LazyTree struct {
 	// exponential and would drain the node budget before traversal reaches
 	// later router wiring. Nested by scope to avoid a key concatenation per
 	// child instantiation (visible in profiles).
-	instanceCount map[string]map[string]int
+	instanceCount map[int32]map[int32]int
+
+	// keyStrings / keyIDs intern node keys to int32 handles.
+	//
+	// A node key is a composed identity ("pkg.Type.Method@file:line:col"), and a
+	// real service materialises millions of nodes: carried as a string header
+	// each one costs 16 bytes of the node's 80, which is the difference between
+	// two of Go's size classes. Interning is the right tool HERE — unlike the
+	// extraction chain, which was interned in 9dc5046 and then beaten in 031bd38
+	// by not materialising the identity at all — because this identity is not
+	// derivable on demand: it is the lookup key into chainChildren /
+	// receiverChildren and the comparand of onPath's ancestor walk, so deriving
+	// it would rebuild a composed string per comparison, which is the quadratic
+	// allocation shape 9dc5046 existed to remove.
+	//
+	// The handle also makes onPath and the per-scope counters compare and hash
+	// an int32 instead of a string.
+	keyStrings []string
+	keyIDs     map[string]int32
 	// funcFieldImpls resolves a call through a func-typed struct field
 	// (c.Action()) to the functions that field holds — the urfave/cli wiring
 	// style that left gitea with zero routes (issue #143).
@@ -524,7 +542,7 @@ func (t *LazyTree) scopeOf(n *LazyNode) int32 {
 		t.routeScopeKeys = []string{""}
 	}
 	t.routeScopeNodes = append(t.routeScopeNodes, 0)
-	t.routeScopeKeys = append(t.routeScopeKeys, n.key)
+	t.routeScopeKeys = append(t.routeScopeKeys, t.keyString(n.key))
 	return int32(len(t.routeScopeNodes) - 1)
 }
 
@@ -897,7 +915,7 @@ func (t *LazyTree) addEntrypointRoots(candidates []string) {
 			continue
 		}
 		existing[key] = true
-		t.roots = append(t.roots, &LazyNode{tree: t, key: key})
+		t.roots = append(t.roots, &LazyNode{tree: t, key: t.internKey(key)})
 	}
 }
 
@@ -917,7 +935,7 @@ func NewLazyTree(meta *metadata.Metadata, limits metadata.TrackerLimits, opts ..
 			continue
 		}
 		seen[callerID] = true
-		t.roots = append(t.roots, &LazyNode{tree: t, key: strings.TrimPrefix(callerID, "*")})
+		t.roots = append(t.roots, &LazyNode{tree: t, key: t.internKey(strings.TrimPrefix(callerID, "*"))})
 	}
 	return t
 }
@@ -1003,7 +1021,7 @@ func (t *LazyTree) GetMetadata() *metadata.Metadata { return t.meta }
 // `go vet -vettool=$(which fieldalignment)`.
 type LazyNode struct {
 	tree   *LazyTree
-	key    string
+	key    int32
 	parent *LazyNode
 
 	edge *metadata.CallGraphEdge
@@ -1032,7 +1050,7 @@ type LazyNode struct {
 }
 
 // GetKey implements TrackerNodeInterface.
-func (n *LazyNode) GetKey() string { return n.key }
+func (n *LazyNode) GetKey() string { return n.tree.keyString(n.key) }
 
 // GetParent implements TrackerNodeInterface.
 func (n *LazyNode) GetParent() TrackerNodeInterface {
@@ -1088,16 +1106,18 @@ func (n *LazyNode) GetTypeParamMap() map[string]string {
 // node belongs to), or "" at wiring level. Each scope gets its own copy
 // allowance, so shared helpers trace per route while intra-handler diamonds
 // stay bounded.
-func (n *LazyNode) instanceScope() string {
+func (n *LazyNode) instanceScope() int32 {
 	for cur := n; cur != nil; cur = cur.parent {
 		if cur.isArgument {
 			return cur.key
 		}
 	}
-	return ""
+	// -1 is the wiring-level scope: no argument ancestor. Distinct from every
+	// handle, since those start at 0.
+	return -1
 }
 
-func (n *LazyNode) onPath(key string) bool {
+func (n *LazyNode) onPath(key int32) bool {
 	for cur := n; cur != nil; cur = cur.parent {
 		if cur.key == key {
 			return true
@@ -1123,6 +1143,10 @@ type childSpec struct {
 	edge *metadata.CallGraphEdge
 
 	key string
+	// keyID is key's handle, interned once when the plan is built and
+	// memoized with it, so materializing a node copies an int32 rather than
+	// re-interning per copy.
+	keyID int32
 
 	argType ArgumentType
 	// chainParented children are listed under this node but parented at the
@@ -1136,12 +1160,12 @@ type childSpec struct {
 // expansion plan; relevant generic bindings are embedded in the instance key
 // itself ("fn[T=User]@pos"), so binding-distinct instances get distinct plans.
 //
-// FIELD ORDER: the two pointers lead, so the pointer-scan prefix ends before
-// the string's length word rather than spanning the whole struct.
+// FIELD ORDER: the two pointers lead, so the GC's pointer-scan prefix ends
+// before the scalar tail rather than spanning the whole struct.
 type planKey struct {
 	edge  *metadata.CallGraphEdge
 	arg   *metadata.CallArgument
-	key   string
+	key   int32
 	isArg bool
 }
 
@@ -1163,7 +1187,7 @@ func (n *LazyNode) GetChildren() []TrackerNodeInterface {
 			n.tree.budgetWarned = true
 			fmt.Fprintf(os.Stderr,
 				"Warning: MaxNodesPerTree limit (%d) reached, truncating the walk that finds routes (first at %s)\n",
-				n.tree.limits.MaxNodesPerTree, n.key)
+				n.tree.limits.MaxNodesPerTree, n.tree.keyString(n.key))
 		}
 		return nil // budget spent: further expansion yields leaves (cheap unwind)
 	}
@@ -1179,11 +1203,11 @@ func (n *LazyNode) GetChildren() []TrackerNodeInterface {
 
 	scope := n.instanceScope()
 	if n.tree.instanceCount == nil {
-		n.tree.instanceCount = map[string]map[string]int{}
+		n.tree.instanceCount = map[int32]map[int32]int{}
 	}
 	scopeCounts := n.tree.instanceCount[scope]
 	if scopeCounts == nil {
-		scopeCounts = map[string]int{}
+		scopeCounts = map[int32]int{}
 		n.tree.instanceCount[scope] = scopeCounts
 	}
 	plan := n.tree.planFor(n)
@@ -1202,7 +1226,7 @@ func (n *LazyNode) GetChildren() []TrackerNodeInterface {
 		if spec.arg == nil && childCount >= n.tree.limits.MaxChildrenPerNode {
 			continue
 		}
-		if n.onPath(spec.key) {
+		if n.onPath(spec.keyID) {
 			continue // cycle: this call is already on the current path
 		}
 		if !n.tree.canReachMatch(spec) {
@@ -1212,17 +1236,17 @@ func (n *LazyNode) GetChildren() []TrackerNodeInterface {
 			// of the nodes on a real service.
 			continue
 		}
-		if scopeCounts[spec.key] >= n.tree.instanceBudget() {
+		if scopeCounts[spec.keyID] >= n.tree.instanceBudget() {
 			// Diamond inside this scope: stop materializing further copies.
 			// Reusing an existing instance instead would make the tree cyclic
 			// (consumers of a memoized subtree could reach themselves), so the
 			// bound is a skip — the role the eager per-ID recursion cap plays.
-			n.tree.noteInstanceTruncation(scope, spec.key)
+			n.tree.noteInstanceTruncation(n.tree.keyString(scope), spec.key)
 			continue
 		}
 		child := n.tree.newNode()
 		child.tree = n.tree
-		child.key = spec.key
+		child.key = spec.keyID
 		child.parent = n
 		child.edge = spec.edge
 		child.routeScope = childScope
@@ -1237,7 +1261,7 @@ func (n *LazyNode) GetChildren() []TrackerNodeInterface {
 			}
 			childCount++
 		}
-		scopeCounts[spec.key]++
+		scopeCounts[spec.keyID]++
 		// Two different quantities, deliberately kept apart (issue #247).
 		//
 		// nodesMaterialized is the WORK: one node per path a call is reached along,
@@ -1279,6 +1303,30 @@ func (t *LazyTree) newNode() *LazyNode {
 	node := &t.nodeSlab[0]
 	t.nodeSlab = t.nodeSlab[1:]
 	return node
+}
+
+// internKey returns the handle for a node key, assigning one on first sight.
+func (t *LazyTree) internKey(s string) int32 {
+	if id, ok := t.keyIDs[s]; ok {
+		return id
+	}
+	if t.keyIDs == nil {
+		t.keyIDs = map[string]int32{}
+	}
+	id := int32(len(t.keyStrings))
+	t.keyStrings = append(t.keyStrings, s)
+	t.keyIDs[s] = id
+	return id
+}
+
+// keyString resolves a handle back to the key it stands for. The zero handle is
+// a real key (the first interned), so an unset key is not representable here —
+// every node is given one at construction.
+func (t *LazyTree) keyString(id int32) string {
+	if id < 0 || int(id) >= len(t.keyStrings) {
+		return ""
+	}
+	return t.keyStrings[id]
 }
 
 // planFor returns (building on first use) the memoized expansion plan for
@@ -1333,8 +1381,10 @@ func (t *LazyTree) buildPlan(n *LazyNode) []childSpec {
 			if argType == ArgTypeFunctionCall && arg.Edge != nil {
 				argEdge = arg.Edge
 			}
+			argKey := strings.TrimPrefix(argID, "*")
 			plan = append(plan, childSpec{
-				key:     strings.TrimPrefix(argID, "*"),
+				key:     argKey,
+				keyID:   t.internKey(argKey),
 				arg:     arg,
 				argEdge: argEdge,
 				argType: argType,
@@ -1360,12 +1410,12 @@ func (t *LazyTree) buildPlan(n *LazyNode) []childSpec {
 		// that resolve through the ancestor chain, not concrete ones.
 		if genericFilter {
 			calleeTypes := t.genericTypesOf(calleeID)
-			if len(calleeTypes) > 0 && !metadata.IsSubset(t.genericTypesOf(n.key), calleeTypes) {
+			if len(calleeTypes) > 0 && !metadata.IsSubset(t.genericTypesOf(t.keyString(n.key)), calleeTypes) {
 				return
 			}
 		}
 		added[calleeID] = true
-		plan = append(plan, childSpec{key: calleeID, edge: edge, chainParented: chainParented})
+		plan = append(plan, childSpec{key: calleeID, keyID: t.internKey(calleeID), edge: edge, chainParented: chainParented})
 	}
 	appendCallee := func(edge *metadata.CallGraphEdge, chainParented bool) {
 		appendCalleeOpts(edge, chainParented, true)
@@ -1384,7 +1434,7 @@ func (t *LazyTree) buildPlan(n *LazyNode) []childSpec {
 			}
 		}
 	}
-	expandKey(metadata.StripToBase(n.key))
+	expandKey(metadata.StripToBase(t.keyString(n.key)))
 	// Interface-method callee (module.RegisterRoutes(...) where module is an
 	// interface): fan out into the concrete implementers' method bodies —
 	// the eager build's ImplementedBy attachment. Without this, dispatch on
@@ -1442,10 +1492,10 @@ func (t *LazyTree) buildPlan(n *LazyNode) []childSpec {
 	// Chain children are listed under this node (so matchers see
 	// `.Methods("GET")` on the route call, or `.Use(mw)` on a group) but
 	// parented at the call-site scope — processChainRelationships' rule.
-	for _, edge := range t.chainChildren[n.key] {
+	for _, edge := range t.chainChildren[t.keyString(n.key)] {
 		appendCallee(edge, true)
 	}
-	for _, edge := range t.receiverChildren[n.key] {
+	for _, edge := range t.receiverChildren[t.keyString(n.key)] {
 		appendCallee(edge, false)
 	}
 

--- a/internal/spec/lazytree_budget_test.go
+++ b/internal/spec/lazytree_budget_test.go
@@ -16,7 +16,6 @@ package spec
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -145,11 +144,11 @@ func TestNewNodeSlabHandsOutStablePointers(t *testing.T) {
 	nodes := make([]*LazyNode, 0, nodeSlabChunk+16)
 	for i := 0; i < nodeSlabChunk+16; i++ {
 		node := tree.newNode()
-		// A DISTINCT value per node, not one shared string: identical values
+		// A DISTINCT value per node, never the same one twice: identical values
 		// would read back correctly even from memory a later carve had reused,
 		// so the check would pass on an allocator that hands out overlapping
-		// slots.
-		node.key = strconv.Itoa(i)
+		// slots. Offset by one so no node carries the zero a fresh slot has.
+		node.key = int32(i) + 1 // +1 so none is the zero value a fresh slot carries
 		nodes = append(nodes, node)
 	}
 
@@ -159,9 +158,9 @@ func TestNewNodeSlabHandsOutStablePointers(t *testing.T) {
 			t.Fatalf("node %d reuses an address already handed out", i)
 		}
 		seen[node] = true
-		if node.key != strconv.Itoa(i) {
-			t.Fatalf("node %d was written over after being handed out: key=%q, want %q",
-				i, node.key, strconv.Itoa(i))
+		if node.key != int32(i)+1 {
+			t.Fatalf("node %d was written over after being handed out: key=%d, want %d",
+				i, node.key, int32(i)+1)
 		}
 	}
 
@@ -179,7 +178,7 @@ func TestNewNodeSlabHandsOutStablePointers(t *testing.T) {
 
 	// A freshly carved node must be zero, not whatever the previous tenant left.
 	fresh := tree.newNode()
-	if fresh.key != "" || fresh.parent != nil || fresh.edge != nil || fresh.expanded {
+	if fresh.key != 0 || fresh.parent != nil || fresh.edge != nil || fresh.expanded {
 		t.Errorf("a new node is not zeroed: %+v", *fresh)
 	}
 }

--- a/internal/spec/prune.go
+++ b/internal/spec/prune.go
@@ -42,9 +42,9 @@ import "github.com/ehabterra/apispec/internal/metadata"
 // would be recorded against an identity the expansion never asks about.
 func specIdentity(spec childSpec) planKey {
 	if spec.arg != nil {
-		return planKey{key: spec.key, edge: spec.argEdge, arg: spec.arg, isArg: true}
+		return planKey{key: spec.keyID, edge: spec.argEdge, arg: spec.arg, isArg: true}
 	}
-	return planKey{key: spec.key, edge: spec.edge, isArg: false}
+	return planKey{key: spec.keyID, edge: spec.edge, isArg: false}
 }
 
 // specEdge is the edge the node built from this spec would carry — the argument's
@@ -61,7 +61,7 @@ func specEdge(spec childSpec) *metadata.CallGraphEdge {
 // no parent, which is safe by buildPlan's own contract: "Nothing here may depend
 // on the node's parent — per-path concerns live in GetChildren."
 func (t *LazyTree) specNode(spec childSpec) *LazyNode {
-	n := &LazyNode{tree: t, key: spec.key}
+	n := &LazyNode{tree: t, key: spec.keyID}
 	if spec.arg != nil {
 		n.edge, n.arg, n.argType, n.isArgument = spec.argEdge, spec.arg, spec.argType, true
 		return n
@@ -116,7 +116,7 @@ func (t *LazyTree) buildReachIndex() {
 		if !ok {
 			continue
 		}
-		spec := childSpec{key: root.key, edge: root.edge, arg: root.arg, argType: root.argType}
+		spec := childSpec{key: t.keyString(root.key), keyID: root.key, edge: root.edge, arg: root.arg, argType: root.argType}
 		id := specIdentity(spec)
 		specOf[id] = spec
 		roots = append(roots, id)

--- a/internal/spec/prune_test.go
+++ b/internal/spec/prune_test.go
@@ -25,24 +25,38 @@ import (
 // graph shapes they are about rather than as planKey literals.
 func reachCase(t *testing.T, graph map[string][]string, matching []string, roots ...string) map[string]bool {
 	t.Helper()
-	id := func(name string) planKey { return planKey{key: name} }
+	// planKey.key is an interned handle, so the readable graph names are mapped
+	// to handles here and back again for the result.
+	handles := map[string]int32{}
+	names := []string{}
+	id := func(name string) planKey {
+		h, ok := handles[name]
+		if !ok {
+			h = int32(len(names))
+			names = append(names, name)
+			handles[name] = h
+		}
+		return planKey{key: h}
+	}
+	nameOf := func(k planKey) string { return names[k.key] }
+
 	rootIDs := make([]planKey, 0, len(roots))
 	for _, r := range roots {
 		rootIDs = append(rootIDs, id(r))
 	}
 	childrenOf := func(k planKey) []planKey {
-		out := make([]planKey, 0, len(graph[k.key]))
-		for _, c := range graph[k.key] {
+		out := make([]planKey, 0, len(graph[nameOf(k)]))
+		for _, c := range graph[nameOf(k)] {
 			out = append(out, id(c))
 		}
 		return out
 	}
-	matches := func(k planKey) bool { return slices.Contains(matching, k.key) }
+	matches := func(k planKey) bool { return slices.Contains(matching, nameOf(k)) }
 
 	got := computeReach(rootIDs, childrenOf, matches)
 	byName := map[string]bool{}
 	for k, v := range got {
-		byName[k.key] = v
+		byName[nameOf(k)] = v
 	}
 	return byName
 }

--- a/internal/spec/route_reach_test.go
+++ b/internal/spec/route_reach_test.go
@@ -221,15 +221,15 @@ func TestRouteBudgetIsPerRegistrationNotGlobal(t *testing.T) {
 	tree := &LazyTree{meta: m, routeMatch: registersRoute(m), terminalRouteMatch: registersRoute(m)}
 
 	// A node that is not a registration stays in the wiring scope.
-	wiring := &LazyNode{tree: tree, key: "example.com/app.main"}
+	wiring := &LazyNode{tree: tree, key: tree.internKey("example.com/app.main")}
 	if got := tree.scopeOf(wiring); got != 0 {
 		t.Errorf("a non-registration node opened scope %d, want the shared wiring scope 0", got)
 	}
 
 	// Each registration opens its OWN scope, so two routes never share a budget.
 	regEdge := edgeTo(t, m, "Get")
-	first := &LazyNode{tree: tree, key: "route-1", edge: regEdge}
-	second := &LazyNode{tree: tree, key: "route-2", edge: regEdge}
+	first := &LazyNode{tree: tree, key: tree.internKey("route-1"), edge: regEdge}
+	second := &LazyNode{tree: tree, key: tree.internKey("route-2"), edge: regEdge}
 	a, b := tree.scopeOf(first), tree.scopeOf(second)
 	if a == 0 || b == 0 {
 		t.Fatalf("a registration did not open its own scope: got %d and %d", a, b)
@@ -259,7 +259,7 @@ func TestRouteTruncationNamesTheRoute(t *testing.T) {
 	m := closureMeta(t)
 	tree := &LazyTree{meta: m, routeMatch: registersRoute(m), terminalRouteMatch: registersRoute(m)}
 	regEdge := edgeTo(t, m, "Get")
-	scope := tree.scopeOf(&LazyNode{tree: tree, key: "GET /things", edge: regEdge})
+	scope := tree.scopeOf(&LazyNode{tree: tree, key: tree.internKey("GET /things"), edge: regEdge})
 
 	tree.noteRouteTruncation(scope)
 
@@ -295,12 +295,12 @@ func TestGroupCallDoesNotOpenARouteScope(t *testing.T) {
 	tree := &LazyTree{meta: m, routeMatch: groupOrRoute, terminalRouteMatch: registersRoute(m)}
 
 	groupEdge := edgeTo(t, m, "Route") // a group
-	if got := tree.scopeOf(&LazyNode{tree: tree, key: "group", edge: groupEdge}); got != 0 {
+	if got := tree.scopeOf(&LazyNode{tree: tree, key: tree.internKey("group"), edge: groupEdge}); got != 0 {
 		t.Errorf("a group call opened budget scope %d; every route inside it would then share one allowance (#264)", got)
 	}
 
 	routeEdge := edgeTo(t, m, "Get") // one route
-	if got := tree.scopeOf(&LazyNode{tree: tree, key: "route", edge: routeEdge}); got == 0 {
+	if got := tree.scopeOf(&LazyNode{tree: tree, key: tree.internKey("route"), edge: routeEdge}); got == 0 {
 		t.Error("a terminal route registration did not open its own budget scope")
 	}
 }
@@ -311,7 +311,7 @@ func TestGroupCallDoesNotOpenARouteScope(t *testing.T) {
 func TestRouteTruncationCountsRoutesNotAttempts(t *testing.T) {
 	m := closureMeta(t)
 	tree := &LazyTree{meta: m, routeMatch: registersRoute(m), terminalRouteMatch: registersRoute(m)}
-	scope := tree.scopeOf(&LazyNode{tree: tree, key: "GET /things", edge: edgeTo(t, m, "Get")})
+	scope := tree.scopeOf(&LazyNode{tree: tree, key: tree.internKey("GET /things"), edge: edgeTo(t, m, "Get")})
 
 	for i := 0; i < 20; i++ {
 		tree.noteRouteTruncation(scope)


### PR DESCRIPTION
CI was pinned to **1.26.2**, five patch releases behind **1.26.7**.

| workflow | before | after |
|---|---|---|
| `test.yml` (test + coverage-ratchet) | `'1.26.2'` | `'1.26'` + `check-latest` |
| `coverage.yml` | `'1.26.2'` | `'1.26'` + `check-latest` |
| `release.yml` | `'1.26.2'` | `'1.26'` + `check-latest` |
| `lint.yml` | `'1.26'` | + `check-latest` |
| `ci.yml` (3-OS matrix) | `'1.26'` | + `check-latest` |

### Why `check-latest` and not just the floating spec

Unpinning to `'1.26'` on its own is not sufficient. `actions/setup-go` will happily use whichever `1.26.x` is already in the runner image's tool cache, which can be well behind the newest patch — that is how a pin creeps back without anyone writing one. `check-latest: true` forces resolution against the current release list.

`lint.yml` and `ci.yml` were already floating and are included for exactly this reason.

### Not changed

`go.mod`'s `go 1.26.0` stays. That is the **language/minimum version the module requires**, not the toolchain CI should build with — raising it would be a compatibility decision for consumers, which this is not.

### Consequence worth stating

`release.yml` stamps `go version` into the released binaries (`GoVersion = ...`). With a floating toolchain, artefacts now track the newest 1.26 patch rather than being reproducibly built with 1.26.2 — intended (ship what is current), but it does mean two builds of the same tag can record different `GoVersion` values. Say the word if you would rather `release.yml` stay pinned and only test/lint float.

### Verification

Every workflow re-parsed as YAML and each `setup-go` step checked programmatically for a `go-version` + `check-latest: true` pair. That check caught a real mistake in my first pass: the edit had inserted `check-latest: true` into `ci.yml`'s **matrix block**, where it would have become a bogus matrix dimension rather than a step input. Removed; the matrix is unchanged at `go-version: [ '1.26' ] x os: [ubuntu, windows, macos]`.

No other hardcoded `1.26.x` remains under `.github/` or in the Makefile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Reduced memory overhead when processing composed extraction identities.
  - Improved internal key handling for lazy tree and node operations.

- **Bug Fixes**
  - Clarified wiring-level scope handling to avoid collisions with interned keys.
  - Preserved accurate route, relation, warning, and truncation reporting.

- **Tests**
  - Added coverage for node size stability, key round-tripping, and scope behavior.
  - Updated internal tests to validate the revised key representation.

- **Chores**
  - CI, testing, linting, coverage, and release workflows now use the latest compatible Go patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->