### PR TITLE
fix(spec): read a registration path out of a variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A registration path held in a variable is now read, instead of being
+  reported as unknowable.** `p := "/users"` two lines above the registration is
+  a statically-known path, and it was treated as unreadable: left out of the
+  document (since the change below), or — when the whole path was one variable —
+  rendered as the variable's *type*, so `/string` appeared as if it were an
+  endpoint. A path argument that is a bare identifier now goes through the same
+  resolution ladder as one operand of a concatenation, plus the variable's own
+  assignments: a literal, an alias chain, a variable prefix with a literal tail,
+  and a value assembled from parts that all resolve. Only when every assignment
+  visible at the call site agrees — two branches assigning different paths stays
+  reported, because picking one would document an endpoint the server may not
+  serve, and so does a path assigned from a call. This also resolves a prefix
+  passed to a mount helper as a parameter (`mountAt(prefix, r, sub)`), which had
+  its own change-detector test. Measured on a real project: six phantom
+  `/…/string` paths became flagged placeholders, with no route gained or lost.
+  (#431)
 - **A registration whose path is built at runtime is reported instead of
   documented at a placeholder path.** A route table
   (`mux.HandleFunc(rt.Method+" "+rt.Path, rt.Handler)`) was emitted as an

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ APISpec aims for practical coverage of real-world Go services.
 
 - Import and type aliases, resolved to underlying primitives.
 - Enum resolution from constants, `enum` tags, or `oneof` validator tags — attributed per declared type, never borrowed between two types sharing an underlying type.
-- Assignment & alias tracking: `:=`, `=`, multi-assign, tuple returns, alias chains, latest-wins shadowing.
+- Assignment & alias tracking: `:=`, `=`, multi-assign, tuple returns, alias chains, latest-wins shadowing. Registration **paths** are read through the same tracking (`p := "/users"`, an alias chain, a variable prefix with a literal tail) — but only when every assignment agrees: two branches assigning different paths is reported as unresolvable rather than documented at one of them.
 - Composite literals, maps, slices, fixed-size and variable-length arrays (`[16]byte`, `[5]int`, `[...]int`), pointers and automatic dereferencing, selectors and nested field access.
 - Struct fields, embedded fields, and tag-based metadata (`json`, `xml`, `form`, `validate`, …).
 - Inline (anonymous) struct types as request/response bodies and as nested fields — captured structurally from `go/types`, so the inline schema shows real properties and resolves named field types to `$ref`s.
@@ -216,10 +216,10 @@ registered under `components.securitySchemes`; explicitly-public routes render
   (`/{mountPoint}/clear`), an unresolved segment before a literal tail
   (`/{dynamicBase}/dyn`), and an unreadable tail under a prefix that IS known
   (`/repo/{owner}/{name}/info/lfs/{path}` — a catch-all seen through a wrapper)
-  are all real endpoints, documented approximately. A path held *entirely* in a
-  local variable is reported rather than documented even when its value is a
-  literal, since variables are not yet traced for paths
-  ([#431](https://github.com/ehabterra/apispec/issues/431)).
+  are all real endpoints, documented approximately. A path wrapped in a type
+  conversion (`r.Mount(string(prefix), sub)`) is a worse case still: it renders
+  as the conversion's type, so a phantom `/string/…` path is documented
+  ([#433](https://github.com/ehabterra/apispec/issues/433)).
 - **A payload erased inside a generic envelope** — a helper that re-wraps the
   value as `APIResponse[any]{Data: data}` documents `data` as an open object
   ([#163](https://github.com/ehabterra/apispec/issues/163)).

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -121,7 +121,8 @@ issues, and a Markdown export you can attach to a bug report as-is.
 | Deep/dense project: some routes missing + truncation warning | the budget for the walk that *finds* registrations is spent | raise `--max-nodes` |
 | Named route present but under-detailed + `MaxNodesPerRoute` warning | that one route's own allowance is spent; no other route is affected | raise `--max-nodes-per-route` |
 | Route present, body/params empty | handler not located / binding style unrecognised | insight report (Step 4), check `handlerFound` |
-| Path shows `{someFunc}` placeholder | *part* of the path is built by a function call | statically unknowable; the name comes from the called function, and the rest of the path is real. A path that is **nothing but** a placeholder is not documented at all — see the row above |
+| Path shows `{someFunc}` / `{someVar}` placeholder | *part* of the path is built at runtime | statically unknowable; the name comes from the called function or the variable, and the rest of the path is real. A variable IS traced when its assignments agree (`p := "/users"`), so a placeholder here means a call, a request-time value, or two branches assigning different paths. A path that is **nothing but** a placeholder is not documented at all — see the row above |
+| Path shows a segment named after a TYPE (`/string/…`) | a path wrapped in a type conversion (`string(prefix)`) | [#433](https://github.com/ehabterra/apispec/issues/433) — the conversion is not resolved and renders as its type. Pass the value without the conversion, or set the path literally, until that is fixed |
 
 ## What to include in a bug report
 

--- a/generator/testdata_mount_via_helper_test.go
+++ b/generator/testdata_mount_via_helper_test.go
@@ -62,17 +62,30 @@ func TestTestdata_MountViaHelper(t *testing.T) {
 			"duplicate must be dropped, or every helper-mounted route appears twice")
 	}
 
-	// CHANGE DETECTOR, not an endorsement: the prefix-as-parameter forms are a
-	// different gap — resolving the sub-router's position is done, resolving the
-	// PREFIX through a parameter is not (resolvePathArg does not trace
-	// parameters). Asserted at today's wrong behaviour so this test fails, and
-	// gets updated, the moment that is fixed.
-	t.Run("prefix through a parameter is still unresolved", func(t *testing.T) {
-		for _, notYet := range []string{"/param/things", "/named/things"} {
-			if _, ok := out.Paths[notYet]; ok {
-				t.Errorf("%s now resolves — the parameter-prefix gap is fixed; "+
-					"update this subtest to assert it properly and close the follow-up", notYet)
-			}
+	// The prefix-as-parameter form resolves since #431: a path argument that is
+	// a bare identifier now goes through the same ladder as one operand of a
+	// concatenation, so `r.Mount(prefix, server)` reads the caller's "/param".
+	t.Run("prefix through a parameter resolves", func(t *testing.T) {
+		if _, ok := out.Paths["/param/things"]; !ok {
+			t.Errorf("missing /param/things; documented %v — a prefix passed as a "+
+				"parameter must be read from the caller's argument", mapPathKeys(out.Paths))
+		}
+	})
+
+	// CHANGE DETECTOR, not an endorsement: a prefix wrapped in a CONVERSION at
+	// the Mount call (`r.Mount(string(prefix), server)`) still does not resolve.
+	// Worse, it renders as the conversion's TYPE, so the fixture's mountNamed
+	// route is documented at /string/things — a path that looks literal and
+	// exists nowhere (issue #433). Asserted at today's wrong behaviour so this
+	// fails, and gets updated, the moment that is fixed.
+	t.Run("prefix through a conversion is still unresolved", func(t *testing.T) {
+		if _, ok := out.Paths["/named/things"]; ok {
+			t.Error("/named/things now resolves — the conversion gap is fixed; " +
+				"assert it properly here and close #433")
+		}
+		if _, ok := out.Paths["/string/things"]; !ok {
+			t.Error("/string/things is gone — the conversion no longer renders as its " +
+				"type; update this subtest and close #433")
 		}
 	})
 }

--- a/generator/testdata_variable_path_test.go
+++ b/generator/testdata_variable_path_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestTestdata_VariablePath locks in reading a registration path out of a local
+// variable (issue #431).
+//
+// Before it, `p := "/users"` two lines above the registration was treated as
+// unreadable: reported and left out by #428 when it was one operand of a
+// concatenation, and — when the whole path was the variable — rendered as the
+// variable's TYPE, so `/string` appeared in the document as an endpoint.
+//
+// The fixture puts the resolvable and the genuinely ambiguous side by side,
+// because the value of this change is that they end up different.
+func TestTestdata_VariablePath(t *testing.T) {
+	out, gen := generateWithReports(t, "variable_path")
+	noDanglingRefs(t, out)
+	noUnresolvedPlaceholders(t, out)
+
+	for _, want := range []string{
+		"/users",     // the whole path in one variable
+		"/bare",      // the same, passed as the bare argument
+		"/aliased",   // an alias chain
+		"/api/items", // a variable prefix with a literal tail
+		"/v2/joined", // a variable assembled from parts that all resolve
+	} {
+		if _, ok := out.Paths[want]; !ok {
+			t.Errorf("missing %s; documented %v", want, mapPathKeys(out.Paths))
+		}
+	}
+
+	// Nothing may be documented under a variable's name or type: those are the
+	// two wrong answers this replaces.
+	for path := range out.Paths {
+		if strings.Contains(path, "{") {
+			t.Errorf("path %q keeps a placeholder — every variable here resolves", path)
+		}
+		if path == "/string" || strings.HasPrefix(path, "/string/") {
+			t.Errorf("path %q is the variable's TYPE, not its value", path)
+		}
+	}
+
+	// The two that cannot be read are reported rather than guessed at: one
+	// assigned in two branches, one assigned from a call.
+	reports := gen.UnresolvedPaths()
+	if len(reports) != 2 {
+		t.Fatalf("want the ambiguous and the runtime-built registrations reported, got %d: %+v",
+			len(reports), reports)
+	}
+	handlers := map[string]bool{}
+	for _, r := range reports {
+		handlers[r.Handler[strings.LastIndexByte(r.Handler, '.')+1:]] = true
+		if r.Position == "" {
+			t.Errorf("report %+v should locate the registration", r)
+		}
+	}
+	for _, want := range []string{"ambiguous", "fromCall"} {
+		if !handlers[want] {
+			t.Errorf("handler %s should be reported; got %v", want, handlers)
+		}
+	}
+	// Neither may be documented at whichever branch the walk saw last.
+	for _, notWanted := range []string{"/first", "/second", "/built"} {
+		if _, ok := out.Paths[notWanted]; ok {
+			t.Errorf("%s is documented, but the path is not knowable — picking one is a guess", notWanted)
+		}
+	}
+}

--- a/internal/spec/concat_path_test.go
+++ b/internal/spec/concat_path_test.go
@@ -459,7 +459,7 @@ func TestConcatPathHelpers(t *testing.T) {
 	})
 
 	t.Run("a nil operand contributes nothing", func(t *testing.T) {
-		if value, name := b.resolvePathOperand(nil, nil); value != "" || name != "" {
+		if value, name := b.resolvePathOperand(nil, nil, 0); value != "" || name != "" {
 			t.Errorf("got (%q, %q), want empties", value, name)
 		}
 	})

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -2271,9 +2271,13 @@ func callerAssignmentMap(impl *ContextProviderImpl, edge *metadata.CallGraphEdge
 // assignmentsAt returns the assignments to the variable `name` visible at the
 // given call site: the call edge's own AssignmentMap first, then the enclosing
 // function's scope (via callerAssignmentMap) for a variable assigned in the
-// handler body rather than at the edge. The edge map and the function scope
-// record the same assignment for a given variable, so consulting the edge first
-// is a fast path, not a different answer.
+// handler body rather than at the edge.
+//
+// The two scopes agree on the assignment IN EFFECT at the call, which is what
+// every caller here wants — but not on how many there are: for a variable
+// reassigned in a branch, the edge map carries the effective one alone while the
+// function scope carries them all. A consumer that needs to know a value is
+// AMBIGUOUS therefore cannot use this (see pathVarAssignments, issue #431).
 //
 // This is the one canonical call-site assignment lookup (issue #182): the
 // request-body / response-destination resolvers reach it via latestAssignment

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -52,19 +52,35 @@ func NewBasePatternMatcher(cfg *APISpecConfig, contextProvider ContextProvider) 
 // A concatenation (`opts.BaseURL + "/things"`) folds to the joined value —
 // see resolveConcatenatedPath, which is what generated servers need (#274).
 //
-// All other kinds fall through to GetArgumentInfo for backwards
-// compatibility — handling KindIdent (non-const variable) similarly is a
-// possible follow-up.
+// A local variable is traced through its assignments (`p := "/users"`, issue
+// #431) — see variableValue, which resolves it only when every assignment
+// visible at the call site agrees.
+//
+// All other kinds fall through to GetArgumentInfo.
 func (b *BasePatternMatcher) resolvePathArg(arg *metadata.CallArgument, node TrackerNodeInterface) (path string, dynamicNames []string) {
 	if arg == nil {
 		return "", nil
 	}
 	switch arg.GetKind() {
 	case metadata.KindBinary:
-		return b.resolveConcatenatedPath(arg, node)
+		return b.resolveConcatenatedPath(arg, node, 0)
 	case metadata.KindCall:
 		p, name := placeholderFor(arg)
 		return p, dynamicNameList(name)
+	case metadata.KindIdent:
+		// A whole path in one identifier is the same question as one operand of
+		// a concatenation, so it is answered by the same ladder: a constant or
+		// package-level var, the argument a caller passed for this parameter, a
+		// field read off a struct literal, or a local variable's assignments
+		// (issue #431).
+		//
+		// It used to fall through to rendering the argument, which yields the
+		// identifier's TYPE — `mux.HandleFunc(p, h)` came out as `/string`, and
+		// two different helper parameters collapsed onto that one key. A
+		// placeholder says what is true when nothing resolves, and #428 reports
+		// it rather than emitting it.
+		value, name := b.resolvePathOperand(arg, node, 0)
+		return value, dynamicNameList(name)
 	}
 	return b.contextProvider.GetArgumentInfo(arg), nil
 }
@@ -104,7 +120,7 @@ func placeholderFor(arg *metadata.CallArgument) (path, dynamicName string) {
 // order. An operand that cannot be evaluated becomes a {placeholder} rather
 // than disappearing: an unresolved prefix must leave the route addressable and
 // visibly incomplete, not silently shorten its path.
-func (b *BasePatternMatcher) resolveConcatenatedPath(arg *metadata.CallArgument, node TrackerNodeInterface) (path string, dynamicNames []string) {
+func (b *BasePatternMatcher) resolveConcatenatedPath(arg *metadata.CallArgument, node TrackerNodeInterface, depth int) (path string, dynamicNames []string) {
 	operands := flattenConcat(arg, nil)
 	if operands == nil {
 		// Not a `+` chain (no other operator builds a path); treat the whole
@@ -115,7 +131,7 @@ func (b *BasePatternMatcher) resolveConcatenatedPath(arg *metadata.CallArgument,
 
 	var sb strings.Builder
 	for _, operand := range operands {
-		value, name := b.resolvePathOperand(operand, node)
+		value, name := b.resolvePathOperand(operand, node, depth)
 		sb.WriteString(value)
 		// EVERY placeholder needs its name reported: each one becomes a declared
 		// path parameter, and a `{name}` left undeclared is an invalid path
@@ -150,7 +166,7 @@ func flattenConcat(arg *metadata.CallArgument, acc []*metadata.CallArgument) []*
 // resolvePathOperand evaluates one operand of a concatenated path. It returns
 // the value to append and, when the operand had to be approximated, the
 // placeholder name the caller registers as a parameter.
-func (b *BasePatternMatcher) resolvePathOperand(arg *metadata.CallArgument, node TrackerNodeInterface) (value, dynamicName string) {
+func (b *BasePatternMatcher) resolvePathOperand(arg *metadata.CallArgument, node TrackerNodeInterface, depth int) (value, dynamicName string) {
 	if arg == nil {
 		return "", ""
 	}
@@ -172,7 +188,113 @@ func (b *BasePatternMatcher) resolvePathOperand(arg *metadata.CallArgument, node
 	if v, ok := b.structFieldValue(arg, node); ok {
 		return v, ""
 	}
+	// A local variable holding this part of the path (issue #431).
+	if v, ok := b.variableValue(arg, node, depth); ok {
+		return v, ""
+	}
 	return placeholderFor(arg)
+}
+
+// maxPathVarDepth bounds the walk through assignments. An alias chain this long
+// is pathological, and the bound is also what makes a cycle (`a = b; b = a`)
+// terminate.
+const maxPathVarDepth = 8
+
+// variableValue resolves an identifier to the path it holds, by reading the
+// assignments visible at the call site (issue #431).
+//
+// `p := "/users"` two lines above the registration is a path that is statically
+// known, and before this it was treated as unreadable — reported and left out
+// of the document by #428, or worse, rendered as the variable's TYPE.
+//
+// Three rules keep it honest (golden rule #7):
+//
+//   - every assignment visible at the site must agree. Two branches assigning
+//     different paths is real ambiguity, and picking one would document an
+//     endpoint the server may not serve;
+//   - an alias chain is followed (`a := "/x"; b := a`), bounded by
+//     maxPathVarDepth;
+//   - a value that is not itself readable — assigned from a call, read off a
+//     request — resolves to nothing, which is the case the placeholder exists
+//     for.
+func (b *BasePatternMatcher) variableValue(arg *metadata.CallArgument, node TrackerNodeInterface, depth int) (string, bool) {
+	if arg == nil || node == nil || depth >= maxPathVarDepth {
+		return "", false
+	}
+	if arg.GetKind() != metadata.KindIdent || arg.GetName() == "" {
+		return "", false
+	}
+	edge := node.GetEdge()
+	if edge == nil {
+		return "", false
+	}
+	assigns := pathVarAssignments(b.contextProvider, edge, arg.GetName())
+	if len(assigns) == 0 {
+		return "", false
+	}
+	value := ""
+	for i := range assigns {
+		v, ok := b.assignedPathValue(&assigns[i], node, depth)
+		if !ok {
+			return "", false
+		}
+		if i > 0 && v != value {
+			return "", false
+		}
+		value = v
+	}
+	return value, true
+}
+
+// pathVarAssignments returns EVERY assignment to name visible at the call site,
+// not only the one in effect there.
+//
+// assignmentsAt is the canonical lookup for "what does this variable hold here",
+// and its edge fast path answers with the LATEST assignment — which is what a
+// request-body or status resolver wants. Reading a path is the opposite
+// question: two assignments with different values mean the path is ambiguous,
+// and taking the latest would document one branch's route as the endpoint
+// (golden rule #7). Measured on `amb := "/one"; if … { amb = "/two" }`, the
+// fast path resolved to "/two" with no sign that "/one" existed.
+//
+// The enclosing function's scope records them all, so it answers when it knows
+// the variable; the edge map remains the fallback. An assignment written AFTER
+// the registration counts too, since a loop can make it the live value — that
+// can only make the path unreadable, never wrong.
+func pathVarAssignments(cp ContextProvider, edge *metadata.CallGraphEdge, name string) []metadata.Assignment {
+	if impl, ok := cp.(*ContextProviderImpl); ok {
+		if am := callerAssignmentMap(impl, edge, name); len(am[name]) > 0 {
+			return am[name]
+		}
+	}
+	if edge == nil {
+		return nil
+	}
+	return edge.AssignmentMap[name]
+}
+
+// assignedPathValue reads one assignment's right-hand side as a path value.
+//
+// A concatenation is accepted only when EVERY operand resolved: a placeholder
+// inside the value would be reported as what the variable holds, which is a
+// worse answer than reporting the variable as unreadable.
+func (b *BasePatternMatcher) assignedPathValue(a *metadata.Assignment, node TrackerNodeInterface, depth int) (string, bool) {
+	if a == nil {
+		return "", false
+	}
+	rhs := &a.Value
+	if v, ok := b.contextProvider.ConstantValue(rhs); ok {
+		return v, true
+	}
+	switch rhs.GetKind() {
+	case metadata.KindIdent:
+		return b.variableValue(rhs, node, depth+1)
+	case metadata.KindBinary:
+		if v, dyn := b.resolveConcatenatedPath(rhs, node, depth+1); len(dyn) == 0 {
+			return v, true
+		}
+	}
+	return "", false
 }
 
 // structFieldValue resolves `x.Field` when x traces back to a composite literal

--- a/internal/spec/variable_path_test.go
+++ b/internal/spec/variable_path_test.go
@@ -1,0 +1,197 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// assignTo builds one recorded assignment `name = <value>`.
+func assignTo(meta *metadata.Metadata, name string, value *metadata.CallArgument) metadata.Assignment {
+	return metadata.Assignment{
+		VariableName: meta.StringPool.Get(name),
+		Value:        *value,
+	}
+}
+
+// nodeWithAssignments returns a node whose edge records the given assignments,
+// which is the fallback scope pathVarAssignments reads when the metadata holds
+// no enclosing function.
+func nodeWithAssignments(meta *metadata.Metadata, assigns map[string][]metadata.Assignment) TrackerNodeInterface {
+	return &pathNode{edge: &metadata.CallGraphEdge{
+		Caller:        metadata.Call{Meta: meta, Name: meta.StringPool.Get("main"), Pkg: meta.StringPool.Get("app"), RecvType: -1},
+		Callee:        metadata.Call{Meta: meta, Name: meta.StringPool.Get("HandleFunc"), Pkg: meta.StringPool.Get("net/http"), RecvType: -1},
+		AssignmentMap: assigns,
+	}}
+}
+
+// TestVariableValue covers reading a path out of a local variable (issue #431).
+// Before it, `p := "/users"` two lines above the registration was treated as
+// unreadable — reported and left out by #428, or rendered as the variable's
+// TYPE, which put `/string` in the document as if it were an endpoint.
+func TestVariableValue(t *testing.T) {
+	meta := newTestMeta()
+	b := &BasePatternMatcher{contextProvider: NewContextProvider(meta)}
+
+	t.Run("one literal assignment resolves", func(t *testing.T) {
+		node := nodeWithAssignments(meta, map[string][]metadata.Assignment{
+			"p": {assignTo(meta, "p", concatLit(meta, "/users"))},
+		})
+		if v, ok := b.variableValue(concatIdent(meta, "p"), node, 0); !ok || v != "/users" {
+			t.Errorf("got (%q, %v), want (\"/users\", true)", v, ok)
+		}
+	})
+
+	t.Run("an alias chain is followed", func(t *testing.T) {
+		node := nodeWithAssignments(meta, map[string][]metadata.Assignment{
+			"first":  {assignTo(meta, "first", concatLit(meta, "/aliased"))},
+			"second": {assignTo(meta, "second", concatIdent(meta, "first"))},
+		})
+		if v, ok := b.variableValue(concatIdent(meta, "second"), node, 0); !ok || v != "/aliased" {
+			t.Errorf("got (%q, %v), want (\"/aliased\", true)", v, ok)
+		}
+	})
+
+	t.Run("a value assembled from resolvable parts resolves", func(t *testing.T) {
+		node := nodeWithAssignments(meta, map[string][]metadata.Assignment{
+			"root":   {assignTo(meta, "root", concatLit(meta, "/v2"))},
+			"joined": {assignTo(meta, "joined", concatOf(meta, concatIdent(meta, "root"), concatLit(meta, "/joined")))},
+		})
+		if v, ok := b.variableValue(concatIdent(meta, "joined"), node, 0); !ok || v != "/v2/joined" {
+			t.Errorf("got (%q, %v), want (\"/v2/joined\", true)", v, ok)
+		}
+	})
+
+	t.Run("two assignments that disagree resolve to nothing", func(t *testing.T) {
+		// Branches assigning different paths is real ambiguity: taking the
+		// latest would document one branch's route as the endpoint.
+		node := nodeWithAssignments(meta, map[string][]metadata.Assignment{
+			"amb": {
+				assignTo(meta, "amb", concatLit(meta, "/first")),
+				assignTo(meta, "amb", concatLit(meta, "/second")),
+			},
+		})
+		if v, ok := b.variableValue(concatIdent(meta, "amb"), node, 0); ok {
+			t.Errorf("want no value for an ambiguous variable, got %q", v)
+		}
+	})
+
+	t.Run("two assignments that agree resolve", func(t *testing.T) {
+		node := nodeWithAssignments(meta, map[string][]metadata.Assignment{
+			"same": {
+				assignTo(meta, "same", concatLit(meta, "/same")),
+				assignTo(meta, "same", concatLit(meta, "/same")),
+			},
+		})
+		if v, ok := b.variableValue(concatIdent(meta, "same"), node, 0); !ok || v != "/same" {
+			t.Errorf("got (%q, %v), want (\"/same\", true)", v, ok)
+		}
+	})
+
+	t.Run("a value assigned from a call resolves to nothing", func(t *testing.T) {
+		call := metadata.NewCallArgument(meta)
+		call.SetKind(metadata.KindCall)
+		call.SetName("buildPath")
+		node := nodeWithAssignments(meta, map[string][]metadata.Assignment{
+			"built": {assignTo(meta, "built", call)},
+		})
+		if v, ok := b.variableValue(concatIdent(meta, "built"), node, 0); ok {
+			t.Errorf("a runtime-built path must stay unresolved, got %q", v)
+		}
+	})
+
+	t.Run("a partly-resolvable value resolves to nothing", func(t *testing.T) {
+		// Accepting it would report the placeholder as what the variable holds.
+		call := metadata.NewCallArgument(meta)
+		call.SetKind(metadata.KindCall)
+		call.SetName("dynamic")
+		node := nodeWithAssignments(meta, map[string][]metadata.Assignment{
+			"mixed": {assignTo(meta, "mixed", concatOf(meta, call, concatLit(meta, "/tail")))},
+		})
+		if v, ok := b.variableValue(concatIdent(meta, "mixed"), node, 0); ok {
+			t.Errorf("want no value when part of it is unreadable, got %q", v)
+		}
+	})
+
+	t.Run("a self-referential alias terminates", func(t *testing.T) {
+		node := nodeWithAssignments(meta, map[string][]metadata.Assignment{
+			"loop": {assignTo(meta, "loop", concatIdent(meta, "loop"))},
+		})
+		if v, ok := b.variableValue(concatIdent(meta, "loop"), node, 0); ok {
+			t.Errorf("want no value for a cyclic alias, got %q", v)
+		}
+	})
+
+	t.Run("guards", func(t *testing.T) {
+		node := nodeWithAssignments(meta, nil)
+		if _, ok := b.variableValue(nil, node, 0); ok {
+			t.Error("nil argument must not resolve")
+		}
+		if _, ok := b.variableValue(concatIdent(meta, "p"), nil, 0); ok {
+			t.Error("no node means no call site to read assignments at")
+		}
+		if _, ok := b.variableValue(concatLit(meta, "/x"), node, 0); ok {
+			t.Error("only an identifier names a variable")
+		}
+		if _, ok := b.variableValue(concatIdent(meta, "unknown"), node, 0); ok {
+			t.Error("a variable with no recorded assignment must not resolve")
+		}
+		if _, ok := b.variableValue(concatIdent(meta, "p"), node, maxPathVarDepth); ok {
+			t.Error("the depth bound must stop the walk")
+		}
+	})
+}
+
+// TestPathVarAssignmentsPrefersFunctionScope pins why this lookup exists rather
+// than reusing assignmentsAt: the edge's map answers with the assignment in
+// EFFECT at the call, so a variable reassigned in a branch looks unambiguous
+// there. Measured on `amb := "/one"; if … { amb = "/two" }` — the edge map
+// yielded "/two" alone, and the route was documented at it.
+func TestPathVarAssignmentsPrefersFunctionScope(t *testing.T) {
+	meta := newTestMeta()
+	both := []metadata.Assignment{
+		assignTo(meta, "amb", concatLit(meta, "/one")),
+		assignTo(meta, "amb", concatLit(meta, "/two")),
+	}
+	meta.Packages = map[string]*metadata.Package{
+		"app": {Files: map[string]*metadata.File{
+			"main.go": {Functions: map[string]*metadata.Function{
+				"main": {AssignmentMap: map[string][]metadata.Assignment{"amb": both}},
+			}},
+		}},
+	}
+	edge := &metadata.CallGraphEdge{
+		Caller: metadata.Call{Meta: meta, Name: meta.StringPool.Get("main"), Pkg: meta.StringPool.Get("app"), RecvType: -1},
+		Callee: metadata.Call{Meta: meta, Name: meta.StringPool.Get("HandleFunc"), Pkg: meta.StringPool.Get("net/http"), RecvType: -1},
+		// The fast path an ordinary resolver would take: the latest only.
+		AssignmentMap: map[string][]metadata.Assignment{"amb": {both[1]}},
+	}
+
+	cp := NewContextProvider(meta)
+	if got := len(pathVarAssignments(cp, edge, "amb")); got != 2 {
+		t.Fatalf("want both assignments from the function scope, got %d", got)
+	}
+	if got := len(assignmentsAt(cp, edge, "amb")); got != 1 {
+		t.Fatalf("assignmentsAt is expected to answer with the effective one; got %d — "+
+			"if this changed, pathVarAssignments may no longer be needed", got)
+	}
+
+	b := &BasePatternMatcher{contextProvider: cp}
+	if v, ok := b.variableValue(concatIdent(meta, "amb"), &pathNode{edge: edge}, 0); ok {
+		t.Errorf("the ambiguity must survive the lookup, got %q", v)
+	}
+}

--- a/testdata/variable_path/go.mod
+++ b/testdata/variable_path/go.mod
@@ -1,0 +1,3 @@
+module github.com/ehabterra/apispec/testdata/variable_path
+
+go 1.22

--- a/testdata/variable_path/main.go
+++ b/testdata/variable_path/main.go
@@ -1,0 +1,89 @@
+// Package main holds registration paths in VARIABLES (issue #431). A path
+// assigned two lines above the registration is statically known, and used to be
+// treated as unreadable: reported and left out by #428, or — for a path held
+// entirely in one variable — rendered as the variable's TYPE, so `/string`
+// appeared in the document as if it were an endpoint.
+//
+// The shapes are side by side because they must not resolve alike: a value the
+// assignments agree on is documented, and one they do not is still reported.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+)
+
+type User struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+func list(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode([]User{})
+}
+
+func one(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode(User{})
+}
+
+func create(w http.ResponseWriter, r *http.Request) {
+	var in User
+	_ = json.NewDecoder(r.Body).Decode(&in)
+	w.WriteHeader(http.StatusCreated)
+}
+
+func ambiguous(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func fromCall(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+// buildPath is evaluated at runtime, so a path assigned from it stays unknown.
+func buildPath() string {
+	return "/built/" + os.Getenv("SUFFIX")
+}
+
+func main() {
+	mux := http.NewServeMux()
+
+	// The whole path in one variable. Rendering the argument would give the
+	// variable's type, not its value.
+	whole := "/users"
+	mux.HandleFunc("GET "+whole, list)
+
+	// A bare variable argument, with no verb to split off.
+	bare := "/bare"
+	mux.HandleFunc(bare, create)
+
+	// An alias chain.
+	first := "/aliased"
+	second := first
+	mux.HandleFunc("GET "+second, one)
+
+	// A variable prefix with a literal tail: both halves resolve, so the whole
+	// path is real rather than approximate.
+	prefix := "/api"
+	mux.HandleFunc("GET "+prefix+"/items", list)
+
+	// A variable assembled from parts that all resolve.
+	root := "/v2"
+	joined := root + "/joined"
+	mux.HandleFunc("GET "+joined, list)
+
+	// Two branches assign different paths: genuinely ambiguous, so it is
+	// reported rather than documented at whichever the walk saw last.
+	amb := "/first"
+	if os.Getenv("ALT") != "" {
+		amb = "/second"
+	}
+	mux.HandleFunc("GET "+amb, ambiguous)
+
+	// Assigned from a call: unknowable, and still reported.
+	built := buildPath()
+	mux.HandleFunc("GET "+built, fromCall)
+
+	http.ListenAndServe(":8080", mux)
+}


### PR DESCRIPTION
Fixes #431.

`p := "/users"` two lines above the registration is a statically-known path, and
it was treated as unreadable. Two symptoms, depending on where the variable sat:

| shape | before | after |
|---|---|---|
| `whole := "/users"; mux.HandleFunc("GET "+whole, h)` | reported, left out (#428) | `/users` |
| `bare := "/bare"; mux.HandleFunc(bare, h)` | **`/string`** — the identifier's TYPE, documented as an endpoint | `/bare` |
| `first := "/aliased"; second := first` | reported | `/aliased` |
| `prefix := "/api"; …"GET "+prefix+"/items"` | `/{prefix}/items` | `/api/items` |
| `root := "/v2"; joined := root + "/joined"` | reported | `/v2/joined` |
| `amb := "/first"; if … { amb = "/second" }` | reported | **still reported** |
| `built := buildPath()` | reported | **still reported** |

A bare identifier now goes through the same ladder as one operand of a
concatenation — constant, caller's argument, struct field — extended with the
variable's own assignments. Three rules keep it honest (golden rule #7): every
assignment visible at the call site must agree, an alias chain is followed
(bounded, which also terminates a cycle), and a value that is not itself
readable resolves to nothing.

## The lookup needed to be its own

`assignmentsAt` is the canonical "what does this variable hold here" lookup, and
its edge fast path answers with the assignment **in effect** at the call — right
for a request body or a status, wrong for a path. Measured on
`amb := "/one"; if … { amb = "/two" }`: it resolved to `/two` with no sign that
`/one` existed, and the route was documented at one branch. `pathVarAssignments`
prefers the enclosing function's scope, which records them all;
`assignmentsAt`'s doc comment claimed the two scopes were interchangeable and is
corrected.

## A fixture's change detector fired, as designed

Reusing the operand ladder also resolved a prefix passed to a mount helper as a
parameter — `mountParam("/param", r, sub)` reaching `r.Mount(prefix, server)`.
`testdata/mount_via_helper` has carried a subtest asserting today's *wrong*
behavior since #275, with instructions to update it when fixed; it now asserts
`/param/things` properly.

## Drift

- **103 of the 105 fixtures byte-identical.** `mount_via_helper` gains
  `/param/things`; `variable_path` is new.
- **gitea: 894 paths before and after** — and six phantom `/…/string` keys
  became flagged `{fullPattern}` placeholders:

  ```diff
  - /login/oauth/string:
  + /login/oauth/{fullPattern}:
  - /{username}/arch/string:
  + /{username}/arch/{fullPattern}:
  ```

  `fullPattern := r.getPattern(pattern)` is assigned from a call, so declining
  it is the correct answer — and the placeholder carries the synthesized-param
  warning, where `/string` looked like a real endpoint. No route gained or lost,
  no new reports.
- Full suite green: goldens, determinism, both engines' parity tests, all
  framework fixtures.

## Filed from this work

**#433** — a path wrapped in a type conversion (`r.Mount(string(prefix), sub)`)
still renders as the conversion's type, so `mount_via_helper` documents
`/string/things` and not `/named/things`. It is the last shape that falls
through to rendering an argument as a path; the fixture's subtest pins today's
behavior and names the issue, and `docs/DEBUGGING.md` gains a row for the
symptom.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Registration paths stored in local variables are now resolved when assignments agree.
  - Alias chains, prefixes, concatenations, and mount-helper parameters are supported.
  - Conflicting assignments and runtime-derived values remain marked as unresolved.
  - Improved handling of partially unresolved paths and type-converted values.

- **Documentation**
  - Updated troubleshooting and usage guidance for variable-based paths, unresolved placeholders, and type-named path segments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->