### PR TITLE
fix(apispecui): a symlink in the module no longer reads files outside it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **apispecui: a symlink inside the analyzed module could no longer be used to
+  read files outside it.** `GET /api/insight/source` serves source only from the
+  analyzed module, GOROOT, or the module cache, but the check was lexical: for a
+  link at `<module>/leak.go` pointing anywhere on disk, the relative path never
+  left the module *as a string*, so the request was allowed and the linked
+  file's contents were returned — reported under the in-module path. Two
+  defects compounded, because the guard also validated one path while
+  `SourceSnippet` re-derived and opened another. Containment is now decided on
+  symlink-resolved paths on both sides, the resolved path is the one read, and a
+  path that cannot be resolved fails closed instead of falling through to the
+  lexical comparison. Resolving the roots as well matters: a module under a
+  symlinked path (on macOS `/tmp` is `/private/tmp`) would otherwise be refused
+  its own source. `apispecui` binds to localhost, so this needed a symlink in a
+  repo the developer chose to analyze — plausible for an untrusted checkout,
+  which is what the tool is for. (#424)
+
 - **An inline struct's schema no longer publishes an interned string as its doc
   comment.** An anonymous-struct request body carried a `description` that was
   never a comment: the synthetic type recorded no `Comments` index, and the zero

--- a/cmd/apispecui/insight_source_guard_test.go
+++ b/cmd/apispecui/insight_source_guard_test.go
@@ -1,0 +1,216 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"go/build"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// sourceGuardModule lays out a module to serve source from, a file inside it,
+// and a secret outside it that an in-module symlink points at.
+func sourceGuardModule(t *testing.T) (dir, secret string) {
+	t.Helper()
+	root := t.TempDir()
+
+	dir = filepath.Join(root, "module")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module guarded\n\ngo 1.26\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	secret = filepath.Join(root, "secret", "id_rsa")
+	if err := os.MkdirAll(filepath.Dir(secret), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(secret, []byte("-----BEGIN PRIVATE KEY-----\nSTOLEN\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return dir, secret
+}
+
+func getInsightSource(t *testing.T, s *UIServer, pos string) (int, string) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	s.handleInsightSource(rec, httptest.NewRequest(http.MethodGet, "/api/insight/source?pos="+pos, nil))
+	return rec.Code, rec.Body.String()
+}
+
+// A symlink planted inside the analyzed module must not serve what it points
+// at. The guard used to compare paths lexically, so `<module>/leak.go` for a
+// link to ~/.ssh/id_rsa produced rel == "leak.go" — no leading "..", allowed —
+// and the endpoint returned the key's contents while reporting the in-module
+// path as `file` (#424).
+func TestInsightSourceRejectsSymlinkEscape(t *testing.T) {
+	dir, secret := sourceGuardModule(t)
+	link := filepath.Join(dir, "leak.go")
+	if err := os.Symlink(secret, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	s := &UIServer{inputDir: dir}
+
+	code, body := getInsightSource(t, s, link+":1")
+	if code == http.StatusOK {
+		t.Errorf("symlink escape served with 200; body: %s", body)
+	}
+	if strings.Contains(body, "STOLEN") {
+		t.Errorf("response leaked the linked file's contents: %s", body)
+	}
+	if code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", code, http.StatusForbidden)
+	}
+}
+
+// A real file inside the module still works — the guard must not be so tight
+// that the endpoint stops doing its job.
+//
+// This also covers the module sitting under a SYMLINKED path, which is the
+// regression resolving the roots prevents: on macOS t.TempDir() lives below
+// /var, itself a link to /private/var, so the requested file resolves to
+// /private/var/... while the root reads /var/... . Comparing those without
+// resolving the root puts ".." in the relative path and refuses the module its
+// own source. Verified by removing the root resolution: this test fails 403.
+func TestInsightSourceServesInModuleFile(t *testing.T) {
+	dir, _ := sourceGuardModule(t)
+	s := &UIServer{inputDir: dir}
+
+	code, body := getInsightSource(t, s, filepath.Join(dir, "main.go")+":1")
+	if code != http.StatusOK {
+		t.Fatalf("in-module file rejected: status %d, body %s", code, body)
+	}
+	var got struct {
+		File string `json:"file"`
+		Code string `json:"code"`
+	}
+	if err := json.Unmarshal([]byte(body), &got); err != nil {
+		t.Fatalf("bad JSON: %v (%s)", err, body)
+	}
+	if !strings.Contains(got.Code, "package main") {
+		t.Errorf("code = %q, want the file's source", got.Code)
+	}
+}
+
+// A path outside the module is still refused outright.
+func TestInsightSourceRejectsOutsidePath(t *testing.T) {
+	dir, secret := sourceGuardModule(t)
+	s := &UIServer{inputDir: dir}
+
+	code, body := getInsightSource(t, s, secret+":1")
+	if code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d (body %s)", code, http.StatusForbidden, body)
+	}
+	if strings.Contains(body, "STOLEN") {
+		t.Errorf("response leaked contents: %s", body)
+	}
+}
+
+// A symlink is not automatically suspect: one pointing at a file inside the
+// module resolves to a path still under the module, and must be served. The
+// reported path is the resolved one, since that is what was read.
+func TestInsightSourceAllowsSymlinkWithinModule(t *testing.T) {
+	dir, _ := sourceGuardModule(t)
+	link := filepath.Join(dir, "alias.go")
+	if err := os.Symlink(filepath.Join(dir, "main.go"), link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	s := &UIServer{inputDir: dir}
+
+	code, body := getInsightSource(t, s, link+":1")
+	if code != http.StatusOK {
+		t.Fatalf("in-module symlink rejected: status %d, body %s", code, body)
+	}
+	var got struct {
+		File string `json:"file"`
+		Code string `json:"code"`
+	}
+	if err := json.Unmarshal([]byte(body), &got); err != nil {
+		t.Fatalf("bad JSON: %v (%s)", err, body)
+	}
+	if !strings.Contains(got.Code, "package main") {
+		t.Errorf("code = %q, want the target's source", got.Code)
+	}
+	if strings.HasSuffix(got.File, "alias.go") {
+		t.Errorf("file = %q, want the resolved target rather than the link", got.File)
+	}
+}
+
+// A relative escape is refused: filepath.Abs cleans the "..", so this lands
+// outside the module and never reaches the read.
+func TestInsightSourceRejectsDotDotEscape(t *testing.T) {
+	dir, secret := sourceGuardModule(t)
+	s := &UIServer{inputDir: dir}
+
+	pos := filepath.Join(dir, "..", "secret", "id_rsa") + ":1"
+	code, body := getInsightSource(t, s, pos)
+	if code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d (body %s)", code, http.StatusForbidden, body)
+	}
+	if strings.Contains(body, "STOLEN") {
+		t.Errorf("response leaked contents: %s", body)
+	}
+	_ = secret
+}
+
+// A path that does not exist fails closed, and says so rather than claiming the
+// file lives outside the module: EvalSymlinks cannot resolve it, and the old
+// code's lexical fallback is exactly what made the escape possible.
+func TestInsightSourceMissingFileFailsClosed(t *testing.T) {
+	dir, _ := sourceGuardModule(t)
+	s := &UIServer{inputDir: dir}
+
+	code, body := getInsightSource(t, s, filepath.Join(dir, "absent.go")+":1")
+	if code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d (body %s)", code, http.StatusNotFound, body)
+	}
+}
+
+// Stdlib source is still served: GOROOT is one of the allowed roots, and it is
+// commonly reached through a symlinked toolchain path.
+func TestInsightSourceServesGOROOT(t *testing.T) {
+	stdlib := filepath.Join(build.Default.GOROOT, "src", "net", "http", "server.go")
+	if _, err := os.Stat(stdlib); err != nil {
+		t.Skipf("stdlib source not present: %v", err)
+	}
+	dir, _ := sourceGuardModule(t)
+	s := &UIServer{inputDir: dir}
+
+	code, body := getInsightSource(t, s, stdlib+":1")
+	if code != http.StatusOK {
+		t.Fatalf("stdlib source rejected: status %d, body %s", code, body)
+	}
+}
+
+// A position with no line is a bad request, not a read.
+func TestInsightSourceRejectsPositionWithoutLine(t *testing.T) {
+	dir, _ := sourceGuardModule(t)
+	s := &UIServer{inputDir: dir}
+
+	for _, pos := range []string{"", filepath.Join(dir, "main.go"), filepath.Join(dir, "main.go") + ":0"} {
+		if code, body := getInsightSource(t, s, pos); code != http.StatusBadRequest {
+			t.Errorf("pos %q: status = %d, want %d (body %s)", pos, code, http.StatusBadRequest, body)
+		}
+	}
+}

--- a/cmd/apispecui/main.go
+++ b/cmd/apispecui/main.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"embed"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"go/build"
@@ -1793,42 +1794,74 @@ func (s *UIServer) handleInsightSource(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	pos := r.URL.Query().Get("pos")
-	file := insight.PosFile(pos)
-	if file == "" {
+	file, line := insight.ParsePos(pos)
+	if file == "" || line <= 0 {
 		writeError(w, http.StatusBadRequest, "pos is required (file:line)")
 		return
 	}
-	abs, err := filepath.Abs(file)
+	// Resolve and authorize BEFORE reading, and read exactly what was
+	// authorized: `resolved`, never `file` or `pos` again (#424).
+	resolved, err := s.servableSourcePath(file)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "bad path: "+err.Error())
-		return
-	}
-	if !s.sourcePathAllowed(abs) {
+		if errors.Is(err, errSourceMissing) {
+			writeError(w, http.StatusNotFound, "source not available for this position")
+			return
+		}
 		writeError(w, http.StatusForbidden, "source is outside the analyzed module / module cache")
 		return
 	}
 	before := queryInt(r, "before", 3)
 	after := queryInt(r, "after", 26)
-	code, start, line := insight.SourceSnippet(pos, before, after)
+	code, start, target := insight.SourceSnippetAt(resolved, line, before, after)
 	if code == "" {
 		writeError(w, http.StatusNotFound, "source not available for this position")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]interface{}{
-		"file":      abs,
+		"file":      resolved,
 		"code":      code,
 		"startLine": start,
-		"line":      line,
+		"line":      target,
 	})
 }
 
