### PR TITLE
fix(spec): split a `switch r.Method` written in a closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A `switch r.Method` written in a closure is now split into one operation per
+  verb.** The split worked for a named handler but not for the shape
+  `http.HandleFunc("/x", func(w, r) { switch r.Method { … } })`: a function
+  literal has no `Function` record, so its arms were folded into the enclosing
+  declaration's — mixed with every other closure's — and unreachable from the
+  route, which fell to the POST default carrying *every* arm's responses. So
+  `GET /x` was undocumented while `POST /x` advertised a body only the GET arm
+  writes. The dispatch of a closure is now recorded under the closure's own
+  identity, with the range that scopes its arms; closures registered from a
+  method are covered too. Attribution also follows the **call chain** rather
+  than only the response statement, so arms that delegate
+  (`case http.MethodGet: h.Get(w, r)`) get their bodies instead of losing them,
+  and a registration that named its verb (`mux.HandleFunc("GET /x", h)`) stops
+  documenting the arms the router never sends it. (#382)
 - **A route registered with per-route middleware documented the middleware, not
   the handler.** gin and fiber take their handler chain variadically
   (`r.GET(path, mw, handler)`), so the endpoint handler is the *last* argument;

--- a/generator/testdata_method_switch_closure_test.go
+++ b/generator/testdata_method_switch_closure_test.go
@@ -1,0 +1,151 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/spec"
+)
+
+// TestTestdata_MethodSwitchClosure locks in method dispatch written in a
+// CLOSURE (issue #382). A function literal has no Function record, so its
+// `switch r.Method` used to be invisible from the route: every one of these
+// paths was documented as a single POST carrying every arm's responses.
+//
+// The fixture puts the shapes side by side, and each assertion below is about a
+// different way the attribution can go wrong:
+//
+//   - /inline, /inline-second — two closures registered from ONE function, so a
+//     file-scoped attribution would mix their arms;
+//   - /via-methods — the arms call methods, so the response statement is a
+//     frame deeper and only the CALL CHAIN says which arm reached it;
+//   - /from-factory — the dispatch is in a closure the handler function returns;
+//   - /from-method — registered from a method, which has no Function record at
+//     all, so the dispatch has to be recorded from a whole-file walk;
+//   - /explicit — a registration that named its verb: one operation, scoped to
+//     that verb's arm.
+func TestTestdata_MethodSwitchClosure(t *testing.T) {
+	out := loadTestdataWithFixtureConfig(t, "method_switch_closure", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+	noUnresolvedPlaceholders(t, out)
+
+	want := map[string][]string{
+		"/inline":        {"GET", "POST"},
+		"/inline-second": {"PUT", "DELETE"},
+		"/via-methods":   {"GET", "POST"},
+		"/from-factory":  {"GET", "POST"},
+		"/from-method":   {"GET", "DELETE"},
+		"/explicit":      {"GET"},
+	}
+	for path, methods := range want {
+		item, ok := out.Paths[path]
+		if !ok {
+			t.Errorf("path %q missing; have %v", path, mapPathKeys(out.Paths))
+			continue
+		}
+		for _, m := range methods {
+			if opFor(item, m) == nil {
+				t.Errorf("%s %s: expected operation, missing", m, path)
+			}
+		}
+		// Nothing may keep the ExtractRoute POST default it used to fall to.
+		if !contains(methods, "POST") && opFor(item, "POST") != nil {
+			t.Errorf("%s should not carry a POST operation", path)
+		}
+	}
+
+	// Per-arm bodies: the POST arm's request body and 201 belong to POST alone.
+	for _, path := range []string{"/inline", "/via-methods", "/from-factory"} {
+		item := out.Paths[path]
+		post, get := opFor(item, "POST"), opFor(item, "GET")
+		if post == nil || post.RequestBody == nil {
+			t.Errorf("POST %s should carry a request body", path)
+		}
+		if get == nil || get.RequestBody != nil {
+			t.Errorf("GET %s should not carry a request body", path)
+		}
+		if post != nil {
+			if _, ok := post.Responses["201"]; !ok {
+				t.Errorf("POST %s should carry the 201 written in its arm", path)
+			}
+		}
+		if get != nil {
+			if _, ok := get.Responses["200"]; !ok {
+				t.Errorf("GET %s should carry the 200 written in its arm", path)
+			}
+			if _, ok := get.Responses["201"]; ok {
+				t.Errorf("GET %s must not carry the POST arm's 201", path)
+			}
+		}
+	}
+
+	// The `default:` arm's 405 names no verb, so it belongs to no operation.
+	for _, m := range []string{"GET", "POST"} {
+		if op := opFor(out.Paths["/inline"], m); op != nil {
+			if _, ok := op.Responses["405"]; ok {
+				t.Errorf("%s /inline must not carry the default arm's 405", m)
+			}
+		}
+	}
+
+	// The second closure in the same function keeps its own arms: DELETE is
+	// bodyless (204) and must not pick up the PUT arm's user body.
+	if del := opFor(out.Paths["/inline-second"], "DELETE"); del != nil {
+		if del.RequestBody != nil {
+			t.Errorf("DELETE /inline-second should not carry a request body")
+		}
+		if _, ok := del.Responses["200"]; ok {
+			t.Errorf("DELETE /inline-second must not carry the PUT arm's 200")
+		}
+	}
+
+	// An explicit verb is not split, and the arms the router never sends it are
+	// not documented on it either.
+	explicit := opFor(out.Paths["/explicit"], "GET")
+	if explicit == nil {
+		t.Fatal("GET /explicit missing")
+	}
+	if _, ok := explicit.Responses["201"]; ok {
+		t.Errorf("GET /explicit must not carry the POST arm's 201: %v", explicit.Responses)
+	}
+
+	// operationIds stay unique across every split.
+	seen := map[string]bool{}
+	for path := range want {
+		for _, m := range []string{"GET", "POST", "PUT", "DELETE", "HEAD"} {
+			op := opFor(out.Paths[path], m)
+			if op == nil {
+				continue
+			}
+			if op.OperationID == "" {
+				t.Errorf("%s %s: empty operationId", m, path)
+			}
+			if seen[op.OperationID] {
+				t.Errorf("duplicate operationId %q across the method split", op.OperationID)
+			}
+			seen[op.OperationID] = true
+		}
+	}
+}
+
+func contains(list []string, want string) bool {
+	for _, v := range list {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -358,6 +358,11 @@ func GenerateMetadataWithLogger(pkgs map[string]map[string]*ast.File, fileToInfo
 			// Process functions
 			processFunctions(file, info, pkgName, fset, f, fileToInfo, funcMap, metadata)
 
+			// Record the method dispatch of function literals, which have no
+			// Function record of their own (issue #382). Whole-file, so a
+			// closure registered inside a method is covered too.
+			detectLitDispatch(file, info, pkgName, fset, metadata)
+
 			// Process variables and constants
 			processVariables(file, info, pkgName, fset, f, metadata)
 

--- a/internal/metadata/method_dispatch.go
+++ b/internal/metadata/method_dispatch.go
@@ -78,6 +78,56 @@ func detectMethodDispatch(body *ast.BlockStmt, info *types.Info, fset *token.Fil
 	return branches
 }
 
+// detectLitDispatch records the r.Method dispatch of every function literal in
+// the file that has one, keyed by the literal's identity — the same
+// `pkg.FuncLit:<stable position>` a closure route carries as its handler.
+//
+// A literal is not in File.Functions, so the dispatch of a closure written at a
+// registration site (`http.HandleFunc("/x", func(w, r) { switch r.Method … })`)
+// had no record reachable from the route's handler: it was folded into the
+// ENCLOSING declaration's MethodDispatch, alongside the arms of every other
+// literal in that function, and a consumer holding the closure's identity could
+// neither find it nor tell the arms apart (issue #382).
+//
+// The whole file is walked rather than each declaration's body, because a
+// registration is as often written inside a method (`func (s *Server) routes()`)
+// as inside a plain function, and methods are not in File.Functions at all.
+//
+// Nested literals are recorded independently, and an outer literal's entry also
+// covers the arms of a literal nested inside it. Both are true statements about
+// where the dispatch is written, and the range each entry carries is what tells
+// a consumer which arms are its own.
+func detectLitDispatch(file *ast.File, info *types.Info, pkgName string, fset *token.FileSet, meta *Metadata) {
+	if file == nil || info == nil || fset == nil || meta == nil {
+		return
+	}
+	ast.Inspect(file, func(n ast.Node) bool {
+		lit, ok := n.(*ast.FuncLit)
+		if !ok || lit.Body == nil {
+			return true
+		}
+		branches := detectMethodDispatch(lit.Body, info, fset)
+		if len(branches) == 0 {
+			return true
+		}
+		key := pkgName + "." + funcLitName(meta.stablePosition(lit.Pos(), fset))
+		if meta.LitDispatch == nil {
+			meta.LitDispatch = map[string]LitDispatch{}
+		}
+		start, end := fset.Position(lit.Body.Lbrace), fset.Position(lit.Body.Rbrace)
+		meta.LitDispatch[key] = LitDispatch{
+			File: meta.StringPool.Get(start.Filename),
+			Body: Block{
+				Kind:      BlockFuncLit,
+				StartLine: start.Line, StartCol: start.Column,
+				EndLine: end.Line, EndCol: end.Column,
+			},
+			Branches: branches,
+		}
+		return true
+	})
+}
+
 // isRequestMethodExpr reports whether expr is `<request>.Method` where
 // <request> is typed `*net/http.Request`.
 func isRequestMethodExpr(expr ast.Expr, info *types.Info) bool {

--- a/internal/metadata/method_dispatch_test.go
+++ b/internal/metadata/method_dispatch_test.go
@@ -212,3 +212,128 @@ func TestDetectMethodDispatch_NilSafety(t *testing.T) {
 		t.Errorf("nil inputs should yield nil, got %v", got)
 	}
 }
+
+// typeCheckFile parses and type-checks a whole file, returning what
+// detectLitDispatch needs.
+func typeCheckFile(t *testing.T, src string) (*ast.File, *types.Info, *token.FileSet) {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "reg.go", src, 0)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	info := &types.Info{
+		Types: map[ast.Expr]types.TypeAndValue{},
+		Defs:  map[*ast.Ident]types.Object{},
+		Uses:  map[*ast.Ident]types.Object{},
+	}
+	conf := types.Config{Importer: importer.Default()}
+	if _, err := conf.Check("p", fset, []*ast.File{file}, info); err != nil {
+		t.Fatalf("typecheck: %v", err)
+	}
+	return file, info, fset
+}
+
+// TestDetectLitDispatch records a closure's dispatch under the closure's own
+// identity, and keeps two closures written in one function apart — the whole
+// point of the record, since the enclosing declaration's MethodDispatch holds
+// both sets of arms with nothing to tell them apart (issue #382).
+func TestDetectLitDispatch(t *testing.T) {
+	file, info, fset := typeCheckFile(t, `package p
+
+import "net/http"
+
+func register() {
+	http.HandleFunc("/a", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_ = w
+		case http.MethodPost:
+			_ = r
+		}
+	})
+	http.HandleFunc("/b", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			_ = w
+		}
+	})
+	http.HandleFunc("/c", func(w http.ResponseWriter, r *http.Request) {
+		_ = w // no dispatch: no entry
+	})
+}
+`)
+	meta := &Metadata{StringPool: NewStringPool()}
+	detectLitDispatch(file, info, "p", fset, meta)
+
+	if len(meta.LitDispatch) != 2 {
+		t.Fatalf("want an entry for each DISPATCHING closure (2), got %d: %v",
+			len(meta.LitDispatch), sortedLitKeys(meta.LitDispatch))
+	}
+	byMethods := map[string]LitDispatch{}
+	for key, lit := range meta.LitDispatch {
+		if !strings.HasPrefix(key, "p."+FuncLitPrefix) {
+			t.Errorf("key %q should be the closure's identity (pkg.FuncLit:<position>)", key)
+		}
+		byMethods[methodsOf(lit.Branches)] = lit
+	}
+	for _, want := range []string{"GET,POST", "DELETE"} {
+		lit, ok := byMethods[want]
+		if !ok {
+			t.Fatalf("no entry with arms %q; have %v", want, sortedLitKeys(meta.LitDispatch))
+		}
+		// The body range is what scopes the arms to THIS literal.
+		if lit.Body.StartLine <= 0 || lit.Body.EndLine < lit.Body.StartLine || lit.Body.StartCol <= 0 {
+			t.Errorf("arms %q: body range %+v is not usable", want, lit.Body)
+		}
+		for _, b := range lit.Branches {
+			if b.StartLine < lit.Body.StartLine || b.EndLine > lit.Body.EndLine {
+				t.Errorf("arms %q: branch %v at [%d,%d] falls outside the literal body %+v",
+					want, b.Methods, b.StartLine, b.EndLine, lit.Body)
+			}
+		}
+		if meta.StringPool.GetString(lit.File) != "reg.go" {
+			t.Errorf("arms %q: file = %q, want the absolute path of the literal's file",
+				want, meta.StringPool.GetString(lit.File))
+		}
+	}
+}
+
+// A closure inside a METHOD is recorded too: methods are not in File.Functions,
+// so a per-declaration walk would miss the `func (s *Server) routes()` shape
+// entirely.
+func TestDetectLitDispatchInsideMethod(t *testing.T) {
+	file, info, fset := typeCheckFile(t, `package p
+
+import "net/http"
+
+type server struct{}
+
+func (s *server) routes() {
+	http.HandleFunc("/x", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut:
+			_ = w
+		}
+	})
+}
+`)
+	meta := &Metadata{StringPool: NewStringPool()}
+	detectLitDispatch(file, info, "p", fset, meta)
+	if len(meta.LitDispatch) != 1 {
+		t.Fatalf("want the method's closure recorded, got %d entries", len(meta.LitDispatch))
+	}
+	for _, lit := range meta.LitDispatch {
+		if got := methodsOf(lit.Branches); got != "PUT" {
+			t.Errorf("arms = %q, want PUT", got)
+		}
+	}
+}
+
+func sortedLitKeys(m map[string]LitDispatch) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -215,6 +215,14 @@ type Metadata struct {
 	// Current module path for external type detection
 	CurrentModulePath string `yaml:"-"`
 
+	// LitDispatch records the r.Method dispatch of every function literal that
+	// has one, keyed by the literal's identity ("pkg.FuncLit:<stable position>").
+	// A literal has no Function record to hang it on, so a closure handler's
+	// dispatch was only visible folded into the enclosing declaration's
+	// MethodDispatch, mixed with every other literal's arms — see
+	// detectLitDispatch (issue #382).
+	LitDispatch map[string]LitDispatch `yaml:"lit_dispatch,omitempty"`
+
 	// ExternalTypes records facts about external (third-party) named types
 	// referenced anywhere in the analyzed code, keyed by every name form
 	// under which the type may later be looked up (full import path and
@@ -965,6 +973,27 @@ type Function struct {
 	// it is what lets a consumer tell that two statements sit in arms of one
 	// conditional that cannot both run, which line order alone cannot say.
 	Blocks []Block `yaml:"blocks,omitempty"`
+}
+
+// LitDispatch is one function literal's r.Method dispatch: the arms, plus where
+// the literal is written so a call site can be attributed to an arm.
+type LitDispatch struct {
+	// File is the pooled ABSOLUTE path of the file holding the literal. The
+	// literal's own identity carries a MODULE-RELATIVE filename, so that a
+	// closure's name (and the operationId built from it) is the same in every
+	// checkout (stablePosition, issue #216) — while every recorded call-site
+	// position is absolute. The two cannot be compared, so the absolute form is
+	// recorded here for the consumer that has to.
+	File int `yaml:"file,omitempty"`
+
+	// Body is the literal's body range. It is what lets a call site be tested
+	// for membership in THIS literal rather than merely in the same FILE — the
+	// distinction that matters as soon as one function registers two closures.
+	Body Block `yaml:"body,omitempty"`
+
+	// Branches are the dispatch arms, exactly as Function.MethodDispatch
+	// records them for a declared handler.
+	Branches []MethodBranch `yaml:"branches,omitempty"`
 }
 
 // Block is one control-flow region of a function body: an `if` or `else` arm, a

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -152,6 +152,10 @@ type RequestInfo struct {
 	// to attribute it to an r.Method dispatch branch (see splitMethodDispatchRoutes).
 	File string
 	Line int
+
+	// EntrySites are the call sites the walk passed through to reach this body,
+	// the statement's own site last. See ResponseInfo.EntrySites.
+	EntrySites []codePos
 }
 
 // ResponseInfo represents response information
@@ -172,6 +176,16 @@ type ResponseInfo struct {
 	// attribute it to an r.Method dispatch branch (see splitMethodDispatchRoutes).
 	File string
 	Line int
+
+	// EntrySites are the call sites the walk passed through to reach this
+	// response — the frames entered from the route down, the statement's own
+	// site last.
+	//
+	// Attribution needs them because the statement itself is usually NOT in the
+	// handler: `case http.MethodGet: h.Get(w, r)` writes its body inside h.Get,
+	// whose position says nothing about which arm reached it. The site that does
+	// is the call written in the arm, which is one of these (issue #382).
+	EntrySites []codePos
 
 	StatusCode int
 
@@ -1125,6 +1139,10 @@ func (e *Extractor) findTargetNode(assignment *metadata.CallArgument) TrackerNod
 type responseCandidate struct {
 	node  TrackerNodeInterface
 	chain string
+	// sites is the FULL chain of frames the walk entered to reach the node, kept
+	// as call-site positions for method-dispatch attribution. Copied because the
+	// walk reuses one chain buffer; only actual candidates pay for it.
+	sites []codePos
 }
 
 // chainSep separates call-site instance IDs in chain keys.
@@ -1174,6 +1192,25 @@ func frameChainKey(chain []string, node TrackerNodeInterface) string {
 	return "" // route/handler frame
 }
 
+// chainSites renders the walk's current chain as call-site positions, outermost
+// first. Built only for a node that actually carries a body — the chain buffer
+// itself is reused across the walk, so it cannot be retained (see the push/pop
+// in extractRouteChildrenScoped).
+func chainSites(chain []string) []codePos {
+	if len(chain) == 0 {
+		return nil
+	}
+	sites := make([]codePos, 0, len(chain))
+	for _, frame := range chain {
+		file, line, col := positionOfInstanceID(frame)
+		if file == "" || line <= 0 {
+			continue
+		}
+		sites = append(sites, codePos{file: file, line: line, col: col})
+	}
+	return sites
+}
+
 func (e *Extractor) extractRouteChildren(routeNode TrackerNodeInterface, route *RouteInfo, mountTags []string, routes *[]*RouteInfo, visitedEdges map[string]bool, chain *[]string, respCandidates *[]responseCandidate) {
 	e.extractRouteChildrenScoped(routeNode, route, mountTags, routes, visitedEdges, chain, respCandidates, true, true, 0)
 }
@@ -1212,8 +1249,9 @@ func (e *Extractor) extractRouteChildrenScoped(routeNode TrackerNodeInterface, r
 		if req := e.extractRequestFromNode(child, route); req != nil && childBodyScope {
 			// Record the call site so a method-dispatch handler can attribute
 			// this request body to the right verb branch by line range.
-			if f, l, _ := calleePosition(child); req.File == "" {
+			if f, l, c := calleePosition(child); req.File == "" {
 				req.File, req.Line = f, l
+				req.EntrySites = append(chainSites(*chain), codePos{file: f, line: l, col: c})
 			}
 			route.Request = preferRequestInfo(route.Request, req)
 		}
@@ -1230,7 +1268,11 @@ func (e *Extractor) extractRouteChildrenScoped(routeNode TrackerNodeInterface, r
 			candKey := candidateKey(*chain, child.GetEdge().Callee.ID())
 			if !visitedEdges[candKey] {
 				visitedEdges[candKey] = true
-				*respCandidates = append(*respCandidates, responseCandidate{node: child, chain: frameChainKey(*chain, child)})
+				*respCandidates = append(*respCandidates, responseCandidate{
+					node:  child,
+					chain: frameChainKey(*chain, child),
+					sites: chainSites(*chain),
+				})
 			}
 		}
 
@@ -1374,6 +1416,12 @@ func (e *Extractor) pairAndFillResponses(route *RouteInfo, candidates []response
 		route.Response = map[string]*ResponseInfo{} // pure extraction: no slot peeking
 		resps := e.extractResponsesMatched(cand.node, route)
 		file, line, col := calleePosition(cand.node)
+		// The sites to attribute this candidate by: the frames it was reached
+		// through, then its own statement. Built once per candidate and shared
+		// by its fragments — nothing mutates it in place (see appendUniqueSites).
+		sites := make([]codePos, 0, len(cand.sites)+1)
+		sites = append(sites, cand.sites...)
+		sites = append(sites, codePos{file: file, line: line, col: col})
 		siteID := cand.node.GetEdge().Callee.ID()
 		caller := cand.node.GetEdge().Caller.BaseID()
 		for _, resp := range resps {
@@ -1390,9 +1438,11 @@ func (e *Extractor) pairAndFillResponses(route *RouteInfo, candidates []response
 				continue
 			}
 			seen[dedupeKey] = true
-			// Carry the call-site position so a method-dispatch handler can
-			// attribute this response to the right verb branch by line range.
+			// Carry the call-site position, and the frames it was reached
+			// through, so a method-dispatch handler can attribute this response
+			// to the right verb branch.
 			resp.File, resp.Line = file, line
+			resp.EntrySites = sites
 			frags = append(frags, fragment{resp: resp, chain: cand.chain, caller: caller, file: file, line: line, col: col})
 		}
 	}
@@ -1433,6 +1483,13 @@ func (e *Extractor) pairAndFillResponses(route *RouteInfo, candidates []response
 			route.Response[slot] = mergeResponseAlternatives(existing, resp)
 		default:
 			route.Response[slot] = preferResponseInfo(existing, resp)
+		}
+		// Whichever fragment the slot kept, the arms that produced BOTH are
+		// still facts about it: two branches reaching one status is a response
+		// both of them send, and dropping the loser's sites would attribute it
+		// to only one (see ResponseInfo.EntrySites).
+		if kept := route.Response[slot]; kept != nil && existing != nil {
+			kept.EntrySites = appendUniqueSites(appendUniqueSites(nil, existing.EntrySites), resp.EntrySites)
 		}
 	}
 
@@ -1555,6 +1612,24 @@ func (e *Extractor) pairAndFillResponses(route *RouteInfo, candidates []response
 	}
 }
 
+// appendUniqueSites appends the sites not already present, so a slot's site set
+// stays a set however many fragments merged into it.
+func appendUniqueSites(dst []codePos, src []codePos) []codePos {
+	for _, s := range src {
+		found := false
+		for _, d := range dst {
+			if d == s {
+				found = true
+				break
+			}
+		}
+		if !found {
+			dst = append(dst, s)
+		}
+	}
+	return dst
+}
+
 // handlerCallDepths returns the call-graph distance (in hops) from the
 // route's handler function to every function reachable from it, via a BFS
 // over meta.Callers. Used to rank undetermined-status response fragments by
@@ -1610,7 +1685,15 @@ func calleePosition(n TrackerNodeInterface) (string, int, int) {
 	if edge == nil {
 		return "", 0, 0
 	}
-	pos := edge.Callee.ID()
+	return positionOfInstanceID(edge.Callee.ID())
+}
+
+// positionOfInstanceID parses the "file:line:col" call-site position out of a
+// call's instance ID ("pkg.Func@file:line:col"). Instance IDs are what the
+// extraction chain is made of, so this is also how a frame the walk passed
+// through is located.
+func positionOfInstanceID(id string) (string, int, int) {
+	pos := id
 	at := strings.LastIndexByte(pos, '@')
 	if at < 0 {
 		return pos, 0, 0

--- a/internal/spec/method_dispatch.go
+++ b/internal/spec/method_dispatch.go
@@ -15,6 +15,7 @@
 package spec
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/ehabterra/apispec/internal/metadata"
@@ -22,59 +23,157 @@ import (
 
 // splitMethodDispatchRoutes expands each route whose handler dispatches on
 // r.Method (a `switch r.Method` or `if r.Method == …` chain — recorded as
-// metadata.Function.MethodDispatch) into one route per HTTP method, attributing
-// each verb branch's request and responses to its own operation. Routes whose
-// handler does not dispatch pass through unchanged.
+// metadata.Function.MethodDispatch for a declared handler, or
+// metadata.LitDispatch for a closure) into one route per HTTP method,
+// attributing each verb branch's request and responses to its own operation.
+// Routes whose handler does not dispatch pass through unchanged.
 //
-// Attribution is by source position: a request/response located inside the
-// handler is assigned to the branch whose line range contains it; one located
-// outside the handler (a shared helper in another file, or with no recoverable
-// position) is attached to every method, and one located inside the handler but
-// outside every verb branch (e.g. the `default:` arm's 405) is dropped. Two
-// branches that return the *same* status with different bodies are a known
-// limitation — the earlier status-slot pairing keeps one, so they don't split.
+// Attribution is by source position, over the call sites the walk passed
+// through to reach a body (ResponseInfo.EntrySites) and not only the body's own
+// statement: the statement is usually written in a callee, and it is the call in
+// the arm that says which verb reached it. A body with a site inside the handler
+// belongs to the arms containing such a site; one whose sites are all outside
+// the handler (a shared helper with no recoverable chain) is attached to every
+// method; one written inside the handler but in no arm (the `default:` case's
+// 405) is dropped. Two branches that return the *same* status with different
+// bodies are a known limitation — the earlier status-slot pairing keeps one, so
+// they don't split.
+//
+// A route registered with a concrete verb is not split — the router sends it
+// that verb only — but it IS scoped to the matching arm: the other arms are dead
+// for this route, and their bodies documented a `router.GET` operation with the
+// POST arm's 201.
 func splitMethodDispatchRoutes(routes []*RouteInfo) []*RouteInfo {
 	out := make([]*RouteInfo, 0, len(routes))
 	for _, route := range routes {
-		branches, handlerFile := methodDispatchFor(route)
+		branches, scope := methodDispatchFor(route)
 		if len(branches) == 0 {
 			out = append(out, route)
 			continue
 		}
-		out = append(out, splitRouteByMethodBranches(route, branches, handlerFile)...)
+		if route.MethodExplicit {
+			out = append(out, scopeRouteToDispatchArm(route, branches, scope))
+			continue
+		}
+		out = append(out, splitRouteByMethodBranches(route, branches, scope)...)
 	}
 	return out
 }
 
-// methodDispatchFor returns the handler's r.Method dispatch branches and the
-// source file the handler is defined in (for same-file position scoping), or
-// nil when the route's handler doesn't dispatch on the method.
-func methodDispatchFor(route *RouteInfo) ([]metadata.MethodBranch, string) {
+// scopeRouteToDispatchArm keeps only the bodies the route's own verb produces,
+// for a registration that named its verb.
+//
+// The route is not split and not renamed: it is one operation either way. What
+// changes is that `mux.HandleFunc("GET /x", h)` with an `r.Method` switch in h
+// stops documenting the POST arm's request body and 201 — arms the router never
+// sends this route. When the verb has no arm at all (a handler shared across
+// registrations, or a switch that does not name it) nothing is scoped away:
+// the arms say nothing about this verb, so removing bodies on their say-so
+// would be a guess (golden rule #7).
+func scopeRouteToDispatchArm(route *RouteInfo, branches []metadata.MethodBranch, scope handlerScope) *RouteInfo {
+	ranges, _ := dispatchRanges(branches)
+	rs, ok := ranges[route.Method]
+	if !ok {
+		return route
+	}
+	return routeScopedToArm(route, route.Method, "", rs, scope)
+}
+
+// handlerScope is where a route's handler is written: the file, and the range
+// within it the handler body occupies.
+//
+// The range is what tells a call site written in the handler from one written
+// elsewhere in the same file — which is the whole question as soon as a function
+// registers two closures, since both share the file and every arm of both is
+// recorded against the enclosing declaration.
+type handlerScope struct {
+	file  string
+	start codePos
+	end   codePos
+}
+
+// contains reports whether a call site sits inside the handler's body.
+func (h handlerScope) contains(p codePos) bool {
+	if h.file == "" || !p.valid() || p.file != h.file {
+		return false
+	}
+	if h.start.valid() && !h.start.beforeOrAt(p) {
+		return false
+	}
+	return h.end.line <= 0 || p.line < h.end.line ||
+		(p.line == h.end.line && (h.end.col <= 0 || p.col <= h.end.col))
+}
+
+// methodDispatchFor returns the handler's r.Method dispatch branches and where
+// the handler is written, or nil when the route's handler doesn't dispatch on
+// the method.
+func methodDispatchFor(route *RouteInfo) ([]metadata.MethodBranch, handlerScope) {
 	meta := route.Metadata
 	if meta == nil || route.Function == "" {
-		return nil, ""
-	}
-	// A route registered with a concrete verb (router.GET, "POST /x", …) only
-	// receives that verb, so its handler's incidental r.Method branches are dead
-	// for this route — never split it. Only verb-less registrations dispatch.
-	if route.MethodExplicit {
-		return nil, ""
+		return nil, handlerScope{}
 	}
 	bare := route.Function
 	if route.Package != "" {
 		bare = strings.TrimPrefix(route.Function, route.Package+".")
 	}
+	// A closure handler is identified by where it is written, and its dispatch is
+	// recorded under that identity: it has no Function record to carry it, and
+	// the enclosing declaration's MethodDispatch mixes in every other literal's
+	// arms (issue #382).
+	if strings.HasPrefix(bare, metadata.FuncLitPrefix) {
+		lit, ok := meta.LitDispatch[route.Function]
+		if !ok || len(lit.Branches) == 0 {
+			return nil, handlerScope{}
+		}
+		file := meta.StringPool.GetString(lit.File)
+		return lit.Branches, handlerScope{
+			file:  file,
+			start: codePos{file: file, line: lit.Body.StartLine, col: lit.Body.StartCol},
+			end:   codePos{file: file, line: lit.Body.EndLine, col: lit.Body.EndCol},
+		}
+	}
 	fn := findFunctionByName(meta, route.Package, bare)
 	if fn == nil || len(fn.MethodDispatch) == 0 {
-		return nil, ""
+		return nil, handlerScope{}
 	}
-	return fn.MethodDispatch, fileOfPosition(meta.StringPool.GetString(fn.Position))
+	pos := meta.StringPool.GetString(fn.Position)
+	file, line, col := parsePosition(pos)
+	return fn.MethodDispatch, handlerScope{
+		file:  file,
+		start: codePos{file: file, line: line, col: col},
+		// EndCol 0: the declaration's last line is recorded, its column is not,
+		// so the whole closing line counts as inside.
+		end: codePos{file: file, line: fn.EndLine},
+	}
 }
 
 // splitRouteByMethodBranches builds one RouteInfo per HTTP method named across
 // the dispatch branches, with request/response scoped to that method.
-func splitRouteByMethodBranches(route *RouteInfo, branches []metadata.MethodBranch, handlerFile string) []*RouteInfo {
-	type lineRange struct{ start, end int }
+func splitRouteByMethodBranches(route *RouteInfo, branches []metadata.MethodBranch, scope handlerScope) []*RouteInfo {
+	ranges, order := dispatchRanges(branches)
+	if len(order) == 0 {
+		return []*RouteInfo{route}
+	}
+
+	result := make([]*RouteInfo, 0, len(order))
+	for _, m := range order {
+		// The method is the operationId suffix too: neither verb of a split is
+		// the primary one, and two operations differing only in method would
+		// otherwise collide.
+		result = append(result, routeScopedToArm(route, m, m, ranges[m], scope))
+	}
+	return result
+}
+
+// lineRange is one dispatch arm's source range, lines only (see Block: a case
+// clause is compared against, where the column distinction does not arise).
+type lineRange struct{ start, end int }
+
+// dispatchRanges groups the arms by the HTTP method they name, keeping the
+// methods in source order so a split is deterministic (golden rule #1). One
+// method may have several arms, and one arm several methods
+// (`case http.MethodGet, http.MethodHead:`).
+func dispatchRanges(branches []metadata.MethodBranch) (map[string][]lineRange, []string) {
 	ranges := map[string][]lineRange{}
 	var order []string
 	for _, b := range branches {
@@ -85,16 +184,13 @@ func splitRouteByMethodBranches(route *RouteInfo, branches []metadata.MethodBran
 			ranges[m] = append(ranges[m], lineRange{b.StartLine, b.EndLine})
 		}
 	}
-	if len(order) == 0 {
-		return []*RouteInfo{route}
-	}
+	return ranges, order
+}
 
-	// insideHandler reports whether a call site sits in the handler's own file
-	// (so its line can be compared against the branch ranges).
-	insideHandler := func(file string, line int) bool {
-		return handlerFile != "" && line > 0 && file == handlerFile
-	}
-	inRanges := func(rs []lineRange, line int) bool {
+// routeScopedToArm copies the route with only the request and responses that
+// belong to one verb's arms.
+func routeScopedToArm(route *RouteInfo, method, idSuffix string, rs []lineRange, scope handlerScope) *RouteInfo {
+	inArm := func(line int) bool {
 		for _, r := range rs {
 			if line >= r.start && line <= r.end {
 				return true
@@ -102,37 +198,75 @@ func splitRouteByMethodBranches(route *RouteInfo, branches []metadata.MethodBran
 		}
 		return false
 	}
-	// belongsTo reports whether a call site at (file,line) belongs to method m:
-	// either it's outside the handler (shared → every method) or it falls in one
-	// of m's branch ranges. A site inside the handler but in no branch (default
-	// arm) belongs to no method.
-	belongsTo := func(rs []lineRange, file string, line int) bool {
-		if !insideHandler(file, line) {
-			return true
-		}
-		return inRanges(rs, line)
-	}
-
-	result := make([]*RouteInfo, 0, len(order))
-	for _, m := range order {
-		rs := ranges[m]
-		nr := *route // shallow copy; per-method Method/Request/Response below
-		nr.Method = m
-		nr.OperationIDSuffix = m // keep operationIds unique across the split
-		nr.Response = map[string]*ResponseInfo{}
-		nr.Request = nil
-
-		for slot, resp := range route.Response {
-			if resp != nil && belongsTo(rs, resp.File, resp.Line) {
-				nr.Response[slot] = resp
+	// belongsTo reports whether a body reached through these call sites belongs
+	// to method m. A site inside one of m's arms is decisive; a site inside the
+	// handler but in no arm (the `default:` case, or code before the switch)
+	// belongs to no method; and a body with no site inside the handler at all —
+	// a shared helper whose chain was not recovered — is attached to every
+	// method rather than dropped, since it is genuinely part of this route.
+	//
+	// The test is over the whole set rather than the innermost site, because a
+	// slot's sites can come from several fragments: one status reached from two
+	// arms is a response both arms send (see the merge in pairAndFillResponses).
+	belongsTo := func(sites []codePos) bool {
+		insideHandler := false
+		for _, s := range sites {
+			if !scope.contains(s) {
+				continue
+			}
+			insideHandler = true
+			if inArm(s.line) {
+				return true
 			}
 		}
-		if route.Request != nil && belongsTo(rs, route.Request.File, route.Request.Line) {
-			nr.Request = route.Request
-		}
-		result = append(result, &nr)
+		return !insideHandler
 	}
-	return result
+
+	nr := *route // shallow copy; Method/Request/Response are per-arm below
+	nr.Method = method
+	nr.OperationIDSuffix = idSuffix
+	nr.Response = map[string]*ResponseInfo{}
+	nr.Request = nil
+
+	for slot, resp := range route.Response {
+		if resp != nil && belongsTo(sitesOf(resp.EntrySites, resp.File, resp.Line)) {
+			nr.Response[slot] = resp
+		}
+	}
+	if route.Request != nil &&
+		belongsTo(sitesOf(route.Request.EntrySites, route.Request.File, route.Request.Line)) {
+		nr.Request = route.Request
+	}
+	return &nr
+}
+
+// sitesOf returns the call sites to attribute a body by, falling back to its own
+// statement position when no chain was recorded (a body matched outside the
+// route walk, or one carried over from a route that predates EntrySites).
+func sitesOf(sites []codePos, file string, line int) []codePos {
+	if len(sites) > 0 {
+		return sites
+	}
+	if file == "" || line <= 0 {
+		return nil
+	}
+	return []codePos{{file: file, line: line}}
+}
+
+// parsePosition splits a "file:line:col" position string, tolerating a Windows
+// drive-letter colon the same way fileOfPosition does.
+func parsePosition(pos string) (string, int, int) {
+	file := fileOfPosition(pos)
+	if len(pos) <= len(file) {
+		return file, 0, 0
+	}
+	rest := strings.Split(pos[len(file)+1:], ":")
+	line, _ := strconv.Atoi(rest[0])
+	col := 0
+	if len(rest) > 1 {
+		col, _ = strconv.Atoi(rest[1])
+	}
+	return file, line, col
 }
 
 // fileOfPosition returns the file portion of a "file:line:col" position string,

--- a/internal/spec/method_dispatch_test.go
+++ b/internal/spec/method_dispatch_test.go
@@ -36,6 +36,12 @@ func TestFileOfPosition(t *testing.T) {
 	}
 }
 
+// wholeFileScope is the handler scope a declaration with no recorded EndLine
+// gets: every position in its file counts as inside it.
+func wholeFileScope(file string) handlerScope {
+	return handlerScope{file: file, start: codePos{file: file, line: 1, col: 1}}
+}
+
 // resp is a small helper to build a positioned response.
 func resp(status int, file string, line int) *ResponseInfo {
 	return &ResponseInfo{StatusCode: status, BodyType: "T", File: file, Line: line}
@@ -61,7 +67,7 @@ func TestSplitRouteByMethodBranches_Scoping(t *testing.T) {
 		Request: &RequestInfo{BodyType: "CreateReq", File: handlerFile, Line: 14}, // POST branch
 	}
 
-	got := splitRouteByMethodBranches(route, branches, handlerFile)
+	got := splitRouteByMethodBranches(route, branches, wholeFileScope(handlerFile))
 	if len(got) != 2 {
 		t.Fatalf("want 2 method routes, got %d", len(got))
 	}
@@ -113,7 +119,7 @@ func TestSplitRouteByMethodBranches_MultiMethodBranch(t *testing.T) {
 		Function: "pkg.ping",
 		Response: map[string]*ResponseInfo{"200": resp(200, "h.go", 6)},
 	}
-	got := splitRouteByMethodBranches(route, branches, "h.go")
+	got := splitRouteByMethodBranches(route, branches, wholeFileScope("h.go"))
 	if len(got) != 2 {
 		t.Fatalf("want GET+HEAD = 2 routes, got %d", len(got))
 	}
@@ -227,4 +233,228 @@ func equalStrs(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+// TestSplitMethodDispatchRoutes_ClosureHandler drives the split for a handler
+// that is a function literal. Its dispatch is recorded under the closure's
+// identity rather than on a Function, because a literal has no Function record
+// and the enclosing declaration's MethodDispatch mixes in every other literal's
+// arms (issue #382).
+func TestSplitMethodDispatchRoutes_ClosureHandler(t *testing.T) {
+	const file = "main.go"
+	const key = "pkg.FuncLit:main.go:10:30"
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	meta.LitDispatch = map[string]metadata.LitDispatch{
+		key: {
+			File: meta.StringPool.Get(file),
+			Body: metadata.Block{
+				Kind: metadata.BlockFuncLit,
+				// The literal's body opens on the SAME line as the
+				// registration call that carries it.
+				StartLine: 10, StartCol: 70,
+				EndLine: 20, EndCol: 3,
+			},
+			Branches: []metadata.MethodBranch{
+				{Methods: []string{"GET"}, StartLine: 12, EndLine: 13},
+				{Methods: []string{"POST"}, StartLine: 14, EndLine: 16},
+			},
+		},
+	}
+	route := &RouteInfo{
+		Path: "/users", Method: "POST",
+		Function: key, Package: "pkg", Metadata: meta,
+		Response: map[string]*ResponseInfo{
+			"200": {StatusCode: 200, BodyType: "User", File: file, Line: 12},
+			"201": {StatusCode: 201, File: file, Line: 15},
+			// The default arm's 405: inside the literal, in no arm.
+			"405": {StatusCode: 405, File: file, Line: 18},
+			// A second closure further down the same file: outside THIS
+			// literal, so it is not one of its arms' bodies either.
+			"418": {StatusCode: 418, BodyType: "Teapot", File: file, Line: 30},
+		},
+	}
+
+	got := splitMethodDispatchRoutes([]*RouteInfo{route})
+	byMethod := map[string]*RouteInfo{}
+	for _, r := range got {
+		byMethod[r.Method] = r
+	}
+	if len(got) != 2 || byMethod["GET"] == nil || byMethod["POST"] == nil {
+		t.Fatalf("want a GET and a POST route, got %d: %v", len(got), byMethod)
+	}
+	if _, ok := byMethod["GET"].Response["200"]; !ok {
+		t.Error("GET should own the 200 written in its arm")
+	}
+	if _, ok := byMethod["GET"].Response["201"]; ok {
+		t.Error("GET must not carry the POST arm's 201")
+	}
+	for _, m := range []string{"GET", "POST"} {
+		if _, ok := byMethod[m].Response["405"]; ok {
+			t.Errorf("%s must not carry the default arm's 405", m)
+		}
+		// Outside the literal with no chain to place it: shared, as for any
+		// body whose arm cannot be determined.
+		if _, ok := byMethod[m].Response["418"]; !ok {
+			t.Errorf("%s should keep the body written outside the literal", m)
+		}
+	}
+}
+
+// A response written in a CALLEE is attributed by the call site in the arm that
+// reached it — the statement's own position is in another function and says
+// nothing about the verb (issue #382).
+func TestSplitRouteByMethodBranches_AttributesByChain(t *testing.T) {
+	const file = "main.go"
+	scope := handlerScope{
+		file:  file,
+		start: codePos{file: file, line: 10, col: 70},
+		end:   codePos{file: file, line: 20, col: 3},
+	}
+	branches := []metadata.MethodBranch{
+		{Methods: []string{"GET"}, StartLine: 12, EndLine: 13},
+		{Methods: []string{"POST"}, StartLine: 14, EndLine: 16},
+	}
+	// Both bodies are written in handlers.go, one frame down; the arm is only
+	// visible in EntrySites.
+	route := &RouteInfo{
+		Path: "/users", Method: "POST",
+		Response: map[string]*ResponseInfo{
+			"200": {StatusCode: 200, BodyType: "User", File: "handlers.go", Line: 5,
+				EntrySites: []codePos{{file: file, line: 13, col: 4}, {file: "handlers.go", line: 5, col: 2}}},
+			"201": {StatusCode: 201, File: "handlers.go", Line: 12,
+				EntrySites: []codePos{{file: file, line: 15, col: 4}, {file: "handlers.go", line: 12, col: 2}}},
+		},
+		Request: &RequestInfo{BodyType: "CreateReq", File: "handlers.go", Line: 10,
+			EntrySites: []codePos{{file: file, line: 15, col: 4}, {file: "handlers.go", line: 10, col: 2}}},
+	}
+	got := splitRouteByMethodBranches(route, branches, scope)
+	byMethod := map[string]*RouteInfo{}
+	for _, r := range got {
+		byMethod[r.Method] = r
+	}
+	get, post := byMethod["GET"], byMethod["POST"]
+	if get == nil || post == nil {
+		t.Fatalf("want GET and POST, got %v", byMethod)
+	}
+	if _, ok := get.Response["200"]; !ok {
+		t.Error("the 200 was reached from the GET arm, so GET should own it")
+	}
+	if _, ok := get.Response["201"]; ok {
+		t.Error("the 201 was reached from the POST arm; GET must not carry it")
+	}
+	if get.Request != nil {
+		t.Error("the request body was decoded under the POST arm; GET must not carry it")
+	}
+	if post.Request == nil {
+		t.Error("POST should carry the request body decoded in its arm")
+	}
+}
+
+// A registration that named its verb is not split — the router sends it that
+// verb only — but the other arms' bodies are dead for it and must not be
+// documented on it.
+func TestSplitMethodDispatchRoutes_ExplicitMethodScopedToArm(t *testing.T) {
+	const file = "h.go"
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool()}
+	meta.Packages = map[string]*metadata.Package{
+		"pkg": {Files: map[string]*metadata.File{
+			file: {Functions: map[string]*metadata.Function{
+				"h": {
+					Position: meta.StringPool.Get(file + ":1:1"),
+					EndLine:  10,
+					MethodDispatch: []metadata.MethodBranch{
+						{Methods: []string{"GET"}, StartLine: 2, EndLine: 3},
+						{Methods: []string{"POST"}, StartLine: 4, EndLine: 6},
+					},
+				},
+			}},
+		}},
+	}
+	route := &RouteInfo{
+		Path: "/x", Method: "GET", MethodExplicit: true, // e.g. router.GET("/x", h)
+		Function: "pkg.h", Package: "pkg", Metadata: meta,
+		Response: map[string]*ResponseInfo{
+			"200": {StatusCode: 200, BodyType: "User", File: file, Line: 2},
+			"201": {StatusCode: 201, File: file, Line: 5},
+		},
+		Request: &RequestInfo{BodyType: "CreateReq", File: file, Line: 5},
+	}
+	got := splitMethodDispatchRoutes([]*RouteInfo{route})
+	if len(got) != 1 || got[0].Method != "GET" {
+		t.Fatalf("explicit-method route must not split; got %d routes %+v", len(got), got)
+	}
+	if got[0].OperationIDSuffix != "" {
+		t.Errorf("a route that did not split must keep its operationId, got suffix %q", got[0].OperationIDSuffix)
+	}
+	if _, ok := got[0].Response["200"]; !ok {
+		t.Error("GET should keep the 200 written in the GET arm")
+	}
+	if _, ok := got[0].Response["201"]; ok {
+		t.Error("GET must not document the POST arm's 201")
+	}
+	if got[0].Request != nil {
+		t.Error("GET must not document the POST arm's request body")
+	}
+
+	// A verb the switch does not name says nothing about this route: nothing is
+	// scoped away rather than everything (golden rule #7).
+	route.Method = "PATCH"
+	got = splitMethodDispatchRoutes([]*RouteInfo{route})
+	if len(got) != 1 || got[0] != route {
+		t.Fatalf("a verb with no arm must pass the route through untouched, got %+v", got)
+	}
+}
+
+func TestHandlerScopeContains(t *testing.T) {
+	scope := handlerScope{
+		file:  "main.go",
+		start: codePos{file: "main.go", line: 10, col: 70},
+		end:   codePos{file: "main.go", line: 20, col: 3},
+	}
+	cases := []struct {
+		name string
+		pos  codePos
+		want bool
+	}{
+		// The registration call shares the literal's opening line but is
+		// written before it — a line-only test would call this inside.
+		{"registration call on the opening line", codePos{file: "main.go", line: 10, col: 2}, false},
+		{"inside the body", codePos{file: "main.go", line: 15, col: 4}, true},
+		{"on the closing line, before the brace", codePos{file: "main.go", line: 20, col: 2}, true},
+		{"after the closing brace", codePos{file: "main.go", line: 20, col: 40}, false},
+		{"below the literal", codePos{file: "main.go", line: 30, col: 2}, false},
+		{"another file", codePos{file: "other.go", line: 15, col: 4}, false},
+		{"no position", codePos{}, false},
+	}
+	for _, c := range cases {
+		if got := scope.contains(c.pos); got != c.want {
+			t.Errorf("%s: contains(%+v) = %v, want %v", c.name, c.pos, got, c.want)
+		}
+	}
+	// A declaration with no recorded EndLine falls back to its whole file, the
+	// behaviour before ranges existed.
+	whole := wholeFileScope("main.go")
+	if !whole.contains(codePos{file: "main.go", line: 900, col: 1}) {
+		t.Error("a scope with no end line must cover its whole file")
+	}
+}
+
+func TestParsePosition(t *testing.T) {
+	cases := []struct {
+		in   string
+		file string
+		line int
+		col  int
+	}{
+		{"/a/b/x.go:10:5", "/a/b/x.go", 10, 5},
+		{`C:\a\x.go:10:20`, `C:\a\x.go`, 10, 20},
+		{"nocolon", "nocolon", 0, 0},
+	}
+	for _, c := range cases {
+		file, line, col := parsePosition(c.in)
+		if file != c.file || line != c.line || col != c.col {
+			t.Errorf("parsePosition(%q) = %q,%d,%d; want %q,%d,%d",
+				c.in, file, line, col, c.file, c.line, c.col)
+		}
+	}
 }

--- a/testdata/method_switch_closure/go.mod
+++ b/testdata/method_switch_closure/go.mod
@@ -1,0 +1,3 @@
+module github.com/ehabterra/apispec/testdata/method_switch_closure
+
+go 1.22

--- a/testdata/method_switch_closure/main.go
+++ b/testdata/method_switch_closure/main.go
@@ -1,0 +1,135 @@
+// Package main exercises control-flow method dispatch written in a CLOSURE
+// rather than in a named handler (issue #382). A function literal has no
+// Function record in the metadata, so its `switch r.Method` used to be folded
+// into the enclosing declaration's — invisible from the route, which then fell
+// to the POST default with every branch's responses merged onto it.
+//
+// The shapes here are deliberately side by side: two closures registered from
+// one function (so a per-FILE scope would mix their arms), a closure whose arms
+// call methods (so the arm has to be found on the call chain, not at the
+// response statement), a named factory returning the same closure, a closure
+// inside a method (which is not in Functions at all), and an explicit-verb
+// registration that must NOT split.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type User struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+type CreateUserRequest struct {
+	Name string `json:"name"`
+}
+
+type UpdateUserRequest struct {
+	Name string `json:"name"`
+}
+
+type handlers struct{}
+
+// Get writes the 200 body one call away from the arm that reaches it.
+func (h *handlers) Get(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode(User{})
+}
+
+// Create reads the request body and answers 201, again one call from the arm.
+func (h *handlers) Create(w http.ResponseWriter, r *http.Request) {
+	var req CreateUserRequest
+	_ = json.NewDecoder(r.Body).Decode(&req)
+	w.WriteHeader(http.StatusCreated)
+}
+
+// namedMethods is the factory shape: the dispatch is in the returned closure,
+// while the route's handler resolves to the factory.
+func namedMethods(h *handlers) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			h.Get(w, r)
+		case http.MethodPost:
+			h.Create(w, r)
+		}
+	}
+}
+
+type server struct {
+	h *handlers
+}
+
+// routes registers from a METHOD, whose body holds no Function record — the
+// closure's dispatch has to be recorded from a whole-file walk to be found.
+func (s *server) routes(mux *http.ServeMux) {
+	mux.HandleFunc("/from-method", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			s.h.Get(w, r)
+		case http.MethodDelete:
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+}
+
+func main() {
+	h := &handlers{}
+
+	// (a) inline arm bodies: the response statements are in the arms.
+	http.HandleFunc("/inline", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(User{})
+		case http.MethodPost:
+			var req CreateUserRequest
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			w.WriteHeader(http.StatusCreated)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+
+	// (b) a second closure in the SAME function: its arms must not leak into
+	// the one above, which a file-scoped attribution would let them do.
+	http.HandleFunc("/inline-second", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			var req UpdateUserRequest
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			_ = json.NewEncoder(w).Encode(User{})
+		} else if r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+
+	// (c) arms that call methods: the response is written a frame deeper, so
+	// the arm is only visible on the call chain.
+	http.HandleFunc("/via-methods", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			h.Get(w, r)
+		case http.MethodPost:
+			h.Create(w, r)
+		}
+	})
+
+	// (d) the factory shape.
+	http.HandleFunc("/from-factory", namedMethods(h))
+
+	// (e) an explicit verb: the router only sends GET here, so the closure's
+	// POST arm is dead for this route and the route must stay a single GET.
+	http.HandleFunc("GET /explicit", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(User{})
+		case http.MethodPost:
+			w.WriteHeader(http.StatusCreated)
+		}
+	})
+
+	mux := http.NewServeMux()
+	(&server{h: h}).routes(mux)
+
+	http.ListenAndServe(":8080", nil)
+}


### PR DESCRIPTION
Fixes #382.

## The bug

`splitMethodDispatchRoutes` expands a verb-less registration whose handler branches on `r.Method` into one operation per method. It did that for a **named** handler and not for a **closure written at the registration site** — the shape `http.HandleFunc("/x", func(w, r) { switch r.Method { … } })`.

A function literal has no `Function` record, so its arms were folded into the *enclosing* declaration's `MethodDispatch`, alongside every other literal's arms in that function, with nothing to tell them apart. The route then fell to the `ExtractRoute` POST default carrying every arm's responses: `GET /x` undocumented, and `POST /x` advertising a 200 body that only the GET arm writes.

## The fix

**metadata records the fact** (`Metadata.LitDispatch`): a literal's dispatch under the literal's own identity — `pkg.FuncLit:<stable position>`, the name a closure route already carries as its handler — together with the body range that scopes its arms. The walk is whole-file rather than per declaration, because a registration is as often written inside a method (`func (s *Server) routes()`), and methods are not in `File.Functions` at all.

**Attribution follows the call chain**, not only the response statement. In `case http.MethodGet: h.Get(w, r)` the body is written inside `h.Get`, whose position says nothing about the verb; the call in the arm does, and it is on the chain the walk already passes through. That chain is now carried on `RequestInfo`/`ResponseInfo` as `EntrySites` (built per response candidate — a few hundred a run — not per visited node).

Without this half the fix would have traded merged responses for *no* responses on every delegating handler: the factory shape already split and documented `default` for both verbs, which is the same gap seen from the other side.

**An explicit verb is scoped, not split.** `mux.HandleFunc("GET /x", h)` stays one operation, but stops documenting the POST arm's request body and 201 — arms the router never sends it. A verb with **no** arm scopes nothing away: the arms say nothing about it, and dropping bodies on their say-so would be a guess (golden rule #7).

**Handler scoping is by range, not by file**, which is what tells two closures registered from one function apart. Columns are compared, since a literal opens on the same line as the registration call carrying it.

## Effect

`testdata/enum_validation` (unchanged fixture, three closures with dispatch):

| | before | after |
|---|---|---|
| `/users` | POST — 200 (GET arm's), 201, 400, body | **GET** — 200 · **POST** — 201, 400, body |
| `/users/` | POST — 200, 204 (DELETE arm's), 400, body | **GET** — 200 · **PUT** — 200, 400, body · **DELETE** — 204 |
| `/products/` | POST | POST *(unchanged; single arm)* |

`testdata/method_switch_closure` is new and puts the shapes side by side — inline arms, a second closure in the same function, arms that delegate to methods, the factory, a closure inside a method, and an explicit-verb registration that must not split — with `TestTestdata_MethodSwitchClosure` asserting the methods, the per-arm bodies, the dropped `default:` 405, and unique operationIds.

## Drift

- Full suite green: goldens byte-identical (no fixture had literal dispatch), determinism, both engines' parity tests, all framework fixtures.
- gitea: 899 paths before and after, and the generated spec is **byte-identical**.
- No measurable cost: the mapping stage ranged 86–100s across four runs of the two builds, with the ordering dominating (new build fastest in one position, old in the other); RSS within 1% paired.

## Not in scope

`internal/insight`'s verb-dispatch view still lists the *enclosing* function for a closure's arms; it reads `Function.MethodDispatch` and could now read the per-literal record instead. Unchanged here to keep this one reviewable change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved HTTP route documentation for handlers defined as closures, including closures registered from methods or factories.
  - Correctly associates each HTTP method with its reachable request and response bodies.
  - Preserves response bodies when handlers delegate to other calls.
  - Prevents unreachable method branches from appearing in explicitly verb-named routes.
  - Keeps generated operation IDs unique across method-specific route entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->