### PR TITLE
docs(readme): re-audit "Not supported (yet)" against the current build

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ APISpec aims for practical coverage of real-world Go services.
 - Function literals (anonymous handlers) and handler factories — a route registered as a *call* that returns the framework's handler type (`g.POST("/users", h.Create())`), including when dispatched through an interface implemented in another package.
 - **House routers and house contexts, detected automatically** — a project that puts its own type in front of the framework is documented with no configuration. See [Automatic wrapper detection](#automatic-wrapper-detection).
 - Go 1.22 `net/http.ServeMux` method-aware routing — `mux.HandleFunc("GET /users/{id}", …)` splits into method + path, `{id}` wildcards become path parameters, and ServeMux-only syntax (`{path...}`, `{$}`) is normalised to OpenAPI templating.
-- Method dispatch in the handler — one handler registered without a verb that branches on `r.Method` is split into one operation per HTTP method, each with its own body, responses and operationId.
+- Method dispatch in the handler — one handler registered without a verb that branches on `r.Method` is split into one operation per HTTP method, each with its own body, responses and operationId. Named handlers and closures written at the registration site both split, and a body written a call deeper (`case http.MethodGet: h.Get(w, r)`) is attributed to the arm that reached it. A registration that named its verb stays one operation, scoped to the matching arm.
 - **CLI-dispatched services** — routing code hanging off a command library's callback (`&cli.Command{Action: runWeb}`, `&cobra.Command{RunE: runServe}`) has no call edge from your code. APISpec treats those fields as entrypoints and documents everything below them. Presets ship for urfave/cli v1/v2/v3, spf13/cobra and peterbourgon/ff; a house dispatcher declares its own via [`entrypointPatterns`](#entrypoints-cli-dispatched-services).
 - Route registration behind a func-typed struct field invoked in-module — package-level command vars, cross-package function values, method values and inline closures.
 
@@ -196,14 +196,40 @@ registered under `components.securitySchemes`; explicitly-public routes render
 
 ### Not supported (yet)
 
-- Same path + same status code with different schemas.
-- Receiver/parent type tracing is limited; `Decode` on non-body targets may be misclassified (see [Request body source disambiguation](#request-body-source-disambiguation)).
-- Only `go-playground/validator`-style `validate:` tags are read; Gin/Echo `binding:` tags and comparison validators (`gt`/`gte`/`lt`/`lte`) are not yet mapped.
-- Routes registered from a **table** rather than a call (`for _, r := range routes { adapter.Add(r.Method, r.Path, r.Handler) }`) — the paths exist only as runtime values.
-- House routers whose registration is **chained through a returned object** (`Combo("/x").Get(h).Post(h)`) are reported as detected-but-incomplete and left unapplied, rather than guessed at.
-- Payloads whose generic type argument is erased to `any` behind a helper, and aliases over an instantiation (`type UserPage = Page[User]`). Cross-package type arguments resolve, but the component name drops the argument's package.
-- `r.Method` dispatch inside a **receiver-method** handler — the split only finds handlers declared as plain functions.
-- Command libraries that dispatch through a **factory map** (`mitchellh/cli`, `hashicorp/cli`) or **reflection-invoked methods** (`alecthomas/kong`).
+- **Two bodies under one status that never state that status.** Alternative
+  bodies on branches that *do* write their status compose into an `anyOf`; two
+  that merely fall back to the framework's implicit status keep the first one
+  and drop the rest. Within an `r.Method` split, an `anyOf` that two arms share
+  is documented on **both** operations rather than divided between them.
+- Only `go-playground/validator`-style `validate:` tags are read; Gin/Echo
+  `binding:` tags and comparison validators (`gt`/`gte`/`lt`/`lte`) are not yet
+  mapped.
+- **A path that exists only as a runtime value is documented as a placeholder,
+  not skipped.** Routes registered from a **table**
+  (`for _, r := range routes { adapter.Add(r.Method, r.Path, r.Handler) }`) come
+  out under `/{Method} {Path}`, and a house router chained through a returned
+  object (`Combo("/x").Get(h).Post(h)`) under `/{pattern}`. The auto-declared
+  parameters carry an `x-warning` saying the value was not resolvable, and
+  `--verbose` reports the chained wrapper as *incomplete, not applied* — but the
+  operation is still in the spec, so it needs excluding rather than ignoring
+  ([#428](https://github.com/ehabterra/apispec/issues/428)).
+- **A payload erased inside a generic envelope** — a helper that re-wraps the
+  value as `APIResponse[any]{Data: data}` documents `data` as an open object
+  ([#163](https://github.com/ehabterra/apispec/issues/163)).
+  A plain `any`/`interface{}` **parameter** is not affected: that resolves, and
+  keeps resolving when one helper serves several routes with different types.
+  A cross-package type used as a **type argument** also loses its package in the
+  component name (`app_Page_Product`, where the same type returned directly is
+  `app_inner_Product`).
+- **`r.Method` dispatch inside a receiver-method handler** — the split covers
+  plain functions and closures; a method (`func (h *H) Users(w, r)`) stays one
+  operation with every arm's responses on it, because the dispatch is recorded
+  per declared function and methods are not among them
+  ([#427](https://github.com/ehabterra/apispec/issues/427)).
+- Command libraries that dispatch through a **factory map** (`mitchellh/cli`,
+  `hashicorp/cli`) or **reflection-invoked methods** (`alecthomas/kong`) — the
+  command body is never reached from your code, so nothing it registers is
+  documented.
 
 ### Examples
 

--- a/internal/spec/config_entrypoints.go
+++ b/internal/spec/config_entrypoints.go
@@ -94,9 +94,15 @@ func entrypointBundles() []entrypointBundle {
 			// gap: nothing to match on, and guessing would break the
 			// honest-over-wrong rule.
 			//
-			// Same for alecthomas/kong and google/subcommands, which dispatch
-			// through an interface METHOD — those already resolve via the
-			// existing interface-implementer fan-out and need no entrypoint.
+			// alecthomas/kong is the same gap for a different reason, and NOT
+			// (as this comment previously claimed) resolved by the
+			// interface-implementer fan-out: kong reaches a command's `Run` by
+			// reflecting over the struct's fields, so the method implements no
+			// interface this module can see and `kong.Context.Run` — the only
+			// caller — lives in a dependency that is never analysed. Measured:
+			// a kong program whose `Run` registers routes documents 0 paths.
+			// Rooting it needs an entrypoint rule keyed on something other than
+			// a field's declared type, which is why there is no preset here.
 			Name:          "",
 			ImportRegexes: nil,
 			Patterns:      nil,


### PR DESCRIPTION
Every bullet in **What APISpec Understands → Not supported (yet)** was probed
against a build of `main`, not reviewed by reading. Six of the eight needed a
change.

| bullet | probe | verdict |
|---|---|---|
| Same path + same status, different schemas | two branches, each writing `200` with a different type | **stale** — composes into `anyOf` |
| … the same with no explicit status write | both bodies default to the implicit 200 | still true — first body wins, rest dropped |
| … the same across two dispatch arms | `GET`/`POST` arms both writing `200` | still true — the shared `anyOf` lands on both operations |
| `Decode` on non-body targets misclassified | file decode, upstream `resp.Body`, one `io.Reader` helper called with both, reader in a struct field, reader chosen in a branch | **not reproducible** — all classify correctly |
| only `validate:` tags; no `binding:`, no `gt/gte/lt/lte` | struct with all four | accurate — confirmed in the tag switch too |
| table-driven routes | `for _, rt := range routes { mux.HandleFunc(rt.Method+" "+rt.Path, rt.Handler) }` | understated — emits `/{Method} {Path}` |
| chained house router | `rt.Combo("/users").Get(list).Post(create)` | understated — derivation declines, then the inner `mux.HandleFunc` is matched anyway → `/{pattern}` |
| generic arg erased to `any`; alias over instantiation | shared `writeAny(w, v any)` with two payload types, `type UserPage = Page[User]` | **stale** — both resolve |
| … the generic envelope (#163's own repro) | `APIResponse[any]{Data: data}` | still true — `data` is an open object |
| … cross-package type argument | `Page[inner.Product]` vs returning `inner.Product` | still true — `app_Page_Product` vs the correct `app_inner_Product` |
| `r.Method` in a receiver-method handler | `func (h *H) Users(w, r)` with a switch | half stale — closures split since #382, methods still don't |
| factory-map / reflection CLI dispatch | kong program with the real dependency, `Run()` registering routes | accurate — 0 paths |

## Filed from this

- **#427** — a `switch r.Method` in a receiver-method handler is never split.
  `detectMethodDispatch` runs from `processFunctions`, which skips `fn.Recv != nil`,
  and `metadata.Method` has no `MethodDispatch`/`EndLine`/`Blocks` to hold it.
- **#428** — an unresolvable registration path is *emitted* as a placeholder
  operation rather than reported. Worse than a missing route: it breaks a
  spec-lint gate, generates a client method for a non-existent endpoint, and
  keeps the route count plausible while the real routes are absent.

## Also in this PR

One code change: the comment in `config_entrypoints.go` claiming alecthomas/kong
"already resolve[s] via the existing interface-implementer fan-out" is wrong and
is corrected with what was measured. kong reaches a command's `Run` by
reflecting over the struct's fields, so the method implements no interface this
module can see, and `kong.Context.Run` — its only caller — is in a dependency
that is never analysed. A kong program whose `Run` registers routes documents
0 paths, with the dependency present.

The supported-features bullet on method dispatch is also updated for what #426
shipped (closures split; a body written a call deeper is attributed to the arm
that reached it; an explicit verb is scoped to its arm).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified currently unsupported routing and handler scenarios, including alternative response bodies, runtime-only paths, generic payloads, and method dispatch.
  - Expanded details on command dispatch limitations involving reflection and factory-based patterns.
  - Updated entrypoint guidance to explain how Kong command dispatch is handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->