### PR TITLE
fix(spec): resolve a path through a type conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A path wrapped in a type conversion no longer documents a phantom
+  endpoint.** `r.Mount(string(prefix), sub)` rendered as the conversion's
+  *target type*, so a path named `/string/…` appeared in the document: literal
+  in appearance, carrying no warning, matching nothing. A conversion changes the
+  type and never the string inside it, so it is now looked through — metadata
+  records it as its own kind, so this reads a fact rather than guessing a shape.
+  Getting the value out also needed the parameter under the conversion, which
+  the tracker cannot bind for this shape (the walk reaches such a registration
+  under a *different* helper's frame), so a last resolution step reads a
+  parameter from the call sites of the function the registration is written in —
+  only when every caller passes the same thing, so a helper mounted at two
+  prefixes keeps its placeholder rather than adopting one. `mount_via_helper`
+  now documents all four of its mount forms, including `/named/things`. (#433)
 - **A registration path held in a variable is now read, instead of being
   reported as unknowable.** `p := "/users"` two lines above the registration is
   a statically-known path, and it was treated as unreadable: left out of the

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ APISpec aims for practical coverage of real-world Go services.
 
 - Import and type aliases, resolved to underlying primitives.
 - Enum resolution from constants, `enum` tags, or `oneof` validator tags — attributed per declared type, never borrowed between two types sharing an underlying type.
-- Assignment & alias tracking: `:=`, `=`, multi-assign, tuple returns, alias chains, latest-wins shadowing. Registration **paths** are read through the same tracking (`p := "/users"`, an alias chain, a variable prefix with a literal tail) — but only when every assignment agrees: two branches assigning different paths is reported as unresolvable rather than documented at one of them.
+- Assignment & alias tracking: `:=`, `=`, multi-assign, tuple returns, alias chains, latest-wins shadowing. Registration **paths** are read through the same tracking (`p := "/users"`, an alias chain, a variable prefix with a literal tail), through a type conversion (`r.Mount(string(prefix), sub)`), and — for a prefix a helper takes as a parameter — from the helper's call sites. Always subject to agreement: two branches assigning different paths, or two callers passing different prefixes, is reported as unresolvable rather than documented at one of them.
 - Composite literals, maps, slices, fixed-size and variable-length arrays (`[16]byte`, `[5]int`, `[...]int`), pointers and automatic dereferencing, selectors and nested field access.
 - Struct fields, embedded fields, and tag-based metadata (`json`, `xml`, `form`, `validate`, …).
 - Inline (anonymous) struct types as request/response bodies and as nested fields — captured structurally from `go/types`, so the inline schema shows real properties and resolves named field types to `$ref`s.
@@ -216,10 +216,7 @@ registered under `components.securitySchemes`; explicitly-public routes render
   (`/{mountPoint}/clear`), an unresolved segment before a literal tail
   (`/{dynamicBase}/dyn`), and an unreadable tail under a prefix that IS known
   (`/repo/{owner}/{name}/info/lfs/{path}` — a catch-all seen through a wrapper)
-  are all real endpoints, documented approximately. A path wrapped in a type
-  conversion (`r.Mount(string(prefix), sub)`) is a worse case still: it renders
-  as the conversion's type, so a phantom `/string/…` path is documented
-  ([#433](https://github.com/ehabterra/apispec/issues/433)).
+  are all real endpoints, documented approximately.
 - **A payload erased inside a generic envelope** — a helper that re-wraps the
   value as `APIResponse[any]{Data: data}` documents `data` as an open object
   ([#163](https://github.com/ehabterra/apispec/issues/163)).

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -121,8 +121,7 @@ issues, and a Markdown export you can attach to a bug report as-is.
 | Deep/dense project: some routes missing + truncation warning | the budget for the walk that *finds* registrations is spent | raise `--max-nodes` |
 | Named route present but under-detailed + `MaxNodesPerRoute` warning | that one route's own allowance is spent; no other route is affected | raise `--max-nodes-per-route` |
 | Route present, body/params empty | handler not located / binding style unrecognised | insight report (Step 4), check `handlerFound` |
-| Path shows `{someFunc}` / `{someVar}` placeholder | *part* of the path is built at runtime | statically unknowable; the name comes from the called function or the variable, and the rest of the path is real. A variable IS traced when its assignments agree (`p := "/users"`), so a placeholder here means a call, a request-time value, or two branches assigning different paths. A path that is **nothing but** a placeholder is not documented at all — see the row above |
-| Path shows a segment named after a TYPE (`/string/…`) | a path wrapped in a type conversion (`string(prefix)`) | [#433](https://github.com/ehabterra/apispec/issues/433) — the conversion is not resolved and renders as its type. Pass the value without the conversion, or set the path literally, until that is fixed |
+| Path shows `{someFunc}` / `{someVar}` placeholder | *part* of the path is built at runtime | statically unknowable; the name comes from the called function or the variable, and the rest of the path is real. A variable IS traced when its assignments agree (`p := "/users"`), a conversion is looked through, and a helper's prefix parameter is read from its call sites — so a placeholder here means a call, a request-time value, or values that disagree (two branches, or two callers passing different prefixes). A path that is **nothing but** a placeholder is not documented at all — see the row above |
 
 ## What to include in a bug report
 

--- a/generator/testdata_mount_via_helper_test.go
+++ b/generator/testdata_mount_via_helper_test.go
@@ -16,6 +16,7 @@ package generator
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ehabterra/apispec/internal/engine"
@@ -72,20 +73,22 @@ func TestTestdata_MountViaHelper(t *testing.T) {
 		}
 	})
 
-	// CHANGE DETECTOR, not an endorsement: a prefix wrapped in a CONVERSION at
-	// the Mount call (`r.Mount(string(prefix), server)`) still does not resolve.
-	// Worse, it renders as the conversion's TYPE, so the fixture's mountNamed
-	// route is documented at /string/things — a path that looks literal and
-	// exists nowhere (issue #433). Asserted at today's wrong behaviour so this
-	// fails, and gets updated, the moment that is fixed.
-	t.Run("prefix through a conversion is still unresolved", func(t *testing.T) {
-		if _, ok := out.Paths["/named/things"]; ok {
-			t.Error("/named/things now resolves — the conversion gap is fixed; " +
-				"assert it properly here and close #433")
+	// A prefix wrapped in a conversion resolves since #433: the conversion is
+	// unwrapped (it changes the type, never the string), and the parameter under
+	// it is read from the helper's call sites — the tree cannot answer for this
+	// one, because the walk reaches this Mount under a different helper's frame.
+	t.Run("prefix through a conversion resolves", func(t *testing.T) {
+		if _, ok := out.Paths["/named/things"]; !ok {
+			t.Errorf("missing /named/things; documented %v — `r.Mount(string(prefix), server)` "+
+				"must resolve to the converted value", mapPathKeys(out.Paths))
 		}
-		if _, ok := out.Paths["/string/things"]; !ok {
-			t.Error("/string/things is gone — the conversion no longer renders as its " +
-				"type; update this subtest and close #433")
+		// The phantom it used to produce: rendering the conversion gave its
+		// TARGET TYPE, so a path named after `string` was documented as if it
+		// were an endpoint.
+		for path := range out.Paths {
+			if strings.HasPrefix(path, "/string/") {
+				t.Errorf("path %q is the conversion's type, not its value", path)
+			}
 		}
 	})
 }

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -67,12 +67,12 @@ func (b *BasePatternMatcher) resolvePathArg(arg *metadata.CallArgument, node Tra
 	case metadata.KindCall:
 		p, name := placeholderFor(arg)
 		return p, dynamicNameList(name)
-	case metadata.KindIdent:
-		// A whole path in one identifier is the same question as one operand of
-		// a concatenation, so it is answered by the same ladder: a constant or
-		// package-level var, the argument a caller passed for this parameter, a
-		// field read off a struct literal, or a local variable's assignments
-		// (issue #431).
+	case metadata.KindIdent, metadata.KindTypeConversion:
+		// A whole path in one identifier — or in a conversion of one — is the
+		// same question as one operand of a concatenation, so it is answered by
+		// the same ladder: a constant or package-level var, the argument a
+		// caller passed for this parameter, a field read off a struct literal,
+		// or a local variable's assignments (issues #431, #433).
 		//
 		// It used to fall through to rendering the argument, which yields the
 		// identifier's TYPE — `mux.HandleFunc(p, h)` came out as `/string`, and
@@ -107,6 +107,22 @@ func placeholderFor(arg *metadata.CallArgument) (path, dynamicName string) {
 		name = "path"
 	}
 	return "{" + name + "}", name
+}
+
+// conversionOperand returns the value a type conversion wraps, and whether the
+// argument is one.
+//
+// Rendering a conversion yields its TARGET TYPE — the right answer for a
+// response body, whose type is the question, and the wrong one for a path,
+// whose value is. That is how `r.Mount(string(prefix), sub)` put a phantom
+// `/string/…` in the document: a key that looks literal, carries no warning,
+// and matches nothing (issue #433). Metadata records the conversion as its own
+// kind, so this is a fact to read rather than a shape to guess at.
+func conversionOperand(arg *metadata.CallArgument) (*metadata.CallArgument, bool) {
+	if arg == nil || arg.GetKind() != metadata.KindTypeConversion || len(arg.Args) != 1 {
+		return nil, false
+	}
+	return arg.Args[0], arg.Args[0] != nil
 }
 
 // resolveConcatenatedPath folds a `+` chain into one path (issue #274).
@@ -170,6 +186,11 @@ func (b *BasePatternMatcher) resolvePathOperand(arg *metadata.CallArgument, node
 	if arg == nil {
 		return "", ""
 	}
+	// A conversion changes the TYPE and never the string inside it, so
+	// `string(prefix)` is resolved as `prefix` is (issue #433).
+	if inner, ok := conversionOperand(arg); ok {
+		return b.resolvePathOperand(inner, node, depth)
+	}
 	// Literals and constants, including a const declared in another package.
 	if v, ok := b.contextProvider.ConstantValue(arg); ok {
 		return v, ""
@@ -177,6 +198,11 @@ func (b *BasePatternMatcher) resolvePathOperand(arg *metadata.CallArgument, node
 	// A prefix the caller passed in: `registerCRUD(r, "/users")` reaching
 	// `m.Delete(base+"/{id}", h)`, or a generated server handed its base URL.
 	if caller, ok := b.callerArgFor(arg, node); ok {
+		// Through a conversion at the call site too — `mountNamed(RoutePrefix("/named"), …)`
+		// hands the parameter a converted literal.
+		if inner, isConv := conversionOperand(caller); isConv {
+			caller = inner
+		}
 		if v, ok := b.contextProvider.ConstantValue(caller); ok {
 			return v, ""
 		}
@@ -192,7 +218,89 @@ func (b *BasePatternMatcher) resolvePathOperand(arg *metadata.CallArgument, node
 	if v, ok := b.variableValue(arg, node, depth); ok {
 		return v, ""
 	}
+	// A parameter of the enclosing function, resolved from that function's CALL
+	// SITES rather than from the tree (issue #433).
+	if v, ok := b.paramValueFromCallSites(arg, node, depth); ok {
+		return v, ""
+	}
 	return placeholderFor(arg)
+}
+
+// paramValueFromCallSites resolves a parameter of the function the call is
+// written in by reading what its callers pass for it, when they all pass the
+// same thing.
+//
+// callerArgFor answers the same question from the TREE, which is better when it
+// works: the frame it walks up to is the invocation this route was reached
+// through. It does not always work. `mountNamed(RoutePrefix("/named"), r, sub)`
+// registers through a helper whose Mount node the walk reaches under a
+// DIFFERENT helper's frame (measured: the parent frame is mountLiteral's), so
+// the parameter has no binding to read there and the prefix stayed a
+// placeholder.
+//
+// Reading the call graph instead is frame-blind, which is exactly why it is the
+// last rung: it can only answer for a function whose callers agree, and it is
+// consulted after every frame-aware rung has declined. A helper called twice
+// with different prefixes keeps its placeholder rather than adopting one of
+// them (golden rule #7).
+func (b *BasePatternMatcher) paramValueFromCallSites(arg *metadata.CallArgument, node TrackerNodeInterface, depth int) (string, bool) {
+	if arg == nil || node == nil || depth >= maxPathVarDepth {
+		return "", false
+	}
+	if arg.GetKind() != metadata.KindIdent || arg.GetName() == "" {
+		return "", false
+	}
+	impl, ok := b.contextProvider.(*ContextProviderImpl)
+	if !ok || impl.meta == nil {
+		return "", false
+	}
+	edge := node.GetEdge()
+	if edge == nil {
+		return "", false
+	}
+	// The function the registration is written IN — its parameters are what an
+	// identifier here can be.
+	enclosing := edge.Caller.BaseID()
+	if enclosing == "" {
+		return "", false
+	}
+	value, found := "", false
+	for _, call := range impl.meta.Callees[enclosing] {
+		bound, ok := call.ParamArgMap[arg.GetName()]
+		if !ok {
+			return "", false // a caller that does not bind it: nothing to agree on
+		}
+		v, resolved := b.callSiteArgValue(&bound, depth)
+		if !resolved {
+			return "", false
+		}
+		if found && v != value {
+			return "", false // callers disagree
+		}
+		value, found = v, true
+	}
+	return value, found
+}
+
+// callSiteArgValue reads an argument written at a call site, without reference
+// to any frame: a literal, a constant, or either of those inside a conversion.
+// Anything whose meaning depends on where it is evaluated — another parameter, a
+// local variable, a call — is deliberately not followed here, since this rung
+// has no frame to evaluate it in.
+func (b *BasePatternMatcher) callSiteArgValue(arg *metadata.CallArgument, depth int) (string, bool) {
+	if arg == nil || depth >= maxPathVarDepth {
+		return "", false
+	}
+	if inner, ok := conversionOperand(arg); ok {
+		return b.callSiteArgValue(inner, depth+1)
+	}
+	if arg.GetKind() == metadata.KindBinary {
+		if v, dyn := b.resolveConcatenatedPath(arg, nil, depth+1); len(dyn) == 0 {
+			return v, true
+		}
+		return "", false
+	}
+	return b.contextProvider.ConstantValue(arg)
 }
 
 // maxPathVarDepth bounds the walk through assignments. An alias chain this long
@@ -283,6 +391,9 @@ func (b *BasePatternMatcher) assignedPathValue(a *metadata.Assignment, node Trac
 		return "", false
 	}
 	rhs := &a.Value
+	if inner, ok := conversionOperand(rhs); ok {
+		rhs = inner // `p := RoutePrefix("/x")` holds the string, not the type
+	}
 	if v, ok := b.contextProvider.ConstantValue(rhs); ok {
 		return v, true
 	}

--- a/internal/spec/variable_path_test.go
+++ b/internal/spec/variable_path_test.go
@@ -195,3 +195,203 @@ func TestPathVarAssignmentsPrefersFunctionScope(t *testing.T) {
 		t.Errorf("the ambiguity must survive the lookup, got %q", v)
 	}
 }
+
+// TestConversionOperand covers reading through a type conversion (issue #433).
+// A conversion changes the TYPE and never the string inside it, but rendering
+// one yields its TARGET TYPE — right for a response body, whose type is the
+// question, and wrong for a path, whose value is. That is how a phantom
+// `/string/…` reached the document.
+func TestConversionOperand(t *testing.T) {
+	meta := newTestMeta()
+
+	conv := func(typeName string, inner *metadata.CallArgument) *metadata.CallArgument {
+		a := metadata.NewCallArgument(meta)
+		a.SetKind(metadata.KindTypeConversion)
+		a.Fun = concatIdent(meta, typeName)
+		if inner != nil {
+			a.Args = []*metadata.CallArgument{inner}
+		}
+		return a
+	}
+
+	t.Run("the wrapped value is returned", func(t *testing.T) {
+		inner, ok := conversionOperand(conv("string", concatLit(meta, "/named")))
+		if !ok || inner == nil || inner.GetValue() != `"/named"` {
+			t.Errorf("got (%+v, %v), want the wrapped literal", inner, ok)
+		}
+	})
+
+	t.Run("only a conversion with exactly one operand", func(t *testing.T) {
+		if _, ok := conversionOperand(nil); ok {
+			t.Error("nil is not a conversion")
+		}
+		if _, ok := conversionOperand(concatIdent(meta, "prefix")); ok {
+			t.Error("an identifier is not a conversion")
+		}
+		if _, ok := conversionOperand(conv("string", nil)); ok {
+			t.Error("a conversion with no operand resolves to nothing")
+		}
+	})
+
+	b := &BasePatternMatcher{contextProvider: NewContextProvider(meta)}
+
+	t.Run("a converted literal resolves as the literal", func(t *testing.T) {
+		if path, dyn := b.resolvePathArg(conv("RoutePrefix", concatLit(meta, "/named")), nil); path != "/named" || len(dyn) != 0 {
+			t.Errorf("got (%q, %v), want (\"/named\", no placeholders)", path, dyn)
+		}
+	})
+
+	t.Run("nested conversions resolve", func(t *testing.T) {
+		arg := conv("string", conv("RoutePrefix", concatLit(meta, "/deep")))
+		if path, _ := b.resolvePathArg(arg, nil); path != "/deep" {
+			t.Errorf("got %q, want \"/deep\"", path)
+		}
+	})
+
+	t.Run("a converted variable resolves through its assignments", func(t *testing.T) {
+		node := nodeWithAssignments(meta, map[string][]metadata.Assignment{
+			"p": {assignTo(meta, "p", concatLit(meta, "/converted"))},
+		})
+		if path, _ := b.resolvePathArg(conv("string", concatIdent(meta, "p")), node); path != "/converted" {
+			t.Errorf("got %q, want \"/converted\"", path)
+		}
+	})
+
+	t.Run("an assignment through a conversion resolves", func(t *testing.T) {
+		// `p := RoutePrefix("/x")` holds the string, not the type.
+		node := nodeWithAssignments(meta, map[string][]metadata.Assignment{
+			"p": {assignTo(meta, "p", conv("RoutePrefix", concatLit(meta, "/assigned")))},
+		})
+		if v, ok := b.variableValue(concatIdent(meta, "p"), node, 0); !ok || v != "/assigned" {
+			t.Errorf("got (%q, %v), want (\"/assigned\", true)", v, ok)
+		}
+	})
+
+	t.Run("an unreadable conversion becomes a placeholder named after its value", func(t *testing.T) {
+		// Never named after the TYPE: that is the phantom this replaces.
+		call := metadata.NewCallArgument(meta)
+		call.SetKind(metadata.KindCall)
+		call.SetName("buildPath")
+		path, dyn := b.resolvePathArg(conv("string", call), nil)
+		if path != "{buildPath}" || len(dyn) != 1 || dyn[0] != "buildPath" {
+			t.Errorf("got (%q, %v), want a placeholder named after the wrapped call", path, dyn)
+		}
+	})
+}
+
+// TestParamValueFromCallSites covers the last rung of the path ladder: a
+// parameter read from the CALL SITES of the function the registration is
+// written in (issue #433).
+//
+// The tree answers this better when it can, and for the shape that prompted
+// this it cannot — the walk reaches the registration under a different
+// helper's frame, so there is no binding for the parameter there. Reading the
+// call graph is frame-blind, so it may only answer when every caller agrees.
+func TestParamValueFromCallSites(t *testing.T) {
+	// helperNode returns a node whose edge is a call written INSIDE `helper`,
+	// with metadata recording the given calls to helper.
+	helperNode := func(meta *metadata.Metadata, calls ...map[string]metadata.CallArgument) TrackerNodeInterface {
+		helper := metadata.Call{Meta: meta, Name: meta.StringPool.Get("helper"), Pkg: meta.StringPool.Get("app"), RecvType: -1}
+		meta.Callees = map[string][]*metadata.CallGraphEdge{}
+		for _, bound := range calls {
+			meta.Callees[helper.BaseID()] = append(meta.Callees[helper.BaseID()], &metadata.CallGraphEdge{
+				Caller:      metadata.Call{Meta: meta, Name: meta.StringPool.Get("main"), Pkg: meta.StringPool.Get("app"), RecvType: -1},
+				Callee:      helper,
+				ParamArgMap: bound,
+			})
+		}
+		return &pathNode{edge: &metadata.CallGraphEdge{
+			Caller: helper,
+			Callee: metadata.Call{Meta: meta, Name: meta.StringPool.Get("Mount"), Pkg: meta.StringPool.Get("chi"), RecvType: -1},
+		}}
+	}
+
+	t.Run("one caller's literal resolves", func(t *testing.T) {
+		meta := newTestMeta()
+		b := &BasePatternMatcher{contextProvider: NewContextProvider(meta)}
+		node := helperNode(meta, map[string]metadata.CallArgument{"prefix": *concatLit(meta, "/named")})
+		if v, ok := b.paramValueFromCallSites(concatIdent(meta, "prefix"), node, 0); !ok || v != "/named" {
+			t.Errorf("got (%q, %v), want (\"/named\", true)", v, ok)
+		}
+	})
+
+	t.Run("a converted literal at the call site resolves", func(t *testing.T) {
+		meta := newTestMeta()
+		b := &BasePatternMatcher{contextProvider: NewContextProvider(meta)}
+		conv := metadata.NewCallArgument(meta)
+		conv.SetKind(metadata.KindTypeConversion)
+		conv.Fun = concatIdent(meta, "RoutePrefix")
+		conv.Args = []*metadata.CallArgument{concatLit(meta, "/named")}
+		node := helperNode(meta, map[string]metadata.CallArgument{"prefix": *conv})
+		if v, ok := b.paramValueFromCallSites(concatIdent(meta, "prefix"), node, 0); !ok || v != "/named" {
+			t.Errorf("got (%q, %v), want (\"/named\", true)", v, ok)
+		}
+	})
+
+	t.Run("callers that agree resolve", func(t *testing.T) {
+		meta := newTestMeta()
+		b := &BasePatternMatcher{contextProvider: NewContextProvider(meta)}
+		node := helperNode(meta,
+			map[string]metadata.CallArgument{"prefix": *concatLit(meta, "/same")},
+			map[string]metadata.CallArgument{"prefix": *concatLit(meta, "/same")},
+		)
+		if v, ok := b.paramValueFromCallSites(concatIdent(meta, "prefix"), node, 0); !ok || v != "/same" {
+			t.Errorf("got (%q, %v), want (\"/same\", true)", v, ok)
+		}
+	})
+
+	t.Run("callers that disagree resolve to nothing", func(t *testing.T) {
+		// Two helpers mounted at different prefixes: adopting one would document
+		// the other's routes at the wrong path.
+		meta := newTestMeta()
+		b := &BasePatternMatcher{contextProvider: NewContextProvider(meta)}
+		node := helperNode(meta,
+			map[string]metadata.CallArgument{"prefix": *concatLit(meta, "/one")},
+			map[string]metadata.CallArgument{"prefix": *concatLit(meta, "/two")},
+		)
+		if v, ok := b.paramValueFromCallSites(concatIdent(meta, "prefix"), node, 0); ok {
+			t.Errorf("want no value when callers disagree, got %q", v)
+		}
+	})
+
+	t.Run("a caller that does not bind the name resolves to nothing", func(t *testing.T) {
+		meta := newTestMeta()
+		b := &BasePatternMatcher{contextProvider: NewContextProvider(meta)}
+		node := helperNode(meta,
+			map[string]metadata.CallArgument{"prefix": *concatLit(meta, "/one")},
+			map[string]metadata.CallArgument{"other": *concatLit(meta, "/two")},
+		)
+		if v, ok := b.paramValueFromCallSites(concatIdent(meta, "prefix"), node, 0); ok {
+			t.Errorf("want no value when a caller binds nothing for it, got %q", v)
+		}
+	})
+
+	t.Run("a value whose meaning needs a frame resolves to nothing", func(t *testing.T) {
+		// Another parameter, a local, or a call: this rung has no frame to
+		// evaluate them in, so it declines rather than guessing.
+		meta := newTestMeta()
+		b := &BasePatternMatcher{contextProvider: NewContextProvider(meta)}
+		node := helperNode(meta, map[string]metadata.CallArgument{"prefix": *concatIdent(meta, "outer")})
+		if v, ok := b.paramValueFromCallSites(concatIdent(meta, "prefix"), node, 0); ok {
+			t.Errorf("want no value for a frame-dependent argument, got %q", v)
+		}
+	})
+
+	t.Run("guards", func(t *testing.T) {
+		meta := newTestMeta()
+		b := &BasePatternMatcher{contextProvider: NewContextProvider(meta)}
+		node := helperNode(meta, map[string]metadata.CallArgument{"prefix": *concatLit(meta, "/x")})
+		if _, ok := b.paramValueFromCallSites(nil, node, 0); ok {
+			t.Error("nil argument must not resolve")
+		}
+		if _, ok := b.paramValueFromCallSites(concatIdent(meta, "prefix"), nil, 0); ok {
+			t.Error("no node means no enclosing function to read call sites of")
+		}
+		if _, ok := b.paramValueFromCallSites(concatIdent(meta, "prefix"), node, maxPathVarDepth); ok {
+			t.Error("the depth bound must stop the walk")
+		}
+		if _, ok := b.paramValueFromCallSites(concatIdent(meta, "unknown"), node, 0); ok {
+			t.Error("a name no caller binds must not resolve")
+		}
+	})
+}


### PR DESCRIPTION
Fixes #433. **Stacked on #434** — review that first; this PR's own diff is the
last two commits' worth (`internal/spec/pattern_matchers.go`, the fixture test,
docs). GitHub retargets the base to `main` when #434 merges.

`r.Mount(string(prefix), sub)` was documented under `/string/…`:

```yaml
paths:
  /api/things:      # literal prefix inside a helper
  /direct/things:   # mounted at the call site
  /param/things:    # prefix through a parameter (#431)
  /string/things:   # <- mountNamed: the conversion, rendered as its TYPE
```

Rendering a conversion yields its **target type** — right for a response body,
whose type is the question, wrong for a path, whose value is. The result looks
literal, carries no warning, matches nothing, and slips past both `#428`'s
report and `noUnresolvedPlaceholders`.

## Two things were needed

**1. Look through the conversion.** A conversion changes the type and never the
string inside it. Metadata already records it as its own kind
(`KindTypeConversion`, target in `Fun`, value in `Args[0]`), so this reads a
recorded fact rather than guessing a shape. Unwrapping applies to the argument,
to a caller's argument, and to an assignment's RHS — so `p := RoutePrefix("/x")`
and nested conversions resolve too. Where the wrapped value is unreadable, the
placeholder is now named after that value (`{buildPath}`), never after the type.

That alone produced `/{prefix}/things`: honest, but not the answer.

**2. Read the parameter from the helper's call sites.** The parameter under the
conversion cannot be bound from the tree for this shape. Instrumenting the frame
chain shows why:

```text
frame0 callee=chi.Mux.Mount   caller=…mountNamed    params=[pattern handler]
frame1 callee=…mountLiteral   caller=…main          params=[r server]
```

The walk reaches `mountNamed`'s Mount under **mountLiteral's** frame, so there is
no binding for `prefix` to read. The ladder therefore gains a last rung that
reads a parameter from the call sites of the function the registration is written
in. It is frame-blind, which is why it goes last — after every frame-aware rung
has declined — and why it may only answer when the callers agree: a helper
mounted at two different prefixes keeps its placeholder rather than adopting one
(golden rule #7). An argument whose meaning needs a frame (another parameter, a
local, a call) is not followed there.

## Result

```diff
- /string/things:
+ /named/things:
```

`testdata/mount_via_helper` now documents all four of its mount forms, and its
change-detector subtest asserts the conversion instead of pinning the phantom.

## Drift

- **104 of 105 fixtures byte-identical**; `mount_via_helper` gains
  `/named/things` and loses `/string/things`.
- **gitea: byte-identical** to the #434 tip — 894 paths, no new reports. The
  call-site rung fires nowhere there, which is the point: it only answers what
  the frame-aware rungs could not, and only when the callers agree.
- Full suite green: goldens, determinism, both engines' parity tests, all
  framework fixtures.

With this, every rung of the path ladder is covered — literal, constant,
package-level var, caller's argument, struct field, local variable, conversion,
call-site parameter — and nothing falls through to rendering an argument as a
path.
