### PR TITLE
deprecate: --legacy-tracker warns, and is described accurately (#410)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+
+- **`--legacy-tracker` (the eager tracker tree) is deprecated and will be
+  removed in a future release.** It reads like a safe fallback and is not one:
+  on a real ~280-route service it documents **194 routes** — 31% missing, with
+  no warning — and runs 1.6x slower; across the fixture suite it resolves four
+  wiring shapes incorrectly. Selecting it now prints a deprecation warning, and
+  the CLI, README and UI describe it accurately instead of offering it as a
+  comparison/escape hatch. If the default engine is missing something, report it
+  rather than switching — switching will usually document *fewer* routes. (#410)
+
 ## [0.5.7] - 2026-08-15
 
 Speed and completeness. The walk that builds the spec no longer visits code that

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ apispec --output openapi.yaml --skip-cgo
 | `--max-nested-args`         | `-md`     | Max depth for nested arguments                         | `100`                           |
 | `--max-recursion-depth`     | `-mrd`    | Max recursion depth (anti-loop)                        | `10`                            |
 | `--max-instances-per-key`   |           | Max copies of one callee within an instance scope (lazy engine) | `100`                  |
-| `--legacy-tracker`          |           | Use the legacy (eager) tracker tree instead of the default lazy tracker | `false`        |
+| `--legacy-tracker`          |           | **Deprecated**, to be removed in a future release. Use the legacy (eager) tracker tree; documents fewer routes than the default and is slower | `false`        |
 | `--skip-cgo`                |           | Skip CGO packages                                      | `true`                          |
 | `--include-file`            |           | Include files matching pattern (repeatable)            | `""`                            |
 | `--include-package`         |           | Include packages matching pattern (repeatable)         | `""`                            |
@@ -975,9 +975,9 @@ func main() {
 The [tracker tree](#the-pipeline-step-by-step) — the expansion of each route down to its real handler and the calls inside it — can be built by either of two engines. They share the metadata, extraction, and mapping stages, so their **output is equivalent** (guarded by a parity test over the fixtures); they differ only in *how* the tree is built and bounded.
 
 - **Lazy (default).** Expands subtrees on demand, only along the paths a query actually touches. Cost scales with what's *reachable from routes*, not with the total size of the codebase — so it tends to win on large projects where much of the code never participates in routing, and is comparable on projects where almost everything is reachable. It degrades gracefully on dense or cyclic graphs (a cumulative budget, then leaf stubs) rather than expanding exponentially.
-- **Eager (`--legacy-tracker`).** Materializes the whole tree up front. Retained as a comparison/escape hatch; occasionally marginally faster when nearly all code is reachable anyway, but uses more memory (the full tree is held at once).
+- **Eager (`--legacy-tracker`) — deprecated, to be removed in a future release.** Materializes the whole tree up front. It is **not a safe fallback**: on a real ~280-route service it documents 194 routes (31% missing, silently) and runs 1.6x slower, and across the fixture suite it resolves four wiring shapes incorrectly. It uses less memory on small projects, which is the only thing it still wins at.
 
-Choose with `--legacy-tracker` on the CLI, or the analysis-engine selector in the browser UI. When in doubt, keep the default (lazy).
+The default is lazy and there is no reason to change it. If the default is missing something, please [open an issue](https://github.com/ehabterra/apispec/issues) rather than switching engines — switching will usually document *fewer* routes, not more.
 
 ### Limits
 

--- a/cmd/apispec/main.go
+++ b/cmd/apispec/main.go
@@ -292,7 +292,9 @@ func parseFlags(args []string) (*CLIConfig, error) {
 	fs.IntVar(&config.MaxNodesPerRoute, "max-nodes-per-route", engine.DefaultMaxNodesPerRoute,
 		"Maximum tree nodes expanded below one route registration, bounding a route's detail without starving the others (lazy tracker only; ignored with --legacy-tracker)")
 
-	fs.BoolVar(&config.LegacyTracker, "legacy-tracker", false, "Use the legacy (eager) tracker tree instead of the default lazy tracker")
+	fs.BoolVar(&config.LegacyTracker, "legacy-tracker", false,
+		"DEPRECATED, to be removed in a future release: use the legacy (eager) tracker tree. "+
+			"It documents FEWER routes than the default on real projects and is slower; do not reach for it to work around a problem")
 
 	// Include/exclude flags
 	fs.Var((*stringSliceFlag)(&config.IncludeFiles), "include-file", "Include files matching pattern (can be specified multiple times)")
@@ -365,8 +367,28 @@ func parseFlags(args []string) (*CLIConfig, error) {
 	return config, nil
 }
 
+// warnLegacyTracker says so, once, when a run selects the eager tracker.
+//
+// Written as a warning rather than left to the help text because the flag reads
+// like a safe fallback and is not one: on a real ~280-route service the eager
+// tree documents 194 routes, so reaching for it to work around a problem
+// silently returns a SMALLER spec than the default (issue #410). Anyone using it
+// today is the audience for the removal notice.
+func warnLegacyTracker(enabled bool) {
+	if !enabled {
+		return
+	}
+	fmt.Fprintln(os.Stderr,
+		"Warning: --legacy-tracker is deprecated and will be removed in a future release.")
+	fmt.Fprintln(os.Stderr,
+		"         The eager tracker documents FEWER routes than the default on real projects "+
+			"and is slower; if the default is missing something, please report it instead.")
+}
+
 // runGeneration generates the OpenAPI specification and returns the spec object directly (like metadata)
 func runGeneration(config *CLIConfig) (*spec.OpenAPISpec, *engine.Engine, error) {
+	warnLegacyTracker(config.LegacyTracker)
+
 	// Create engine configuration
 	engineConfig := &engine.EngineConfig{
 		InputDir:                     config.InputDir,

--- a/cmd/apispecui/assets/js/config.js
+++ b/cmd/apispecui/assets/js/config.js
@@ -360,12 +360,12 @@ export function ConfigMode() {
             ${txt("Default response status", c.defaults?.responseStatus, (e) => setDefaults({ responseStatus: parseInt(e.target.value, 10) || 0 }), "200")}
           <//>
 
-          <${Section} title="Analysis engine" help="Which tracker tree powers the analysis, and how far it is allowed to walk. The lazy tracker (default) expands the call tree on demand — it covers the same wiring styles as the legacy tree, resolves some responses/bodies the legacy tree misses, and is bounded on very dense call graphs. Choose Legacy (eager) only to compare against the previous engine's output. The limits below bound that walk; leave them blank to use the defaults shown.">
+          <${Section} title="Analysis engine" help="Which tracker tree powers the analysis, and how far it is allowed to walk. The lazy tracker (default) expands the call tree on demand. Legacy (eager) is DEPRECATED and will be removed in a future release — it documents fewer routes than the default on real projects and is slower, so it is not a safe fallback; if the default is missing something, please report it. The limits below bound that walk; leave them blank to use the defaults shown.">
             <div class="field">
               <label>Tracker tree</label>
               <select class="input" value=${s.legacyTracker ? "legacy" : "lazy"} onChange=${(e) => setState({ legacyTracker: e.target.value === "legacy" })}>
                 <option value="lazy">Lazy (default)</option>
-                <option value="legacy">Legacy (eager)</option>
+                <option value="legacy">Legacy (eager) — deprecated</option>
               </select>
             </div>
             <${TrackerLimits} />


### PR DESCRIPTION
Steps **2 and 3** of #410. Step 1 (insight + the tracker-tree diagram rendering the engine's own tree) landed in #415; removal is steps 4–6 and stays open.

This is the prerequisite for removing the flag in a later release — you cannot delete a flag that was never deprecated.

### Why this is more than a label

The flag read like a safe fallback. It is the opposite:

- on a real ~280-route service the eager tree documents **194 routes** — 31% missing, with no warning
- 1.6× slower there, 2.1× slower on a 374-route service
- across the 98-fixture suite it resolves **four** wiring shapes incorrectly (`mount_via_helper` finds 1 of 3 paths; `group_arg_inline` loses every group prefix)

README described it as *"Retained as a comparison/escape hatch; occasionally marginally faster"* — precisely the framing that gets someone to reach for it when the default looks wrong, and then hands them a **smaller** spec with nothing saying why.

### Changes

```console
$ apispec --dir ./svc --output openapi.yaml --legacy-tracker
apispec - Copyright 2026 Ehab Terra
Warning: --legacy-tracker is deprecated and will be removed in a future release.
         The eager tracker documents FEWER routes than the default on real projects and is
         slower; if the default is missing something, please report it instead.
```

- `--help` marks the flag `DEPRECATED` and says it documents fewer routes.
- The warning prints once, on stderr, only when the flag is selected — verified that a default run prints nothing.
- The UI's engine selector reads **"Legacy (eager) — deprecated"**, and its help no longer suggests using it to compare engines.
- README's flag table and the Lazy/Eager section carry the measured numbers and point at the issue tracker instead of at the flag.
- `CHANGELOG.md` gains a `### Deprecated` entry under `[Unreleased]`.

The recommendation is now explicit: if the default is missing something, **open an issue rather than switching engines** — switching will usually document fewer routes, not more.

Full suite + lint + vet + gofmt clean. No behaviour change beyond the warning; the flag still works exactly as before.