### PR TITLE
test: pin the assignment-matching limit behind #436

### DIFF
--- a/generator/testdata_variable_path_test.go
+++ b/generator/testdata_variable_path_test.go
@@ -46,16 +46,33 @@ func TestTestdata_VariablePath(t *testing.T) {
 		}
 	}
 
-	// Nothing may be documented under a variable's name or type: those are the
-	// two wrong answers this replaces.
+	// Nothing may be documented under a variable's TYPE: that is the wrong
+	// answer this replaces.
 	for path := range out.Paths {
-		if strings.Contains(path, "{") {
-			t.Errorf("path %q keeps a placeholder — every variable here resolves", path)
-		}
 		if path == "/string" || strings.HasPrefix(path, "/string/") {
 			t.Errorf("path %q is the variable's TYPE, not its value", path)
 		}
 	}
+
+	// CHANGE DETECTOR, not an endorsement (issue #436): assignments are matched
+	// by NAME, so a shadowed binding and a write after the registration each
+	// look like two disagreeing values and keep a placeholder. Both paths ARE
+	// knowable. Asserted at today's conservative behaviour — approximate rather
+	// than wrong — so this fails, and gets updated, when #436 lands.
+	t.Run("a shadowed binding and a later write are not read yet", func(t *testing.T) {
+		for _, notYet := range []string{"/outer/a", "/inner/b", "/first/c"} {
+			if _, ok := out.Paths[notYet]; ok {
+				t.Errorf("%s now resolves — assignments are matched per binding; "+
+					"assert it properly here and close #436", notYet)
+			}
+		}
+		for _, stillApprox := range []string{"/{shadowed}/a", "/{shadowed}/b", "/{later}/c"} {
+			if _, ok := out.Paths[stillApprox]; !ok {
+				t.Errorf("%s is gone — the route must stay documented (approximately) "+
+					"while its prefix is unreadable; have %v", stillApprox, mapPathKeys(out.Paths))
+			}
+		}
+	})
 
 	// The two that cannot be read are reported rather than guessed at: one
 	// assigned in two branches, one assigned from a call.

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -366,9 +366,15 @@ func (b *BasePatternMatcher) variableValue(arg *metadata.CallArgument, node Trac
 // fast path resolved to "/two" with no sign that "/one" existed.
 //
 // The enclosing function's scope records them all, so it answers when it knows
-// the variable; the edge map remains the fallback. An assignment written AFTER
-// the registration counts too, since a loop can make it the live value — that
-// can only make the path unreadable, never wrong.
+// the variable; the edge map remains the fallback.
+//
+// KNOWN LIMIT (issue #436): the scope is keyed by NAME, so this also collects
+// assignments that belong to a different binding of it (an inner block's
+// `prefix := …`) or that cannot reach this call (a write below it). Both read as
+// disagreement, so a knowable path keeps its placeholder. That is the safe
+// direction — approximate, never wrong — and it stays until metadata records
+// which binding an assignment writes to; a write below the call cannot simply be
+// filtered out either, since a loop can carry it back.
 func pathVarAssignments(cp ContextProvider, edge *metadata.CallGraphEdge, name string) []metadata.Assignment {
 	if impl, ok := cp.(*ContextProviderImpl); ok {
 		if am := callerAssignmentMap(impl, edge, name); len(am[name]) > 0 {

--- a/testdata/variable_path/main.go
+++ b/testdata/variable_path/main.go
@@ -85,5 +85,23 @@ func main() {
 	built := buildPath()
 	mux.HandleFunc("GET "+built, fromCall)
 
+	// CHANGE DETECTOR (issue #436): these two ARE knowable, and are not read
+	// today, because assignments are matched by name alone. The inner block
+	// re-declares `shadowed`, and `later` is written after its registration —
+	// so each registration sees two disagreeing values and keeps a placeholder.
+	// Documented approximately rather than wrongly, which is why it is a
+	// precision gap and not a correctness one.
+	shadowed := "/outer"
+	mux.HandleFunc("GET "+shadowed+"/a", list)
+	{
+		shadowed := "/inner"
+		mux.HandleFunc("GET "+shadowed+"/b", list)
+	}
+
+	later := "/first"
+	mux.HandleFunc("GET "+later+"/c", list)
+	later = "/second"
+	_ = later
+
 	http.ListenAndServe(":8080", mux)
 }


### PR DESCRIPTION
Follow-up to the CodeRabbit finding on #434, which landed before this could go
into it. No behavior change — a fixture, its assertions, and a comment.

## The finding, verified

`pathVarAssignments` collects the function-scope assignments that share the
identifier's **name**, so two of them that have nothing to do with each other
read as disagreement and the agreement rule rejects:

```yaml
paths:
  /{shadowed}/a:   # shadowed := "/outer"              should be /outer/a
  /{shadowed}/b:   # inner block: shadowed := "/inner"  should be /inner/b
  /{later}/c:      # later = "/second" written below it should be /first/c
  /only/d:         # control — resolves
```

**Precision, not correctness.** The failure mode is an approximate path carrying
a flagged synthesized parameter, never a wrong one, and a path with no literal
part at all is reported and left out (#428). What it costs is resolutions that
were available.

## Why it is pinned rather than fixed

Half of it cannot be implemented from what metadata records:

- **Reachability** (a write below the registration) *is* implementable —
  `Assignment.Position` plus the call-site position — but not as a source-order
  filter: in `for { p = "/x"; register(p) }` a write further down the body
  reaches the next iteration. `Function.Blocks` and `blockIndex.dominates`
  (`internal/spec/control_flow.go`) exist for exactly that question.
- **Lexical binding** is blocked. `Assignment.Scope` is `getScope(name)` —
  exported/unexported, not a scope — and the assignment token is not recorded,
  so `:=` (a new binding) and `=` (a write to one) are indistinguishable. Block
  ranges are no substitute: two assignments in different blocks are as often one
  binding written twice (`if`/`else`) as two bindings. Approximating it there
  would trade this false negative for a false positive, which golden rule #9
  forbids.

Both halves are written up in **#436** with the reproduction.

## What is here

- the three shapes added to `testdata/variable_path`;
- change-detector assertions in `TestTestdata_VariablePath`: the knowable paths
  must NOT resolve yet, and the approximate ones must stay documented — so the
  test fails, and gets updated, as each half of #436 lands;
- the limit recorded on `pathVarAssignments`, where the rule lives, including
  why a write below the call cannot simply be filtered out.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how generated paths are represented when variable bindings are shadowed or assignments occur later in a scope.
  - Documented that uncertain paths remain approximate placeholders rather than being presented as potentially incorrect concrete paths.

- **Tests**
  - Expanded coverage for variable-path resolution, including shadowed bindings, later writes, and preventing documentation under variable type paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->