### PR TITLE
fix(spec): make the call-graph diagram deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The call-graph diagram is deterministic.** Two generations of an unchanged
+  project emitted the same `--diagram` file with a pair of node labels swapped,
+  because a node's parameter labels were collected by ranging the call edge's
+  parameter map. They are now collected in sorted order. The spec has been
+  deterministic since #340 precisely so it can be committed and diffed in CI;
+  the diagram is an output too, and a project that commits `diagram.html` was
+  getting a spurious diff on every run. Content is unchanged — the same labels,
+  in a stable order. (#443)
+
 - **A credential is no longer documented twice.** The header read a security
   scheme was derived from was also emitted as an ordinary header parameter, so
   one `c.GetHeader("Authorization")` inside a middleware produced both

--- a/internal/spec/visualization.go
+++ b/internal/spec/visualization.go
@@ -16,6 +16,8 @@ package spec
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/ehabterra/apispec/internal/metadata"
@@ -656,9 +658,19 @@ func extractParameterInfo(edge *metadata.CallGraphEdge) ([]string, []string) {
 	var paramTypes []string
 	var passedParams []string
 
-	// Extract from ParamArgMap if available (this gives us parameter name -> argument mapping)
+	// Extract from ParamArgMap if available (this gives us parameter name ->
+	// argument mapping).
+	//
+	// Names are visited in SORTED order because both slices built here reach the
+	// diagram (a node's param_types and param_values), and a map range would
+	// order them differently on every run — two generations of an unchanged
+	// project emitted the same file with two labels swapped (issue #443).
+	// Sorting by name rather than by parameter position because the edge records
+	// the mapping by name; position would have to be recovered from the callee's
+	// signature, and an arbitrary-but-stable order is what determinism needs.
 	if edge.ParamArgMap != nil {
-		for paramName, arg := range edge.ParamArgMap {
+		for _, paramName := range slices.Sorted(maps.Keys(edge.ParamArgMap)) {
+			arg := edge.ParamArgMap[paramName]
 			// Get the parameter type
 			argType := arg.GetType()
 			if argType == "" {

--- a/internal/spec/visualization_determinism_test.go
+++ b/internal/spec/visualization_determinism_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// paramEdge builds a call edge whose parameters are bound by NAME, which is how
+// the diagram's labels are produced.
+func paramEdge(meta *metadata.Metadata, params map[string]string) *metadata.CallGraphEdge {
+	edge := &metadata.CallGraphEdge{
+		Caller: metadata.Call{Meta: meta, Name: meta.StringPool.Get("main"), Pkg: meta.StringPool.Get("app"), RecvType: -1},
+		Callee: metadata.Call{Meta: meta, Name: meta.StringPool.Get("HandleFunc"), Pkg: meta.StringPool.Get("net/http"), RecvType: -1},
+	}
+	edge.ParamArgMap = map[string]metadata.CallArgument{}
+	for name, value := range params {
+		arg := metadata.NewCallArgument(meta)
+		arg.SetKind(metadata.KindLiteral)
+		arg.SetValue(`"` + value + `"`)
+		arg.Type = meta.StringPool.Get("string")
+		edge.ParamArgMap[name] = *arg
+	}
+	return edge
+}
+
+// TestExtractParameterInfoIsOrdered pins the ordering of the diagram's
+// parameter labels (issue #443).
+//
+// They were produced by ranging the edge's ParamArgMap, so two generations of
+// an unchanged project emitted the same diagram with two labels swapped — the
+// spec has been deterministic since #340 precisely so it can be committed and
+// diffed, and the diagram is an output too.
+func TestExtractParameterInfoIsOrdered(t *testing.T) {
+	meta := newTestMeta()
+	edge := paramEdge(meta, map[string]string{
+		"pattern": "/item",
+		"handler": "itemHandler",
+		"zzz":     "last",
+		"aaa":     "first",
+	})
+
+	wantTypes := []string{"aaa:string", "handler:string", "pattern:string", "zzz:string"}
+	wantValues := []string{"aaa: first", "handler: itemHandler", "pattern: /item", "zzz: last"}
+
+	// Repeated because Go randomises map iteration per range: one pass could
+	// pass by luck, twenty could not.
+	for i := 0; i < 20; i++ {
+		types, values := extractParameterInfo(edge)
+		if !reflect.DeepEqual(types, wantTypes) {
+			t.Fatalf("run %d: param types = %v, want %v", i, types, wantTypes)
+		}
+		if !reflect.DeepEqual(values, wantValues) {
+			t.Fatalf("run %d: param values = %v, want %v", i, values, wantValues)
+		}
+	}
+}
+
+// TestDrawCallGraphIsDeterministic is the guard one level up, over the drawing
+// that actually emits these labels: `--diagram` renders the CALL GRAPH, and its
+// per-node call paths are where the parameter values appear.
+//
+// Marshalled repeatedly rather than compared field by field, because the point
+// is the bytes a user commits — and it would catch a future map range anywhere
+// in the payload, not only the one #443 was about.
+func TestDrawCallGraphIsDeterministic(t *testing.T) {
+	meta := newTestMeta()
+	meta.CallGraph = []metadata.CallGraphEdge{
+		*paramEdge(meta, map[string]string{
+			"pattern": "/item",
+			"handler": "itemHandler",
+			"mw":      "auth",
+			"opts":    "defaults",
+		}),
+	}
+	meta.BuildCallGraphMaps()
+
+	var first string
+	for i := 0; i < 20; i++ {
+		payload, err := json.Marshal(DrawCallGraphCytoscape(meta))
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if i == 0 {
+			first = string(payload)
+			if !strings.Contains(first, "pattern: /item") {
+				t.Fatalf("the fixture does not reach the parameter labels; payload=%s", first)
+			}
+			continue
+		}
+		if string(payload) != first {
+			t.Fatalf("run %d produced a different diagram payload than run 0", i)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #443. Found while diffing diagrams to prove #425 changed nothing.

## The bug

Two generations of an unchanged project emitted the same `--diagram` file with a
pair of node labels swapped:

```diff
                "param_values": [
-                 "handler: itemHandler",
-                 "pattern: /item"
+                 "pattern: /item",
+                 "handler: itemHandler"
                ]
```

A node's parameter labels were collected by ranging the call edge's
`ParamArgMap`, so both slices that reach the payload — `param_types` and
`param_values` — came out in a fresh order every run.

The spec has been deterministic since #340 precisely so it can be committed and
diffed in CI (golden rule #1). The diagram is an output too, and a project that
commits `diagram.html` was getting a spurious diff on every regeneration.

## The fix

Collect in sorted key order. Sorted by **name** rather than by parameter
position, because the edge records the mapping by name — recovering position
means reading the callee's signature, and stable-but-arbitrary is all
determinism needs.

## The guards, and one that didn't work

Two levels, and **both were checked to fail without the fix** — a determinism
test that cannot fail is worthless:

- `TestExtractParameterInfoIsOrdered` asserts the exact order over 20 passes
  (Go randomises map iteration per range, so one pass could pass by luck);
- `TestDrawCallGraphIsDeterministic` marshals the whole payload 20 times and
  compares bytes — it would catch a future map range anywhere in the drawing.

My first attempt at the second guard drove
`DrawTrackerTreeCytoscapeWithMetadata` and **passed five times on unfixed
code**: `--diagram` renders the CALL GRAPH, and the tracker-tree drawing no
longer reaches these labels at all — that enrichment went with the eager tree
in #425. Retargeted at `DrawCallGraphCytoscape`, it fails on run 1.

## Verification

| check | before | after |
|---|---|---|
| 5 `--diagram` runs, `method_switch` | varied | **1 distinct output** |
| 5 `--diagram` runs, `complex_chi_router` | varied | **1 distinct output** |
| label multiset / line count | — | **unchanged** (22 labels, 1311 lines) |
| generated spec | — | untouched |

Content is the same; only the order moved. The paginated diagram path in
`internal/diagserver` already sorts its own map-derived slices and routes
through the same function, so it is covered by this too. Suite, lint and the
coverage ratchet (96.2%, floor 96) all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed call-graph diagram generation so parameter labels appear in a consistent, sorted order.
  * Repeated generations of an unchanged project now produce identical diagram output.

* **Tests**
  * Added coverage to verify stable parameter ordering and repeatable diagram serialization.

* **Documentation**
  * Added an entry to the unreleased changelog describing the deterministic diagram output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->