### PR TITLE
fix(metadata): an inline struct's schema no longer describes itself with a pooled string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **An inline struct's schema no longer publishes an interned string as its doc
+  comment.** An anonymous-struct request body carried a `description` that was
+  never a comment: the synthetic type recorded no `Comments` index, and the zero
+  value is a *valid* pool index — the first string interned in that run — so the
+  body and every property of it were described as `literal`, `func_type`, or the
+  type's own internal key. One real service published 211 of them. Because the
+  text is "whatever was pooled first", it also moved with pooling order, so an
+  unchanged project drifted between versions. Inline structs now say they have
+  no comment; documented named types are unaffected. (#448)
+
 ### Added
 
 - **Type and field doc comments become schema descriptions.** A documented Go

--- a/generator/testdata_smoke_test.go
+++ b/generator/testdata_smoke_test.go
@@ -244,6 +244,27 @@ func TestTestdata_AnonymousStruct(t *testing.T) {
 		}
 	}
 	noUnresolvedPlaceholders(t, out)
+
+	// An inline struct has no doc comment, so it must carry no description.
+	// It used to carry pool entry 0 — whichever string the run pooled first,
+	// so "literal", "func_type" or the type's own synthetic key — on the body
+	// and on every property of it (#448). A real project published 211
+	// of them, and the word changed between versions as pooling order moved.
+	for _, p := range []string{"/orders", "/bulk-update", "/tags"} {
+		body := firstRequestSchema(t, out, p)
+		if body == nil {
+			continue
+		}
+		if body.Description != "" {
+			t.Errorf("%s inline requestBody has description %q, want none", p, body.Description)
+		}
+		for name, prop := range body.Properties {
+			if prop != nil && prop.Description != "" {
+				t.Errorf("%s inline requestBody property %q has description %q, want none",
+					p, name, prop.Description)
+			}
+		}
+	}
 }
 
 // ---------------------------------------------------------------------