-// sourcePathAllowed reports whether abs is inside a directory we're willing to
-// serve source from: the analyzed module root, GOROOT (stdlib), or the Go
-// module cache (third-party deps). Everything else is rejected.
-func (s *UIServer) sourcePathAllowed(abs string) bool {
+// errSourceMissing and errSourceForbidden separate "there is nothing there" from
+// "you may not read that", so a developer whose file was deleted is not told it
+// lives outside the module.
+var (
+	errSourceMissing   = errors.New("source file does not exist")
+	errSourceForbidden = errors.New("source is outside the analyzed module / module cache")
+)
+
+// servableSourcePath returns the path that may be read for file: the analyzed
+// module root, GOROOT (stdlib), or the module cache (third-party deps).
+// Everything else is refused.
+//
+// Containment is decided on paths with their symlinks resolved, on BOTH sides.
+// A lexical comparison accepted `<module>/leak.go` for a link pointing at
+// ~/.ssh/id_rsa, because as a *string* that path never leaves the module —
+// filepath.Rel reported "leak.go", no leading "..", allowed — and the endpoint
+// then served the key (#424).
+//
+// The roots are resolved too, or the guard would reject a module's own files
+// whenever the module sits under a symlinked path (on macOS /tmp is
+// /private/tmp, so this is the common case, not an exotic one).
+//
+// A path that cannot be resolved fails closed: EvalSymlinks needs the file to
+// exist, and falling back to a lexical comparison when it does not is precisely
+// the hole being closed. The caller MUST read the returned path — validating
+// one string and opening another was the second half of the same bug.
+func (s *UIServer) servableSourcePath(file string) (string, error) {
+	abs, err := filepath.Abs(file)
+	if err != nil {
+		return "", errSourceMissing
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", errSourceMissing
+	}
 	root, _ := findModuleRoot(s.currentDir())
-	roots := []string{root, build.Default.GOROOT, goModCache()}
-	for _, base := range roots {
+	for _, base := range []string{root, build.Default.GOROOT, goModCache()} {
 		if base == "" {
 			continue
 		}
@@ -1836,11 +1869,18 @@ func (s *UIServer) sourcePathAllowed(abs string) bool {
 		if err != nil {
 			continue
 		}
-		if rel, err := filepath.Rel(baseAbs, abs); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-			return true
+		if r, err := filepath.EvalSymlinks(baseAbs); err == nil {
+			baseAbs = r
+		}
+		rel, err := filepath.Rel(baseAbs, resolved)
+		if err != nil {
+			continue
+		}
+		if rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return resolved, nil
 		}
 	}
-	return false
+	return "", errSourceForbidden
 }
 
 // goModCache returns the Go module cache directory (where third-party source

--- a/internal/insight/export.go
+++ b/internal/insight/export.go
@@ -248,6 +248,12 @@ func reqStr(req bool) string {
 // effort — never fatal).
 func readSourceWindow(pos string, before, after int) string {
 	file, line := parsePos(pos)
+	return readSourceWindowAt(file, line, before, after)
+}
+
+// readSourceWindowAt is readSourceWindow for a caller that already has the
+// file and line, so the path it validated is the path that gets opened.
+func readSourceWindowAt(file string, line, before, after int) string {
 	if file == "" || line <= 0 {
 		return ""
 	}
@@ -293,6 +299,17 @@ func PosFile(pos string) string {
 // Best-effort: returns ("", 0, 0) on any problem.
 func SourceSnippet(pos string, before, after int) (code string, startLine, targetLine int) {
 	file, line := parsePos(pos)
+	return SourceSnippetAt(file, line, before, after)
+}
+
+// SourceSnippetAt is SourceSnippet for an explicit file and line.
+//
+// A caller that has checked whether a path may be served MUST use this rather
+// than SourceSnippet: passing the position string back in means the file is
+// re-derived from it and opened, so the path that was validated and the path
+// that is read are two different strings — half of the symlink escape in #424
+// was exactly that.
+func SourceSnippetAt(file string, line, before, after int) (code string, startLine, targetLine int) {
 	if file == "" || line <= 0 {
 		return "", 0, 0
 	}
@@ -300,7 +317,13 @@ func SourceSnippet(pos string, before, after int) (code string, startLine, targe
 	if start < 1 {
 		start = 1
 	}
-	return readSourceWindow(pos, before, after), start, line
+	return readSourceWindowAt(file, line, before, after), start, line
+}
+
+// ParsePos splits a "file:line" or "file:line:col" position into its file and
+// line, returning ("", 0) when it is not a position at all.
+func ParsePos(pos string) (file string, line int) {
+	return parsePos(pos)
 }
 
 // parsePos splits "file:line:col" (col optional). File paths may contain


### PR DESCRIPTION
Fixes #424.

`GET /api/insight/source` is meant to serve source only from the analyzed
module, GOROOT, or the module cache. It did not hold:

```bash
ln -s ~/.ssh/id_rsa leak.go
curl 'localhost:8088/api/insight/source?pos=leak.go:1'   # 200, key contents
```

## Two defects, both required

**The check was lexical.** `filepath.Abs` and `filepath.Rel` do not follow
symlinks, so `<module>/leak.go` yielded `rel == "leak.go"` — no leading `..` —
and passed, whatever the link pointed at.

**The validated path was not the path read.** The guard ran on `abs`, then
`SourceSnippet` re-parsed `pos` and opened *that*. Even a guard that resolved
symlinks correctly would have been checking a different string from the one
being opened, so fixing only the first half would have left the hole open.

## The fix

* Containment is decided on **symlink-resolved paths, both sides**.
* The resolved path is **what gets read** — `insight.SourceSnippetAt` takes an
  explicit file and line, so the position string is never re-derived. The old
  `SourceSnippet(pos, …)` stays for callers that pass trusted internal
  positions.
* A path that cannot be resolved **fails closed** instead of falling through to
  the lexical comparison.
* Missing and forbidden are distinguished (404 vs 403), so a developer whose
  file was deleted is not told it lives outside the module.

## Resolving the roots is load-bearing, not defensive

A module under a symlinked path would otherwise be refused its **own** source,
and since macOS puts temp dirs under `/var` → `/private/var`, that is the
common case rather than an exotic one. Verified by removing the root
resolution: `TestInsightSourceServesInModuleFile` fails with 403.

## Coverage — probed, not assumed

| shape | expected | result |
|---|---|---|
| symlink → outside the module | refuse | 403, no contents (**fails on unfixed code**: 200 + `STOLEN`) |
| symlink → inside the module | serve | 200, reports the resolved target |
| module under a symlinked path | serve | 200 (403 without root resolution) |
| `..` escape | refuse | 403 |
| plain outside path | refuse | 403 |
| missing file | fail closed | 404 |
| stdlib under GOROOT | serve | 200 |
| position with no line | reject | 400 |

Confirmed end to end against a running server, with the issue's own request:
403 and no contents, while in-module source still returns 200.

Suite, `make lint` and the ratchet (96.2%, floor 96) pass.

## Note on severity

Unchanged from the issue: `apispecui` binds to localhost, so this needs a
symlink planted in a repo the developer chose to analyze. That is a plausible
path — analyzing an untrusted checkout is what the tool is for — but it is not
remotely reachable by default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened source-code access controls to prevent symlink and relative-path escapes outside the analyzed module.
  * Source requests now fail safely when paths cannot be resolved or files are missing, without exposing protected contents.
  * Valid source files—including in-module symlinks, standard library files, and module-cache files—continue to display correctly.
  * Improved handling of invalid source positions with clearer request rejection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->