### PR TITLE
fix(spec): report a registration whose path is built at runtime, don't emit it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A registration whose path is built at runtime is reported instead of
+  documented at a placeholder path.** A route table
+  (`mux.HandleFunc(rt.Method+" "+rt.Path, rt.Handler)`) was emitted as an
+  operation at `/{Method} {Path}`, and a house router that carries its pattern
+  on a returned object (`Combo("/x").Get(h).Post(h)`) at `/{pattern}` — paths no
+  request can match, which fail a spec-lint gate, generate client methods for
+  endpoints that do not exist, and keep the path count plausible while the real
+  routes are missing. Such a registration is now named on stderr with its source
+  position and returned by `Generator.UnresolvedPaths()`, and the "0 paths"
+  message says which of the two things happened: nothing matched, or everything
+  that matched builds its path at runtime. A *partly* resolved path is
+  unaffected — an unresolved mount prefix, an unresolved segment before a
+  literal tail, and an unreadable tail under a prefix that IS known (a catch-all
+  seen through a wrapper) all still get their operation, with the placeholder
+  flagged; measured on a real project, judging on the route's own path alone
+  deleted three such operations. For the chained-wrapper shape this also makes two decisions agree: wrapper derivation
+  already declined it as "incomplete, not applied", and the framework call
+  inside the wrapper is no longer documented behind its back. A path held
+  entirely in a local variable is now reported rather than documented under the
+  variable's name; tracing it is #431. (#428)
 - **A `switch r.Method` written in a method is now split into one operation per
   verb.** With #382 (closures) this completes the set: every handler shape —
   plain function, closure, and method with either receiver kind, in any package

--- a/README.md
+++ b/README.md
@@ -204,15 +204,22 @@ registered under `components.securitySchemes`; explicitly-public routes render
 - Only `go-playground/validator`-style `validate:` tags are read; Gin/Echo
   `binding:` tags and comparison validators (`gt`/`gte`/`lt`/`lte`) are not yet
   mapped.