--- a/generator/testdata_smoke_test.go
+++ b/generator/testdata_smoke_test.go
@@ -250,21 +250,31 @@ func TestTestdata_AnonymousStruct(t *testing.T) {
 	// so "literal", "func_type" or the type's own synthetic key — on the body
 	// and on every property of it (#448). A real project published 211
 	// of them, and the word changed between versions as pooling order moved.
-	for _, p := range []string{"/orders", "/bulk-update", "/tags"} {
-		body := firstRequestSchema(t, out, p)
-		if body == nil {
-			continue
+	//
+	// A missing schema FAILS rather than skipping: a guard that quietly
+	// verifies nothing when the body it inspects disappears is the shape that
+	// let this bug live in the first place.
+	assertUndescribed := func(what string, s *intspec.Schema) {
+		if s == nil {
+			t.Errorf("%s: no inline schema, so the description guard checked nothing", what)
+			return
 		}
-		if body.Description != "" {
-			t.Errorf("%s inline requestBody has description %q, want none", p, body.Description)
+		if s.Description != "" {
+			t.Errorf("%s has description %q, want none", what, s.Description)
 		}
-		for name, prop := range body.Properties {
+		for name, prop := range s.Properties {
 			if prop != nil && prop.Description != "" {
-				t.Errorf("%s inline requestBody property %q has description %q, want none",
-					p, name, prop.Description)
+				t.Errorf("%s property %q has description %q, want none", what, name, prop.Description)
 			}
 		}
 	}
+	for _, p := range []string{"/orders", "/bulk-update", "/tags"} {
+		assertUndescribed(p+" inline requestBody", firstRequestSchema(t, out, p))
+	}
+	// And on a RESPONSE body, which is where gitea's five were — the bug was
+	// never request-only.
+	assertUndescribed("/summary inline 200 response",
+		firstResponseSchemaAtStatus(t, out, "/summary", "200"))
 }
 
 // ---------------------------------------------------------------------
@@ -563,9 +573,9 @@ func TestTestdata_HelperResponseBody(t *testing.T) {
 }
 
 // firstResponseSchemaAtStatus returns the response schema attached to a
-// specific status code on the path's first operation. Helper local to
-// the helper_response_body test because every other test inspects
-// either request bodies or the *first* response only.
+// specific status code on the path's first operation. Used by the
+// helper_response_body test and by anonymous_struct's description guard;
+// every other test inspects either request bodies or the *first* response.
 func firstResponseSchemaAtStatus(t *testing.T, out *spec.OpenAPISpec, path, status string) *intspec.Schema {
 	t.Helper()
 	item, ok := out.Paths[path]

--- a/internal/metadata/anon_struct_comments_test.go
+++ b/internal/metadata/anon_struct_comments_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata_test
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/go/packages"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// An inline struct has no doc comment, and the metadata has to say so with
+// NoString rather than by leaving the field unset: zero is pool index 0, a
+// real string, so the omission published whichever string the run pooled
+// first as the schema's description — on the body and on every property of
+// it (#448). The junk was arbitrary and moved with pooling order, so
+// the same source drifted between versions ("literal" -> "func_type").
+func TestAnonStructTypeHasNoComment(t *testing.T) {
+	src := `package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func main() {
+	http.HandleFunc("POST /thing", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Code string ` + "`json:\"code\"`" + `
+			Name string ` + "`json:\"name\"`" + `
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+	})
+	_ = http.ListenAndServe(":8080", nil)
+}
+`
+	cfg := exportModules(t, []testModule{{Name: "anoncomment", Files: map[string]interface{}{"main.go": src}}})
+	fset := token.NewFileSet()
+	cfg.Mode = packages.NeedName | packages.NeedFiles | packages.NeedSyntax | packages.NeedTypes | packages.NeedTypesInfo | packages.NeedImports
+	cfg.Fset = fset
+	cfg.Tests = false
+
+	pkgs, err := packages.Load(cfg, "./...")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pkgFiles := map[string]map[string]*ast.File{}
+	fileToInfo := map[*ast.File]*types.Info{}
+	importPaths := map[string]string{}
+	for _, pkg := range pkgs {
+		if pkg.PkgPath == "" {
+			continue
+		}
+		pkgFiles[pkg.PkgPath] = map[string]*ast.File{}
+		for i, f := range pkg.Syntax {
+			if i < len(pkg.GoFiles) {
+				pkgFiles[pkg.PkgPath][pkg.GoFiles[i]] = f
+				fileToInfo[f] = pkg.TypesInfo
+				importPaths[pkg.GoFiles[i]] = pkg.PkgPath
+			}
+		}
+	}
+
+	meta := metadata.GenerateMetadata(pkgFiles, fileToInfo, importPaths, fset)
+
+	// The trap this guards: index 0 is a legitimate, non-empty pooled string,
+	// so an unset index reads as prose rather than as nothing.
+	if first := meta.StringPool.GetString(0); first == "" {
+		t.Fatal("pool index 0 is empty, so this test can no longer tell an unset index from an absent one")
+	}
+
+	var checked int
+	for _, pkg := range meta.Packages {
+		for _, file := range pkg.Files {
+			for name, typ := range file.Types {
+				if !strings.Contains(name, metadata.AnonStructTypePrefix) {
+					continue
+				}
+				checked++
+				if typ.Comments != metadata.NoString {
+					t.Errorf("anon struct %s: Comments = %d, want NoString (%d); it reads as %q",
+						name, typ.Comments, metadata.NoString, meta.StringPool.GetString(typ.Comments))
+				}
+				for _, f := range typ.Fields {
+					if f.Comments != metadata.NoString {
+						t.Errorf("anon struct %s field %q: Comments = %d, want NoString (%d); it reads as %q",
+							name, meta.StringPool.GetString(f.Name), f.Comments, metadata.NoString,
+							meta.StringPool.GetString(f.Comments))
+					}
+				}
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no anonymous-struct type was recorded, so nothing was verified")
+	}
+}

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -1022,6 +1022,14 @@ func buildAnonStructType(s *types.Struct, name, pkgName string, metadata *Metada
 		Name: metadata.StringPool.Get(name),
 		Pkg:  metadata.StringPool.Get(pkgName),
 		Kind: metadata.StringPool.Get("struct"),
+		// An inline struct has no doc comment, and saying so has to be
+		// explicit: the zero value is pool index 0 — a real string, whichever
+		// one the run pooled first — so leaving it unset published that string
+		// as the schema's description, on the body and on every property of
+		// it. What it read was arbitrary ("literal", "func_type", the type's
+		// own synthetic key) and changed with pooling order, so the same source
+		// drifted between runs of different versions (#448).
+		Comments: NoString,
 	}
 	for i := 0; i < s.NumFields(); i++ {
 		fv := s.Field(i)
@@ -1029,9 +1037,10 @@ func buildAnonStructType(s *types.Struct, name, pkgName string, metadata *Metada
 		fieldType := fv.Type()
 
 		f := Field{
-			Name: metadata.StringPool.Get(fv.Name()),
-			Type: metadata.StringPool.Get(fieldType.String()),
-			Tag:  metadata.StringPool.Get(tag),
+			Name:     metadata.StringPool.Get(fv.Name()),
+			Type:     metadata.StringPool.Get(fieldType.String()),
+			Tag:      metadata.StringPool.Get(tag),
+			Comments: NoString, // as above: a field of an inline struct has none
 		}
 
 		// Inline-struct field: record it as a NestedType so the

--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -78,9 +78,20 @@ func NewStringPool() *StringPool {
 	}
 }
 
+// NoString is the index that means "no string here". Get returns it for the
+// empty string, and GetString maps it back to "".
+//
+// It is NOT zero: zero is a perfectly valid index (the first string pooled in
+// a run), so a struct that leaves a pooled-index field unset points at that
+// string rather than at nothing. Fields are therefore set explicitly to
+// NoString when absent — see buildAnonStructType, where the omission published
+// pool entry 0 as a doc comment (#448). Reserving slot 0 for "" would retire
+// the footgun itself; that is #449.
+const NoString = -1
+
 func (sp *StringPool) Get(s string) int {
 	if s == "" {
-		return -1
+		return NoString
 	}
 
 	if idx, exists := sp.strings[s]; exists {
@@ -88,7 +99,7 @@ func (sp *StringPool) Get(s string) int {
 	}
 
 	if sp.strings == nil {
-		return -1
+		return NoString
 	}
 
 	idx := len(sp.values)


### PR DESCRIPTION
Fixes #448. Found while reviewing a spec comparison on two real projects, as
the explanation for 213 CHANGED keys that had nothing to do with any code
change.

## The bug

Every anonymous-struct body carried a `description` that was never a doc
comment — and the same one on the body and on each property:

```yaml
schema:
  type: object
  description: _apispec_anonstruct_probe_inline_main_go_10_7_8cc533a0
  properties:
    code:
      type: string
      description: _apispec_anonstruct_probe_inline_main_go_10_7_8cc533a0
```

`buildAnonStructType` recorded no `Comments` index for the synthetic type or
its fields, and the Go **zero value is a valid pool index** — the first string
interned in that run — so `docComment` read it and published it. What it said
was arbitrary: `literal`, `func_type`, or (in a small module) the type's own
internal key. One real service published **211** of them.

Named types were never affected: `processStructFields` goes through
`StringPool.Get(comments)`, which returns -1 for the empty string.

## Why it looked like version drift

The text is "whatever was pooled first", so it moves with pooling order. The
same 211 descriptions read `literal` in one snapshot and `func_type` in the
next, on unchanged source — which is how this surfaced at all: as unexplained
CHANGED keys in a comparison of two snapshots.

## The fix

Inline structs now state that they have no comment. The sentinel is named
(`NoString`) and documents the trap at the pool, because the omission was
silent by construction: "absent" is -1 while the zero value is a real string,
so forgetting the field publishes prose instead of nothing.

Retiring the footgun itself — reserving slot 0 for `""` so a zero index reads
as absent — shifts every index and regenerates every golden, so it is **#449**
rather than this change.

## Guards (both fail on unfixed code — checked)

* metadata unit test asserting `Comments == NoString`, quoting the junk string
  it read. It first asserts pool index 0 is non-empty, so it cannot silently
  stop testing anything if pooling changes.
* the `anonymous_struct` fixture test asserting the inline bodies and their
  properties carry no description.

Against unfixed code the unit test reports exactly the defect:

```
Comments = 0, want NoString (-1); it reads as "_apispec_anonstruct_anoncomment_main_go_10_7_42f90f87"
```

## Drift

| project | before | after |
|---|---|---|
| 280-path service | 280 paths, 313 schemas, 211 junk descriptions | identical, **0** junk, zero status changes |
| gitea | 894 paths, 5 junk descriptions | identical, **0** junk, zero status changes |

No goldens contain anonymous structs, so there is no golden churn. gitea's five
were on a **response** body — the bug was not request-only. Full suite and
`make lint` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed generated schemas for inline request bodies so they no longer display arbitrary or changing descriptions.
  - Inline struct properties now correctly have no descriptions, while documented named types remain unaffected.

- **Tests**
  - Added coverage to verify anonymous structs and their fields consistently omit descriptions across generated endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->