-- **A path that exists only as a runtime value is documented as a placeholder,
-  not skipped.** Routes registered from a **table**
-  (`for _, r := range routes { adapter.Add(r.Method, r.Path, r.Handler) }`) come
-  out under `/{Method} {Path}`, and a house router chained through a returned
-  object (`Combo("/x").Get(h).Post(h)`) under `/{pattern}`. The auto-declared
-  parameters carry an `x-warning` saying the value was not resolvable, and
-  `--verbose` reports the chained wrapper as *incomplete, not applied* — but the
-  operation is still in the spec, so it needs excluding rather than ignoring
-  ([#428](https://github.com/ehabterra/apispec/issues/428)).
+- **A path that exists only as a runtime value.** Routes registered from a
+  **table** (`for _, r := range routes { adapter.Add(r.Method, r.Path, r.Handler) }`)
+  or by a house router chained through a returned object
+  (`Combo("/x").Get(h).Post(h)`) cannot be located, so they are **reported and
+  left out** rather than documented at the placeholder standing in for the
+  expression. Each one names the registration site on stderr, and
+  `Generator.UnresolvedPaths()` returns the list, so the gap is countable
+  instead of silent. A path that is only *partly* unresolved keeps its
+  operation, with the placeholder flagged: an unresolved prefix
+  (`/{mountPoint}/clear`), an unresolved segment before a literal tail
+  (`/{dynamicBase}/dyn`), and an unreadable tail under a prefix that IS known
+  (`/repo/{owner}/{name}/info/lfs/{path}` — a catch-all seen through a wrapper)
+  are all real endpoints, documented approximately. A path held *entirely* in a
+  local variable is reported rather than documented even when its value is a
+  literal, since variables are not yet traced for paths
+  ([#431](https://github.com/ehabterra/apispec/issues/431)).
 - **A payload erased inside a generic envelope** — a helper that re-wraps the
   value as `APIResponse[any]{Data: data}` documents `data` as an open object
   ([#163](https://github.com/ehabterra/apispec/issues/163)).

--- a/cmd/apispec/main.go
+++ b/cmd/apispec/main.go
@@ -575,11 +575,16 @@ func writeOutput(openAPISpec interface{}, config *CLIConfig, genEngine *engine.E
 
 		// "Successfully generated" over a document with no paths is what made an
 		// unmatched router look like a working run (issue #379). The engine has
-		// already said why on stderr; this line must not contradict it.
-		if genEngine.GetRouteDiscovery().Paths == 0 {
-			fmt.Println("Generated (0 paths — nothing matched):", outputPath)
-		} else {
+		// already said why on stderr; this line must not contradict it —
+		// including when something DID match and was dropped for an unreadable
+		// path, which is not the same finding (issue #428).
+		switch {
+		case genEngine.GetRouteDiscovery().Paths > 0:
 			fmt.Println("Successfully generated:", outputPath)
+		case len(genEngine.GetUnresolvedPaths()) > 0:
+			fmt.Println("Generated (0 paths — every registration builds its path at runtime):", outputPath)
+		default:
+			fmt.Println("Generated (0 paths — nothing matched):", outputPath)
 		}
 	}
 	return nil

--- a/cmd/apispecui/main.go
+++ b/cmd/apispecui/main.go
@@ -1097,6 +1097,21 @@ func (s *UIServer) handleGenerate(w http.ResponseWriter, r *http.Request) {
 			}
 			msg += trunc
 		}
+		if unresolved := gen.GetUnresolvedPaths(); len(unresolved) > 0 {
+			// Same class of silent shortfall: the registration matched and the
+			// handler is known, but its path is built at runtime, so there is no
+			// operation to show and nothing in the document to say so (#428).
+			where := unresolved[0].Position
+			if where == "" {
+				where = unresolved[0].Handler
+			}
+			line := fmt.Sprintf("%d registration(s) build their path at runtime and are not documented (first at %s). Register those paths statically to include them.",
+				len(unresolved), where)
+			if msg != "" {
+				msg += " "
+			}
+			msg += line
+		}
 		resp := GenerateResponse{
 			OK:                 true,
 			Framework:          req.Framework,

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -116,12 +116,12 @@ issues, and a Markdown export you can attach to a bug report as-is.
 | One wiring style missing (e.g. `r.Method(...)`) | no route pattern for it | extend config (Step 1), report the style |
 | Second framework's routes missing in a mixed binary | should work — all detected frameworks merge in (scoped patterns), and `net/http` is always layered underneath | confirm `used-config.yaml` contains both frameworks' patterns (Step 1); if it doesn't, report it |
 | Framework router mounted under a `net/http` mux: routes present but missing the mount prefix (`/users` instead of `/api/users`) | cross-framework mount composition not implemented yet | tracked in [#138](https://github.com/ehabterra/apispec/issues/138); until then apply the prefix via a config override or mount inside one framework |
-| Routes behind `for … range routeTable` missing | runtime values, statically unknowable | register statically, or accept the gap |
+| Routes behind `for … range routeTable` missing | runtime values, statically unknowable | the registration is named on stderr (`[routes] …: path is not statically resolvable`) and listed by `Generator.UnresolvedPaths()`; register statically, or accept the gap |
 | Verb-less registrations show POST | historic default for unknown method | handlers that `switch r.Method` split automatically; otherwise the default applies |
 | Deep/dense project: some routes missing + truncation warning | the budget for the walk that *finds* registrations is spent | raise `--max-nodes` |
 | Named route present but under-detailed + `MaxNodesPerRoute` warning | that one route's own allowance is spent; no other route is affected | raise `--max-nodes-per-route` |
 | Route present, body/params empty | handler not located / binding style unrecognised | insight report (Step 4), check `handlerFound` |
-| Path shows `{someFunc}` placeholder | path built by a function call | statically unknowable; name comes from the called function |
+| Path shows `{someFunc}` placeholder | *part* of the path is built by a function call | statically unknowable; the name comes from the called function, and the rest of the path is real. A path that is **nothing but** a placeholder is not documented at all — see the row above |
 
 ## What to include in a bug report
 

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -79,6 +79,18 @@ func (g *Generator) PathParamMismatches() []intspec.PathParamMismatch {
 	return g.engine.GetPathParamMismatches()
 }
 
+// UnresolvedPaths returns the registrations the last generation left out of the
+// document because their path is built at runtime — a route table, or a house
+// router that carries the pattern on an object (issue #428). Non-empty means the
+// spec is missing endpoints that exist in the code, which is what a placeholder
+// path like `/{Method} {Path}` used to hide.
+func (g *Generator) UnresolvedPaths() []intspec.UnresolvedPathRoute {
+	if g.engine == nil {
+		return nil
+	}
+	return g.engine.GetUnresolvedPaths()
+}
+
 // UnresolvedRefs returns the $refs the last generation could not satisfy, after
 // they were repaired with a placeholder. Non-empty means the document loads but
 // some type resolved to nothing useful — the actionable fix is usually

--- a/generator/testdata_unresolved_path_test.go
+++ b/generator/testdata_unresolved_path_test.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ehabterra/apispec/spec"
+)
+
+// generateWithReports runs a fixture through its own Generator so the test can
+// read what the generation reported, not only what it emitted.
+func generateWithReports(t *testing.T, name string) (*spec.OpenAPISpec, *Generator) {
+	t.Helper()
+	dir := filepath.Join("..", "testdata", name)
+	gen := NewGenerator(spec.DefaultHTTPConfig())
+	out, err := gen.GenerateFromDirectory(dir)
+	if err != nil {
+		t.Fatalf("GenerateFromDirectory(%s): %v", dir, err)
+	}
+	if out == nil || out.Paths == nil {
+		t.Fatalf("nil spec or paths for %s", name)
+	}
+	return out, gen
+}
+
+// assertNoPlaceholderOnlyPath fails when the document contains a path that is
+// nothing but placeholders — the shape issue #428 is about. Written as a
+// property over the whole document rather than as a check for the two specific
+// keys, so any other expression that starts resolving to a bare placeholder
+// fails here too.
+func assertNoPlaceholderOnlyPath(t *testing.T, out *spec.OpenAPISpec) {
+	t.Helper()
+	for path := range out.Paths {
+		stripped := path
+		for {
+			open := strings.IndexByte(stripped, '{')
+			if open < 0 {
+				break
+			}
+			close := strings.IndexByte(stripped[open:], '}')
+			if close < 0 {
+				break
+			}
+			stripped = stripped[:open] + stripped[open+close+1:]
+		}
+		if strings.Trim(stripped, "/ ") == "" {
+			t.Errorf("path %q is nothing but placeholders: an unresolvable registration must be reported, not emitted", path)
+		}
+	}
+}
+
+// TestTestdata_RouteTable locks in the reporting of a registration read from a
+// route table (issue #428): `mux.HandleFunc(rt.Method+" "+rt.Path, rt.Handler)`
+// used to be documented at `/{Method} {Path}`, an operation no request can
+// match. The literal and partly-resolved registrations beside it must survive —
+// dropping those would trade one wrong answer for a missing API.
+func TestTestdata_RouteTable(t *testing.T) {
+	out, gen := generateWithReports(t, "route_table")
+	noDanglingRefs(t, out)
+	assertNoPlaceholderOnlyPath(t, out)
+
+	if _, ok := out.Paths["/{Method} {Path}"]; ok {
+		t.Error("the table registration must not be documented under its placeholder path")
+	}
+	// The routes the table registers are not in the document at all: their paths
+	// exist only at runtime.
+	for _, path := range []string{"/users", "/users/{id}"} {
+		if _, ok := out.Paths[path]; ok {
+			t.Errorf("path %q cannot be recovered from a table; documenting it would be a guess", path)
+		}
+	}
+
+	// What IS readable is still documented.
+	if _, ok := out.Paths["/health"]; !ok {
+		t.Errorf("the literal registration must still be documented; have %v", mapPathKeys(out.Paths))
+	}
+	// A prefix that could not be read leaves a real endpoint with a flagged
+	// placeholder — kept, not dropped (#274/#34).
+	if _, ok := out.Paths["/{prefix}/partly"]; !ok {
+		t.Errorf("a partly-resolved path must still be documented; have %v", mapPathKeys(out.Paths))
+	}
+
+	// The drop is reported, with the registration site.
+	reports := gen.UnresolvedPaths()
+	if len(reports) != 1 {
+		t.Fatalf("want exactly the table registration reported, got %d: %+v", len(reports), reports)
+	}
+	r := reports[0]
+	if !strings.Contains(r.Path, "{") {
+		t.Errorf("report should name the placeholder path it would have emitted, got %q", r.Path)
+	}
+	if r.Reason == "" {
+		t.Error("report should say which way the path failed")
+	}
+	if !strings.Contains(r.Position, "main.go:") {
+		t.Errorf("report should locate the registration, got %q", r.Position)
+	}
+	if r.Handler == "" {
+		t.Error("report should name the handler")
+	}
+}
+
+// TestTestdata_ChainedWrapper locks in the same for a house router that carries
+// the pattern on a returned object: wrapper derivation already declined it as
+// "incomplete, not applied", and the framework call inside the wrapper is no
+// longer documented at `/{pattern}` behind its back (issue #428).
+func TestTestdata_ChainedWrapper(t *testing.T) {
+	out, gen := generateWithReports(t, "chained_wrapper")
+	noDanglingRefs(t, out)
+	assertNoPlaceholderOnlyPath(t, out)
+
+	if _, ok := out.Paths["/{pattern}"]; ok {
+		t.Error("the chained registration must not be documented under its placeholder path")
+	}
+	if _, ok := out.Paths["/items"]; ok {
+		t.Error("the chained pattern is not readable at the framework call; documenting /items would be a guess")
+	}
+
+	// The ordinary method on the same router still resolves: what is unsupported
+	// is the chained wiring, not this project's router.
+	item, ok := out.Paths["/health"]
+	if !ok {
+		t.Fatalf("the forwarded-parameter registration must still be documented; have %v", mapPathKeys(out.Paths))
+	}
+	if opFor(item, "GET") == nil {
+		t.Error("GET /health missing")
+	}
+
+	// Both chained calls are reported.
+	if reports := gen.UnresolvedPaths(); len(reports) != 2 {
+		t.Errorf("want the chained Get and Post reported, got %d: %+v", len(reports), reports)
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -292,6 +292,10 @@ type Engine struct {
 	// whose key matches no route placeholder, gathered during the last generation.
 	pathParamMismatches []intspec.PathParamMismatch
 
+	// unresolvedPaths lists registrations left out of the last generation
+	// because their path is built at runtime (issue #428).
+	unresolvedPaths []intspec.UnresolvedPathRoute
+
 	// routeDiscovery records what the route search had to work with and what it
 	// found during the last generation (issue #379).
 	routeDiscovery RouteDiscovery
@@ -912,7 +916,9 @@ func (e *Engine) GenerateOpenAPI() (*spec.OpenAPISpec, error) {
 		e.unresolvedSecurity = secDiag.UnresolvedMiddleware
 		e.pathParamMismatches = secDiag.PathParamMismatches
 		e.unresolvedRefs = secDiag.UnresolvedRefs
+		e.unresolvedPaths = secDiag.UnresolvedPaths
 		e.reportUnresolvedRefs()
+		e.reportUnresolvedPaths()
 	}
 	// Read after mapping: with the lazy tree the entrypoint gate runs during
 	// expansion, which mapping is what triggers.
@@ -1359,6 +1365,27 @@ func (e *Engine) reportUnresolvedRefs() {
 		len(e.unresolvedRefs), sites, b.String()), 0)
 }
 
+// reportUnresolvedPaths says so when a registration was found and understood
+// except for its path, so it is missing from the document.
+//
+// Louder than the mapper's per-route line, and phrased as a count: one
+// table-driven registration inside a loop is every route of that table, so the
+// shortfall is usually the whole API rather than one endpoint.
+func (e *Engine) reportUnresolvedPaths() {
+	if len(e.unresolvedPaths) == 0 {
+		return
+	}
+	first := e.unresolvedPaths[0]
+	where := first.Position
+	if where == "" {
+		where = first.Handler
+	}
+	e.reportPhase(fmt.Sprintf(
+		"%d registration(s) build their path at runtime and are NOT documented (first at %s) — "+
+			"the routes they register are missing from the spec",
+		len(e.unresolvedPaths), where), 0)
+}
+
 // reportNoRoutes says so when the walk analysed real code and matched no route
 // registration in it — the case that used to print "Successfully generated"
 // over an empty document and exit 0, indistinguishable from a project that
@@ -1370,6 +1397,14 @@ func (e *Engine) reportUnresolvedRefs() {
 func (e *Engine) reportNoRoutes() {
 	d := e.routeDiscovery
 	if !d.NothingMatched() {
+		return
+	}
+	// A registration that matched and was then dropped for an unreadable path is
+	// a different diagnosis, and the advice below would send the reader looking
+	// for an unsupported router they do not have (issue #428).
+	if len(e.unresolvedPaths) > 0 {
+		log.Printf("[engine] 0 paths documented: every registration that matched builds its path at runtime — see the %d line(s) above",
+			len(e.unresolvedPaths))
 		return
 	}
 	frameworks := strings.Join(d.Frameworks, ", ")
@@ -1426,6 +1461,14 @@ func (e *Engine) reportSkippedPackages() {
 // operation's shape is a placeholder.
 func (e *Engine) GetUnresolvedRefs() []intspec.UnresolvedRef {
 	return e.unresolvedRefs
+}
+
+// GetUnresolvedPaths returns the registrations the most recent generation left
+// undocumented because their path is built at runtime. Non-empty means the spec
+// is missing endpoints that DO exist in the code — the count is the size of the
+// gap, which a placeholder path used to hide.
+func (e *Engine) GetUnresolvedPaths() []intspec.UnresolvedPathRoute {
+	return e.unresolvedPaths
 }
 
 // GetRouteDiscovery returns what the route search walked and what it found in

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -109,10 +109,13 @@ type RouteInfo struct {
 
 	// PathUnresolved marks a route whose OWN path contributed nothing but such
 	// placeholders — a registration read from a table, or one a house router
-	// carries on an object. It is not documented: there is no endpoint there to
-	// document, at any prefix (see UnresolvedPathRoute, issue #428). Set where
-	// the path is resolved, since only there is the route's own contribution
-	// separable from the mount chain's.
+	// carries on an object. Set where the path is resolved, since only there is
+	// the route's own contribution separable from the mount chain's.
+	//
+	// It is an input to the omission decision, not the decision: a route whose
+	// tail is unreadable under a prefix that IS known stays documented, because
+	// the endpoint is still locatable. undocumentablePath owns the rule
+	// (issue #428).
 	PathUnresolved bool
 
 	// Node is the tracker-tree node where this route was matched (the route

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -107,6 +107,14 @@ type RouteInfo struct {
 	// instead of inlining a fresh declaration on every route.
 	DynamicParams []string
 
+	// PathUnresolved marks a route whose OWN path contributed nothing but such
+	// placeholders — a registration read from a table, or one a house router
+	// carries on an object. It is not documented: there is no endpoint there to
+	// document, at any prefix (see UnresolvedPathRoute, issue #428). Set where
+	// the path is resolved, since only there is the route's own contribution
+	// separable from the mount chain's.
+	PathUnresolved bool
+
 	// Node is the tracker-tree node where this route was matched (the route
 	// registration call). Its subtree is the interface-resolved handler flow;
 	// the insight view traverses it to build the resolution trace. Not part of

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -225,6 +225,12 @@ type SecurityDiagnostics struct {
 	// its shape is not. Reported here rather than only on stderr so the UI and
 	// a CI gate can read it (issue #327).
 	UnresolvedRefs []UnresolvedRef
+
+	// UnresolvedPaths lists registrations left OUT of the document because
+	// their path is built at runtime. The complement of UnresolvedRefs: there
+	// the operation is documented and its shape is not, here there is no
+	// operation to document (issue #428).
+	UnresolvedPaths []UnresolvedPathRoute
 }
 
 // MapMetadataToOpenAPI maps metadata to OpenAPI specification.
@@ -241,6 +247,20 @@ func MapMetadataToOpenAPIWithDiagnostics(tree TrackerTreeInterface, cfg *APISpec
 
 	// Extract routes
 	routes := extractor.ExtractRoutes()
+
+	// Drop the registrations whose own path never resolved, before anything
+	// downstream builds an operation out of one. They are reported instead:
+	// a placeholder path is not an endpoint (issue #428).
+	routes, unresolvedPaths := dropUnresolvedPathRoutes(routes)
+	for _, r := range unresolvedPaths {
+		where := r.Position
+		if where == "" {
+			where = "position unknown"
+		}
+		log.Printf("[routes] %s: %s, so handler %s is not documented "+
+			"(it would have been emitted at %s)",
+			where, r.Reason, r.Handler, r.Path)
+	}
 
 	// Warn about auth middleware that was detected but matched no
 	// SecurityMapping, so the user knows what to map. apispecui surfaces the
@@ -330,6 +350,7 @@ func MapMetadataToOpenAPIWithDiagnostics(tree TrackerTreeInterface, cfg *APISpec
 		UnresolvedMiddleware: extractor.UnresolvedSecurity(),
 		PathParamMismatches:  extractor.PathParamMismatches(),
 		UnresolvedRefs:       unresolvedRefs,
+		UnresolvedPaths:      unresolvedPaths,
 	}
 	return spec, diag, nil
 }

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -601,6 +601,10 @@ func (r *RoutePatternMatcherImpl) extractRouteDetails(node TrackerNodeInterface,
 			}
 			path = normalizeServeMuxPath(path)
 		}
+		// Judged on the path AFTER the verb is split off: `"GET "+c.pattern`
+		// resolves its literal half into the method, and what is left for the
+		// path is the placeholder alone.
+		routeInfo.PathUnresolved = pathIsAllPlaceholders(path, dynNames)
 		routeInfo.Path = path
 		if routeInfo.Path == "" {
 			routeInfo.Path = "/"

--- a/internal/spec/unresolved_path.go
+++ b/internal/spec/unresolved_path.go
@@ -1,0 +1,166 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"strconv"
+	"strings"
+)
+
+// UnresolvedPathRoute is a registration that was found and understood except
+// for the one thing an operation cannot be written without: its path.
+//
+// It is reported rather than emitted (issue #428). A path built at runtime —
+// from a table of routes, or by a house router that carries the pattern on an
+// object — used to be documented under the placeholder standing in for the
+// expression, `/{Method} {Path}` or `/{pattern}`. That is worse than a missing
+// route in three concrete ways: it fails a spec-lint gate on an otherwise clean
+// project, it generates a client method for an endpoint that does not exist,
+// and — since the real routes are missing at the same time — the path count
+// stays plausible enough for the loss to go unnoticed.
+type UnresolvedPathRoute struct {
+	// Path is the placeholder path that would have been emitted, e.g.
+	// "/{Method} {Path}". Kept because it names the expression that could not be
+	// read: the placeholder is the called function or the field read.
+	Path string
+
+	// Reason says which way the path failed, since the two need different
+	// answers from the reader: a path nothing is known about is a wiring style
+	// to register statically, while an invalid template means the verb went
+	// unread too.
+	Reason string
+
+	// Method is the HTTP method the registration resolved to, which is often
+	// the ExtractRoute default rather than a stated verb.
+	Method string
+
+	// Handler is the handler identity, so the registration can be found by what
+	// it serves when the position is not recoverable.
+	Handler string
+
+	// Position is where the registration is written ("file:line"), the
+	// actionable half of the report.
+	Position string
+}
+
+// dropUnresolvedPathRoutes splits the routes into the ones that can be
+// documented and the ones whose own path never resolved.
+//
+// Order is preserved so the report reads in the order the walk found them, and
+// the kept slice is only reallocated when something is actually dropped — the
+// overwhelmingly common case is that nothing is.
+func dropUnresolvedPathRoutes(routes []*RouteInfo) ([]*RouteInfo, []UnresolvedPathRoute) {
+	dropped := 0
+	for _, route := range routes {
+		if _, bad := undocumentablePath(route); bad {
+			dropped++
+		}
+	}
+	if dropped == 0 {
+		return routes, nil
+	}
+
+	kept := make([]*RouteInfo, 0, len(routes)-dropped)
+	reports := make([]UnresolvedPathRoute, 0, dropped)
+	for _, route := range routes {
+		reason, bad := undocumentablePath(route)
+		if !bad {
+			kept = append(kept, route)
+			continue
+		}
+		reports = append(reports, UnresolvedPathRoute{
+			Path:     route.OpenAPIPath(),
+			Reason:   reason,
+			Method:   route.Method,
+			Handler:  route.Function,
+			Position: routeRegistrationPosition(route),
+		})
+	}
+	return kept, reports
+}
+
+// undocumentablePath reports whether the route cannot be given an operation,
+// and why. Two ways, both about the path APISpec would emit:
+//
+//  1. Nothing about the location is known — the route's own path resolved to
+//     placeholders and so did the prefix it is mounted at. `/{pattern}` from a
+//     house router that carries the pattern on a returned object.
+//
+//  2. The path is not a valid template because it still contains whitespace,
+//     which is what a registration whose VERB is unreadable collapses to:
+//     `rt.Method+" "+rt.Path` leaves `{Method} {Path}`, a key no request can
+//     match. Checked independently of the first, since the mount prefix may
+//     well be literal (`/api/{Method} {Path}`) — a resolved prefix does not
+//     rescue a path that cannot be a path.
+//
+// Deliberately NOT dropped: a route whose own path is unreadable under a prefix
+// that IS known. `/repo/{username}/{reponame}/info/lfs/{path}` is gitea's
+// catch-all `Any()` registration seen through its wrapper — the tail is
+// approximate, but the endpoint is there and locatable, and its responses are
+// real. Measured: judging on the route's own path alone deleted three such
+// operations from gitea's spec.
+func undocumentablePath(route *RouteInfo) (string, bool) {
+	if route == nil {
+		return "", false
+	}
+	final := route.OpenAPIPath()
+	if route.PathUnresolved && pathIsAllPlaceholders(final, route.DynamicParams) {
+		return "no part of its path could be read", true
+	}
+	if strings.ContainsAny(final, " \t\n") {
+		return "the path is not a valid template (the registration's verb could not be read either)", true
+	}
+	return "", false
+}
+
+// routeRegistrationPosition renders "file:line" for the registration call, or
+// "" when the route carries no node to read it from (a hand-built RouteInfo in
+// a test, or a route completed from something other than a call).
+func routeRegistrationPosition(route *RouteInfo) string {
+	if route == nil || route.Node == nil {
+		return ""
+	}
+	file, line, _ := calleePosition(route.Node)
+	if file == "" || line <= 0 {
+		return file
+	}
+	return file + ":" + strconv.Itoa(line)
+}
+
+// pathIsAllPlaceholders reports whether a path contributes nothing but the
+// placeholders synthesized for expressions that could not be read — so the
+// registration says which handler serves it and nothing about where.
+//
+// The test is deliberately about the route's OWN path rather than the path it
+// is finally emitted at. An unresolved MOUNT prefix leaves a real endpoint
+// whose location is unknown (`/{mountPoint}/clear` — the route is "/clear",
+// mounted somewhere this analysis could not follow), and an unresolved prefix
+// within the path itself leaves the literal tail (`/{dynamicBase}/dyn`, issue
+// #274). Both are worth documenting with the placeholder flagged. A route whose
+// own path is nothing but a placeholder is not: there is no endpoint there to
+// document, at any prefix.
+//
+// Separators do not count as content: `/{pattern}/` says no more than
+// `{pattern}` does.
+func pathIsAllPlaceholders(path string, dynamic []string) bool {
+	if path == "" || len(dynamic) == 0 {
+		return false
+	}
+	rest := path
+	for _, name := range dynamic {
+		rest = strings.ReplaceAll(rest, "{"+name+"}", "")
+	}
+	return strings.Trim(rest, "/ \t") == ""
+}

--- a/internal/spec/unresolved_path_test.go
+++ b/internal/spec/unresolved_path_test.go
@@ -1,0 +1,162 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import "testing"
+
+func TestPathIsAllPlaceholders(t *testing.T) {
+	cases := []struct {
+		name    string
+		path    string
+		dynamic []string
+		want    bool
+	}{
+		{
+			// The table-driven registration: the verb and the path are both
+			// read off a struct at runtime.
+			name: "verb and path both synthesized", path: "{Method} {Path}",
+			dynamic: []string{"Method", "Path"}, want: true,
+		},
+		{
+			// The chained house router, after the literal verb was split off.
+			name: "bare placeholder", path: "{pattern}",
+			dynamic: []string{"pattern"}, want: true,
+		},
+		{
+			name: "placeholder with separators only", path: "/{pattern}/",
+			dynamic: []string{"pattern"}, want: true,
+		},
+		{
+			// #274: an unresolved prefix with a literal tail is a real endpoint
+			// documented approximately, not a non-endpoint.
+			name: "unresolved prefix, literal tail", path: "{dynamicBase}/dyn",
+			dynamic: []string{"dynamicBase"}, want: false,
+		},
+		{
+			// A route's own path is fully literal; the placeholder in the
+			// EMITTED path comes from the mount chain, which is not this test's
+			// input (see the doc comment).
+			name: "no placeholders at all", path: "/users", dynamic: nil, want: false,
+		},
+		{
+			// A genuine path parameter is content: the endpoint is real and
+			// parameterized. Only SYNTHESIZED names are subtracted.
+			name: "real path parameter", path: "/{id}", dynamic: nil, want: false,
+		},
+		{
+			name: "synthesized alongside a real parameter", path: "{base}/{id}",
+			dynamic: []string{"base"}, want: false,
+		},
+		{name: "empty path", path: "", dynamic: []string{"x"}, want: false},
+	}
+	for _, c := range cases {
+		if got := pathIsAllPlaceholders(c.path, c.dynamic); got != c.want {
+			t.Errorf("%s: pathIsAllPlaceholders(%q, %v) = %v, want %v",
+				c.name, c.path, c.dynamic, got, c.want)
+		}
+	}
+}
+
+func TestUndocumentablePath(t *testing.T) {
+	cases := []struct {
+		name  string
+		route *RouteInfo
+		want  bool
+	}{
+		{
+			// Nothing about the location is known.
+			name: "bare placeholder path",
+			route: &RouteInfo{Path: "/{pattern}", DynamicParams: []string{"pattern"},
+				PathUnresolved: true},
+			want: true,
+		},
+		{
+			// The verb went unread too, so the key carries a space: not a path
+			// template at any prefix.
+			name: "unreadable verb leaves whitespace",
+			route: &RouteInfo{Path: "/{Method} {Path}", DynamicParams: []string{"Method", "Path"},
+				PathUnresolved: true},
+			want: true,
+		},
+		{
+			name: "unreadable verb under a literal mount",
+			route: &RouteInfo{MountPath: "/api", Path: "/{Method} {Path}",
+				DynamicParams: []string{"Method", "Path"}, PathUnresolved: true},
+			want: true,
+		},
+		{
+			// gitea's Any() through its wrapper: the tail is approximate, the
+			// endpoint is locatable. Measured — dropping this deleted three real
+			// operations from gitea's spec.
+			name: "unreadable tail under a literal mount",
+			route: &RouteInfo{MountPath: "/repo/{username}/info/lfs", Path: "/{path}",
+				DynamicParams: []string{"path"}, PathUnresolved: true},
+			want: false,
+		},
+		{
+			// The subrouter's root, mounted somewhere unreadable: the route's
+			// own path resolved, so it is not this rule's business.
+			name: "resolved path under an unreadable mount",
+			route: &RouteInfo{MountPath: "/{mountPoint}", Path: "/",
+				DynamicParams: []string{"mountPoint"}},
+			want: false,
+		},
+		{name: "ordinary route", route: &RouteInfo{Path: "/users"}, want: false},
+		{name: "nil route", route: nil, want: false},
+	}
+	for _, c := range cases {
+		reason, got := undocumentablePath(c.route)
+		if got != c.want {
+			t.Errorf("%s: undocumentablePath() = %v (%q), want %v", c.name, got, reason, c.want)
+		}
+		if got && reason == "" {
+			t.Errorf("%s: a dropped route must carry a reason", c.name)
+		}
+	}
+}
+
+func TestDropUnresolvedPathRoutes(t *testing.T) {
+	keep := &RouteInfo{Path: "/health", Method: "GET", Function: "pkg.health"}
+	partly := &RouteInfo{Path: "/{prefix}/partly", Method: "GET", Function: "pkg.partly",
+		DynamicParams: []string{"prefix"}}
+	drop := &RouteInfo{Path: "/{pattern}", Method: "POST", Function: "pkg.h",
+		DynamicParams: []string{"pattern"}, PathUnresolved: true}
+
+	kept, reports := dropUnresolvedPathRoutes([]*RouteInfo{keep, drop, partly})
+	if len(kept) != 2 || kept[0] != keep || kept[1] != partly {
+		t.Fatalf("want the documentable routes kept in order, got %+v", kept)
+	}
+	if len(reports) != 1 {
+		t.Fatalf("want one report, got %d: %+v", len(reports), reports)
+	}
+	if reports[0].Path != "/{pattern}" || reports[0].Method != "POST" || reports[0].Handler != "pkg.h" {
+		t.Errorf("report = %+v, want the dropped route's path, method and handler", reports[0])
+	}
+	// No node on a hand-built route: the position is unknown, not a panic.
+	if reports[0].Position != "" {
+		t.Errorf("position = %q, want empty for a route with no registration node", reports[0].Position)
+	}
+
+	// Nothing to drop: the input slice is returned as it is, so the ordinary
+	// case allocates nothing.
+	in := []*RouteInfo{keep, partly}
+	out, none := dropUnresolvedPathRoutes(in)
+	if none != nil {
+		t.Errorf("want no reports, got %+v", none)
+	}
+	if len(out) != len(in) || &out[0] != &in[0] {
+		t.Error("with nothing to drop the routes must pass through untouched")
+	}
+}

--- a/testdata/chained_wrapper/go.mod
+++ b/testdata/chained_wrapper/go.mod
@@ -1,0 +1,3 @@
+module github.com/ehabterra/apispec/testdata/chained_wrapper
+
+go 1.22

--- a/testdata/chained_wrapper/main.go
+++ b/testdata/chained_wrapper/main.go
@@ -1,0 +1,84 @@
+// Package main is a house router whose registration is CHAINED through a
+// returned object: `Combo("/items").Get(h).Post(h)` holds the pattern on the
+// returned value, so by the time the framework call runs, the path is a field
+// read rather than a literal.
+//
+// Wrapper derivation already declines this shape — `--verbose` reports it as
+// "incomplete, not applied" — but the framework call inside the wrapper was
+// then matched on its own and documented at `/{pattern}` (issue #428). The two
+// decisions now agree: the registration is reported and left out.
+//
+// The ordinary method on the SAME router must still resolve, which is what
+// separates "this wiring style is not supported" from "this router is not".
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type Item struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// Router is the house router.
+type Router struct {
+	mux *http.ServeMux
+}
+
+// Combo starts a chained registration: the pattern travels on the returned
+// object rather than into the framework call.
+func (r *Router) Combo(pattern string) *Combo {
+	return &Combo{r: r, pattern: pattern}
+}
+
+// Get registers a plain route, forwarding its own parameters — the shape
+// wrapper derivation does resolve.
+func (r *Router) Get(pattern string, h http.HandlerFunc) {
+	r.mux.HandleFunc("GET "+pattern, h)
+}
+
+// Combo carries the pattern between chained calls.
+type Combo struct {
+	r       *Router
+	pattern string
+}
+
+// Get registers the chained GET.
+func (c *Combo) Get(h http.HandlerFunc) *Combo {
+	c.r.mux.HandleFunc("GET "+c.pattern, h)
+	return c
+}
+
+// Post registers the chained POST.
+func (c *Combo) Post(h http.HandlerFunc) *Combo {
+	c.r.mux.HandleFunc("POST "+c.pattern, h)
+	return c
+}
+
+func listItems(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode([]Item{})
+}
+
+func createItem(w http.ResponseWriter, r *http.Request) {
+	var in Item
+	_ = json.NewDecoder(r.Body).Decode(&in)
+	w.WriteHeader(http.StatusCreated)
+}
+
+func health(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func main() {
+	rt := &Router{mux: http.NewServeMux()}
+
+	// Dropped: the path is read off the chained object.
+	rt.Combo("/items").Get(listItems).Post(createItem)
+
+	// Kept: the pattern is forwarded from the wrapper's own parameter.
+	rt.Get("/health", health)
+
+	http.ListenAndServe(":8080", rt.mux)
+}

--- a/testdata/route_table/go.mod
+++ b/testdata/route_table/go.mod
@@ -1,0 +1,3 @@
+module github.com/ehabterra/apispec/testdata/route_table
+
+go 1.22

--- a/testdata/route_table/main.go
+++ b/testdata/route_table/main.go
@@ -1,0 +1,78 @@
+// Package main registers routes from a TABLE, whose method and path exist only
+// as runtime values (issue #428). Such a registration is reported and left out
+// of the document: it used to be emitted under the placeholder standing in for
+// the expression — `/{Method} {Path}` — which is an operation no request can
+// match and a client method for an endpoint that does not exist.
+//
+// The literal and PARTLY-resolved registrations alongside it must still be
+// documented: an unresolved prefix leaves a real endpoint whose location is
+// approximate, which is worth keeping with the placeholder flagged (#274/#34).
+//
+// The variant where such a table is registered on a sub-mux MOUNTED at a
+// literal prefix — dropped for the other reason, since `/api/{Method} {Path}`
+// is not a valid path template whatever the prefix — is covered by a unit test
+// instead (TestUndocumentablePath). Two tables in one fixture render the same
+// handler identity (`route.Handler`, the field read), so they conflate into one
+// route and the fixture would be a change detector for that instead.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type User struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+func listUsers(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode([]User{})
+}
+
+func getUser(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode(User{})
+}
+
+func health(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func partly(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode(User{})
+}
+
+type route struct {
+	Method  string
+	Path    string
+	Handler http.HandlerFunc
+}
+
+// routes is the table: nothing here is readable from the registration site.
+var routes = []route{
+	{"GET", "/users", listUsers},
+	{"GET", "/users/{id}", getUser},
+}
+
+// prefix is evaluated at runtime, so the path it contributes is a placeholder —
+// but the rest of the path is written literally.
+func prefix() string {
+	return "/api"
+}
+
+func main() {
+	mux := http.NewServeMux()
+
+	// Dropped: neither the verb nor the path can be read here.
+	for _, rt := range routes {
+		mux.HandleFunc(rt.Method+" "+rt.Path, rt.Handler)
+	}
+
+	// Kept: written literally.
+	mux.HandleFunc("GET /health", health)
+
+	// Kept: the prefix is a placeholder, the tail is real.
+	mux.HandleFunc("GET "+prefix()+"/partly", partly)
+
+	http.ListenAndServe(":8080", mux)
+}


### PR DESCRIPTION
Fixes #428.

A route table and a chained house router were documented at the placeholder
standing in for the expression that could not be read:

```yaml
paths:
  /{Method} {Path}:      # for _, rt := range routes { mux.HandleFunc(rt.Method+" "+rt.Path, rt.Handler) }
  /{pattern}:            # rt.Combo("/items").Get(list).Post(create)
```

Neither key can be matched by a request. That is worse than a missing route: it
fails a spec-lint gate on an otherwise clean project, it generates a client
method for an endpoint that does not exist, and — because the real routes are
missing at the same time — the path count stays plausible enough for the loss to
go unnoticed.

## Reported instead

| surface | what it says |
|---|---|
| stderr `[routes]` | `main.go:68: no part of its path could be read, so handler …route.Handler is not documented (it would have been emitted at /{Method} {Path})` |
| engine phase log | `1 registration(s) build their path at runtime and are NOT documented (first at main.go:68)` |
| `Generator.UnresolvedPaths()` | path, reason, method, handler, position — for library consumers and a CI gate (#297) |
| apispecui | one sentence in the result message, beside the truncation and skipped-package warnings |
| the CLI's "0 paths" line | now distinguishes *nothing matched* from *every registration builds its path at runtime* — the old wording sent readers looking for an unsupported router they do not have |

## The rule, and why the obvious version is wrong

Two conditions drop a route:

1. **Nothing about the location is known** — the route's own path resolved to
   placeholders *and* so did the prefix it is mounted at.
2. **The emitted key contains whitespace**, which is what an unreadable *verb*
   collapses to (`/api/{Method} {Path}`). A resolved mount prefix does not
   rescue a path that cannot be a path.

My first attempt used only "the route's own path is all placeholders", which
reads like the sharper rule. **On gitea it deleted three real operations** —
`/user/{path}`, `/devtest/{path}` and
`/repo/{username}/{reponame}/info/lfs/{path}`, which are its `Any()` catch-alls
seen through `func (r *Router) Any(pattern string, h ...any)`: the tail comes
from `r.getPattern(pattern)` and is approximate, but the endpoint is locatable
and its responses are real. So an unreadable tail under a known prefix is
explicitly kept, and the four boundary cases are pinned in
`TestUndocumentablePath`:

| shape | verdict |
|---|---|
| `/{pattern}` — own path and prefix both unreadable | dropped |
| `/{Method} {Path}`, `/api/{Method} {Path}` — verb unread, invalid template | dropped |
| `/repo/{owner}/{name}/info/lfs/{path}` — unreadable tail, known prefix | kept |
| `/{mountPoint}/` — resolved path, unreadable mount | kept |

Also unchanged: `/{dynamicBase}/dyn` (#274) and the whole
`dynamic_mount_prefix` family — a partly-unresolved path is a real endpoint
documented approximately, and #428 was never about those.

## Two decisions now agree

For the chained wrapper, `--verbose` already declined the derivation:

```text
Router wrappers: …*Combo [Get Post] route via net/http.HandleFunc (incomplete, not applied);
                 …*Router [Get] route via net/http.HandleFunc (applied)
```

…and then the framework call *inside* the wrapper was matched on its own and
documented at `/{pattern}` behind its back. The fixture asserts that the
ordinary `rt.Get("/health", h)` on the same router still resolves — what is
unsupported is the chained wiring, not the router.

## Drift

- **All 103 pre-existing fixtures generate byte-identically** — only the two new
  fixtures differ, which is the behavior change.
- **gitea: 894 paths before and after, spec byte-identical, zero reports.**
- Full suite green: goldens, determinism, both engines' parity tests, all
  framework fixtures.

## Filed from this work

**#431** — a path held *entirely* in a local variable is not traced, so
`lit := "/literal"; mux.HandleFunc("GET "+lit, h)` is now reported rather than
documented at `/{lit}`. Before this PR it was documented at `/{lit}`, which was
already wrong; the honest fix is to trace the assignment (the machinery exists —
`latestAssignment`/`assignmentsAt`), which is its own change. The concatenated
form (`base+"/users"`) is unaffected and still documented as `/{base}/users`.

## Not in this PR

`internal/insight` does not yet include these in its overview report; it is
filled by the UI caller and would want its own field plus frontend rendering.
The UI does surface the count in the result message today.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Routes whose paths are built entirely at runtime are no longer documented under misleading placeholder paths.
  - Unresolved registrations are reported with source locations and omitted from generated specifications.
  - Partially resolved routes continue to be documented correctly.
  - Zero-route messages now distinguish between no matches and registrations with runtime-built paths.
  - The CLI and UI now warn when registrations are skipped for this reason.

- **Documentation**
  - Added guidance for identifying and resolving dynamic route paths.
  - Clarified how placeholder paths are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->