### PR TITLE
fix(metadata): reserve string-pool slot 0 so an unset index means "no string"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   its own source. `apispecui` binds to localhost, so this needed a symlink in a
   repo the developer chose to analyze — plausible for an untrusted checkout,
   which is what the tool is for. (#424)
+- **A metadata field that records no string now reads as absent, not as an
+  arbitrary one.** Pooled strings are stored by index, and 0 was a valid index —
+  the first string interned in a run — so any record that left an index field
+  unset pointed at that string instead of at nothing. That is what published 211
+  junk schema `description` values (#448), and it was silent by construction:
+  the junk is plausible prose, and it changed with interning order, so it read
+  as version drift rather than as a bug. Slot 0 of the pool is now reserved for
+  the empty string, so the Go zero value means "no string" by construction.
+  Every pool index shifts by one, which regenerates the metadata goldens; all
+  109 fixture specs are byte-identical. (#449)
+- **A parameter with no name is no longer emitted.** OpenAPI requires `name`,
+  and a parameter without one cannot be sent, matched or validated. One was
+  reaching a real project's spec, readable only because the unset name index
+  resolved to a pooled string (`name: func_type`) — reserving pool slot 0
+  exposed it. A `$ref` parameter is unaffected, since its name lives in the
+  component it points at. Why a parameter is recorded without a name is tracked
+  separately in #452. (#449)
 
 - **An inline struct's schema no longer publishes an interned string as its doc
   comment.** An anonymous-struct request body carried a `description` that was

--- a/internal/metadata/anon_struct_comments_test.go
+++ b/internal/metadata/anon_struct_comments_test.go
@@ -81,10 +81,12 @@ func main() {
 
 	meta := metadata.GenerateMetadata(pkgFiles, fileToInfo, importPaths, fset)
 
-	// The trap this guards: index 0 is a legitimate, non-empty pooled string,
-	// so an unset index reads as prose rather than as nothing.
-	if first := meta.StringPool.GetString(0); first == "" {
-		t.Fatal("pool index 0 is empty, so this test can no longer tell an unset index from an absent one")
+	// Slot 0 is now reserved for "" (#449), so an unset index no longer reads
+	// as prose. The explicit NoString below is still what this test pins: the
+	// reservation is a backstop, and stating "no comment" at the site is what
+	// keeps the metadata honest if the reservation ever moves.
+	if first := meta.StringPool.GetString(0); first != "" {
+		t.Errorf("slot 0 should be the reserved empty string, got %q", first)
 	}
 
 	var checked int

--- a/internal/metadata/anon_struct_comments_test.go
+++ b/internal/metadata/anon_struct_comments_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"golang.org/x/tools/go/packages"
+	"gopkg.in/yaml.v3"
 
 	"github.com/ehabterra/apispec/internal/metadata"
 )
@@ -113,5 +114,52 @@ func main() {
 	}
 	if checked == 0 {
 		t.Fatal("no anonymous-struct type was recorded, so nothing was verified")
+	}
+}
+
+// A pool serialized before slot 0 was reserved keeps the string that is there.
+//
+// This is the deliberate answer to "enforce the reserved slot on load": in such
+// a file index 0 is a real value — the goldens from before the change reference
+// `kind: 0`, meaning "ident", a hundred times in one package — so shifting
+// indices to insert "" would rewrite each of those into a different string, and
+// rejecting the file would refuse data that reads back correctly. The ambiguity
+// is unresolvable after the fact; what is fixed is that every pool this code
+// writes reserves the slot, so new metadata is never ambiguous.
+func TestStringPoolLegacyPoolLoadsAsWritten(t *testing.T) {
+	var legacy metadata.StringPool
+	if err := yaml.Unmarshal([]byte("- func_type\n- ident\n"), &legacy); err != nil {
+		t.Fatal(err)
+	}
+	if got := legacy.GetString(0); got != "func_type" {
+		t.Errorf("legacy slot 0 = %q, want it left as written (%q)", got, "func_type")
+	}
+	if got := legacy.Get("func_type"); got != 0 {
+		t.Errorf("legacy lookup of the slot-0 string = %d, want 0 — indices must not shift", got)
+	}
+	if got := legacy.GetString(1); got != "ident" {
+		t.Errorf("legacy slot 1 = %q, want %q", got, "ident")
+	}
+
+	// A pool this code writes always reserves the slot, so a fresh one — and
+	// anything round-tripped from it — is unambiguous.
+	fresh := metadata.NewStringPool()
+	fresh.Get("func_type")
+	if got := fresh.GetString(0); got != "" {
+		t.Errorf("fresh slot 0 = %q, want the reserved empty string", got)
+	}
+	out, err := yaml.Marshal(fresh)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var round metadata.StringPool
+	if err := yaml.Unmarshal(out, &round); err != nil {
+		t.Fatal(err)
+	}
+	if got := round.GetString(0); got != "" {
+		t.Errorf("round-tripped slot 0 = %q, want the reserved empty string", got)
+	}
+	if round.Get("func_type") != fresh.Get("func_type") {
+		t.Errorf("round-trip moved an index: %d -> %d", fresh.Get("func_type"), round.Get("func_type"))
 	}
 }

--- a/internal/metadata/metadata_test.go
+++ b/internal/metadata/metadata_test.go
@@ -1240,8 +1240,9 @@ func TestStringPool(t *testing.T) {
 	assert.Equal(t, "", pool.GetString(-1))
 	assert.Equal(t, "", pool.GetString(1000))
 
-	// Test size
-	assert.Equal(t, 2, pool.GetSize()) // "test" and "another"
+	// Test size: "test", "another", and the reserved empty slot 0 (#449)
+	assert.Equal(t, 3, pool.GetSize())
+	assert.Equal(t, "", pool.GetString(0))
 }
 
 // TestMethodChaining tests the ability to analyze method chaining patterns

--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -166,6 +166,19 @@ func (sp *StringPool) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 		sp.strings[s] = i
 	}
+	// A pool written before slot 0 was reserved is loaded exactly as written,
+	// slot 0 included, and that is deliberate.
+	//
+	// In such a file index 0 is a REAL value: the goldens from before this
+	// change reference `kind: 0` — meaning "ident" — a hundred times in one
+	// package. Shifting every index to insert "" would rewrite each of those
+	// into a different string, and refusing the file would reject data that
+	// reads back correctly. "0 means absent" and "0 means the string at slot
+	// 0" are indistinguishable once written, which is the bug itself; it can
+	// be prevented for new writes (every pool this code creates reserves the
+	// slot) but not diagnosed retroactively.
+	//
+	// TestStringPoolLegacyPoolLoadsAsWritten pins this.
 	sp.reserveEmpty()
 	return nil
 }

--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -72,21 +72,42 @@ type StringPool struct {
 }
 
 func NewStringPool() *StringPool {
-	return &StringPool{
+	sp := &StringPool{
 		strings: make(map[string]int, 1000), // Pre-allocate with estimated capacity
 		values:  make([]string, 0, 1000),    // Pre-allocate slice capacity
+	}
+	sp.reserveEmpty()
+	return sp
+}
+
+// reserveEmpty keeps slot 0 of the pool as the empty string, so that the Go
+// zero value of a pooled-index field means "no string" by construction.
+//
+// Without it, 0 is the first string interned in the run, so a struct literal
+// that omits an index field does not read as absent — it reads as whatever
+// that string happens to be. That shipped 211 junk `description` values in a
+// real spec (#448), was invisible in fixtures because the junk is plausible
+// prose ("literal", "func_type"), and moved between versions with interning
+// order, so it surfaced as unexplained drift rather than as a bug (#449).
+//
+// It is called from Get as well as the constructor: a pool built as a struct
+// literal would otherwise reintroduce exactly that, and the check costs one
+// length comparison.
+func (sp *StringPool) reserveEmpty() {
+	if len(sp.values) == 0 {
+		sp.values = append(sp.values, "")
 	}
 }
 
 // NoString is the index that means "no string here". Get returns it for the
 // empty string, and GetString maps it back to "".
 //
-// It is NOT zero: zero is a perfectly valid index (the first string pooled in
-// a run), so a struct that leaves a pooled-index field unset points at that
-// string rather than at nothing. Fields are therefore set explicitly to
-// NoString when absent — see buildAnonStructType, where the omission published
-// pool entry 0 as a doc comment (#448). Reserving slot 0 for "" would retire
-// the footgun itself; that is #449.
+// It is not zero, and zero is no longer a live index either: slot 0 of the pool
+// is reserved for "" (reserveEmpty, #449), so an unset field reads as absent
+// rather than as the first string interned in the run. Setting a field to
+// NoString explicitly when it is absent — as buildAnonStructType does, after
+// the omission published pool entry 0 as a doc comment (#448) — states the
+// intent at the site and does not rely on that reservation.
 const NoString = -1
 
 func (sp *StringPool) Get(s string) int {
@@ -102,6 +123,7 @@ func (sp *StringPool) Get(s string) int {
 		return NoString
 	}
 
+	sp.reserveEmpty()
 	idx := len(sp.values)
 	sp.strings[s] = idx
 	sp.values = append(sp.values, s)
@@ -115,7 +137,9 @@ func (sp *StringPool) GetString(idx int) string {
 	return ""
 }
 
-// GetSize returns the number of unique strings in the pool
+// GetSize returns the number of slots in the pool, which is one more than the
+// number of interned strings: slot 0 is the reserved empty string (#449). It
+// bounds a valid index, so callers iterating i < GetSize() stay in range.
 func (sp *StringPool) GetSize() int {
 	return len(sp.values)
 }
@@ -135,8 +159,14 @@ func (sp *StringPool) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	sp.values = values
 	sp.strings = make(map[string]int)
 	for i, s := range values {
+		// "" is never interned (Get returns NoString for it), so skipping it
+		// makes a round-tripped pool behave exactly like a fresh one.
+		if s == "" {
+			continue
+		}
 		sp.strings[s] = i
 	}
+	sp.reserveEmpty()
 	return nil
 }
 

--- a/internal/spec/extractor_test.go
+++ b/internal/spec/extractor_test.go
@@ -151,14 +151,18 @@ func TestContextProvider(t *testing.T) {
 	meta := &metadata.Metadata{
 		StringPool: metadata.NewStringPool(),
 	}
-	meta.StringPool.Get("test") // Add a string to the pool
+	idx := meta.StringPool.Get("test") // Add a string to the pool
 
 	contextProvider := NewContextProvider(meta)
 
-	// Test GetString
-	result := contextProvider.GetString(0)
+	// Test GetString. The index comes from Get rather than being written as 0:
+	// slot 0 is the reserved empty string (#449).
+	result := contextProvider.GetString(idx)
 	if result != "test" {
 		t.Errorf("Expected 'test', got '%s'", result)
+	}
+	if got := contextProvider.GetString(0); got != "" {
+		t.Errorf("slot 0 is reserved for the empty string, got %q", got)
 	}
 
 	// Test GetString with invalid index

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -709,6 +709,20 @@ func deduplicateParameters(params []Parameter) []Parameter {
 	seen := make(map[string]struct{})
 	result := make([]Parameter, 0, len(params))
 	for _, p := range params {
+		// A nameless inline parameter never reaches the document: OpenAPI
+		// requires `name`, and one without it cannot be sent, matched or
+		// validated, so emitting it makes the spec invalid while saying
+		// nothing. A $ref is exempt — it carries its name in the component it
+		// points at.
+		//
+		// These were previously emitted under whichever string sat at pool
+		// slot 0 (`name: func_type` on a real project), which read as a real
+		// header until slot 0 was reserved (#449) and left the name empty.
+		// This keeps the document valid; why a parameter is recorded with no
+		// name is #452.
+		if p.Name == "" && p.Ref == "" {
+			continue
+		}
 		key := p.Name + ":" + p.In
 		if _, exists := seen[key]; !exists {
 			seen[key] = struct{}{}

--- a/internal/spec/mapper_comprehensive_test.go
+++ b/internal/spec/mapper_comprehensive_test.go
@@ -760,6 +760,27 @@ func TestDeduplicateParameters_Comprehensive(t *testing.T) {
 			},
 			expected: 3,
 		},
+		{
+			// OpenAPI requires `name`, and a parameter without one cannot be
+			// sent, matched or validated — gitea published such a header
+			// parameter, readable only because the unset name index resolved
+			// to pool slot 0 ("func_type") before #449 reserved it. (#452)
+			name: "nameless_inline_param_dropped",
+			params: []Parameter{
+				{Name: "id", In: "path"},
+				{In: "header"},
+			},
+			expected: 1,
+		},
+		{
+			// A $ref is exempt: its name lives in the component it points at.
+			name: "nameless_ref_param_kept",
+			params: []Parameter{
+				{Ref: "#/components/parameters/PathParam"},
+				{In: "header"},
+			},
+			expected: 1,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/spec/tests/complex.yaml
+++ b/internal/spec/tests/complex.yaml
@@ -1,4 +1,5 @@
 string_pool:
+  - ""
   - ident
   - s
   - complex
@@ -114,25 +115,25 @@ packages:
       complex/service.go:
         types:
           Handler:
-            name: 60
-            pkg: 2
-            kind: 58
+            name: 61
+            pkg: 3
+            kind: 59
             fields:
-              - name: 42
-                type: 10
+              - name: 43
+                type: 11
                 tag: -1
-                scope: 33
+                scope: 34
                 comments: -1
-            scope: 15
+            scope: 16
             methods:
-              - name: 47
-                receiver: 55
+              - name: 48
+                receiver: 56
                 signature:
-                  kind: 12
+                  kind: 13
                   name: -1
                   value: -1
                   fun:
-                    kind: 13
+                    kind: 14
                     name: -1
                     value: -1
                     raw: -1
@@ -142,13 +143,13 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   args:
-                    - kind: 0
-                      name: 38
+                    - kind: 1
+                      name: 39
                       value: -1
                       raw: -1
                       pkg: -1
-                      type: 6
-                      position: 37
+                      type: 7
+                      position: 38
                       resolved_type: -1
                       generic_type_name: -1
                   raw: -1
@@ -157,231 +158,231 @@ packages:
                   position: -1
                   resolved_type: -1
                   generic_type_name: -1
-                signature_str: 57
-                position: 56
-                scope: 15
+                signature_str: 58
+                position: 57
+                scope: 16
                 comments: -1
-                filename: 16
+                filename: 17
                 assignments:
                   name:
-                    - variable_name: 5
-                      pkg: 2
-                      concrete_type: 6
-                      position: 46
-                      scope: 33
+                    - variable_name: 6
+                      pkg: 3
+                      concrete_type: 7
+                      position: 47
+                      scope: 34
                       value:
-                        kind: 31
+                        kind: 32
                         name: -1
                         value: -1
                         fun:
-                          kind: 8
+                          kind: 9
                           name: -1
                           value: -1
                           x:
-                            kind: 8
+                            kind: 9
                             name: -1
                             value: -1
                             x:
-                              kind: 0
-                              name: 39
+                              kind: 1
+                              name: 40
                               value: -1
                               raw: -1
-                              pkg: 2
-                              type: 40
-                              position: 41
+                              pkg: 3
+                              type: 41
+                              position: 42
                               resolved_type: -1
                               generic_type_name: -1
                             sel:
-                              kind: 0
-                              name: 42
+                              kind: 1
+                              name: 43
                               value: -1
                               raw: -1
-                              pkg: 2
-                              type: 3
-                              position: 43
+                              pkg: 3
+                              type: 4
+                              position: 44
                               resolved_type: -1
                               generic_type_name: -1
                             raw: -1
-                            pkg: 2
-                            type: 3
-                            position: 41
+                            pkg: 3
+                            type: 4
+                            position: 42
                             resolved_type: -1
                             generic_type_name: -1
                           sel:
-                            kind: 0
-                            name: 9
+                            kind: 1
+                            name: 10
                             value: -1
                             raw: -1
-                            pkg: 2
-                            type: 17
-                            position: 44
+                            pkg: 3
+                            type: 18
+                            position: 45
                             resolved_type: -1
                             generic_type_name: -1
                           raw: -1
-                          pkg: 2
-                          type: 17
-                          position: 41
+                          pkg: 3
+                          type: 18
+                          position: 42
                           resolved_type: -1
                           generic_type_name: -1
                           receiver_type:
-                            kind: 0
-                            name: 45
+                            kind: 1
+                            name: 46
                             value: -1
                             raw: -1
-                            pkg: 2
-                            type: 45
+                            pkg: 3
+                            type: 46
                             position: -1
                             resolved_type: -1
                             generic_type_name: -1
                         raw: -1
                         pkg: -1
-                        type: 6
-                        position: 41
+                        type: 7
+                        position: 42
                         resolved_type: -1
                         generic_type_name: -1
                       lhs:
-                        kind: 0
-                        name: 5
+                        kind: 1
+                        name: 6
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 6
-                        position: 46
+                        pkg: 3
+                        type: 7
+                        position: 47
                         resolved_type: -1
                         generic_type_name: -1
-                      func: 47
+                      func: 48
                       callee_func: GetName
                       callee_pkg: complex
                   processed:
-                    - variable_name: 53
-                      pkg: 2
-                      concrete_type: 6
-                      position: 54
-                      scope: 33
+                    - variable_name: 54
+                      pkg: 3
+                      concrete_type: 7
+                      position: 55
+                      scope: 34
                       value:
-                        kind: 31
+                        kind: 32
                         name: -1
                         value: -1
                         fun:
-                          kind: 8
+                          kind: 9
                           name: -1
                           value: -1
                           x:
-                            kind: 8
+                            kind: 9
                             name: -1
                             value: -1
                             x:
-                              kind: 0
-                              name: 39
+                              kind: 1
+                              name: 40
                               value: -1
                               raw: -1
-                              pkg: 2
-                              type: 40
-                              position: 49
-                              resolved_type: -1
-                              generic_type_name: -1
-                            sel:
-                              kind: 0
-                              name: 42
-                              value: -1
-                              raw: -1
-                              pkg: 2
-                              type: 3
+                              pkg: 3
+                              type: 41
                               position: 50
                               resolved_type: -1
                               generic_type_name: -1
+                            sel:
+                              kind: 1
+                              name: 43
+                              value: -1
+                              raw: -1
+                              pkg: 3
+                              type: 4
+                              position: 51
+                              resolved_type: -1
+                              generic_type_name: -1
                             raw: -1
-                            pkg: 2
-                            type: 3
-                            position: 49
+                            pkg: 3
+                            type: 4
+                            position: 50
                             resolved_type: -1
                             generic_type_name: -1
                           sel:
-                            kind: 0
-                            name: 34
+                            kind: 1
+                            name: 35
                             value: -1
                             raw: -1
-                            pkg: 2
-                            type: 51
-                            position: 52
+                            pkg: 3
+                            type: 52
+                            position: 53
                             resolved_type: -1
                             generic_type_name: -1
                           raw: -1
-                          pkg: 2
-                          type: 51
-                          position: 49
+                          pkg: 3
+                          type: 52
+                          position: 50
                           resolved_type: -1
                           generic_type_name: -1
                           receiver_type:
-                            kind: 0
-                            name: 45
+                            kind: 1
+                            name: 46
                             value: -1
                             raw: -1
-                            pkg: 2
-                            type: 45
+                            pkg: 3
+                            type: 46
                             position: -1
                             resolved_type: -1
                             generic_type_name: -1
                         args:
-                          - kind: 0
-                            name: 38
+                          - kind: 1
+                            name: 39
                             value: -1
                             raw: -1
-                            pkg: 2
-                            type: 6
-                            position: 48
+                            pkg: 3
+                            type: 7
+                            position: 49
                             resolved_type: -1
                             generic_type_name: -1
                         raw: -1
                         pkg: -1
-                        type: 6
-                        position: 49
+                        type: 7
+                        position: 50
                         resolved_type: -1
                         generic_type_name: -1
                       lhs:
-                        kind: 0
-                        name: 53
+                        kind: 1
+                        name: 54
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 6
-                        position: 54
+                        pkg: 3
+                        type: 7
+                        position: 55
                         resolved_type: -1
                         generic_type_name: -1
-                      func: 47
+                      func: 48
                       callee_func: Process
                       callee_pkg: complex
             comments: -1
           Service:
-            name: 45
-            pkg: 2
-            kind: 58
+            name: 46
+            pkg: 3
+            kind: 59
             fields:
-              - name: 5
-                type: 6
+              - name: 6
+                type: 7
                 tag: -1
-                scope: 33
+                scope: 34
                 comments: -1
-            scope: 15
+            scope: 16
             methods:
-              - name: 9
-                receiver: 10
+              - name: 10
+                receiver: 11
                 signature:
-                  kind: 12
+                  kind: 13
                   name: -1
                   value: -1
                   fun:
-                    kind: 13
+                    kind: 14
                     name: -1
                     value: -1
                     args:
-                      - kind: 0
-                        name: 6
+                      - kind: 1
+                        name: 7
                         value: -1
                         raw: -1
                         pkg: -1
-                        type: 6
-                        position: 11
+                        type: 7
+                        position: 12
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
@@ -394,91 +395,91 @@ packages:
                   pkg: -1
                   type: -1
                   position: -1
-                  resolved_type: 6
+                  resolved_type: 7
                   generic_type_name: -1
-                signature_str: 17
-                position: 14
-                scope: 15
+                signature_str: 18
+                position: 15
+                scope: 16
                 comments: -1
-                filename: 16
+                filename: 17
                 return_vars:
-                  - kind: 8
+                  - kind: 9
                     name: -1
                     value: -1
                     x:
-                      kind: 0
-                      name: 1
+                      kind: 1
+                      name: 2
                       value: -1
                       raw: -1
-                      pkg: 2
-                      type: 3
-                      position: 4
+                      pkg: 3
+                      type: 4
+                      position: 5
                       resolved_type: -1
                       generic_type_name: -1
                     sel:
-                      kind: 0
-                      name: 5
+                      kind: 1
+                      name: 6
                       value: -1
                       raw: -1
-                      pkg: 2
-                      type: 6
-                      position: 7
+                      pkg: 3
+                      type: 7
+                      position: 8
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
-                    pkg: 2
-                    type: 6
-                    position: 4
+                    pkg: 3
+                    type: 7
+                    position: 5
                     resolved_type: -1
                     generic_type_name: -1
                 returns:
-                  - - kind: 8
+                  - - kind: 9
                       name: -1
                       value: -1
                       x:
-                        kind: 0
-                        name: 1
+                        kind: 1
+                        name: 2
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 3
-                        position: 4
+                        pkg: 3
+                        type: 4
+                        position: 5
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 0
-                        name: 5
-                        value: -1
-                        raw: -1
-                        pkg: 2
-                        type: 6
-                        position: 7
-                        resolved_type: -1
-                        generic_type_name: -1
-                      raw: -1
-                      pkg: 2
-                      type: 6
-                      position: 4
-                      resolved_type: -1
-                      generic_type_name: -1
-              - name: 34
-                receiver: 10
-                signature:
-                  kind: 12
-                  name: -1
-                  value: -1
-                  fun:
-                    kind: 13
-                    name: -1
-                    value: -1
-                    args:
-                      - kind: 0
+                        kind: 1
                         name: 6
                         value: -1
                         raw: -1
+                        pkg: 3
+                        type: 7
+                        position: 8
+                        resolved_type: -1
+                        generic_type_name: -1
+                      raw: -1
+                      pkg: 3
+                      type: 7
+                      position: 5
+                      resolved_type: -1
+                      generic_type_name: -1
+              - name: 35
+                receiver: 11
+                signature:
+                  kind: 13
+                  name: -1
+                  value: -1
+                  fun:
+                    kind: 14
+                    name: -1
+                    value: -1
+                    args:
+                      - kind: 1
+                        name: 7
+                        value: -1
+                        raw: -1
                         pkg: -1
-                        type: 6
-                        position: 22
+                        type: 7
+                        position: 23
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
@@ -488,156 +489,156 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   args:
-                    - kind: 0
-                      name: 21
+                    - kind: 1
+                      name: 22
                       value: -1
                       raw: -1
                       pkg: -1
-                      type: 6
-                      position: 20
+                      type: 7
+                      position: 21
                       resolved_type: -1
                       generic_type_name: -1
                   raw: -1
                   pkg: -1
                   type: -1
                   position: -1
-                  resolved_type: 6
+                  resolved_type: 7
                   generic_type_name: -1
-                signature_str: 36
-                position: 35
-                scope: 15
+                signature_str: 37
+                position: 36
+                scope: 16
                 comments: -1
-                filename: 16
+                filename: 17
                 return_vars:
-                  - kind: 0
-                    name: 18
+                  - kind: 1
+                    name: 19
                     value: -1
                     raw: -1
-                    pkg: 2
-                    type: 6
-                    position: 19
+                    pkg: 3
+                    type: 7
+                    position: 20
                     resolved_type: -1
                     generic_type_name: -1
                 returns:
-                  - - kind: 0
-                      name: 18
+                  - - kind: 1
+                      name: 19
                       value: -1
                       raw: -1
-                      pkg: 2
-                      type: 6
-                      position: 19
+                      pkg: 3
+                      type: 7
+                      position: 20
                       resolved_type: -1
                       generic_type_name: -1
                 assignments:
                   result:
-                    - variable_name: 18
-                      pkg: 2
-                      concrete_type: 6
-                      position: 32
-                      scope: 33
+                    - variable_name: 19
+                      pkg: 3
+                      concrete_type: 7
+                      position: 33
+                      scope: 34
                       value:
-                        kind: 31
+                        kind: 32
                         name: -1
                         value: -1
                         fun:
-                          kind: 8
+                          kind: 9
                           name: -1
                           value: -1
                           x:
-                            kind: 0
-                            name: 26
+                            kind: 1
+                            name: 27
                             value: -1
                             raw: -1
-                            pkg: 26
+                            pkg: 27
                             type: -1
-                            position: 27
+                            position: 28
                             resolved_type: -1
                             generic_type_name: -1
                           sel:
-                            kind: 0
-                            name: 28
+                            kind: 1
+                            name: 29
                             value: -1
                             raw: -1
-                            pkg: 26
-                            type: 29
-                            position: 30
+                            pkg: 27
+                            type: 30
+                            position: 31
                             resolved_type: -1
                             generic_type_name: -1
                           raw: -1
-                          pkg: 26
-                          type: 29
-                          position: 27
+                          pkg: 27
+                          type: 30
+                          position: 28
                           resolved_type: -1
                           generic_type_name: -1
                         args:
-                          - kind: 23
+                          - kind: 24
                             name: -1
-                            value: 24
+                            value: 25
                             raw: -1
                             pkg: -1
                             type: -1
                             position: -1
                             resolved_type: -1
                             generic_type_name: -1
-                          - kind: 0
-                            name: 21
+                          - kind: 1
+                            name: 22
                             value: -1
                             raw: -1
-                            pkg: 2
-                            type: 6
-                            position: 25
+                            pkg: 3
+                            type: 7
+                            position: 26
                             resolved_type: -1
                             generic_type_name: -1
                         raw: -1
                         pkg: -1
-                        type: 6
-                        position: 27
+                        type: 7
+                        position: 28
                         resolved_type: -1
                         generic_type_name: -1
                       lhs:
-                        kind: 0
-                        name: 18
+                        kind: 1
+                        name: 19
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 6
-                        position: 32
+                        pkg: 3
+                        type: 7
+                        position: 33
                         resolved_type: -1
                         generic_type_name: -1
-                      func: 34
+                      func: 35
                       callee_func: Sprintf
                       callee_pkg: fmt
             comments: -1
         functions:
           NewHandler:
-            name: 81
-            pkg: 2
+            name: 82
+            pkg: 3
             signature:
-              kind: 12
+              kind: 13
               name: -1
               value: -1
               fun:
-                kind: 13
+                kind: 14
                 name: -1
                 value: -1
                 args:
-                  - kind: 72
+                  - kind: 73
                     name: -1
                     value: -1
                     x:
-                      kind: 0
-                      name: 60
+                      kind: 1
+                      name: 61
                       value: -1
                       raw: -1
-                      pkg: 2
-                      type: 60
-                      position: 84
+                      pkg: 3
+                      type: 61
+                      position: 85
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
                     pkg: -1
                     type: -1
-                    position: 85
+                    position: 86
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -647,185 +648,185 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 72
-                  name: 78
+                - kind: 73
+                  name: 79
                   value: -1
                   x:
-                    kind: 0
-                    name: 45
+                    kind: 1
+                    name: 46
                     value: -1
                     raw: -1
-                    pkg: 2
-                    type: 45
-                    position: 82
+                    pkg: 3
+                    type: 46
+                    position: 83
                     resolved_type: -1
                     generic_type_name: -1
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 83
+                  position: 84
                   resolved_type: -1
                   generic_type_name: -1
               raw: -1
               pkg: -1
               type: -1
               position: -1
-              resolved_type: 55
+              resolved_type: 56
               generic_type_name: -1
-            signature_str: 87
-            position: 86
-            scope: 15
+            signature_str: 88
+            position: 87
+            scope: 16
             comments: -1
             return_vars:
-              - kind: 66
+              - kind: 67
                 name: -1
-                value: 67
+                value: 68
                 x:
-                  kind: 65
+                  kind: 66
                   name: -1
                   value: -1
                   x:
-                    kind: 0
-                    name: 60
+                    kind: 1
+                    name: 61
                     value: -1
                     raw: -1
-                    pkg: 2
-                    type: 60
-                    position: 76
+                    pkg: 3
+                    type: 61
+                    position: 77
                     resolved_type: -1
                     generic_type_name: -1
                   args:
-                    - kind: 64
+                    - kind: 65
                       name: -1
                       value: -1
                       x:
-                        kind: 0
-                        name: 42
+                        kind: 1
+                        name: 43
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 3
-                        position: 77
+                        pkg: 3
+                        type: 4
+                        position: 78
                         resolved_type: -1
                         generic_type_name: -1
                       fun:
-                        kind: 0
-                        name: 78
+                        kind: 1
+                        name: 79
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 3
-                        position: 79
+                        pkg: 3
+                        type: 4
+                        position: 80
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
                       pkg: -1
                       type: -1
-                      position: 77
+                      position: 78
                       resolved_type: -1
                       generic_type_name: -1
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 76
+                  position: 77
                   resolved_type: -1
                   generic_type_name: -1
                 raw: -1
                 pkg: -1
                 type: -1
-                position: 80
+                position: 81
                 resolved_type: -1
                 generic_type_name: -1
             returns:
-              - - kind: 66
+              - - kind: 67
                   name: -1
-                  value: 67
+                  value: 68
                   x:
-                    kind: 65
+                    kind: 66
                     name: -1
                     value: -1
                     x:
-                      kind: 0
-                      name: 60
+                      kind: 1
+                      name: 61
                       value: -1
                       raw: -1
-                      pkg: 2
-                      type: 60
-                      position: 76
+                      pkg: 3
+                      type: 61
+                      position: 77
                       resolved_type: -1
                       generic_type_name: -1
                     args:
-                      - kind: 64
+                      - kind: 65
                         name: -1
                         value: -1
                         x:
-                          kind: 0
-                          name: 42
+                          kind: 1
+                          name: 43
                           value: -1
                           raw: -1
-                          pkg: 2
-                          type: 3
-                          position: 77
+                          pkg: 3
+                          type: 4
+                          position: 78
                           resolved_type: -1
                           generic_type_name: -1
                         fun:
-                          kind: 0
-                          name: 78
+                          kind: 1
+                          name: 79
                           value: -1
                           raw: -1
-                          pkg: 2
-                          type: 3
-                          position: 79
+                          pkg: 3
+                          type: 4
+                          position: 80
                           resolved_type: -1
                           generic_type_name: -1
                         raw: -1
                         pkg: -1
                         type: -1
-                        position: 77
+                        position: 78
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
                     pkg: -1
                     type: -1
-                    position: 76
+                    position: 77
                     resolved_type: -1
                     generic_type_name: -1
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 80
+                  position: 81
                   resolved_type: -1
                   generic_type_name: -1
             end_line: 34
           NewService:
-            name: 69
-            pkg: 2
+            name: 70
+            pkg: 3
             signature:
-              kind: 12
+              kind: 13
               name: -1
               value: -1
               fun:
-                kind: 13
+                kind: 14
                 name: -1
                 value: -1
                 args:
-                  - kind: 72
+                  - kind: 73
                     name: -1
                     value: -1
                     x:
-                      kind: 0
-                      name: 45
+                      kind: 1
+                      name: 46
                       value: -1
                       raw: -1
-                      pkg: 2
-                      type: 45
-                      position: 71
+                      pkg: 3
+                      type: 46
+                      position: 72
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
                     pkg: -1
                     type: -1
-                    position: 73
+                    position: 74
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -835,155 +836,155 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 0
-                  name: 5
+                - kind: 1
+                  name: 6
                   value: -1
                   raw: -1
                   pkg: -1
-                  type: 6
-                  position: 70
+                  type: 7
+                  position: 71
                   resolved_type: -1
                   generic_type_name: -1
               raw: -1
               pkg: -1
               type: -1
               position: -1
-              resolved_type: 10
+              resolved_type: 11
               generic_type_name: -1
-            signature_str: 75
-            position: 74
-            scope: 15
+            signature_str: 76
+            position: 75
+            scope: 16
             comments: -1
             return_vars:
-              - kind: 66
+              - kind: 67
                 name: -1
-                value: 67
+                value: 68
                 x:
-                  kind: 65
+                  kind: 66
                   name: -1
                   value: -1
                   x:
-                    kind: 0
-                    name: 45
+                    kind: 1
+                    name: 46
                     value: -1
                     raw: -1
-                    pkg: 2
-                    type: 45
-                    position: 61
+                    pkg: 3
+                    type: 46
+                    position: 62
                     resolved_type: -1
                     generic_type_name: -1
                   args:
-                    - kind: 64
+                    - kind: 65
                       name: -1
                       value: -1
                       x:
-                        kind: 0
-                        name: 5
+                        kind: 1
+                        name: 6
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 6
-                        position: 62
+                        pkg: 3
+                        type: 7
+                        position: 63
                         resolved_type: -1
                         generic_type_name: -1
                       fun:
-                        kind: 0
-                        name: 5
+                        kind: 1
+                        name: 6
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 6
-                        position: 63
+                        pkg: 3
+                        type: 7
+                        position: 64
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
                       pkg: -1
                       type: -1
-                      position: 62
+                      position: 63
                       resolved_type: -1
                       generic_type_name: -1
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 61
+                  position: 62
                   resolved_type: -1
                   generic_type_name: -1
                 raw: -1
                 pkg: -1
                 type: -1
-                position: 68
+                position: 69
                 resolved_type: -1
                 generic_type_name: -1
             returns:
-              - - kind: 66
+              - - kind: 67
                   name: -1
-                  value: 67
+                  value: 68
                   x:
-                    kind: 65
+                    kind: 66
                     name: -1
                     value: -1
                     x:
-                      kind: 0
-                      name: 45
+                      kind: 1
+                      name: 46
                       value: -1
                       raw: -1
-                      pkg: 2
-                      type: 45
-                      position: 61
+                      pkg: 3
+                      type: 46
+                      position: 62
                       resolved_type: -1
                       generic_type_name: -1
                     args:
-                      - kind: 64
+                      - kind: 65
                         name: -1
                         value: -1
                         x:
-                          kind: 0
-                          name: 5
+                          kind: 1
+                          name: 6
                           value: -1
                           raw: -1
-                          pkg: 2
-                          type: 6
-                          position: 62
+                          pkg: 3
+                          type: 7
+                          position: 63
                           resolved_type: -1
                           generic_type_name: -1
                         fun:
-                          kind: 0
-                          name: 5
+                          kind: 1
+                          name: 6
                           value: -1
                           raw: -1
-                          pkg: 2
-                          type: 6
-                          position: 63
+                          pkg: 3
+                          type: 7
+                          position: 64
                           resolved_type: -1
                           generic_type_name: -1
                         raw: -1
                         pkg: -1
                         type: -1
-                        position: 62
+                        position: 63
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
                     pkg: -1
                     type: -1
-                    position: 61
+                    position: 62
                     resolved_type: -1
                     generic_type_name: -1
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 68
+                  position: 69
                   resolved_type: -1
                   generic_type_name: -1
             end_line: 30
           main:
-            name: 92
-            pkg: 2
+            name: 93
+            pkg: 3
             signature:
-              kind: 12
+              kind: 13
               name: -1
               value: -1
               fun:
-                kind: 13
+                kind: 14
                 name: -1
                 value: -1
                 raw: -1
@@ -998,84 +999,84 @@ packages:
               position: -1
               resolved_type: -1
               generic_type_name: -1
-            signature_str: 99
-            position: 98
-            scope: 33
+            signature_str: 100
+            position: 99
+            scope: 34
             comments: -1
             assignments:
               handler:
-                - variable_name: 96
-                  pkg: 2
-                  concrete_type: 40
-                  position: 97
-                  scope: 33
+                - variable_name: 97
+                  pkg: 3
+                  concrete_type: 41
+                  position: 98
+                  scope: 34
                   value:
-                    kind: 31
+                    kind: 32
                     name: -1
                     value: -1
                     fun:
-                      kind: 0
-                      name: 81
+                      kind: 1
+                      name: 82
                       value: -1
                       raw: -1
-                      pkg: 2
-                      type: 94
-                      position: 95
+                      pkg: 3
+                      type: 95
+                      position: 96
                       resolved_type: -1
                       generic_type_name: -1
                     args:
-                      - kind: 0
-                        name: 78
+                      - kind: 1
+                        name: 79
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 3
-                        position: 93
+                        pkg: 3
+                        type: 4
+                        position: 94
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
                     pkg: -1
-                    type: 40
-                    position: 95
+                    type: 41
+                    position: 96
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 0
-                    name: 96
+                    kind: 1
+                    name: 97
                     value: -1
                     raw: -1
-                    pkg: 2
-                    type: 40
-                    position: 97
+                    pkg: 3
+                    type: 41
+                    position: 98
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 92
+                  func: 93
                   callee_func: NewHandler
                   callee_pkg: complex
               svc:
-                - variable_name: 78
-                  pkg: 2
-                  concrete_type: 3
-                  position: 91
-                  scope: 33
+                - variable_name: 79
+                  pkg: 3
+                  concrete_type: 4
+                  position: 92
+                  scope: 34
                   value:
-                    kind: 31
+                    kind: 32
                     name: -1
                     value: -1
                     fun:
-                      kind: 0
-                      name: 69
+                      kind: 1
+                      name: 70
                       value: -1
                       raw: -1
-                      pkg: 2
-                      type: 89
-                      position: 90
+                      pkg: 3
+                      type: 90
+                      position: 91
                       resolved_type: -1
                       generic_type_name: -1
                     args:
-                      - kind: 23
+                      - kind: 24
                         name: -1
-                        value: 88
+                        value: 89
                         raw: -1
                         pkg: -1
                         type: -1
@@ -1084,58 +1085,58 @@ packages:
                         generic_type_name: -1
                     raw: -1
                     pkg: -1
-                    type: 3
-                    position: 90
-                    resolved_type: -1
-                    generic_type_name: -1
-                  lhs:
-                    kind: 0
-                    name: 78
-                    value: -1
-                    raw: -1
-                    pkg: 2
-                    type: 3
+                    type: 4
                     position: 91
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 92
+                  lhs:
+                    kind: 1
+                    name: 79
+                    value: -1
+                    raw: -1
+                    pkg: 3
+                    type: 4
+                    position: 92
+                    resolved_type: -1
+                    generic_type_name: -1
+                  func: 93
                   callee_func: NewService
                   callee_pkg: complex
             end_line: 40
         struct_instances:
-          - type: 45
-            pkg: 2
-            position: 61
+          - type: 46
+            pkg: 3
+            position: 62
             fields:
-              5: 5
-          - type: 60
-            pkg: 2
-            position: 76
+              6: 6
+          - type: 61
+            pkg: 3
+            position: 77
             fields:
-              42: 78
+              43: 79
         imports:
-          26: 26
+          27: 27
     types:
       Handler:
-        name: 60
-        pkg: 2
-        kind: 58
+        name: 61
+        pkg: 3
+        kind: 59
         fields:
-          - name: 42
-            type: 10
+          - name: 43
+            type: 11
             tag: -1
-            scope: 33
+            scope: 34
             comments: -1
-        scope: 15
+        scope: 16
         methods:
-          - name: 47
-            receiver: 55
+          - name: 48
+            receiver: 56
             signature:
-              kind: 12
+              kind: 13
               name: -1
               value: -1
               fun:
-                kind: 13
+                kind: 14
                 name: -1
                 value: -1
                 raw: -1
@@ -1145,13 +1146,13 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 0
-                  name: 38
+                - kind: 1
+                  name: 39
                   value: -1
                   raw: -1
                   pkg: -1
-                  type: 6
-                  position: 37
+                  type: 7
+                  position: 38
                   resolved_type: -1
                   generic_type_name: -1
               raw: -1
@@ -1160,231 +1161,231 @@ packages:
               position: -1
               resolved_type: -1
               generic_type_name: -1
-            signature_str: 57
-            position: 56
-            scope: 15
+            signature_str: 58
+            position: 57
+            scope: 16
             comments: -1
-            filename: 16
+            filename: 17
             assignments:
               name:
-                - variable_name: 5
-                  pkg: 2
-                  concrete_type: 6
-                  position: 46
-                  scope: 33
+                - variable_name: 6
+                  pkg: 3
+                  concrete_type: 7
+                  position: 47
+                  scope: 34
                   value:
-                    kind: 31
+                    kind: 32
                     name: -1
                     value: -1
                     fun:
-                      kind: 8
+                      kind: 9
                       name: -1
                       value: -1
                       x:
-                        kind: 8
+                        kind: 9
                         name: -1
                         value: -1
                         x:
-                          kind: 0
-                          name: 39
+                          kind: 1
+                          name: 40
                           value: -1
                           raw: -1
-                          pkg: 2
-                          type: 40
-                          position: 41
+                          pkg: 3
+                          type: 41
+                          position: 42
                           resolved_type: -1
                           generic_type_name: -1
                         sel:
-                          kind: 0
-                          name: 42
+                          kind: 1
+                          name: 43
                           value: -1
                           raw: -1
-                          pkg: 2
-                          type: 3
-                          position: 43
+                          pkg: 3
+                          type: 4
+                          position: 44
                           resolved_type: -1
                           generic_type_name: -1
                         raw: -1
-                        pkg: 2
-                        type: 3
-                        position: 41
+                        pkg: 3
+                        type: 4
+                        position: 42
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 0
-                        name: 9
+                        kind: 1
+                        name: 10
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 17
-                        position: 44
+                        pkg: 3
+                        type: 18
+                        position: 45
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 2
-                      type: 17
-                      position: 41
+                      pkg: 3
+                      type: 18
+                      position: 42
                       resolved_type: -1
                       generic_type_name: -1
                       receiver_type:
-                        kind: 0
-                        name: 45
+                        kind: 1
+                        name: 46
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 45
+                        pkg: 3
+                        type: 46
                         position: -1
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
                     pkg: -1
-                    type: 6
-                    position: 41
+                    type: 7
+                    position: 42
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 0
-                    name: 5
+                    kind: 1
+                    name: 6
                     value: -1
                     raw: -1
-                    pkg: 2
-                    type: 6
-                    position: 46
+                    pkg: 3
+                    type: 7
+                    position: 47
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 47
+                  func: 48
                   callee_func: GetName
                   callee_pkg: complex
               processed:
-                - variable_name: 53
-                  pkg: 2
-                  concrete_type: 6
-                  position: 54
-                  scope: 33
+                - variable_name: 54
+                  pkg: 3
+                  concrete_type: 7
+                  position: 55
+                  scope: 34
                   value:
-                    kind: 31
+                    kind: 32
                     name: -1
                     value: -1
                     fun:
-                      kind: 8
+                      kind: 9
                       name: -1
                       value: -1
                       x:
-                        kind: 8
+                        kind: 9
                         name: -1
                         value: -1
                         x:
-                          kind: 0
-                          name: 39
+                          kind: 1
+                          name: 40
                           value: -1
                           raw: -1
-                          pkg: 2
-                          type: 40
-                          position: 49
-                          resolved_type: -1
-                          generic_type_name: -1
-                        sel:
-                          kind: 0
-                          name: 42
-                          value: -1
-                          raw: -1
-                          pkg: 2
-                          type: 3
+                          pkg: 3
+                          type: 41
                           position: 50
                           resolved_type: -1
                           generic_type_name: -1
+                        sel:
+                          kind: 1
+                          name: 43
+                          value: -1
+                          raw: -1
+                          pkg: 3
+                          type: 4
+                          position: 51
+                          resolved_type: -1
+                          generic_type_name: -1
                         raw: -1
-                        pkg: 2
-                        type: 3
-                        position: 49
+                        pkg: 3
+                        type: 4
+                        position: 50
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 0
-                        name: 34
+                        kind: 1
+                        name: 35
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 51
-                        position: 52
+                        pkg: 3
+                        type: 52
+                        position: 53
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 2
-                      type: 51
-                      position: 49
+                      pkg: 3
+                      type: 52
+                      position: 50
                       resolved_type: -1
                       generic_type_name: -1
                       receiver_type:
-                        kind: 0
-                        name: 45
+                        kind: 1
+                        name: 46
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 45
+                        pkg: 3
+                        type: 46
                         position: -1
                         resolved_type: -1
                         generic_type_name: -1
                     args:
-                      - kind: 0
-                        name: 38
+                      - kind: 1
+                        name: 39
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 6
-                        position: 48
+                        pkg: 3
+                        type: 7
+                        position: 49
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
                     pkg: -1
-                    type: 6
-                    position: 49
+                    type: 7
+                    position: 50
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 0
-                    name: 53
+                    kind: 1
+                    name: 54
                     value: -1
                     raw: -1
-                    pkg: 2
-                    type: 6
-                    position: 54
+                    pkg: 3
+                    type: 7
+                    position: 55
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 47
+                  func: 48
                   callee_func: Process
                   callee_pkg: complex
         comments: -1
       Service:
-        name: 45
-        pkg: 2
-        kind: 58
+        name: 46
+        pkg: 3
+        kind: 59
         fields:
-          - name: 5
-            type: 6
+          - name: 6
+            type: 7
             tag: -1
-            scope: 33
+            scope: 34
             comments: -1
-        scope: 15
+        scope: 16
         methods:
-          - name: 9
-            receiver: 10
+          - name: 10
+            receiver: 11
             signature:
-              kind: 12
+              kind: 13
               name: -1
               value: -1
               fun:
-                kind: 13
+                kind: 14
                 name: -1
                 value: -1
                 args:
-                  - kind: 0
-                    name: 6
+                  - kind: 1
+                    name: 7
                     value: -1
                     raw: -1
                     pkg: -1
-                    type: 6
-                    position: 11
+                    type: 7
+                    position: 12
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -1397,91 +1398,91 @@ packages:
               pkg: -1
               type: -1
               position: -1
-              resolved_type: 6
+              resolved_type: 7
               generic_type_name: -1
-            signature_str: 17
-            position: 14
-            scope: 15
+            signature_str: 18
+            position: 15
+            scope: 16
             comments: -1
-            filename: 16
+            filename: 17
             return_vars:
-              - kind: 8
+              - kind: 9
                 name: -1
                 value: -1
                 x:
-                  kind: 0
-                  name: 1
+                  kind: 1
+                  name: 2
                   value: -1
                   raw: -1
-                  pkg: 2
-                  type: 3
-                  position: 4
+                  pkg: 3
+                  type: 4
+                  position: 5
                   resolved_type: -1
                   generic_type_name: -1
                 sel:
-                  kind: 0
-                  name: 5
+                  kind: 1
+                  name: 6
                   value: -1
                   raw: -1
-                  pkg: 2
-                  type: 6
-                  position: 7
+                  pkg: 3
+                  type: 7
+                  position: 8
                   resolved_type: -1
                   generic_type_name: -1
                 raw: -1
-                pkg: 2
-                type: 6
-                position: 4
+                pkg: 3
+                type: 7
+                position: 5
                 resolved_type: -1
                 generic_type_name: -1
             returns:
-              - - kind: 8
+              - - kind: 9
                   name: -1
                   value: -1
                   x:
-                    kind: 0
-                    name: 1
+                    kind: 1
+                    name: 2
                     value: -1
                     raw: -1
-                    pkg: 2
-                    type: 3
-                    position: 4
+                    pkg: 3
+                    type: 4
+                    position: 5
                     resolved_type: -1
                     generic_type_name: -1
                   sel:
-                    kind: 0
-                    name: 5
-                    value: -1
-                    raw: -1
-                    pkg: 2
-                    type: 6
-                    position: 7
-                    resolved_type: -1
-                    generic_type_name: -1
-                  raw: -1
-                  pkg: 2
-                  type: 6
-                  position: 4
-                  resolved_type: -1
-                  generic_type_name: -1
-          - name: 34
-            receiver: 10
-            signature:
-              kind: 12
-              name: -1
-              value: -1
-              fun:
-                kind: 13
-                name: -1
-                value: -1
-                args:
-                  - kind: 0
+                    kind: 1
                     name: 6
                     value: -1
                     raw: -1
+                    pkg: 3
+                    type: 7
+                    position: 8
+                    resolved_type: -1
+                    generic_type_name: -1
+                  raw: -1
+                  pkg: 3
+                  type: 7
+                  position: 5
+                  resolved_type: -1
+                  generic_type_name: -1
+          - name: 35
+            receiver: 11
+            signature:
+              kind: 13
+              name: -1
+              value: -1
+              fun:
+                kind: 14
+                name: -1
+                value: -1
+                args:
+                  - kind: 1
+                    name: 7
+                    value: -1
+                    raw: -1
                     pkg: -1
-                    type: 6
-                    position: 22
+                    type: 7
+                    position: 23
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -1491,176 +1492,176 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 0
-                  name: 21
+                - kind: 1
+                  name: 22
                   value: -1
                   raw: -1
                   pkg: -1
-                  type: 6
-                  position: 20
+                  type: 7
+                  position: 21
                   resolved_type: -1
                   generic_type_name: -1
               raw: -1
               pkg: -1
               type: -1
               position: -1
-              resolved_type: 6
+              resolved_type: 7
               generic_type_name: -1
-            signature_str: 36
-            position: 35
-            scope: 15
+            signature_str: 37
+            position: 36
+            scope: 16
             comments: -1
-            filename: 16
+            filename: 17
             return_vars:
-              - kind: 0
-                name: 18
+              - kind: 1
+                name: 19
                 value: -1
                 raw: -1
-                pkg: 2
-                type: 6
-                position: 19
+                pkg: 3
+                type: 7
+                position: 20
                 resolved_type: -1
                 generic_type_name: -1
             returns:
-              - - kind: 0
-                  name: 18
+              - - kind: 1
+                  name: 19
                   value: -1
                   raw: -1
-                  pkg: 2
-                  type: 6
-                  position: 19
+                  pkg: 3
+                  type: 7
+                  position: 20
                   resolved_type: -1
                   generic_type_name: -1
             assignments:
               result:
-                - variable_name: 18
-                  pkg: 2
-                  concrete_type: 6
-                  position: 32
-                  scope: 33
+                - variable_name: 19
+                  pkg: 3
+                  concrete_type: 7
+                  position: 33
+                  scope: 34
                   value:
-                    kind: 31
+                    kind: 32
                     name: -1
                     value: -1
                     fun:
-                      kind: 8
+                      kind: 9
                       name: -1
                       value: -1
                       x:
-                        kind: 0
-                        name: 26
+                        kind: 1
+                        name: 27
                         value: -1
                         raw: -1
-                        pkg: 26
+                        pkg: 27
                         type: -1
-                        position: 27
+                        position: 28
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 0
-                        name: 28
+                        kind: 1
+                        name: 29
                         value: -1
                         raw: -1
-                        pkg: 26
-                        type: 29
-                        position: 30
+                        pkg: 27
+                        type: 30
+                        position: 31
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 26
-                      type: 29
-                      position: 27
+                      pkg: 27
+                      type: 30
+                      position: 28
                       resolved_type: -1
                       generic_type_name: -1
                     args:
-                      - kind: 23
+                      - kind: 24
                         name: -1
-                        value: 24
+                        value: 25
                         raw: -1
                         pkg: -1
                         type: -1
                         position: -1
                         resolved_type: -1
                         generic_type_name: -1
-                      - kind: 0
-                        name: 21
+                      - kind: 1
+                        name: 22
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 6
-                        position: 25
+                        pkg: 3
+                        type: 7
+                        position: 26
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
                     pkg: -1
-                    type: 6
-                    position: 27
+                    type: 7
+                    position: 28
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 0
-                    name: 18
+                    kind: 1
+                    name: 19
                     value: -1
                     raw: -1
-                    pkg: 2
-                    type: 6
-                    position: 32
+                    pkg: 3
+                    type: 7
+                    position: 33
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 34
+                  func: 35
                   callee_func: Sprintf
                   callee_pkg: fmt
         comments: -1
 call_graph:
   - caller:
-      name: 34
-      pkg: 2
+      name: 35
+      pkg: 3
       position: -1
-      recv_type: 10
-      scope: 15
-      signature_str: 36
+      recv_type: 11
+      scope: 16
+      signature_str: 37
     callee:
-      name: 28
-      pkg: 26
-      position: 27
+      name: 29
+      pkg: 27
+      position: 28
       recv_type: -1
-      scope: 15
-      signature_str: 29
-    position: 27
+      scope: 16
+      signature_str: 30
+    position: 28
     args:
-      - kind: 23
+      - kind: 24
         name: -1
-        value: 24
+        value: 25
         raw: -1
         pkg: -1
         type: -1
         position: -1
         resolved_type: -1
         generic_type_name: -1
-      - kind: 0
-        name: 21
+      - kind: 1
+        name: 22
         value: -1
         raw: -1
-        pkg: 2
-        type: 6
-        position: 25
+        pkg: 3
+        type: 7
+        position: 26
         resolved_type: -1
         generic_type_name: -1
     param_arg_map:
       a:
-        kind: 0
-        name: 21
+        kind: 1
+        name: 22
         value: -1
         raw: -1
-        pkg: 2
-        type: 6
-        position: 25
+        pkg: 3
+        type: 7
+        position: 26
         resolved_type: -1
         generic_type_name: -1
       format:
-        kind: 23
+        kind: 24
         name: -1
-        value: 24
+        value: 25
         raw: -1
         pkg: -1
         type: -1
@@ -1669,195 +1670,195 @@ call_graph:
         generic_type_name: -1
     callee_recv_var_name: result
   - caller:
-      name: 47
-      pkg: 2
+      name: 48
+      pkg: 3
       position: -1
-      recv_type: 55
-      scope: 15
-      signature_str: 57
+      recv_type: 56
+      scope: 16
+      signature_str: 58
     callee:
-      name: 9
-      pkg: 2
-      position: 41
-      recv_type: 10
-      scope: 15
-      signature_str: 17
-    position: 41
+      name: 10
+      pkg: 3
+      position: 42
+      recv_type: 11
+      scope: 16
+      signature_str: 18
+    position: 42
     callee_recv_var_name: name
   - caller:
-      name: 47
-      pkg: 2
+      name: 48
+      pkg: 3
       position: -1
-      recv_type: 55
-      scope: 15
-      signature_str: 57
+      recv_type: 56
+      scope: 16
+      signature_str: 58
     callee:
-      name: 34
-      pkg: 2
-      position: 49
-      recv_type: 10
-      scope: 15
-      signature_str: 51
-    position: 49
+      name: 35
+      pkg: 3
+      position: 50
+      recv_type: 11
+      scope: 16
+      signature_str: 52
+    position: 50
     args:
-      - kind: 0
-        name: 38
+      - kind: 1
+        name: 39
         value: -1
         raw: -1
-        pkg: 2
-        type: 6
-        position: 48
+        pkg: 3
+        type: 7
+        position: 49
         resolved_type: -1
         generic_type_name: -1
     assignments:
       result:
-        - variable_name: 18
-          pkg: 2
-          concrete_type: 6
-          position: 32
-          scope: 33
+        - variable_name: 19
+          pkg: 3
+          concrete_type: 7
+          position: 33
+          scope: 34
           value:
-            kind: 31
+            kind: 32
             name: -1
             value: -1
             fun:
-              kind: 8
+              kind: 9
               name: -1
               value: -1
               x:
-                kind: 0
-                name: 26
+                kind: 1
+                name: 27
                 value: -1
                 raw: -1
-                pkg: 26
+                pkg: 27
                 type: -1
-                position: 27
+                position: 28
                 resolved_type: -1
                 generic_type_name: -1
               sel:
-                kind: 0
-                name: 28
+                kind: 1
+                name: 29
                 value: -1
                 raw: -1
-                pkg: 26
-                type: 29
-                position: 30
+                pkg: 27
+                type: 30
+                position: 31
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
-              pkg: 26
-              type: 29
-              position: 27
+              pkg: 27
+              type: 30
+              position: 28
               resolved_type: -1
               generic_type_name: -1
             args:
-              - kind: 23
+              - kind: 24
                 name: -1
-                value: 24
+                value: 25
                 raw: -1
                 pkg: -1
                 type: -1
                 position: -1
                 resolved_type: -1
                 generic_type_name: -1
-              - kind: 0
-                name: 21
+              - kind: 1
+                name: 22
                 value: -1
                 raw: -1
-                pkg: 2
-                type: 6
-                position: 25
+                pkg: 3
+                type: 7
+                position: 26
                 resolved_type: -1
                 generic_type_name: -1
             raw: -1
             pkg: -1
-            type: 6
-            position: 27
+            type: 7
+            position: 28
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 0
-            name: 18
+            kind: 1
+            name: 19
             value: -1
             raw: -1
-            pkg: 2
-            type: 6
-            position: 32
+            pkg: 3
+            type: 7
+            position: 33
             resolved_type: -1
             generic_type_name: -1
-          func: 34
+          func: 35
           callee_func: Sprintf
           callee_pkg: fmt
     param_arg_map:
       data:
-        kind: 0
-        name: 38
+        kind: 1
+        name: 39
         value: -1
         raw: -1
-        pkg: 2
-        type: 6
-        position: 48
+        pkg: 3
+        type: 7
+        position: 49
         resolved_type: -1
         generic_type_name: -1
     callee_recv_var_name: processed
   - caller:
-      name: 47
-      pkg: 2
+      name: 48
+      pkg: 3
       position: -1
-      recv_type: 55
-      scope: 15
-      signature_str: 57
+      recv_type: 56
+      scope: 16
+      signature_str: 58
     callee:
-      name: 104
-      pkg: 26
-      position: 103
+      name: 105
+      pkg: 27
+      position: 104
       recv_type: -1
-      scope: 15
-      signature_str: 105
-    position: 103
+      scope: 16
+      signature_str: 106
+    position: 104
     args:
-      - kind: 23
+      - kind: 24
         name: -1
-        value: 100
+        value: 101
         raw: -1
         pkg: -1
         type: -1
         position: -1
         resolved_type: -1
         generic_type_name: -1
-      - kind: 0
-        name: 5
+      - kind: 1
+        name: 6
         value: -1
         raw: -1
-        pkg: 2
-        type: 6
-        position: 101
+        pkg: 3
+        type: 7
+        position: 102
         resolved_type: -1
         generic_type_name: -1
-      - kind: 0
-        name: 53
+      - kind: 1
+        name: 54
         value: -1
         raw: -1
-        pkg: 2
-        type: 6
-        position: 102
+        pkg: 3
+        type: 7
+        position: 103
         resolved_type: -1
         generic_type_name: -1
     param_arg_map:
       a:
-        kind: 0
-        name: 5
+        kind: 1
+        name: 6
         value: -1
         raw: -1
-        pkg: 2
-        type: 6
-        position: 101
+        pkg: 3
+        type: 7
+        position: 102
         resolved_type: -1
         generic_type_name: -1
       format:
-        kind: 23
+        kind: 24
         name: -1
-        value: 100
+        value: 101
         raw: -1
         pkg: -1
         type: -1
@@ -1865,24 +1866,24 @@ call_graph:
         resolved_type: -1
         generic_type_name: -1
   - caller:
-      name: 92
-      pkg: 2
+      name: 93
+      pkg: 3
       position: -1
       recv_type: -1
-      scope: 33
-      signature_str: 99
+      scope: 34
+      signature_str: 100
     callee:
-      name: 69
-      pkg: 2
-      position: 90
+      name: 70
+      pkg: 3
+      position: 91
       recv_type: -1
-      scope: 15
-      signature_str: 89
-    position: 90
+      scope: 16
+      signature_str: 90
+    position: 91
     args:
-      - kind: 23
+      - kind: 24
         name: -1
-        value: 88
+        value: 89
         raw: -1
         pkg: -1
         type: -1
@@ -1891,29 +1892,29 @@ call_graph:
         generic_type_name: -1
     assignments:
       svc:
-        - variable_name: 78
-          pkg: 2
-          concrete_type: 3
-          position: 91
-          scope: 33
+        - variable_name: 79
+          pkg: 3
+          concrete_type: 4
+          position: 92
+          scope: 34
           value:
-            kind: 31
+            kind: 32
             name: -1
             value: -1
             fun:
-              kind: 0
-              name: 69
+              kind: 1
+              name: 70
               value: -1
               raw: -1
-              pkg: 2
-              type: 89
-              position: 90
+              pkg: 3
+              type: 90
+              position: 91
               resolved_type: -1
               generic_type_name: -1
             args:
-              - kind: 23
+              - kind: 24
                 name: -1
-                value: 88
+                value: 89
                 raw: -1
                 pkg: -1
                 type: -1
@@ -1922,28 +1923,28 @@ call_graph:
                 generic_type_name: -1
             raw: -1
             pkg: -1
-            type: 3
-            position: 90
-            resolved_type: -1
-            generic_type_name: -1
-          lhs:
-            kind: 0
-            name: 78
-            value: -1
-            raw: -1
-            pkg: 2
-            type: 3
+            type: 4
             position: 91
             resolved_type: -1
             generic_type_name: -1
-          func: 92
+          lhs:
+            kind: 1
+            name: 79
+            value: -1
+            raw: -1
+            pkg: 3
+            type: 4
+            position: 92
+            resolved_type: -1
+            generic_type_name: -1
+          func: 93
           callee_func: NewService
           callee_pkg: complex
     param_arg_map:
       name:
-        kind: 23
+        kind: 24
         name: -1
-        value: 88
+        value: 89
         raw: -1
         pkg: -1
         type: -1
@@ -1952,111 +1953,111 @@ call_graph:
         generic_type_name: -1
     callee_recv_var_name: svc
   - caller:
-      name: 92
-      pkg: 2
+      name: 93
+      pkg: 3
       position: -1
       recv_type: -1
-      scope: 33
-      signature_str: 99
+      scope: 34
+      signature_str: 100
     callee:
-      name: 81
-      pkg: 2
-      position: 95
+      name: 82
+      pkg: 3
+      position: 96
       recv_type: -1
-      scope: 15
-      signature_str: 94
-    position: 95
+      scope: 16
+      signature_str: 95
+    position: 96
     args:
-      - kind: 0
-        name: 78
+      - kind: 1
+        name: 79
         value: -1
         raw: -1
-        pkg: 2
-        type: 3
-        position: 93
+        pkg: 3
+        type: 4
+        position: 94
         resolved_type: -1
         generic_type_name: -1
     assignments:
       handler:
-        - variable_name: 96
-          pkg: 2
-          concrete_type: 40
-          position: 97
-          scope: 33
+        - variable_name: 97
+          pkg: 3
+          concrete_type: 41
+          position: 98
+          scope: 34
           value:
-            kind: 31
+            kind: 32
             name: -1
             value: -1
             fun:
-              kind: 0
-              name: 81
+              kind: 1
+              name: 82
               value: -1
               raw: -1
-              pkg: 2
-              type: 94
-              position: 95
+              pkg: 3
+              type: 95
+              position: 96
               resolved_type: -1
               generic_type_name: -1
             args:
-              - kind: 0
-                name: 78
+              - kind: 1
+                name: 79
                 value: -1
                 raw: -1
-                pkg: 2
-                type: 3
-                position: 93
+                pkg: 3
+                type: 4
+                position: 94
                 resolved_type: -1
                 generic_type_name: -1
             raw: -1
             pkg: -1
-            type: 40
-            position: 95
+            type: 41
+            position: 96
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 0
-            name: 96
+            kind: 1
+            name: 97
             value: -1
             raw: -1
-            pkg: 2
-            type: 40
-            position: 97
+            pkg: 3
+            type: 41
+            position: 98
             resolved_type: -1
             generic_type_name: -1
-          func: 92
+          func: 93
           callee_func: NewHandler
           callee_pkg: complex
     param_arg_map:
       svc:
-        kind: 0
-        name: 78
+        kind: 1
+        name: 79
         value: -1
         raw: -1
-        pkg: 2
-        type: 3
-        position: 93
+        pkg: 3
+        type: 4
+        position: 94
         resolved_type: -1
         generic_type_name: -1
     callee_recv_var_name: handler
   - caller:
-      name: 92
-      pkg: 2
+      name: 93
+      pkg: 3
       position: -1
       recv_type: -1
-      scope: 33
-      signature_str: 99
+      scope: 34
+      signature_str: 100
     callee:
-      name: 47
-      pkg: 2
-      position: 107
-      recv_type: 55
-      scope: 15
-      signature_str: 108
-    position: 107
+      name: 48
+      pkg: 3
+      position: 108
+      recv_type: 56
+      scope: 16
+      signature_str: 109
+    position: 108
     args:
-      - kind: 23
+      - kind: 24
         name: -1
-        value: 106
+        value: 107
         raw: -1
         pkg: -1
         type: -1
@@ -2065,198 +2066,198 @@ call_graph:
         generic_type_name: -1
     assignments:
       name:
-        - variable_name: 5
-          pkg: 2
-          concrete_type: 6
-          position: 46
-          scope: 33
+        - variable_name: 6
+          pkg: 3
+          concrete_type: 7
+          position: 47
+          scope: 34
           value:
-            kind: 31
+            kind: 32
             name: -1
             value: -1
             fun:
-              kind: 8
+              kind: 9
               name: -1
               value: -1
               x:
-                kind: 8
+                kind: 9
                 name: -1
                 value: -1
                 x:
-                  kind: 0
-                  name: 39
+                  kind: 1
+                  name: 40
                   value: -1
                   raw: -1
-                  pkg: 2
-                  type: 40
-                  position: 41
+                  pkg: 3
+                  type: 41
+                  position: 42
                   resolved_type: -1
                   generic_type_name: -1
                 sel:
-                  kind: 0
-                  name: 42
+                  kind: 1
+                  name: 43
                   value: -1
                   raw: -1
-                  pkg: 2
-                  type: 3
-                  position: 43
+                  pkg: 3
+                  type: 4
+                  position: 44
                   resolved_type: -1
                   generic_type_name: -1
                 raw: -1
-                pkg: 2
-                type: 3
-                position: 41
+                pkg: 3
+                type: 4
+                position: 42
                 resolved_type: -1
                 generic_type_name: -1
               sel:
-                kind: 0
-                name: 9
+                kind: 1
+                name: 10
                 value: -1
                 raw: -1
-                pkg: 2
-                type: 17
-                position: 44
+                pkg: 3
+                type: 18
+                position: 45
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
-              pkg: 2
-              type: 17
-              position: 41
+              pkg: 3
+              type: 18
+              position: 42
               resolved_type: -1
               generic_type_name: -1
               receiver_type:
-                kind: 0
-                name: 45
+                kind: 1
+                name: 46
                 value: -1
                 raw: -1
-                pkg: 2
-                type: 45
+                pkg: 3
+                type: 46
                 position: -1
                 resolved_type: -1
                 generic_type_name: -1
             raw: -1
             pkg: -1
-            type: 6
-            position: 41
+            type: 7
+            position: 42
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 0
-            name: 5
+            kind: 1
+            name: 6
             value: -1
             raw: -1
-            pkg: 2
-            type: 6
-            position: 46
+            pkg: 3
+            type: 7
+            position: 47
             resolved_type: -1
             generic_type_name: -1
-          func: 47
+          func: 48
           callee_func: GetName
           callee_pkg: complex
       processed:
-        - variable_name: 53
-          pkg: 2
-          concrete_type: 6
-          position: 54
-          scope: 33
+        - variable_name: 54
+          pkg: 3
+          concrete_type: 7
+          position: 55
+          scope: 34
           value:
-            kind: 31
+            kind: 32
             name: -1
             value: -1
             fun:
-              kind: 8
+              kind: 9
               name: -1
               value: -1
               x:
-                kind: 8
+                kind: 9
                 name: -1
                 value: -1
                 x:
-                  kind: 0
-                  name: 39
+                  kind: 1
+                  name: 40
                   value: -1
                   raw: -1
-                  pkg: 2
-                  type: 40
-                  position: 49
-                  resolved_type: -1
-                  generic_type_name: -1
-                sel:
-                  kind: 0
-                  name: 42
-                  value: -1
-                  raw: -1
-                  pkg: 2
-                  type: 3
+                  pkg: 3
+                  type: 41
                   position: 50
                   resolved_type: -1
                   generic_type_name: -1
+                sel:
+                  kind: 1
+                  name: 43
+                  value: -1
+                  raw: -1
+                  pkg: 3
+                  type: 4
+                  position: 51
+                  resolved_type: -1
+                  generic_type_name: -1
                 raw: -1
-                pkg: 2
-                type: 3
-                position: 49
+                pkg: 3
+                type: 4
+                position: 50
                 resolved_type: -1
                 generic_type_name: -1
               sel:
-                kind: 0
-                name: 34
+                kind: 1
+                name: 35
                 value: -1
                 raw: -1
-                pkg: 2
-                type: 51
-                position: 52
+                pkg: 3
+                type: 52
+                position: 53
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
-              pkg: 2
-              type: 51
-              position: 49
+              pkg: 3
+              type: 52
+              position: 50
               resolved_type: -1
               generic_type_name: -1
               receiver_type:
-                kind: 0
-                name: 45
+                kind: 1
+                name: 46
                 value: -1
                 raw: -1
-                pkg: 2
-                type: 45
+                pkg: 3
+                type: 46
                 position: -1
                 resolved_type: -1
                 generic_type_name: -1
             args:
-              - kind: 0
-                name: 38
+              - kind: 1
+                name: 39
                 value: -1
                 raw: -1
-                pkg: 2
-                type: 6
-                position: 48
+                pkg: 3
+                type: 7
+                position: 49
                 resolved_type: -1
                 generic_type_name: -1
             raw: -1
             pkg: -1
-            type: 6
-            position: 49
+            type: 7
+            position: 50
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 0
-            name: 53
+            kind: 1
+            name: 54
             value: -1
             raw: -1
-            pkg: 2
-            type: 6
-            position: 54
+            pkg: 3
+            type: 7
+            position: 55
             resolved_type: -1
             generic_type_name: -1
-          func: 47
+          func: 48
           callee_func: Process
           callee_pkg: complex
     param_arg_map:
       input:
-        kind: 23
+        kind: 24
         name: -1
-        value: 106
+        value: 107
         raw: -1
         pkg: -1
         type: -1

--- a/internal/spec/tests/constants.yaml
+++ b/internal/spec/tests/constants.yaml
@@ -1,4 +1,5 @@
 string_pool:
+  - ""
   - literal
   - "100"
   - '"test"'
@@ -47,14 +48,14 @@ packages:
       constants/const.go:
         functions:
           UseConstants:
-            name: 23
-            pkg: 10
+            name: 24
+            pkg: 11
             signature:
-              kind: 4
+              kind: 5
               name: -1
               value: -1
               fun:
-                kind: 5
+                kind: 6
                 name: -1
                 value: -1
                 raw: -1
@@ -69,75 +70,75 @@ packages:
               position: -1
               resolved_type: -1
               generic_type_name: -1
-            signature_str: 16
-            position: 29
-            scope: 12
+            signature_str: 17
+            position: 30
+            scope: 13
             comments: -1
             assignments:
               name:
-                - variable_name: 27
-                  pkg: 10
-                  concrete_type: 8
-                  position: 28
-                  scope: 15
+                - variable_name: 28
+                  pkg: 11
+                  concrete_type: 9
+                  position: 29
+                  scope: 16
                   value:
-                    kind: 7
-                    name: 24
-                    value: 2
+                    kind: 8
+                    name: 25
+                    value: 3
                     raw: -1
-                    pkg: 10
-                    type: 25
-                    position: 26
+                    pkg: 11
+                    type: 26
+                    position: 27
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 7
-                    name: 27
+                    kind: 8
+                    name: 28
                     value: -1
                     raw: -1
-                    pkg: 10
-                    type: 8
-                    position: 28
+                    pkg: 11
+                    type: 9
+                    position: 29
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 23
+                  func: 24
               size:
-                - variable_name: 21
-                  pkg: 10
-                  concrete_type: 20
-                  position: 22
-                  scope: 15
+                - variable_name: 22
+                  pkg: 11
+                  concrete_type: 21
+                  position: 23
+                  scope: 16
                   value:
-                    kind: 7
-                    name: 17
+                    kind: 8
+                    name: 18
                     value: -1
                     raw: -1
-                    pkg: 10
-                    type: 18
-                    position: 19
+                    pkg: 11
+                    type: 19
+                    position: 20
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 7
-                    name: 21
+                    kind: 8
+                    name: 22
                     value: -1
                     raw: -1
-                    pkg: 10
-                    type: 20
-                    position: 22
+                    pkg: 11
+                    type: 21
+                    position: 23
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 23
+                  func: 24
             end_line: 23
           init:
-            name: 13
-            pkg: 10
+            name: 14
+            pkg: 11
             signature:
-              kind: 4
+              kind: 5
               name: -1
               value: -1
               fun:
-                kind: 5
+                kind: 6
                 name: -1
                 value: -1
                 raw: -1
@@ -152,21 +153,21 @@ packages:
               position: -1
               resolved_type: -1
               generic_type_name: -1
-            signature_str: 16
-            position: 14
-            scope: 15
+            signature_str: 17
+            position: 15
+            scope: 16
             comments: -1
             assignments:
               Message:
-                - variable_name: 9
-                  pkg: 10
-                  concrete_type: 8
-                  position: 11
-                  scope: 12
+                - variable_name: 10
+                  pkg: 11
+                  concrete_type: 9
+                  position: 12
+                  scope: 13
                   value:
-                    kind: 0
+                    kind: 1
                     name: -1
-                    value: 6
+                    value: 7
                     raw: -1
                     pkg: -1
                     type: -1
@@ -174,66 +175,66 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 7
-                    name: 9
+                    kind: 8
+                    name: 10
                     value: -1
                     raw: -1
-                    pkg: 10
-                    type: 8
-                    position: 11
+                    pkg: 11
+                    type: 9
+                    position: 12
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 13
+                  func: 14
             end_line: 16
         variables:
           GlobalVar:
-            name: 37
-            tok: 38
-            pkg: 10
-            type: 20
-            value: 40
-            position: 39
+            name: 38
+            tok: 39
+            pkg: 11
+            type: 21
+            value: 41
+            position: 40
             comments: -1
             group_index: 1
           MaxSize:
-            name: 17
-            tok: 30
-            pkg: 10
+            name: 18
+            tok: 31
+            pkg: 11
             type: -1
-            resolved_type: 18
-            value: 1
+            resolved_type: 19
+            value: 2
             computed_value: 100
-            position: 31
-            comments: -1
-            group_index: 1
-          Message:
-            name: 9
-            tok: 38
-            pkg: 10
-            type: 8
-            position: 41
-            comments: -1
-            group_index: 1
-          Name:
-            name: 24
-            tok: 30
-            pkg: 10
-            type: -1
-            resolved_type: 25
-            value: 33
-            computed_value: {}
             position: 32
             comments: -1
             group_index: 1
-          Pi:
-            name: 34
-            tok: 30
-            pkg: 10
+          Message:
+            name: 10
+            tok: 39
+            pkg: 11
+            type: 9
+            position: 42
+            comments: -1
+            group_index: 1
+          Name:
+            name: 25
+            tok: 31
+            pkg: 11
             type: -1
-            resolved_type: 36
-            value: 3
+            resolved_type: 26
+            value: 34
             computed_value: {}
-            position: 35
+            position: 33
+            comments: -1
+            group_index: 1
+          Pi:
+            name: 35
+            tok: 31
+            pkg: 11
+            type: -1
+            resolved_type: 37
+            value: 4
+            computed_value: {}
+            position: 36
             comments: -1
             group_index: 1
         imports: {}

--- a/internal/spec/tests/example.yaml
+++ b/internal/spec/tests/example.yaml
@@ -1,4 +1,5 @@
 string_pool:
+  - ""
   - ident
   - u
   - example
@@ -91,20 +92,20 @@ packages:
       example/types.go:
         types:
           Ager:
-            name: 36
-            pkg: 2
-            kind: 33
+            name: 37
+            pkg: 3
+            kind: 34
             implemented_by:
-              - 77
-            scope: 15
+              - 78
+            scope: 16
             methods:
-              - name: 26
+              - name: 27
                 signature:
-                  kind: 12
+                  kind: 13
                   name: -1
                   value: -1
                   fun:
-                    kind: 13
+                    kind: 14
                     name: -1
                     value: -1
                     raw: -1
@@ -114,13 +115,13 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   args:
-                    - kind: 0
-                      name: 20
+                    - kind: 1
+                      name: 21
                       value: -1
                       raw: -1
                       pkg: -1
-                      type: 18
-                      position: 37
+                      type: 19
+                      position: 38
                       resolved_type: -1
                       generic_type_name: -1
                   raw: -1
@@ -129,35 +130,35 @@ packages:
                   position: -1
                   resolved_type: -1
                   generic_type_name: -1
-                signature_str: 28
-                scope: 15
+                signature_str: 29
+                scope: 16
                 comments: -1
             comments: -1
           Namer:
-            name: 34
-            pkg: 2
-            kind: 33
+            name: 35
+            pkg: 3
+            kind: 34
             implemented_by:
-              - 77
-            scope: 15
+              - 78
+            scope: 16
             methods:
-              - name: 9
+              - name: 10
                 signature:
-                  kind: 12
+                  kind: 13
                   name: -1
                   value: -1
                   fun:
-                    kind: 13
+                    kind: 14
                     name: -1
                     value: -1
                     args:
-                      - kind: 0
-                        name: 6
+                      - kind: 1
+                        name: 7
                         value: -1
                         raw: -1
                         pkg: -1
-                        type: 6
-                        position: 35
+                        type: 7
+                        position: 36
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
@@ -170,25 +171,25 @@ packages:
                   pkg: -1
                   type: -1
                   position: -1
-                  resolved_type: 6
+                  resolved_type: 7
                   generic_type_name: -1
-                signature_str: 17
-                scope: 15
+                signature_str: 18
+                scope: 16
                 comments: -1
             comments: -1
           Phoner:
-            name: 38
-            pkg: 2
-            kind: 33
-            scope: 15
+            name: 39
+            pkg: 3
+            kind: 34
+            scope: 16
             methods:
-              - name: 39
+              - name: 40
                 signature:
-                  kind: 12
+                  kind: 13
                   name: -1
                   value: -1
                   fun:
-                    kind: 13
+                    kind: 14
                     name: -1
                     value: -1
                     raw: -1
@@ -198,13 +199,13 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   args:
-                    - kind: 0
-                      name: 41
+                    - kind: 1
+                      name: 42
                       value: -1
                       raw: -1
                       pkg: -1
-                      type: 6
-                      position: 40
+                      type: 7
+                      position: 41
                       resolved_type: -1
                       generic_type_name: -1
                   raw: -1
@@ -213,48 +214,48 @@ packages:
                   position: -1
                   resolved_type: -1
                   generic_type_name: -1
-                signature_str: 42
-                scope: 15
+                signature_str: 43
+                scope: 16
                 comments: -1
             comments: -1
           User:
-            name: 29
-            pkg: 2
-            kind: 30
+            name: 30
+            pkg: 3
+            kind: 31
             implements:
-              - 76
-              - 78
+              - 77
+              - 79
             fields:
-              - name: 5
-                type: 6
-                tag: 31
-                scope: 15
-                comments: -1
-              - name: 22
-                type: 18
+              - name: 6
+                type: 7
                 tag: 32
-                scope: 15
+                scope: 16
                 comments: -1
-            scope: 15
+              - name: 23
+                type: 19
+                tag: 33
+                scope: 16
+                comments: -1
+            scope: 16
             methods:
-              - name: 9
-                receiver: 10
+              - name: 10
+                receiver: 11
                 signature:
-                  kind: 12
+                  kind: 13
                   name: -1
                   value: -1
                   fun:
-                    kind: 13
+                    kind: 14
                     name: -1
                     value: -1
                     args:
-                      - kind: 0
-                        name: 6
+                      - kind: 1
+                        name: 7
                         value: -1
                         raw: -1
                         pkg: -1
-                        type: 6
-                        position: 11
+                        type: 7
+                        position: 12
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
@@ -267,81 +268,81 @@ packages:
                   pkg: -1
                   type: -1
                   position: -1
-                  resolved_type: 6
+                  resolved_type: 7
                   generic_type_name: -1
-                signature_str: 17
-                position: 14
-                scope: 15
+                signature_str: 18
+                position: 15
+                scope: 16
                 comments: -1
-                filename: 16
+                filename: 17
                 return_vars:
-                  - kind: 8
+                  - kind: 9
                     name: -1
                     value: -1
                     x:
-                      kind: 0
-                      name: 1
+                      kind: 1
+                      name: 2
                       value: -1
                       raw: -1
-                      pkg: 2
-                      type: 3
-                      position: 4
+                      pkg: 3
+                      type: 4
+                      position: 5
                       resolved_type: -1
                       generic_type_name: -1
                     sel:
-                      kind: 0
-                      name: 5
+                      kind: 1
+                      name: 6
                       value: -1
                       raw: -1
-                      pkg: 2
-                      type: 6
-                      position: 7
+                      pkg: 3
+                      type: 7
+                      position: 8
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
-                    pkg: 2
-                    type: 6
-                    position: 4
+                    pkg: 3
+                    type: 7
+                    position: 5
                     resolved_type: -1
                     generic_type_name: -1
                 returns:
-                  - - kind: 8
+                  - - kind: 9
                       name: -1
                       value: -1
                       x:
-                        kind: 0
-                        name: 1
+                        kind: 1
+                        name: 2
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 3
-                        position: 4
+                        pkg: 3
+                        type: 4
+                        position: 5
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 0
-                        name: 5
+                        kind: 1
+                        name: 6
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 6
-                        position: 7
+                        pkg: 3
+                        type: 7
+                        position: 8
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 2
-                      type: 6
-                      position: 4
+                      pkg: 3
+                      type: 7
+                      position: 5
                       resolved_type: -1
                       generic_type_name: -1
-              - name: 26
-                receiver: 10
+              - name: 27
+                receiver: 11
                 signature:
-                  kind: 12
+                  kind: 13
                   name: -1
                   value: -1
                   fun:
-                    kind: 13
+                    kind: 14
                     name: -1
                     value: -1
                     raw: -1
@@ -351,13 +352,13 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   args:
-                    - kind: 0
-                      name: 20
+                    - kind: 1
+                      name: 21
                       value: -1
                       raw: -1
                       pkg: -1
-                      type: 18
-                      position: 19
+                      type: 19
+                      position: 20
                       resolved_type: -1
                       generic_type_name: -1
                   raw: -1
@@ -366,89 +367,89 @@ packages:
                   position: -1
                   resolved_type: -1
                   generic_type_name: -1
-                signature_str: 28
-                position: 27
-                scope: 15
+                signature_str: 29
+                position: 28
+                scope: 16
                 comments: -1
-                filename: 16
+                filename: 17
                 assignments:
                   example.User.Age:
-                    - variable_name: 24
-                      pkg: 2
-                      concrete_type: 18
-                      position: 21
-                      scope: 8
+                    - variable_name: 25
+                      pkg: 3
+                      concrete_type: 19
+                      position: 22
+                      scope: 9
                       value:
-                        kind: 0
-                        name: 20
+                        kind: 1
+                        name: 21
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 18
-                        position: 25
+                        pkg: 3
+                        type: 19
+                        position: 26
                         resolved_type: -1
                         generic_type_name: -1
                       lhs:
-                        kind: 8
+                        kind: 9
                         name: -1
                         value: -1
                         x:
-                          kind: 0
-                          name: 1
+                          kind: 1
+                          name: 2
                           value: -1
                           raw: -1
-                          pkg: 2
-                          type: 3
-                          position: 21
+                          pkg: 3
+                          type: 4
+                          position: 22
                           resolved_type: -1
                           generic_type_name: -1
                         sel:
-                          kind: 0
-                          name: 22
+                          kind: 1
+                          name: 23
                           value: -1
                           raw: -1
-                          pkg: 2
-                          type: 18
-                          position: 23
+                          pkg: 3
+                          type: 19
+                          position: 24
                           resolved_type: -1
                           generic_type_name: -1
                         raw: -1
-                        pkg: 2
-                        type: 18
-                        position: 21
+                        pkg: 3
+                        type: 19
+                        position: 22
                         resolved_type: -1
                         generic_type_name: -1
             comments: -1
         functions:
           NewUser:
-            name: 62
-            pkg: 2
+            name: 63
+            pkg: 3
             signature:
-              kind: 12
+              kind: 13
               name: -1
               value: -1
               fun:
-                kind: 13
+                kind: 14
                 name: -1
                 value: -1
                 args:
-                  - kind: 48
+                  - kind: 49
                     name: -1
                     value: -1
                     x:
-                      kind: 0
-                      name: 29
+                      kind: 1
+                      name: 30
                       value: -1
                       raw: -1
-                      pkg: 2
-                      type: 29
-                      position: 47
+                      pkg: 3
+                      type: 30
+                      position: 48
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
                     pkg: -1
                     type: -1
-                    position: 49
+                    position: 50
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -458,171 +459,171 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 0
-                  name: 45
+                - kind: 1
+                  name: 46
                   value: -1
                   raw: -1
                   pkg: -1
-                  type: 6
-                  position: 44
+                  type: 7
+                  position: 45
                   resolved_type: -1
                   generic_type_name: -1
-                - kind: 0
-                  name: 20
+                - kind: 1
+                  name: 21
                   value: -1
                   raw: -1
                   pkg: -1
-                  type: 18
-                  position: 46
+                  type: 19
+                  position: 47
                   resolved_type: -1
                   generic_type_name: -1
               raw: -1
               pkg: -1
               type: -1
               position: -1
-              resolved_type: 10
+              resolved_type: 11
               generic_type_name: -1
-            signature_str: 64
-            position: 63
-            scope: 15
+            signature_str: 65
+            position: 64
+            scope: 16
             comments: -1
             return_vars:
-              - kind: 0
-                name: 1
+              - kind: 1
+                name: 2
                 value: -1
                 raw: -1
-                pkg: 2
-                type: 3
-                position: 43
+                pkg: 3
+                type: 4
+                position: 44
                 resolved_type: -1
                 generic_type_name: -1
             returns:
-              - - kind: 0
-                  name: 1
+              - - kind: 1
+                  name: 2
                   value: -1
                   raw: -1
-                  pkg: 2
-                  type: 3
-                  position: 43
+                  pkg: 3
+                  type: 4
+                  position: 44
                   resolved_type: -1
                   generic_type_name: -1
             assignments:
               u:
-                - variable_name: 1
-                  pkg: 2
-                  concrete_type: 3
-                  position: 60
-                  scope: 61
+                - variable_name: 2
+                  pkg: 3
+                  concrete_type: 4
+                  position: 61
+                  scope: 62
                   value:
-                    kind: 57
+                    kind: 58
                     name: -1
-                    value: 58
+                    value: 59
                     x:
-                      kind: 56
+                      kind: 57
                       name: -1
                       value: -1
                       x:
-                        kind: 0
-                        name: 29
+                        kind: 1
+                        name: 30
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 29
-                        position: 50
+                        pkg: 3
+                        type: 30
+                        position: 51
                         resolved_type: -1
                         generic_type_name: -1
                       args:
-                        - kind: 53
+                        - kind: 54
                           name: -1
                           value: -1
                           x:
-                            kind: 0
-                            name: 5
+                            kind: 1
+                            name: 6
                             value: -1
                             raw: -1
-                            pkg: 2
-                            type: 6
-                            position: 51
-                            resolved_type: -1
-                            generic_type_name: -1
-                          fun:
-                            kind: 0
-                            name: 45
-                            value: -1
-                            raw: -1
-                            pkg: 2
-                            type: 6
+                            pkg: 3
+                            type: 7
                             position: 52
                             resolved_type: -1
                             generic_type_name: -1
+                          fun:
+                            kind: 1
+                            name: 46
+                            value: -1
+                            raw: -1
+                            pkg: 3
+                            type: 7
+                            position: 53
+                            resolved_type: -1
+                            generic_type_name: -1
                           raw: -1
                           pkg: -1
                           type: -1
-                          position: 51
+                          position: 52
                           resolved_type: -1
                           generic_type_name: -1
-                        - kind: 53
+                        - kind: 54
                           name: -1
                           value: -1
                           x:
-                            kind: 0
-                            name: 22
+                            kind: 1
+                            name: 23
                             value: -1
                             raw: -1
-                            pkg: 2
-                            type: 18
-                            position: 54
+                            pkg: 3
+                            type: 19
+                            position: 55
                             resolved_type: -1
                             generic_type_name: -1
                           fun:
-                            kind: 0
-                            name: 20
+                            kind: 1
+                            name: 21
                             value: -1
                             raw: -1
-                            pkg: 2
-                            type: 18
-                            position: 55
+                            pkg: 3
+                            type: 19
+                            position: 56
                             resolved_type: -1
                             generic_type_name: -1
                           raw: -1
                           pkg: -1
                           type: -1
-                          position: 54
+                          position: 55
                           resolved_type: -1
                           generic_type_name: -1
                       raw: -1
                       pkg: -1
                       type: -1
-                      position: 50
+                      position: 51
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
                     pkg: -1
                     type: -1
-                    position: 59
-                    resolved_type: -1
-                    generic_type_name: -1
-                  lhs:
-                    kind: 0
-                    name: 1
-                    value: -1
-                    raw: -1
-                    pkg: 2
-                    type: 3
                     position: 60
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 62
+                  lhs:
+                    kind: 1
+                    name: 2
+                    value: -1
+                    raw: -1
+                    pkg: 3
+                    type: 4
+                    position: 61
+                    resolved_type: -1
+                    generic_type_name: -1
+                  func: 63
             end_line: 37
           main:
-            name: 73
-            pkg: 2
+            name: 74
+            pkg: 3
             signature:
-              kind: 12
+              kind: 13
               name: -1
               value: -1
               fun:
-                kind: 13
+                kind: 14
                 name: -1
                 value: -1
                 raw: -1
@@ -637,42 +638,33 @@ packages:
               position: -1
               resolved_type: -1
               generic_type_name: -1
-            signature_str: 75
-            position: 74
-            scope: 61
+            signature_str: 76
+            position: 75
+            scope: 62
             comments: -1
             assignments:
               user:
-                - variable_name: 71
-                  pkg: 2
-                  concrete_type: 3
-                  position: 72
-                  scope: 61
+                - variable_name: 72
+                  pkg: 3
+                  concrete_type: 4
+                  position: 73
+                  scope: 62
                   value:
-                    kind: 70
+                    kind: 71
                     name: -1
                     value: -1
                     fun:
-                      kind: 0
-                      name: 62
+                      kind: 1
+                      name: 63
                       value: -1
                       raw: -1
-                      pkg: 2
-                      type: 68
-                      position: 69
+                      pkg: 3
+                      type: 69
+                      position: 70
                       resolved_type: -1
                       generic_type_name: -1
                     args:
-                      - kind: 65
-                        name: -1
-                        value: 66
-                        raw: -1
-                        pkg: -1
-                        type: -1
-                        position: -1
-                        resolved_type: -1
-                        generic_type_name: -1
-                      - kind: 65
+                      - kind: 66
                         name: -1
                         value: 67
                         raw: -1
@@ -681,50 +673,59 @@ packages:
                         position: -1
                         resolved_type: -1
                         generic_type_name: -1
+                      - kind: 66
+                        name: -1
+                        value: 68
+                        raw: -1
+                        pkg: -1
+                        type: -1
+                        position: -1
+                        resolved_type: -1
+                        generic_type_name: -1
                     raw: -1
                     pkg: -1
-                    type: 3
-                    position: 69
+                    type: 4
+                    position: 70
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 0
-                    name: 71
+                    kind: 1
+                    name: 72
                     value: -1
                     raw: -1
-                    pkg: 2
-                    type: 3
-                    position: 72
+                    pkg: 3
+                    type: 4
+                    position: 73
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 73
+                  func: 74
                   callee_func: NewUser
                   callee_pkg: example
             end_line: 42
         struct_instances:
-          - type: 29
-            pkg: 2
-            position: 50
+          - type: 30
+            pkg: 3
+            position: 51
             fields:
-              5: 45
-              22: 20
+              6: 46
+              23: 21
         imports: {}
     types:
       Ager:
-        name: 36
-        pkg: 2
-        kind: 33
+        name: 37
+        pkg: 3
+        kind: 34
         implemented_by:
-          - 77
-        scope: 15
+          - 78
+        scope: 16
         methods:
-          - name: 26
+          - name: 27
             signature:
-              kind: 12
+              kind: 13
               name: -1
               value: -1
               fun:
-                kind: 13
+                kind: 14
                 name: -1
                 value: -1
                 raw: -1
@@ -734,13 +735,13 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 0
-                  name: 20
+                - kind: 1
+                  name: 21
                   value: -1
                   raw: -1
                   pkg: -1
-                  type: 18
-                  position: 37
+                  type: 19
+                  position: 38
                   resolved_type: -1
                   generic_type_name: -1
               raw: -1
@@ -749,35 +750,35 @@ packages:
               position: -1
               resolved_type: -1
               generic_type_name: -1
-            signature_str: 28
-            scope: 15
+            signature_str: 29
+            scope: 16
             comments: -1
         comments: -1
       Namer:
-        name: 34
-        pkg: 2
-        kind: 33
+        name: 35
+        pkg: 3
+        kind: 34
         implemented_by:
-          - 77
-        scope: 15
+          - 78
+        scope: 16
         methods:
-          - name: 9
+          - name: 10
             signature:
-              kind: 12
+              kind: 13
               name: -1
               value: -1
               fun:
-                kind: 13
+                kind: 14
                 name: -1
                 value: -1
                 args:
-                  - kind: 0
-                    name: 6
+                  - kind: 1
+                    name: 7
                     value: -1
                     raw: -1
                     pkg: -1
-                    type: 6
-                    position: 35
+                    type: 7
+                    position: 36
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -790,25 +791,25 @@ packages:
               pkg: -1
               type: -1
               position: -1
-              resolved_type: 6
+              resolved_type: 7
               generic_type_name: -1
-            signature_str: 17
-            scope: 15
+            signature_str: 18
+            scope: 16
             comments: -1
         comments: -1
       Phoner:
-        name: 38
-        pkg: 2
-        kind: 33
-        scope: 15
+        name: 39
+        pkg: 3
+        kind: 34
+        scope: 16
         methods:
-          - name: 39
+          - name: 40
             signature:
-              kind: 12
+              kind: 13
               name: -1
               value: -1
               fun:
-                kind: 13
+                kind: 14
                 name: -1
                 value: -1
                 raw: -1
@@ -818,13 +819,13 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 0
-                  name: 41
+                - kind: 1
+                  name: 42
                   value: -1
                   raw: -1
                   pkg: -1
-                  type: 6
-                  position: 40
+                  type: 7
+                  position: 41
                   resolved_type: -1
                   generic_type_name: -1
               raw: -1
@@ -833,48 +834,48 @@ packages:
               position: -1
               resolved_type: -1
               generic_type_name: -1
-            signature_str: 42
-            scope: 15
+            signature_str: 43
+            scope: 16
             comments: -1
         comments: -1
       User:
-        name: 29
-        pkg: 2
-        kind: 30
+        name: 30
+        pkg: 3
+        kind: 31
         implements:
-          - 76
-          - 78
+          - 77
+          - 79
         fields:
-          - name: 5
-            type: 6
-            tag: 31
-            scope: 15
-            comments: -1
-          - name: 22
-            type: 18
+          - name: 6
+            type: 7
             tag: 32
-            scope: 15
+            scope: 16
             comments: -1
-        scope: 15
+          - name: 23
+            type: 19
+            tag: 33
+            scope: 16
+            comments: -1
+        scope: 16
         methods:
-          - name: 9
-            receiver: 10
+          - name: 10
+            receiver: 11
             signature:
-              kind: 12
+              kind: 13
               name: -1
               value: -1
               fun:
-                kind: 13
+                kind: 14
                 name: -1
                 value: -1
                 args:
-                  - kind: 0
-                    name: 6
+                  - kind: 1
+                    name: 7
                     value: -1
                     raw: -1
                     pkg: -1
-                    type: 6
-                    position: 11
+                    type: 7
+                    position: 12
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -887,81 +888,81 @@ packages:
               pkg: -1
               type: -1
               position: -1
-              resolved_type: 6
+              resolved_type: 7
               generic_type_name: -1
-            signature_str: 17
-            position: 14
-            scope: 15
+            signature_str: 18
+            position: 15
+            scope: 16
             comments: -1
-            filename: 16
+            filename: 17
             return_vars:
-              - kind: 8
+              - kind: 9
                 name: -1
                 value: -1
                 x:
-                  kind: 0
-                  name: 1
+                  kind: 1
+                  name: 2
                   value: -1
                   raw: -1
-                  pkg: 2
-                  type: 3
-                  position: 4
+                  pkg: 3
+                  type: 4
+                  position: 5
                   resolved_type: -1
                   generic_type_name: -1
                 sel:
-                  kind: 0
-                  name: 5
+                  kind: 1
+                  name: 6
                   value: -1
                   raw: -1
-                  pkg: 2
-                  type: 6
-                  position: 7
+                  pkg: 3
+                  type: 7
+                  position: 8
                   resolved_type: -1
                   generic_type_name: -1
                 raw: -1
-                pkg: 2
-                type: 6
-                position: 4
+                pkg: 3
+                type: 7
+                position: 5
                 resolved_type: -1
                 generic_type_name: -1
             returns:
-              - - kind: 8
+              - - kind: 9
                   name: -1
                   value: -1
                   x:
-                    kind: 0
-                    name: 1
+                    kind: 1
+                    name: 2
                     value: -1
                     raw: -1
-                    pkg: 2
-                    type: 3
-                    position: 4
+                    pkg: 3
+                    type: 4
+                    position: 5
                     resolved_type: -1
                     generic_type_name: -1
                   sel:
-                    kind: 0
-                    name: 5
+                    kind: 1
+                    name: 6
                     value: -1
                     raw: -1
-                    pkg: 2
-                    type: 6
-                    position: 7
+                    pkg: 3
+                    type: 7
+                    position: 8
                     resolved_type: -1
                     generic_type_name: -1
                   raw: -1
-                  pkg: 2
-                  type: 6
-                  position: 4
+                  pkg: 3
+                  type: 7
+                  position: 5
                   resolved_type: -1
                   generic_type_name: -1
-          - name: 26
-            receiver: 10
+          - name: 27
+            receiver: 11
             signature:
-              kind: 12
+              kind: 13
               name: -1
               value: -1
               fun:
-                kind: 13
+                kind: 14
                 name: -1
                 value: -1
                 raw: -1
@@ -971,13 +972,13 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 0
-                  name: 20
+                - kind: 1
+                  name: 21
                   value: -1
                   raw: -1
                   pkg: -1
-                  type: 18
-                  position: 19
+                  type: 19
+                  position: 20
                   resolved_type: -1
                   generic_type_name: -1
               raw: -1
@@ -986,174 +987,174 @@ packages:
               position: -1
               resolved_type: -1
               generic_type_name: -1
-            signature_str: 28
-            position: 27
-            scope: 15
+            signature_str: 29
+            position: 28
+            scope: 16
             comments: -1
-            filename: 16
+            filename: 17
             assignments:
               example.User.Age:
-                - variable_name: 24
-                  pkg: 2
-                  concrete_type: 18
-                  position: 21
-                  scope: 8
+                - variable_name: 25
+                  pkg: 3
+                  concrete_type: 19
+                  position: 22
+                  scope: 9
                   value:
-                    kind: 0
-                    name: 20
+                    kind: 1
+                    name: 21
                     value: -1
                     raw: -1
-                    pkg: 2
-                    type: 18
-                    position: 25
+                    pkg: 3
+                    type: 19
+                    position: 26
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 8
+                    kind: 9
                     name: -1
                     value: -1
                     x:
-                      kind: 0
-                      name: 1
+                      kind: 1
+                      name: 2
                       value: -1
                       raw: -1
-                      pkg: 2
-                      type: 3
-                      position: 21
+                      pkg: 3
+                      type: 4
+                      position: 22
                       resolved_type: -1
                       generic_type_name: -1
                     sel:
-                      kind: 0
-                      name: 22
+                      kind: 1
+                      name: 23
                       value: -1
                       raw: -1
-                      pkg: 2
-                      type: 18
-                      position: 23
+                      pkg: 3
+                      type: 19
+                      position: 24
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
-                    pkg: 2
-                    type: 18
-                    position: 21
+                    pkg: 3
+                    type: 19
+                    position: 22
                     resolved_type: -1
                     generic_type_name: -1
         comments: -1
 call_graph:
   - caller:
-      name: 62
-      pkg: 2
+      name: 63
+      pkg: 3
       position: -1
       recv_type: -1
-      scope: 15
-      signature_str: 64
+      scope: 16
+      signature_str: 65
     callee:
-      name: 26
-      pkg: 2
-      position: 80
-      recv_type: 10
-      scope: 15
-      signature_str: 81
-    position: 80
+      name: 27
+      pkg: 3
+      position: 81
+      recv_type: 11
+      scope: 16
+      signature_str: 82
+    position: 81
     args:
-      - kind: 0
-        name: 20
+      - kind: 1
+        name: 21
         value: -1
         raw: -1
-        pkg: 2
-        type: 18
-        position: 79
+        pkg: 3
+        type: 19
+        position: 80
         resolved_type: -1
         generic_type_name: -1
     assignments:
       example.User.Age:
-        - variable_name: 24
-          pkg: 2
-          concrete_type: 18
-          position: 21
-          scope: 8
+        - variable_name: 25
+          pkg: 3
+          concrete_type: 19
+          position: 22
+          scope: 9
           value:
-            kind: 0
-            name: 20
+            kind: 1
+            name: 21
             value: -1
             raw: -1
-            pkg: 2
-            type: 18
-            position: 25
+            pkg: 3
+            type: 19
+            position: 26
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 8
+            kind: 9
             name: -1
             value: -1
             x:
-              kind: 0
-              name: 1
+              kind: 1
+              name: 2
               value: -1
               raw: -1
-              pkg: 2
-              type: 3
-              position: 21
+              pkg: 3
+              type: 4
+              position: 22
               resolved_type: -1
               generic_type_name: -1
             sel:
-              kind: 0
-              name: 22
+              kind: 1
+              name: 23
               value: -1
               raw: -1
-              pkg: 2
-              type: 18
-              position: 23
+              pkg: 3
+              type: 19
+              position: 24
               resolved_type: -1
               generic_type_name: -1
             raw: -1
-            pkg: 2
-            type: 18
-            position: 21
+            pkg: 3
+            type: 19
+            position: 22
             resolved_type: -1
             generic_type_name: -1
     param_arg_map:
       age:
-        kind: 0
-        name: 20
+        kind: 1
+        name: 21
         value: -1
         raw: -1
-        pkg: 2
-        type: 18
-        position: 79
+        pkg: 3
+        type: 19
+        position: 80
         resolved_type: -1
         generic_type_name: -1
     callee_var_name: u
     callee_recv_var_name: u
     chain_root: u
   - caller:
-      name: 73
-      pkg: 2
+      name: 74
+      pkg: 3
       position: -1
       recv_type: -1
-      scope: 61
-      signature_str: 75
+      scope: 62
+      signature_str: 76
     callee:
-      name: 62
-      pkg: 2
-      position: 69
+      name: 63
+      pkg: 3
+      position: 70
       recv_type: -1
-      scope: 15
-      signature_str: 68
-    position: 69
+      scope: 16
+      signature_str: 69
+    position: 70
     args:
-      - kind: 65
+      - kind: 66
         name: -1
-        value: 66
+        value: 67
         raw: -1
         pkg: -1
         type: -1
         position: -1
         resolved_type: -1
         generic_type_name: -1
-      - kind: 65
+      - kind: 66
         name: -1
-        value: 67
+        value: 68
         raw: -1
         pkg: -1
         type: -1
@@ -1162,142 +1163,133 @@ call_graph:
         generic_type_name: -1
     assignments:
       u:
-        - variable_name: 1
-          pkg: 2
-          concrete_type: 3
-          position: 60
-          scope: 61
+        - variable_name: 2
+          pkg: 3
+          concrete_type: 4
+          position: 61
+          scope: 62
           value:
-            kind: 57
+            kind: 58
             name: -1
-            value: 58
+            value: 59
             x:
-              kind: 56
+              kind: 57
               name: -1
               value: -1
               x:
-                kind: 0
-                name: 29
+                kind: 1
+                name: 30
                 value: -1
                 raw: -1
-                pkg: 2
-                type: 29
-                position: 50
+                pkg: 3
+                type: 30
+                position: 51
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 53
+                - kind: 54
                   name: -1
                   value: -1
                   x:
-                    kind: 0
-                    name: 5
+                    kind: 1
+                    name: 6
                     value: -1
                     raw: -1
-                    pkg: 2
-                    type: 6
-                    position: 51
-                    resolved_type: -1
-                    generic_type_name: -1
-                  fun:
-                    kind: 0
-                    name: 45
-                    value: -1
-                    raw: -1
-                    pkg: 2
-                    type: 6
+                    pkg: 3
+                    type: 7
                     position: 52
                     resolved_type: -1
                     generic_type_name: -1
+                  fun:
+                    kind: 1
+                    name: 46
+                    value: -1
+                    raw: -1
+                    pkg: 3
+                    type: 7
+                    position: 53
+                    resolved_type: -1
+                    generic_type_name: -1
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 51
+                  position: 52
                   resolved_type: -1
                   generic_type_name: -1
-                - kind: 53
+                - kind: 54
                   name: -1
                   value: -1
                   x:
-                    kind: 0
-                    name: 22
+                    kind: 1
+                    name: 23
                     value: -1
                     raw: -1
-                    pkg: 2
-                    type: 18
-                    position: 54
+                    pkg: 3
+                    type: 19
+                    position: 55
                     resolved_type: -1
                     generic_type_name: -1
                   fun:
-                    kind: 0
-                    name: 20
+                    kind: 1
+                    name: 21
                     value: -1
                     raw: -1
-                    pkg: 2
-                    type: 18
-                    position: 55
+                    pkg: 3
+                    type: 19
+                    position: 56
                     resolved_type: -1
                     generic_type_name: -1
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 54
+                  position: 55
                   resolved_type: -1
                   generic_type_name: -1
               raw: -1
               pkg: -1
               type: -1
-              position: 50
+              position: 51
               resolved_type: -1
               generic_type_name: -1
             raw: -1
             pkg: -1
             type: -1
-            position: 59
-            resolved_type: -1
-            generic_type_name: -1
-          lhs:
-            kind: 0
-            name: 1
-            value: -1
-            raw: -1
-            pkg: 2
-            type: 3
             position: 60
             resolved_type: -1
             generic_type_name: -1
-          func: 62
+          lhs:
+            kind: 1
+            name: 2
+            value: -1
+            raw: -1
+            pkg: 3
+            type: 4
+            position: 61
+            resolved_type: -1
+            generic_type_name: -1
+          func: 63
       user:
-        - variable_name: 71
-          pkg: 2
-          concrete_type: 3
-          position: 72
-          scope: 61
+        - variable_name: 72
+          pkg: 3
+          concrete_type: 4
+          position: 73
+          scope: 62
           value:
-            kind: 70
+            kind: 71
             name: -1
             value: -1
             fun:
-              kind: 0
-              name: 62
+              kind: 1
+              name: 63
               value: -1
               raw: -1
-              pkg: 2
-              type: 68
-              position: 69
+              pkg: 3
+              type: 69
+              position: 70
               resolved_type: -1
               generic_type_name: -1
             args:
-              - kind: 65
-                name: -1
-                value: 66
-                raw: -1
-                pkg: -1
-                type: -1
-                position: -1
-                resolved_type: -1
-                generic_type_name: -1
-              - kind: 65
+              - kind: 66
                 name: -1
                 value: 67
                 raw: -1
@@ -1306,28 +1298,47 @@ call_graph:
                 position: -1
                 resolved_type: -1
                 generic_type_name: -1
+              - kind: 66
+                name: -1
+                value: 68
+                raw: -1
+                pkg: -1
+                type: -1
+                position: -1
+                resolved_type: -1
+                generic_type_name: -1
             raw: -1
             pkg: -1
-            type: 3
-            position: 69
+            type: 4
+            position: 70
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 0
-            name: 71
+            kind: 1
+            name: 72
             value: -1
             raw: -1
-            pkg: 2
-            type: 3
-            position: 72
+            pkg: 3
+            type: 4
+            position: 73
             resolved_type: -1
             generic_type_name: -1
-          func: 73
+          func: 74
           callee_func: NewUser
           callee_pkg: example
     param_arg_map:
       age:
-        kind: 65
+        kind: 66
+        name: -1
+        value: 68
+        raw: -1
+        pkg: -1
+        type: -1
+        position: -1
+        resolved_type: -1
+        generic_type_name: -1
+      name:
+        kind: 66
         name: -1
         value: 67
         raw: -1
@@ -1336,49 +1347,39 @@ call_graph:
         position: -1
         resolved_type: -1
         generic_type_name: -1
-      name:
-        kind: 65
-        name: -1
-        value: 66
-        raw: -1
-        pkg: -1
-        type: -1
-        position: -1
-        resolved_type: -1
-        generic_type_name: -1
     callee_recv_var_name: user
   - caller:
-      name: 73
-      pkg: 2
+      name: 74
+      pkg: 3
       position: -1
       recv_type: -1
-      scope: 61
-      signature_str: 75
+      scope: 62
+      signature_str: 76
     callee:
-      name: 85
-      pkg: 2
-      position: 84
+      name: 86
+      pkg: 3
+      position: 85
       recv_type: -1
-      scope: 15
+      scope: 16
       signature_str: -1
-    position: 84
+    position: 85
     args:
-      - kind: 48
+      - kind: 49
         name: -1
         value: -1
         x:
-          kind: 0
-          name: 71
+          kind: 1
+          name: 72
           value: -1
           raw: -1
-          pkg: 2
-          type: 3
-          position: 82
+          pkg: 3
+          type: 4
+          position: 83
           resolved_type: -1
           generic_type_name: -1
         raw: -1
         pkg: -1
         type: -1
-        position: 83
+        position: 84
         resolved_type: -1
         generic_type_name: -1

--- a/internal/spec/tests/generic.yaml
+++ b/internal/spec/tests/generic.yaml
@@ -1,4 +1,5 @@
 string_pool:
+  - ""
   - ident
   - c
   - generic
@@ -111,35 +112,35 @@ packages:
       generic/generic.go:
         types:
           Container:
-            name: 27
-            pkg: 2
-            kind: 28
+            name: 28
+            pkg: 3
+            kind: 29
             fields:
-              - name: 5
-                type: 6
+              - name: 6
+                type: 7
                 tag: -1
-                scope: 15
+                scope: 16
                 comments: -1
-            scope: 15
+            scope: 16
             methods:
-              - name: 9
-                receiver: 10
+              - name: 10
+                receiver: 11
                 signature:
-                  kind: 12
+                  kind: 13
                   name: -1
                   value: -1
                   fun:
-                    kind: 13
+                    kind: 14
                     name: -1
                     value: -1
                     args:
-                      - kind: 0
-                        name: 6
+                      - kind: 1
+                        name: 7
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 6
-                        position: 11
+                        pkg: 3
+                        type: 7
+                        position: 12
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
@@ -152,81 +153,81 @@ packages:
                   pkg: -1
                   type: -1
                   position: -1
-                  resolved_type: 6
+                  resolved_type: 7
                   generic_type_name: -1
-                signature_str: 17
-                position: 14
-                scope: 15
+                signature_str: 18
+                position: 15
+                scope: 16
                 comments: -1
-                filename: 16
+                filename: 17
                 return_vars:
-                  - kind: 8
+                  - kind: 9
                     name: -1
                     value: -1
                     x:
-                      kind: 0
-                      name: 1
+                      kind: 1
+                      name: 2
                       value: -1
                       raw: -1
-                      pkg: 2
-                      type: 3
-                      position: 4
+                      pkg: 3
+                      type: 4
+                      position: 5
                       resolved_type: -1
                       generic_type_name: -1
                     sel:
-                      kind: 0
-                      name: 5
+                      kind: 1
+                      name: 6
                       value: -1
                       raw: -1
-                      pkg: 2
-                      type: 6
-                      position: 7
+                      pkg: 3
+                      type: 7
+                      position: 8
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
-                    pkg: 2
-                    type: 6
-                    position: 4
+                    pkg: 3
+                    type: 7
+                    position: 5
                     resolved_type: -1
                     generic_type_name: -1
                 returns:
-                  - - kind: 8
+                  - - kind: 9
                       name: -1
                       value: -1
                       x:
-                        kind: 0
-                        name: 1
+                        kind: 1
+                        name: 2
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 3
-                        position: 4
+                        pkg: 3
+                        type: 4
+                        position: 5
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 0
-                        name: 5
+                        kind: 1
+                        name: 6
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 6
-                        position: 7
+                        pkg: 3
+                        type: 7
+                        position: 8
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 2
-                      type: 6
-                      position: 4
+                      pkg: 3
+                      type: 7
+                      position: 5
                       resolved_type: -1
                       generic_type_name: -1
-              - name: 24
-                receiver: 10
+              - name: 25
+                receiver: 11
                 signature:
-                  kind: 12
+                  kind: 13
                   name: -1
                   value: -1
                   fun:
-                    kind: 13
+                    kind: 14
                     name: -1
                     value: -1
                     raw: -1
@@ -236,13 +237,13 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   args:
-                    - kind: 0
-                      name: 19
+                    - kind: 1
+                      name: 20
                       value: -1
                       raw: -1
-                      pkg: 2
-                      type: 6
-                      position: 18
+                      pkg: 3
+                      type: 7
+                      position: 19
                       resolved_type: -1
                       generic_type_name: -1
                   raw: -1
@@ -251,56 +252,56 @@ packages:
                   position: -1
                   resolved_type: -1
                   generic_type_name: -1
-                signature_str: 26
-                position: 25
-                scope: 15
+                signature_str: 27
+                position: 26
+                scope: 16
                 comments: -1
-                filename: 16
+                filename: 17
                 assignments:
                   generic.Container[T].Value:
-                    - variable_name: 22
-                      pkg: 2
-                      concrete_type: 6
-                      position: 20
-                      scope: 8
+                    - variable_name: 23
+                      pkg: 3
+                      concrete_type: 7
+                      position: 21
+                      scope: 9
                       value:
-                        kind: 0
-                        name: 19
+                        kind: 1
+                        name: 20
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 6
-                        position: 23
+                        pkg: 3
+                        type: 7
+                        position: 24
                         resolved_type: -1
                         generic_type_name: -1
                       lhs:
-                        kind: 8
+                        kind: 9
                         name: -1
                         value: -1
                         x:
-                          kind: 0
-                          name: 1
+                          kind: 1
+                          name: 2
                           value: -1
                           raw: -1
-                          pkg: 2
-                          type: 3
-                          position: 20
-                          resolved_type: -1
-                          generic_type_name: -1
-                        sel:
-                          kind: 0
-                          name: 5
-                          value: -1
-                          raw: -1
-                          pkg: 2
-                          type: 6
+                          pkg: 3
+                          type: 4
                           position: 21
                           resolved_type: -1
                           generic_type_name: -1
+                        sel:
+                          kind: 1
+                          name: 6
+                          value: -1
+                          raw: -1
+                          pkg: 3
+                          type: 7
+                          position: 22
+                          resolved_type: -1
+                          generic_type_name: -1
                         raw: -1
-                        pkg: 2
-                        type: 6
-                        position: 20
+                        pkg: 3
+                        type: 7
+                        position: 21
                         resolved_type: -1
                         generic_type_name: -1
             comments: -1
@@ -308,54 +309,54 @@ packages:
               - T
         functions:
           NewContainer:
-            name: 41
-            pkg: 2
+            name: 42
+            pkg: 3
             signature:
-              kind: 12
+              kind: 13
               name: -1
               value: -1
               fun:
-                kind: 13
+                kind: 14
                 name: -1
                 value: -1
                 args:
-                  - kind: 47
+                  - kind: 48
                     name: -1
                     value: -1
                     x:
-                      kind: 33
+                      kind: 34
                       name: -1
                       value: -1
                       x:
-                        kind: 0
-                        name: 27
+                        kind: 1
+                        name: 28
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 30
-                        position: 45
+                        pkg: 3
+                        type: 31
+                        position: 46
                         resolved_type: -1
                         generic_type_name: -1
                       fun:
-                        kind: 0
-                        name: 6
+                        kind: 1
+                        name: 7
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 6
-                        position: 46
+                        pkg: 3
+                        type: 7
+                        position: 47
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
                       pkg: -1
                       type: -1
-                      position: 45
+                      position: 46
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
                     pkg: -1
                     type: -1
-                    position: 48
+                    position: 49
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -365,217 +366,217 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 0
-                  name: 19
+                - kind: 1
+                  name: 20
                   value: -1
                   raw: -1
-                  pkg: 2
-                  type: 6
-                  position: 42
+                  pkg: 3
+                  type: 7
+                  position: 43
                   resolved_type: -1
                   generic_type_name: -1
               tparams:
-                - kind: 0
-                  name: 6
+                - kind: 1
+                  name: 7
                   value: -1
                   raw: -1
                   pkg: -1
-                  type: 43
-                  position: 44
+                  type: 44
+                  position: 45
                   resolved_type: -1
                   generic_type_name: -1
               raw: -1
               pkg: -1
               type: -1
               position: -1
-              resolved_type: 105
+              resolved_type: 106
               generic_type_name: -1
-            signature_str: 50
-            position: 49
-            scope: 15
+            signature_str: 51
+            position: 50
+            scope: 16
             comments: -1
             type_params:
               - T
             return_vars:
-              - kind: 38
+              - kind: 39
                 name: -1
-                value: 39
+                value: 40
                 x:
-                  kind: 37
+                  kind: 38
                   name: -1
                   value: -1
                   x:
-                    kind: 33
+                    kind: 34
                     name: -1
                     value: -1
                     x:
-                      kind: 0
-                      name: 27
+                      kind: 1
+                      name: 28
                       value: -1
                       raw: -1
-                      pkg: 2
-                      type: 30
-                      position: 31
+                      pkg: 3
+                      type: 31
+                      position: 32
                       resolved_type: -1
                       generic_type_name: -1
                     fun:
-                      kind: 0
-                      name: 6
+                      kind: 1
+                      name: 7
                       value: -1
                       raw: -1
-                      pkg: 2
-                      type: 6
-                      position: 32
+                      pkg: 3
+                      type: 7
+                      position: 33
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
                     pkg: -1
                     type: -1
-                    position: 31
+                    position: 32
                     resolved_type: -1
                     generic_type_name: -1
                   args:
-                    - kind: 36
+                    - kind: 37
                       name: -1
                       value: -1
                       x:
-                        kind: 0
-                        name: 5
+                        kind: 1
+                        name: 6
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 6
-                        position: 34
+                        pkg: 3
+                        type: 7
+                        position: 35
                         resolved_type: -1
                         generic_type_name: -1
                       fun:
-                        kind: 0
-                        name: 19
+                        kind: 1
+                        name: 20
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 6
-                        position: 35
+                        pkg: 3
+                        type: 7
+                        position: 36
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
                       pkg: -1
                       type: -1
-                      position: 34
+                      position: 35
                       resolved_type: -1
                       generic_type_name: -1
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 31
+                  position: 32
                   resolved_type: -1
                   generic_type_name: -1
                 raw: -1
                 pkg: -1
                 type: -1
-                position: 40
+                position: 41
                 resolved_type: -1
                 generic_type_name: -1
             returns:
-              - - kind: 38
+              - - kind: 39
                   name: -1
-                  value: 39
+                  value: 40
                   x:
-                    kind: 37
+                    kind: 38
                     name: -1
                     value: -1
                     x:
-                      kind: 33
+                      kind: 34
                       name: -1
                       value: -1
                       x:
-                        kind: 0
-                        name: 27
+                        kind: 1
+                        name: 28
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 30
-                        position: 31
+                        pkg: 3
+                        type: 31
+                        position: 32
                         resolved_type: -1
                         generic_type_name: -1
                       fun:
-                        kind: 0
-                        name: 6
+                        kind: 1
+                        name: 7
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 6
-                        position: 32
+                        pkg: 3
+                        type: 7
+                        position: 33
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
                       pkg: -1
                       type: -1
-                      position: 31
+                      position: 32
                       resolved_type: -1
                       generic_type_name: -1
                     args:
-                      - kind: 36
+                      - kind: 37
                         name: -1
                         value: -1
                         x:
-                          kind: 0
-                          name: 5
+                          kind: 1
+                          name: 6
                           value: -1
                           raw: -1
-                          pkg: 2
-                          type: 6
-                          position: 34
+                          pkg: 3
+                          type: 7
+                          position: 35
                           resolved_type: -1
                           generic_type_name: -1
                         fun:
-                          kind: 0
-                          name: 19
+                          kind: 1
+                          name: 20
                           value: -1
                           raw: -1
-                          pkg: 2
-                          type: 6
-                          position: 35
+                          pkg: 3
+                          type: 7
+                          position: 36
                           resolved_type: -1
                           generic_type_name: -1
                         raw: -1
                         pkg: -1
                         type: -1
-                        position: 34
+                        position: 35
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
                     pkg: -1
                     type: -1
-                    position: 31
+                    position: 32
                     resolved_type: -1
                     generic_type_name: -1
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 40
+                  position: 41
                   resolved_type: -1
                   generic_type_name: -1
             end_line: 17
           Process:
-            name: 58
-            pkg: 2
+            name: 59
+            pkg: 3
             signature:
-              kind: 12
+              kind: 13
               name: -1
               value: -1
               fun:
-                kind: 13
+                kind: 14
                 name: -1
                 value: -1
                 args:
-                  - kind: 0
-                    name: 6
+                  - kind: 1
+                    name: 7
                     value: -1
                     raw: -1
-                    pkg: 2
-                    type: 6
-                    position: 64
+                    pkg: 3
+                    type: 7
+                    position: 65
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -585,84 +586,84 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 60
-                  name: 53
+                - kind: 61
+                  name: 54
                   value: -1
                   x:
-                    kind: 0
-                    name: 6
+                    kind: 1
+                    name: 7
                     value: -1
                     raw: -1
-                    pkg: 2
-                    type: 6
-                    position: 59
+                    pkg: 3
+                    type: 7
+                    position: 60
                     resolved_type: -1
                     generic_type_name: -1
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 61
+                  position: 62
                   resolved_type: -1
                   generic_type_name: -1
               tparams:
-                - kind: 0
-                  name: 6
+                - kind: 1
+                  name: 7
                   value: -1
                   raw: -1
                   pkg: -1
-                  type: 62
-                  position: 63
+                  type: 63
+                  position: 64
                   resolved_type: -1
                   generic_type_name: -1
               raw: -1
               pkg: -1
               type: -1
               position: -1
-              resolved_type: 6
+              resolved_type: 7
               generic_type_name: -1
-            signature_str: 66
-            position: 65
-            scope: 15
+            signature_str: 67
+            position: 66
+            scope: 16
             comments: -1
             type_params:
               - T
             return_vars:
-              - kind: 0
-                name: 51
+              - kind: 1
+                name: 52
                 value: -1
                 raw: -1
-                pkg: 2
-                type: 6
-                position: 52
+                pkg: 3
+                type: 7
+                position: 53
                 resolved_type: -1
                 generic_type_name: -1
             returns:
-              - - kind: 0
-                  name: 51
+              - - kind: 1
+                  name: 52
                   value: -1
                   raw: -1
-                  pkg: 2
-                  type: 6
-                  position: 52
+                  pkg: 3
+                  type: 7
+                  position: 53
                   resolved_type: -1
                   generic_type_name: -1
-              - - kind: 33
+              - - kind: 34
                   name: -1
                   value: -1
                   x:
-                    kind: 0
-                    name: 53
+                    kind: 1
+                    name: 54
                     value: -1
                     raw: -1
-                    pkg: 2
-                    type: 54
-                    position: 55
+                    pkg: 3
+                    type: 55
+                    position: 56
                     resolved_type: -1
                     generic_type_name: -1
                   fun:
-                    kind: 56
+                    kind: 57
                     name: -1
-                    value: 57
+                    value: 58
                     raw: -1
                     pkg: -1
                     type: -1
@@ -672,7 +673,7 @@ packages:
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 55
+                  position: 56
                   resolved_type: -1
                   generic_type_name: -1
             end_line: 25
@@ -685,14 +686,14 @@ packages:
                 terminates: true
                 group: 1
           main:
-            name: 76
-            pkg: 2
+            name: 77
+            pkg: 3
             signature:
-              kind: 12
+              kind: 13
               name: -1
               value: -1
               fun:
-                kind: 13
+                kind: 14
                 name: -1
                 value: -1
                 raw: -1
@@ -707,55 +708,55 @@ packages:
               position: -1
               resolved_type: -1
               generic_type_name: -1
-            signature_str: 94
-            position: 93
-            scope: 75
+            signature_str: 95
+            position: 94
+            scope: 76
             comments: -1
             assignments:
               c:
-                - variable_name: 1
-                  pkg: 2
-                  concrete_type: 73
-                  position: 74
-                  scope: 75
+                - variable_name: 2
+                  pkg: 3
+                  concrete_type: 74
+                  position: 75
+                  scope: 76
                   value:
-                    kind: 72
+                    kind: 73
                     name: -1
                     value: -1
                     fun:
-                      kind: 33
+                      kind: 34
                       name: -1
                       value: -1
                       x:
-                        kind: 0
-                        name: 41
+                        kind: 1
+                        name: 42
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 68
-                        position: 69
+                        pkg: 3
+                        type: 69
+                        position: 70
                         resolved_type: -1
                         generic_type_name: -1
                       fun:
-                        kind: 0
-                        name: 70
+                        kind: 1
+                        name: 71
                         value: -1
                         raw: -1
                         pkg: -1
-                        type: 70
-                        position: 71
+                        type: 71
+                        position: 72
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
                       pkg: -1
                       type: -1
-                      position: 69
+                      position: 70
                       resolved_type: -1
                       generic_type_name: -1
                     args:
-                      - kind: 56
+                      - kind: 57
                         name: -1
-                        value: 67
+                        value: 68
                         raw: -1
                         pkg: -1
                         type: -1
@@ -764,98 +765,89 @@ packages:
                         generic_type_name: -1
                     raw: -1
                     pkg: -1
-                    type: 73
-                    position: 69
+                    type: 74
+                    position: 70
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 0
-                    name: 1
+                    kind: 1
+                    name: 2
                     value: -1
                     raw: -1
-                    pkg: 2
-                    type: 73
-                    position: 74
+                    pkg: 3
+                    type: 74
+                    position: 75
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 76
+                  func: 77
                   callee_func: NewContainer
                   callee_pkg: generic
               result:
-                - variable_name: 91
-                  pkg: 2
-                  concrete_type: 83
-                  position: 92
-                  scope: 75
+                - variable_name: 92
+                  pkg: 3
+                  concrete_type: 84
+                  position: 93
+                  scope: 76
                   value:
-                    kind: 72
+                    kind: 73
                     name: -1
                     value: -1
                     fun:
-                      kind: 33
+                      kind: 34
                       name: -1
                       value: -1
                       x:
-                        kind: 0
-                        name: 58
+                        kind: 1
+                        name: 59
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 88
-                        position: 89
+                        pkg: 3
+                        type: 89
+                        position: 90
                         resolved_type: -1
                         generic_type_name: -1
                       fun:
-                        kind: 0
-                        name: 83
+                        kind: 1
+                        name: 84
                         value: -1
                         raw: -1
                         pkg: -1
-                        type: 83
-                        position: 90
+                        type: 84
+                        position: 91
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
                       pkg: -1
                       type: -1
-                      position: 89
+                      position: 90
                       resolved_type: -1
                       generic_type_name: -1
                     args:
-                      - kind: 37
+                      - kind: 38
                         name: -1
                         value: -1
                         x:
-                          kind: 60
+                          kind: 61
                           name: -1
                           value: -1
                           x:
-                            kind: 0
-                            name: 83
+                            kind: 1
+                            name: 84
                             value: -1
                             raw: -1
                             pkg: -1
-                            type: 83
-                            position: 84
+                            type: 84
+                            position: 85
                             resolved_type: -1
                             generic_type_name: -1
                           raw: -1
                           pkg: -1
                           type: -1
-                          position: 85
+                          position: 86
                           resolved_type: -1
                           generic_type_name: -1
                         args:
-                          - kind: 56
-                            name: -1
-                            value: 86
-                            raw: -1
-                            pkg: -1
-                            type: -1
-                            position: -1
-                            resolved_type: -1
-                            generic_type_name: -1
-                          - kind: 56
+                          - kind: 57
                             name: -1
                             value: 87
                             raw: -1
@@ -864,142 +856,151 @@ packages:
                             position: -1
                             resolved_type: -1
                             generic_type_name: -1
+                          - kind: 57
+                            name: -1
+                            value: 88
+                            raw: -1
+                            pkg: -1
+                            type: -1
+                            position: -1
+                            resolved_type: -1
+                            generic_type_name: -1
                         raw: -1
                         pkg: -1
                         type: -1
-                        position: 85
+                        position: 86
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
                     pkg: -1
-                    type: 83
-                    position: 89
+                    type: 84
+                    position: 90
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 0
-                    name: 91
+                    kind: 1
+                    name: 92
                     value: -1
                     raw: -1
-                    pkg: 2
-                    type: 83
-                    position: 92
+                    pkg: 3
+                    type: 84
+                    position: 93
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 76
+                  func: 77
                   callee_func: Process
                   callee_pkg: generic
               val:
-                - variable_name: 81
-                  pkg: 2
-                  concrete_type: 70
-                  position: 82
-                  scope: 75
+                - variable_name: 82
+                  pkg: 3
+                  concrete_type: 71
+                  position: 83
+                  scope: 76
                   value:
-                    kind: 72
+                    kind: 73
                     name: -1
                     value: -1
                     fun:
-                      kind: 8
+                      kind: 9
                       name: -1
                       value: -1
                       x:
-                        kind: 0
-                        name: 1
+                        kind: 1
+                        name: 2
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 73
-                        position: 77
+                        pkg: 3
+                        type: 74
+                        position: 78
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 0
-                        name: 9
+                        kind: 1
+                        name: 10
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 78
-                        position: 79
+                        pkg: 3
+                        type: 79
+                        position: 80
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 2
-                      type: 78
-                      position: 77
+                      pkg: 3
+                      type: 79
+                      position: 78
                       resolved_type: -1
                       generic_type_name: -1
                       receiver_type:
-                        kind: 0
-                        name: 80
+                        kind: 1
+                        name: 81
                         value: -1
                         raw: -1
-                        pkg: 2
-                        type: 80
+                        pkg: 3
+                        type: 81
                         position: -1
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
                     pkg: -1
-                    type: 70
-                    position: 77
+                    type: 71
+                    position: 78
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 0
-                    name: 81
+                    kind: 1
+                    name: 82
                     value: -1
                     raw: -1
-                    pkg: 2
-                    type: 70
-                    position: 82
+                    pkg: 3
+                    type: 71
+                    position: 83
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 76
+                  func: 77
                   callee_func: Get
                   callee_pkg: generic
             end_line: 35
         struct_instances:
-          - type: 95
-            pkg: 2
-            position: 31
-            fields:
-              5: 19
           - type: 96
-            pkg: 2
-            position: 85
+            pkg: 3
+            position: 32
+            fields:
+              6: 20
+          - type: 97
+            pkg: 3
+            position: 86
         imports: {}
     types:
       Container:
-        name: 27
-        pkg: 2
-        kind: 28
+        name: 28
+        pkg: 3
+        kind: 29
         fields:
-          - name: 5
-            type: 6
+          - name: 6
+            type: 7
             tag: -1
-            scope: 15
+            scope: 16
             comments: -1
-        scope: 15
+        scope: 16
         methods:
-          - name: 9
-            receiver: 10
+          - name: 10
+            receiver: 11
             signature:
-              kind: 12
+              kind: 13
               name: -1
               value: -1
               fun:
-                kind: 13
+                kind: 14
                 name: -1
                 value: -1
                 args:
-                  - kind: 0
-                    name: 6
+                  - kind: 1
+                    name: 7
                     value: -1
                     raw: -1
-                    pkg: 2
-                    type: 6
-                    position: 11
+                    pkg: 3
+                    type: 7
+                    position: 12
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -1012,81 +1013,81 @@ packages:
               pkg: -1
               type: -1
               position: -1
-              resolved_type: 6
+              resolved_type: 7
               generic_type_name: -1
-            signature_str: 17
-            position: 14
-            scope: 15
+            signature_str: 18
+            position: 15
+            scope: 16
             comments: -1
-            filename: 16
+            filename: 17
             return_vars:
-              - kind: 8
+              - kind: 9
                 name: -1
                 value: -1
                 x:
-                  kind: 0
-                  name: 1
+                  kind: 1
+                  name: 2
                   value: -1
                   raw: -1
-                  pkg: 2
-                  type: 3
-                  position: 4
+                  pkg: 3
+                  type: 4
+                  position: 5
                   resolved_type: -1
                   generic_type_name: -1
                 sel:
-                  kind: 0
-                  name: 5
+                  kind: 1
+                  name: 6
                   value: -1
                   raw: -1
-                  pkg: 2
-                  type: 6
-                  position: 7
+                  pkg: 3
+                  type: 7
+                  position: 8
                   resolved_type: -1
                   generic_type_name: -1
                 raw: -1
-                pkg: 2
-                type: 6
-                position: 4
+                pkg: 3
+                type: 7
+                position: 5
                 resolved_type: -1
                 generic_type_name: -1
             returns:
-              - - kind: 8
+              - - kind: 9
                   name: -1
                   value: -1
                   x:
-                    kind: 0
-                    name: 1
+                    kind: 1
+                    name: 2
                     value: -1
                     raw: -1
-                    pkg: 2
-                    type: 3
-                    position: 4
+                    pkg: 3
+                    type: 4
+                    position: 5
                     resolved_type: -1
                     generic_type_name: -1
                   sel:
-                    kind: 0
-                    name: 5
+                    kind: 1
+                    name: 6
                     value: -1
                     raw: -1
-                    pkg: 2
-                    type: 6
-                    position: 7
+                    pkg: 3
+                    type: 7
+                    position: 8
                     resolved_type: -1
                     generic_type_name: -1
                   raw: -1
-                  pkg: 2
-                  type: 6
-                  position: 4
+                  pkg: 3
+                  type: 7
+                  position: 5
                   resolved_type: -1
                   generic_type_name: -1
-          - name: 24
-            receiver: 10
+          - name: 25
+            receiver: 11
             signature:
-              kind: 12
+              kind: 13
               name: -1
               value: -1
               fun:
-                kind: 13
+                kind: 14
                 name: -1
                 value: -1
                 raw: -1
@@ -1096,13 +1097,13 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 0
-                  name: 19
+                - kind: 1
+                  name: 20
                   value: -1
                   raw: -1
-                  pkg: 2
-                  type: 6
-                  position: 18
+                  pkg: 3
+                  type: 7
+                  position: 19
                   resolved_type: -1
                   generic_type_name: -1
               raw: -1
@@ -1111,56 +1112,56 @@ packages:
               position: -1
               resolved_type: -1
               generic_type_name: -1
-            signature_str: 26
-            position: 25
-            scope: 15
+            signature_str: 27
+            position: 26
+            scope: 16
             comments: -1
-            filename: 16
+            filename: 17
             assignments:
               generic.Container[T].Value:
-                - variable_name: 22
-                  pkg: 2
-                  concrete_type: 6
-                  position: 20
-                  scope: 8
+                - variable_name: 23
+                  pkg: 3
+                  concrete_type: 7
+                  position: 21
+                  scope: 9
                   value:
-                    kind: 0
-                    name: 19
+                    kind: 1
+                    name: 20
                     value: -1
                     raw: -1
-                    pkg: 2
-                    type: 6
-                    position: 23
+                    pkg: 3
+                    type: 7
+                    position: 24
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 8
+                    kind: 9
                     name: -1
                     value: -1
                     x:
-                      kind: 0
-                      name: 1
+                      kind: 1
+                      name: 2
                       value: -1
                       raw: -1
-                      pkg: 2
-                      type: 3
-                      position: 20
-                      resolved_type: -1
-                      generic_type_name: -1
-                    sel:
-                      kind: 0
-                      name: 5
-                      value: -1
-                      raw: -1
-                      pkg: 2
-                      type: 6
+                      pkg: 3
+                      type: 4
                       position: 21
                       resolved_type: -1
                       generic_type_name: -1
+                    sel:
+                      kind: 1
+                      name: 6
+                      value: -1
+                      raw: -1
+                      pkg: 3
+                      type: 7
+                      position: 22
+                      resolved_type: -1
+                      generic_type_name: -1
                     raw: -1
-                    pkg: 2
-                    type: 6
-                    position: 20
+                    pkg: 3
+                    type: 7
+                    position: 21
                     resolved_type: -1
                     generic_type_name: -1
         comments: -1
@@ -1168,50 +1169,50 @@ packages:
           - T
 call_graph:
   - caller:
-      name: 58
-      pkg: 2
+      name: 59
+      pkg: 3
       position: -1
       recv_type: -1
-      scope: 15
-      signature_str: 66
+      scope: 16
+      signature_str: 67
     callee:
-      name: 99
-      pkg: 2
-      position: 98
+      name: 100
+      pkg: 3
+      position: 99
       recv_type: -1
-      scope: 75
-      signature_str: 100
-    position: 98
+      scope: 76
+      signature_str: 101
+    position: 99
     args:
-      - kind: 0
-        name: 53
+      - kind: 1
+        name: 54
         value: -1
         raw: -1
-        pkg: 2
-        type: 54
-        position: 97
+        pkg: 3
+        type: 55
+        position: 98
         resolved_type: -1
         generic_type_name: -1
     callee_recv_var_name: generic.Container[T].Value
   - caller:
-      name: 76
-      pkg: 2
+      name: 77
+      pkg: 3
       position: -1
       recv_type: -1
-      scope: 75
-      signature_str: 94
+      scope: 76
+      signature_str: 95
     callee:
-      name: 41
-      pkg: 2
-      position: 69
+      name: 42
+      pkg: 3
+      position: 70
       recv_type: -1
-      scope: 15
-      signature_str: 68
-    position: 69
+      scope: 16
+      signature_str: 69
+    position: 70
     args:
-      - kind: 56
+      - kind: 57
         name: -1
-        value: 67
+        value: 68
         raw: -1
         pkg: -1
         type: -1
@@ -1220,49 +1221,49 @@ call_graph:
         generic_type_name: -1
     assignments:
       c:
-        - variable_name: 1
-          pkg: 2
-          concrete_type: 73
-          position: 74
-          scope: 75
+        - variable_name: 2
+          pkg: 3
+          concrete_type: 74
+          position: 75
+          scope: 76
           value:
-            kind: 72
+            kind: 73
             name: -1
             value: -1
             fun:
-              kind: 33
+              kind: 34
               name: -1
               value: -1
               x:
-                kind: 0
-                name: 41
+                kind: 1
+                name: 42
                 value: -1
                 raw: -1
-                pkg: 2
-                type: 68
-                position: 69
+                pkg: 3
+                type: 69
+                position: 70
                 resolved_type: -1
                 generic_type_name: -1
               fun:
-                kind: 0
-                name: 70
+                kind: 1
+                name: 71
                 value: -1
                 raw: -1
                 pkg: -1
-                type: 70
-                position: 71
+                type: 71
+                position: 72
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
               pkg: -1
               type: -1
-              position: 69
+              position: 70
               resolved_type: -1
               generic_type_name: -1
             args:
-              - kind: 56
+              - kind: 57
                 name: -1
-                value: 67
+                value: 68
                 raw: -1
                 pkg: -1
                 type: -1
@@ -1271,28 +1272,28 @@ call_graph:
                 generic_type_name: -1
             raw: -1
             pkg: -1
-            type: 73
-            position: 69
+            type: 74
+            position: 70
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 0
-            name: 1
+            kind: 1
+            name: 2
             value: -1
             raw: -1
-            pkg: 2
-            type: 73
-            position: 74
+            pkg: 3
+            type: 74
+            position: 75
             resolved_type: -1
             generic_type_name: -1
-          func: 76
+          func: 77
           callee_func: NewContainer
           callee_pkg: generic
     param_arg_map:
       value:
-        kind: 56
+        kind: 57
         name: -1
-        value: 67
+        value: 68
         raw: -1
         pkg: -1
         type: -1
@@ -1303,112 +1304,112 @@ call_graph:
       T: int
     callee_recv_var_name: c
   - caller:
-      name: 76
-      pkg: 2
+      name: 77
+      pkg: 3
       position: -1
       recv_type: -1
-      scope: 75
-      signature_str: 94
+      scope: 76
+      signature_str: 95
     callee:
-      name: 9
-      pkg: 2
-      position: 77
-      recv_type: 101
-      scope: 15
-      signature_str: 78
-    position: 77
+      name: 10
+      pkg: 3
+      position: 78
+      recv_type: 102
+      scope: 16
+      signature_str: 79
+    position: 78
     assignments:
       val:
-        - variable_name: 81
-          pkg: 2
-          concrete_type: 70
-          position: 82
-          scope: 75
+        - variable_name: 82
+          pkg: 3
+          concrete_type: 71
+          position: 83
+          scope: 76
           value:
-            kind: 72
+            kind: 73
             name: -1
             value: -1
             fun:
-              kind: 8
+              kind: 9
               name: -1
               value: -1
               x:
-                kind: 0
-                name: 1
+                kind: 1
+                name: 2
                 value: -1
                 raw: -1
-                pkg: 2
-                type: 73
-                position: 77
+                pkg: 3
+                type: 74
+                position: 78
                 resolved_type: -1
                 generic_type_name: -1
               sel:
-                kind: 0
-                name: 9
+                kind: 1
+                name: 10
                 value: -1
                 raw: -1
-                pkg: 2
-                type: 78
-                position: 79
+                pkg: 3
+                type: 79
+                position: 80
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
-              pkg: 2
-              type: 78
-              position: 77
+              pkg: 3
+              type: 79
+              position: 78
               resolved_type: -1
               generic_type_name: -1
               receiver_type:
-                kind: 0
-                name: 80
+                kind: 1
+                name: 81
                 value: -1
                 raw: -1
-                pkg: 2
-                type: 80
+                pkg: 3
+                type: 81
                 position: -1
                 resolved_type: -1
                 generic_type_name: -1
             raw: -1
             pkg: -1
-            type: 70
-            position: 77
+            type: 71
+            position: 78
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 0
-            name: 81
+            kind: 1
+            name: 82
             value: -1
             raw: -1
-            pkg: 2
-            type: 70
-            position: 82
+            pkg: 3
+            type: 71
+            position: 83
             resolved_type: -1
             generic_type_name: -1
-          func: 76
+          func: 77
           callee_func: Get
           callee_pkg: generic
     callee_var_name: c
     callee_recv_var_name: val
     chain_root: c
   - caller:
-      name: 76
-      pkg: 2
+      name: 77
+      pkg: 3
       position: -1
       recv_type: -1
-      scope: 75
-      signature_str: 94
+      scope: 76
+      signature_str: 95
     callee:
-      name: 24
-      pkg: 2
-      position: 103
-      recv_type: 101
-      scope: 15
-      signature_str: 104
-    position: 103
+      name: 25
+      pkg: 3
+      position: 104
+      recv_type: 102
+      scope: 16
+      signature_str: 105
+    position: 104
     args:
-      - kind: 56
+      - kind: 57
         name: -1
-        value: 102
+        value: 103
         raw: -1
         pkg: -1
         type: -1
@@ -1417,9 +1418,9 @@ call_graph:
         generic_type_name: -1
     param_arg_map:
       value:
-        kind: 56
+        kind: 57
         name: -1
-        value: 102
+        value: 103
         raw: -1
         pkg: -1
         type: -1
@@ -1429,57 +1430,57 @@ call_graph:
     callee_var_name: c
     chain_root: c
   - caller:
-      name: 76
-      pkg: 2
+      name: 77
+      pkg: 3
       position: -1
       recv_type: -1
-      scope: 75
-      signature_str: 94
+      scope: 76
+      signature_str: 95
     callee:
-      name: 58
-      pkg: 2
-      position: 89
+      name: 59
+      pkg: 3
+      position: 90
       recv_type: -1
-      scope: 15
-      signature_str: 88
-    position: 89
+      scope: 16
+      signature_str: 89
+    position: 90
     args:
-      - kind: 37
+      - kind: 38
         name: -1
         value: -1
         x:
-          kind: 60
+          kind: 61
           name: -1
           value: -1
           x:
-            kind: 0
-            name: 83
+            kind: 1
+            name: 84
             value: -1
             raw: -1
             pkg: -1
-            type: 83
-            position: 84
+            type: 84
+            position: 85
             resolved_type: -1
             generic_type_name: -1
           raw: -1
           pkg: -1
           type: -1
-          position: 85
+          position: 86
           resolved_type: -1
           generic_type_name: -1
         args:
-          - kind: 56
+          - kind: 57
             name: -1
-            value: 86
+            value: 87
             raw: -1
             pkg: -1
             type: -1
             position: -1
             resolved_type: -1
             generic_type_name: -1
-          - kind: 56
+          - kind: 57
             name: -1
-            value: 87
+            value: 88
             raw: -1
             pkg: -1
             type: -1
@@ -1489,87 +1490,87 @@ call_graph:
         raw: -1
         pkg: -1
         type: -1
-        position: 85
+        position: 86
         resolved_type: -1
         generic_type_name: -1
     assignments:
       result:
-        - variable_name: 91
-          pkg: 2
-          concrete_type: 83
-          position: 92
-          scope: 75
+        - variable_name: 92
+          pkg: 3
+          concrete_type: 84
+          position: 93
+          scope: 76
           value:
-            kind: 72
+            kind: 73
             name: -1
             value: -1
             fun:
-              kind: 33
+              kind: 34
               name: -1
               value: -1
               x:
-                kind: 0
-                name: 58
+                kind: 1
+                name: 59
                 value: -1
                 raw: -1
-                pkg: 2
-                type: 88
-                position: 89
+                pkg: 3
+                type: 89
+                position: 90
                 resolved_type: -1
                 generic_type_name: -1
               fun:
-                kind: 0
-                name: 83
+                kind: 1
+                name: 84
                 value: -1
                 raw: -1
                 pkg: -1
-                type: 83
-                position: 90
+                type: 84
+                position: 91
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
               pkg: -1
               type: -1
-              position: 89
+              position: 90
               resolved_type: -1
               generic_type_name: -1
             args:
-              - kind: 37
+              - kind: 38
                 name: -1
                 value: -1
                 x:
-                  kind: 60
+                  kind: 61
                   name: -1
                   value: -1
                   x:
-                    kind: 0
-                    name: 83
+                    kind: 1
+                    name: 84
                     value: -1
                     raw: -1
                     pkg: -1
-                    type: 83
-                    position: 84
+                    type: 84
+                    position: 85
                     resolved_type: -1
                     generic_type_name: -1
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 85
+                  position: 86
                   resolved_type: -1
                   generic_type_name: -1
                 args:
-                  - kind: 56
+                  - kind: 57
                     name: -1
-                    value: 86
+                    value: 87
                     raw: -1
                     pkg: -1
                     type: -1
                     position: -1
                     resolved_type: -1
                     generic_type_name: -1
-                  - kind: 56
+                  - kind: 57
                     name: -1
-                    value: 87
+                    value: 88
                     raw: -1
                     pkg: -1
                     type: -1
@@ -1579,66 +1580,66 @@ call_graph:
                 raw: -1
                 pkg: -1
                 type: -1
-                position: 85
+                position: 86
                 resolved_type: -1
                 generic_type_name: -1
             raw: -1
             pkg: -1
-            type: 83
-            position: 89
+            type: 84
+            position: 90
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 0
-            name: 91
+            kind: 1
+            name: 92
             value: -1
             raw: -1
-            pkg: 2
-            type: 83
-            position: 92
+            pkg: 3
+            type: 84
+            position: 93
             resolved_type: -1
             generic_type_name: -1
-          func: 76
+          func: 77
           callee_func: Process
           callee_pkg: generic
     param_arg_map:
       items:
-        kind: 37
+        kind: 38
         name: -1
         value: -1
         x:
-          kind: 60
+          kind: 61
           name: -1
           value: -1
           x:
-            kind: 0
-            name: 83
+            kind: 1
+            name: 84
             value: -1
             raw: -1
             pkg: -1
-            type: 83
-            position: 84
+            type: 84
+            position: 85
             resolved_type: -1
             generic_type_name: -1
           raw: -1
           pkg: -1
           type: -1
-          position: 85
+          position: 86
           resolved_type: -1
           generic_type_name: -1
         args:
-          - kind: 56
+          - kind: 57
             name: -1
-            value: 86
+            value: 87
             raw: -1
             pkg: -1
             type: -1
             position: -1
             resolved_type: -1
             generic_type_name: -1
-          - kind: 56
+          - kind: 57
             name: -1
-            value: 87
+            value: 88
             raw: -1
             pkg: -1
             type: -1
@@ -1648,7 +1649,7 @@ call_graph:
         raw: -1
         pkg: -1
         type: -1
-        position: 85
+        position: 86
         resolved_type: -1
         generic_type_name: -1
     type_param_map:

--- a/internal/spec/tests/main.yaml
+++ b/internal/spec/tests/main.yaml
@@ -1,4 +1,5 @@
 string_pool:
+  - ""
   - func_type
   - func_results
   - literal
@@ -42,14 +43,14 @@ packages:
       main/test.go:
         functions:
           main:
-            name: 7
-            pkg: 7
+            name: 8
+            pkg: 8
             signature:
-              kind: 0
+              kind: 1
               name: -1
               value: -1
               fun:
-                kind: 1
+                kind: 2
                 name: -1
                 value: -1
                 raw: -1
@@ -64,21 +65,21 @@ packages:
               position: -1
               resolved_type: -1
               generic_type_name: -1
-            signature_str: 26
-            position: 25
-            scope: 9
+            signature_str: 27
+            position: 26
+            scope: 10
             comments: -1
             assignments:
               x:
-                - variable_name: 6
-                  pkg: 7
-                  concrete_type: 5
-                  position: 8
-                  scope: 9
+                - variable_name: 7
+                  pkg: 8
+                  concrete_type: 6
+                  position: 9
+                  scope: 10
                   value:
-                    kind: 2
+                    kind: 3
                     name: -1
-                    value: 3
+                    value: 4
                     raw: -1
                     pkg: -1
                     type: -1
@@ -86,26 +87,26 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 4
-                    name: 6
+                    kind: 5
+                    name: 7
                     value: -1
                     raw: -1
-                    pkg: 7
-                    type: 5
-                    position: 8
+                    pkg: 8
+                    type: 6
+                    position: 9
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 7
+                  func: 8
               "y":
-                - variable_name: 12
-                  pkg: 7
-                  concrete_type: 11
-                  position: 13
-                  scope: 9
+                - variable_name: 13
+                  pkg: 8
+                  concrete_type: 12
+                  position: 14
+                  scope: 10
                   value:
-                    kind: 2
+                    kind: 3
                     name: -1
-                    value: 10
+                    value: 11
                     raw: -1
                     pkg: -1
                     type: -1
@@ -113,227 +114,227 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 4
-                    name: 12
+                    kind: 5
+                    name: 13
                     value: -1
                     raw: -1
-                    pkg: 7
-                    type: 11
-                    position: 13
+                    pkg: 8
+                    type: 12
+                    position: 14
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 7
+                  func: 8
               z:
-                - variable_name: 23
-                  pkg: 7
-                  concrete_type: 11
-                  position: 24
-                  scope: 9
+                - variable_name: 24
+                  pkg: 8
+                  concrete_type: 12
+                  position: 25
+                  scope: 10
                   value:
-                    kind: 22
+                    kind: 23
                     name: -1
                     value: -1
                     fun:
-                      kind: 21
+                      kind: 22
                       name: -1
                       value: -1
                       x:
-                        kind: 4
-                        name: 16
+                        kind: 5
+                        name: 17
                         value: -1
                         raw: -1
-                        pkg: 16
+                        pkg: 17
                         type: -1
-                        position: 17
+                        position: 18
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 4
-                        name: 18
+                        kind: 5
+                        name: 19
                         value: -1
                         raw: -1
-                        pkg: 16
-                        type: 19
-                        position: 20
+                        pkg: 17
+                        type: 20
+                        position: 21
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 16
-                      type: 19
-                      position: 17
+                      pkg: 17
+                      type: 20
+                      position: 18
                       resolved_type: -1
                       generic_type_name: -1
                     args:
-                      - kind: 2
+                      - kind: 3
                         name: -1
-                        value: 14
+                        value: 15
                         raw: -1
                         pkg: -1
                         type: -1
                         position: -1
                         resolved_type: -1
                         generic_type_name: -1
-                      - kind: 4
-                        name: 6
+                      - kind: 5
+                        name: 7
                         value: -1
                         raw: -1
-                        pkg: 7
-                        type: 5
-                        position: 15
+                        pkg: 8
+                        type: 6
+                        position: 16
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
                     pkg: -1
-                    type: 11
-                    position: 17
+                    type: 12
+                    position: 18
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 4
-                    name: 23
+                    kind: 5
+                    name: 24
                     value: -1
                     raw: -1
-                    pkg: 7
-                    type: 11
-                    position: 24
+                    pkg: 8
+                    type: 12
+                    position: 25
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 7
+                  func: 8
                   callee_func: Sprintf
                   callee_pkg: fmt
             end_line: 14
         imports:
-          16: 16
-          27: 27
+          17: 17
+          28: 28
 call_graph:
   - caller:
-      name: 7
-      pkg: 7
+      name: 8
+      pkg: 8
       position: -1
       recv_type: -1
-      scope: 9
-      signature_str: 26
+      scope: 10
+      signature_str: 27
     callee:
-      name: 18
-      pkg: 16
-      position: 17
+      name: 19
+      pkg: 17
+      position: 18
       recv_type: -1
-      scope: 28
-      signature_str: 19
-    position: 17
+      scope: 29
+      signature_str: 20
+    position: 18
     args:
-      - kind: 2
+      - kind: 3
         name: -1
-        value: 14
+        value: 15
         raw: -1
         pkg: -1
         type: -1
         position: -1
         resolved_type: -1
         generic_type_name: -1
-      - kind: 4
-        name: 6
+      - kind: 5
+        name: 7
         value: -1
         raw: -1
-        pkg: 7
-        type: 5
-        position: 15
+        pkg: 8
+        type: 6
+        position: 16
         resolved_type: -1
         generic_type_name: -1
     assignments:
       z:
-        - variable_name: 23
-          pkg: 7
-          concrete_type: 11
-          position: 24
-          scope: 9
+        - variable_name: 24
+          pkg: 8
+          concrete_type: 12
+          position: 25
+          scope: 10
           value:
-            kind: 22
+            kind: 23
             name: -1
             value: -1
             fun:
-              kind: 21
+              kind: 22
               name: -1
               value: -1
               x:
-                kind: 4
-                name: 16
+                kind: 5
+                name: 17
                 value: -1
                 raw: -1
-                pkg: 16
+                pkg: 17
                 type: -1
-                position: 17
+                position: 18
                 resolved_type: -1
                 generic_type_name: -1
               sel:
-                kind: 4
-                name: 18
+                kind: 5
+                name: 19
                 value: -1
                 raw: -1
-                pkg: 16
-                type: 19
-                position: 20
+                pkg: 17
+                type: 20
+                position: 21
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
-              pkg: 16
-              type: 19
-              position: 17
+              pkg: 17
+              type: 20
+              position: 18
               resolved_type: -1
               generic_type_name: -1
             args:
-              - kind: 2
+              - kind: 3
                 name: -1
-                value: 14
+                value: 15
                 raw: -1
                 pkg: -1
                 type: -1
                 position: -1
                 resolved_type: -1
                 generic_type_name: -1
-              - kind: 4
-                name: 6
+              - kind: 5
+                name: 7
                 value: -1
                 raw: -1
-                pkg: 7
-                type: 5
-                position: 15
+                pkg: 8
+                type: 6
+                position: 16
                 resolved_type: -1
                 generic_type_name: -1
             raw: -1
             pkg: -1
-            type: 11
-            position: 17
+            type: 12
+            position: 18
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 4
-            name: 23
+            kind: 5
+            name: 24
             value: -1
             raw: -1
-            pkg: 7
-            type: 11
-            position: 24
+            pkg: 8
+            type: 12
+            position: 25
             resolved_type: -1
             generic_type_name: -1
-          func: 7
+          func: 8
           callee_func: Sprintf
           callee_pkg: fmt
     param_arg_map:
       a:
-        kind: 4
-        name: 6
+        kind: 5
+        name: 7
         value: -1
         raw: -1
-        pkg: 7
-        type: 5
-        position: 15
+        pkg: 8
+        type: 6
+        position: 16
         resolved_type: -1
         generic_type_name: -1
       format:
-        kind: 2
+        kind: 3
         name: -1
-        value: 14
+        value: 15
         raw: -1
         pkg: -1
         type: -1
@@ -342,74 +343,74 @@ call_graph:
         generic_type_name: -1
     callee_recv_var_name: z
   - caller:
-      name: 7
-      pkg: 7
+      name: 8
+      pkg: 8
       position: -1
       recv_type: -1
-      scope: 9
-      signature_str: 26
+      scope: 10
+      signature_str: 27
     callee:
-      name: 31
-      pkg: 16
-      position: 30
+      name: 32
+      pkg: 17
+      position: 31
       recv_type: -1
-      scope: 28
-      signature_str: 32
-    position: 30
+      scope: 29
+      signature_str: 33
+    position: 31
     args:
-      - kind: 4
-        name: 23
+      - kind: 5
+        name: 24
         value: -1
         raw: -1
-        pkg: 7
-        type: 11
-        position: 29
+        pkg: 8
+        type: 12
+        position: 30
         resolved_type: -1
         generic_type_name: -1
     param_arg_map:
       a:
-        kind: 4
-        name: 23
+        kind: 5
+        name: 24
         value: -1
         raw: -1
-        pkg: 7
-        type: 11
-        position: 29
+        pkg: 8
+        type: 12
+        position: 30
         resolved_type: -1
         generic_type_name: -1
   - caller:
-      name: 7
-      pkg: 7
+      name: 8
+      pkg: 8
       position: -1
       recv_type: -1
-      scope: 9
-      signature_str: 26
+      scope: 10
+      signature_str: 27
     callee:
-      name: 35
-      pkg: 27
-      position: 34
+      name: 36
+      pkg: 28
+      position: 35
       recv_type: -1
-      scope: 28
-      signature_str: 36
-    position: 34
+      scope: 29
+      signature_str: 37
+    position: 35
     args:
-      - kind: 4
-        name: 12
+      - kind: 5
+        name: 13
         value: -1
         raw: -1
-        pkg: 7
-        type: 11
-        position: 33
+        pkg: 8
+        type: 12
+        position: 34
         resolved_type: -1
         generic_type_name: -1
     param_arg_map:
       s:
-        kind: 4
-        name: 12
+        kind: 5
+        name: 13
         value: -1
         raw: -1
-        pkg: 7
-        type: 11
-        position: 33
+        pkg: 8
+        type: 12
+        position: 34
         resolved_type: -1
         generic_type_name: -1

--- a/internal/spec/tests/multipackage.yaml
+++ b/internal/spec/tests/multipackage.yaml
@@ -1,4 +1,5 @@
 string_pool:
+  - ""
   - func_type
   - func_results
   - literal
@@ -183,14 +184,14 @@ packages:
       multipackage/main.go:
         functions:
           main:
-            name: 19
-            pkg: 16
+            name: 20
+            pkg: 17
             signature:
-              kind: 0
+              kind: 1
               name: -1
               value: -1
               fun:
-                kind: 1
+                kind: 2
                 name: -1
                 value: -1
                 raw: -1
@@ -205,200 +206,191 @@ packages:
               position: -1
               resolved_type: -1
               generic_type_name: -1
-            signature_str: 39
-            position: 38
-            scope: 18
+            signature_str: 40
+            position: 39
+            scope: 19
             comments: -1
             assignments:
               result:
-                - variable_name: 36
-                  pkg: 16
-                  concrete_type: 35
-                  position: 37
-                  scope: 18
+                - variable_name: 37
+                  pkg: 17
+                  concrete_type: 36
+                  position: 38
+                  scope: 19
                   value:
-                    kind: 13
+                    kind: 14
                     name: -1
                     value: -1
                     fun:
-                      kind: 12
+                      kind: 13
                       name: -1
                       value: -1
                       x:
-                        kind: 5
-                        name: 27
+                        kind: 6
+                        name: 28
                         value: -1
                         raw: -1
-                        pkg: 16
-                        type: 26
-                        position: 30
+                        pkg: 17
+                        type: 27
+                        position: 31
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 5
-                        name: 31
+                        kind: 6
+                        name: 32
                         value: -1
                         raw: -1
-                        pkg: 21
-                        type: 32
-                        position: 33
+                        pkg: 22
+                        type: 33
+                        position: 34
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 21
-                      type: 32
-                      position: 30
+                      pkg: 22
+                      type: 33
+                      position: 31
                       resolved_type: -1
                       generic_type_name: -1
                       receiver_type:
-                        kind: 5
-                        name: 34
+                        kind: 6
+                        name: 35
                         value: -1
                         raw: -1
-                        pkg: 21
-                        type: 34
+                        pkg: 22
+                        type: 35
                         position: -1
                         resolved_type: -1
                         generic_type_name: -1
                     args:
-                      - kind: 5
-                        name: 15
+                      - kind: 6
+                        name: 16
                         value: -1
                         raw: -1
-                        pkg: 16
-                        type: 14
-                        position: 29
+                        pkg: 17
+                        type: 15
+                        position: 30
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
                     pkg: -1
-                    type: 35
-                    position: 30
+                    type: 36
+                    position: 31
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 5
-                    name: 36
+                    kind: 6
+                    name: 37
                     value: -1
                     raw: -1
-                    pkg: 16
-                    type: 35
-                    position: 37
+                    pkg: 17
+                    type: 36
+                    position: 38
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 19
+                  func: 20
                   callee_func: ProcessUser
                   callee_pkg: multipackage/services
               service:
-                - variable_name: 27
-                  pkg: 16
-                  concrete_type: 26
-                  position: 28
-                  scope: 18
+                - variable_name: 28
+                  pkg: 17
+                  concrete_type: 27
+                  position: 29
+                  scope: 19
                   value:
-                    kind: 13
+                    kind: 14
                     name: -1
                     value: -1
                     fun:
-                      kind: 12
+                      kind: 13
                       name: -1
                       value: -1
                       x:
-                        kind: 5
-                        name: 20
+                        kind: 6
+                        name: 21
                         value: -1
                         raw: -1
-                        pkg: 21
+                        pkg: 22
                         type: -1
-                        position: 22
+                        position: 23
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 5
-                        name: 23
+                        kind: 6
+                        name: 24
                         value: -1
                         raw: -1
-                        pkg: 21
-                        type: 24
-                        position: 25
+                        pkg: 22
+                        type: 25
+                        position: 26
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 21
-                      type: 24
-                      position: 22
+                      pkg: 22
+                      type: 25
+                      position: 23
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
                     pkg: -1
-                    type: 26
-                    position: 22
+                    type: 27
+                    position: 23
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 5
-                    name: 27
+                    kind: 6
+                    name: 28
                     value: -1
                     raw: -1
-                    pkg: 16
-                    type: 26
-                    position: 28
+                    pkg: 17
+                    type: 27
+                    position: 29
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 19
+                  func: 20
                   callee_func: NewUserService
                   callee_pkg: multipackage/services
               user:
-                - variable_name: 15
-                  pkg: 16
-                  concrete_type: 14
-                  position: 17
-                  scope: 18
+                - variable_name: 16
+                  pkg: 17
+                  concrete_type: 15
+                  position: 18
+                  scope: 19
                   value:
-                    kind: 13
+                    kind: 14
                     name: -1
                     value: -1
                     fun:
-                      kind: 12
+                      kind: 13
                       name: -1
                       value: -1
                       x:
-                        kind: 5
-                        name: 6
+                        kind: 6
+                        name: 7
                         value: -1
                         raw: -1
-                        pkg: 7
+                        pkg: 8
                         type: -1
-                        position: 8
+                        position: 9
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 5
-                        name: 9
+                        kind: 6
+                        name: 10
                         value: -1
                         raw: -1
-                        pkg: 7
-                        type: 10
-                        position: 11
+                        pkg: 8
+                        type: 11
+                        position: 12
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 7
-                      type: 10
-                      position: 8
+                      pkg: 8
+                      type: 11
+                      position: 9
                       resolved_type: -1
                       generic_type_name: -1
                     args:
-                      - kind: 2
-                        name: -1
-                        value: 3
-                        raw: -1
-                        pkg: -1
-                        type: -1
-                        position: -1
-                        resolved_type: -1
-                        generic_type_name: -1
-                      - kind: 2
+                      - kind: 3
                         name: -1
                         value: 4
                         raw: -1
@@ -407,71 +399,80 @@ packages:
                         position: -1
                         resolved_type: -1
                         generic_type_name: -1
+                      - kind: 3
+                        name: -1
+                        value: 5
+                        raw: -1
+                        pkg: -1
+                        type: -1
+                        position: -1
+                        resolved_type: -1
+                        generic_type_name: -1
                     raw: -1
                     pkg: -1
-                    type: 14
-                    position: 8
+                    type: 15
+                    position: 9
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 5
-                    name: 15
+                    kind: 6
+                    name: 16
                     value: -1
                     raw: -1
-                    pkg: 16
-                    type: 14
-                    position: 17
+                    pkg: 17
+                    type: 15
+                    position: 18
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 19
+                  func: 20
                   callee_func: NewUser
                   callee_pkg: multipackage/models
             end_line: 15
         imports:
-          7: 7
-          21: 21
-          40: 40
+          8: 8
+          22: 22
+          41: 41
   multipackage/models:
     files:
       multipackage/models/user.go:
         types:
           User:
-            name: 60
-            pkg: 7
-            kind: 61
+            name: 61
+            pkg: 8
+            kind: 62
             implements:
-              - 172
+              - 173
             fields:
-              - name: 43
-                type: 35
-                tag: 62
-                scope: 49
-                comments: -1
-              - name: 53
-                type: 54
+              - name: 44
+                type: 36
                 tag: 63
-                scope: 49
+                scope: 50
                 comments: -1
-            scope: 49
+              - name: 54
+                type: 55
+                tag: 64
+                scope: 50
+                comments: -1
+            scope: 50
             methods:
-              - name: 45
-                receiver: 46
+              - name: 46
+                receiver: 47
                 signature:
-                  kind: 0
+                  kind: 1
                   name: -1
                   value: -1
                   fun:
-                    kind: 1
+                    kind: 2
                     name: -1
                     value: -1
                     args:
-                      - kind: 5
-                        name: 35
+                      - kind: 6
+                        name: 36
                         value: -1
                         raw: -1
                         pkg: -1
-                        type: 35
-                        position: 47
+                        type: 36
+                        position: 48
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
@@ -484,229 +485,195 @@ packages:
                   pkg: -1
                   type: -1
                   position: -1
-                  resolved_type: 35
+                  resolved_type: 36
                   generic_type_name: -1
-                signature_str: 51
-                position: 48
-                scope: 49
+                signature_str: 52
+                position: 49
+                scope: 50
                 comments: -1
-                filename: 50
+                filename: 51
                 return_vars:
-                  - kind: 12
+                  - kind: 13
                     name: -1
                     value: -1
                     x:
-                      kind: 5
-                      name: 41
+                      kind: 6
+                      name: 42
                       value: -1
                       raw: -1
-                      pkg: 7
-                      type: 14
-                      position: 42
+                      pkg: 8
+                      type: 15
+                      position: 43
                       resolved_type: -1
                       generic_type_name: -1
                     sel:
-                      kind: 5
-                      name: 43
+                      kind: 6
+                      name: 44
                       value: -1
                       raw: -1
-                      pkg: 7
-                      type: 35
-                      position: 44
+                      pkg: 8
+                      type: 36
+                      position: 45
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
-                    pkg: 7
-                    type: 35
-                    position: 42
+                    pkg: 8
+                    type: 36
+                    position: 43
                     resolved_type: -1
                     generic_type_name: -1
                 returns:
-                  - - kind: 12
+                  - - kind: 13
                       name: -1
                       value: -1
                       x:
-                        kind: 5
-                        name: 41
+                        kind: 6
+                        name: 42
                         value: -1
                         raw: -1
-                        pkg: 7
-                        type: 14
-                        position: 42
+                        pkg: 8
+                        type: 15
+                        position: 43
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 5
-                        name: 43
+                        kind: 6
+                        name: 44
                         value: -1
                         raw: -1
-                        pkg: 7
-                        type: 35
-                        position: 44
+                        pkg: 8
+                        type: 36
+                        position: 45
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 7
-                      type: 35
-                      position: 42
+                      pkg: 8
+                      type: 36
+                      position: 43
                       resolved_type: -1
                       generic_type_name: -1
-              - name: 56
-                receiver: 46
+              - name: 57
+                receiver: 47
                 signature:
-                  kind: 0
+                  kind: 1
                   name: -1
                   value: -1
                   fun:
-                    kind: 1
+                    kind: 2
                     name: -1
                     value: -1
                     args:
-                      - kind: 5
+                      - kind: 6
+                        name: 55
+                        value: -1
+                        raw: -1
+                        pkg: -1
+                        type: 55
+                        position: 58
+                        resolved_type: -1
+                        generic_type_name: -1
+                    raw: -1
+                    pkg: -1
+                    type: -1
+                    position: -1
+                    resolved_type: -1
+                    generic_type_name: -1
+                  raw: -1
+                  pkg: -1
+                  type: -1
+                  position: -1
+                  resolved_type: 55
+                  generic_type_name: -1
+                signature_str: 60
+                position: 59
+                scope: 50
+                comments: -1
+                filename: 51
+                return_vars:
+                  - kind: 13
+                    name: -1
+                    value: -1
+                    x:
+                      kind: 6
+                      name: 42
+                      value: -1
+                      raw: -1
+                      pkg: 8
+                      type: 15
+                      position: 53
+                      resolved_type: -1
+                      generic_type_name: -1
+                    sel:
+                      kind: 6
+                      name: 54
+                      value: -1
+                      raw: -1
+                      pkg: 8
+                      type: 55
+                      position: 56
+                      resolved_type: -1
+                      generic_type_name: -1
+                    raw: -1
+                    pkg: 8
+                    type: 55
+                    position: 53
+                    resolved_type: -1
+                    generic_type_name: -1
+                returns:
+                  - - kind: 13
+                      name: -1
+                      value: -1
+                      x:
+                        kind: 6
+                        name: 42
+                        value: -1
+                        raw: -1
+                        pkg: 8
+                        type: 15
+                        position: 53
+                        resolved_type: -1
+                        generic_type_name: -1
+                      sel:
+                        kind: 6
                         name: 54
                         value: -1
                         raw: -1
-                        pkg: -1
-                        type: 54
-                        position: 57
-                        resolved_type: -1
-                        generic_type_name: -1
-                    raw: -1
-                    pkg: -1
-                    type: -1
-                    position: -1
-                    resolved_type: -1
-                    generic_type_name: -1
-                  raw: -1
-                  pkg: -1
-                  type: -1
-                  position: -1
-                  resolved_type: 54
-                  generic_type_name: -1
-                signature_str: 59
-                position: 58
-                scope: 49
-                comments: -1
-                filename: 50
-                return_vars:
-                  - kind: 12
-                    name: -1
-                    value: -1
-                    x:
-                      kind: 5
-                      name: 41
-                      value: -1
-                      raw: -1
-                      pkg: 7
-                      type: 14
-                      position: 52
-                      resolved_type: -1
-                      generic_type_name: -1
-                    sel:
-                      kind: 5
-                      name: 53
-                      value: -1
-                      raw: -1
-                      pkg: 7
-                      type: 54
-                      position: 55
-                      resolved_type: -1
-                      generic_type_name: -1
-                    raw: -1
-                    pkg: 7
-                    type: 54
-                    position: 52
-                    resolved_type: -1
-                    generic_type_name: -1
-                returns:
-                  - - kind: 12
-                      name: -1
-                      value: -1
-                      x:
-                        kind: 5
-                        name: 41
-                        value: -1
-                        raw: -1
-                        pkg: 7
-                        type: 14
-                        position: 52
-                        resolved_type: -1
-                        generic_type_name: -1
-                      sel:
-                        kind: 5
-                        name: 53
-                        value: -1
-                        raw: -1
-                        pkg: 7
-                        type: 54
-                        position: 55
+                        pkg: 8
+                        type: 55
+                        position: 56
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 7
-                      type: 54
-                      position: 52
+                      pkg: 8
+                      type: 55
+                      position: 53
                       resolved_type: -1
                       generic_type_name: -1
             comments: -1
           UserInterface:
-            name: 65
-            pkg: 7
-            kind: 64
+            name: 66
+            pkg: 8
+            kind: 65
             implemented_by:
-              - 173
-            scope: 49
+              - 174
+            scope: 50
             methods:
-              - name: 45
+              - name: 46
                 signature:
-                  kind: 0
+                  kind: 1
                   name: -1
                   value: -1
                   fun:
-                    kind: 1
+                    kind: 2
                     name: -1
                     value: -1
                     args:
-                      - kind: 5
-                        name: 35
+                      - kind: 6
+                        name: 36
                         value: -1
                         raw: -1
                         pkg: -1
-                        type: 35
-                        position: 66
-                        resolved_type: -1
-                        generic_type_name: -1
-                    raw: -1
-                    pkg: -1
-                    type: -1
-                    position: -1
-                    resolved_type: -1
-                    generic_type_name: -1
-                  raw: -1
-                  pkg: -1
-                  type: -1
-                  position: -1
-                  resolved_type: 35
-                  generic_type_name: -1
-                signature_str: 51
-                scope: 49
-                comments: -1
-              - name: 56
-                signature:
-                  kind: 0
-                  name: -1
-                  value: -1
-                  fun:
-                    kind: 1
-                    name: -1
-                    value: -1
-                    args:
-                      - kind: 5
-                        name: 54
-                        value: -1
-                        raw: -1
-                        pkg: -1
-                        type: 54
+                        type: 36
                         position: 67
                         resolved_type: -1
                         generic_type_name: -1
@@ -720,42 +687,76 @@ packages:
                   pkg: -1
                   type: -1
                   position: -1
-                  resolved_type: 54
+                  resolved_type: 36
                   generic_type_name: -1
-                signature_str: 59
-                scope: 49
+                signature_str: 52
+                scope: 50
+                comments: -1
+              - name: 57
+                signature:
+                  kind: 1
+                  name: -1
+                  value: -1
+                  fun:
+                    kind: 2
+                    name: -1
+                    value: -1
+                    args:
+                      - kind: 6
+                        name: 55
+                        value: -1
+                        raw: -1
+                        pkg: -1
+                        type: 55
+                        position: 68
+                        resolved_type: -1
+                        generic_type_name: -1
+                    raw: -1
+                    pkg: -1
+                    type: -1
+                    position: -1
+                    resolved_type: -1
+                    generic_type_name: -1
+                  raw: -1
+                  pkg: -1
+                  type: -1
+                  position: -1
+                  resolved_type: 55
+                  generic_type_name: -1
+                signature_str: 60
+                scope: 50
                 comments: -1
             comments: -1
         functions:
           NewUser:
-            name: 9
-            pkg: 7
+            name: 10
+            pkg: 8
             signature:
-              kind: 0
+              kind: 1
               name: -1
               value: -1
               fun:
-                kind: 1
+                kind: 2
                 name: -1
                 value: -1
                 args:
-                  - kind: 83
+                  - kind: 84
                     name: -1
                     value: -1
                     x:
-                      kind: 5
-                      name: 60
+                      kind: 6
+                      name: 61
                       value: -1
                       raw: -1
-                      pkg: 7
-                      type: 60
-                      position: 82
+                      pkg: 8
+                      type: 61
+                      position: 83
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
                     pkg: -1
                     type: -1
-                    position: 84
+                    position: 85
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -765,259 +766,259 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 5
-                  name: 70
+                - kind: 6
+                  name: 71
                   value: -1
                   raw: -1
                   pkg: -1
-                  type: 35
-                  position: 80
+                  type: 36
+                  position: 81
                   resolved_type: -1
                   generic_type_name: -1
-                - kind: 5
-                  name: 74
+                - kind: 6
+                  name: 75
                   value: -1
                   raw: -1
                   pkg: -1
-                  type: 54
-                  position: 81
+                  type: 55
+                  position: 82
                   resolved_type: -1
                   generic_type_name: -1
               raw: -1
               pkg: -1
               type: -1
               position: -1
-              resolved_type: 46
+              resolved_type: 47
               generic_type_name: -1
-            signature_str: 86
-            position: 85
-            scope: 49
+            signature_str: 87
+            position: 86
+            scope: 50
             comments: -1
             return_vars:
-              - kind: 77
+              - kind: 78
                 name: -1
-                value: 78
+                value: 79
                 x:
-                  kind: 76
+                  kind: 77
                   name: -1
                   value: -1
                   x:
-                    kind: 5
-                    name: 60
+                    kind: 6
+                    name: 61
                     value: -1
                     raw: -1
-                    pkg: 7
-                    type: 60
-                    position: 68
+                    pkg: 8
+                    type: 61
+                    position: 69
                     resolved_type: -1
                     generic_type_name: -1
                   args:
-                    - kind: 72
+                    - kind: 73
                       name: -1
                       value: -1
                       x:
-                        kind: 5
-                        name: 43
+                        kind: 6
+                        name: 44
                         value: -1
                         raw: -1
-                        pkg: 7
-                        type: 35
-                        position: 69
+                        pkg: 8
+                        type: 36
+                        position: 70
                         resolved_type: -1
                         generic_type_name: -1
                       fun:
-                        kind: 5
-                        name: 70
+                        kind: 6
+                        name: 71
                         value: -1
                         raw: -1
-                        pkg: 7
-                        type: 35
-                        position: 71
+                        pkg: 8
+                        type: 36
+                        position: 72
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
                       pkg: -1
                       type: -1
-                      position: 69
+                      position: 70
                       resolved_type: -1
                       generic_type_name: -1
-                    - kind: 72
+                    - kind: 73
                       name: -1
                       value: -1
                       x:
-                        kind: 5
-                        name: 53
+                        kind: 6
+                        name: 54
                         value: -1
                         raw: -1
-                        pkg: 7
-                        type: 54
-                        position: 73
+                        pkg: 8
+                        type: 55
+                        position: 74
                         resolved_type: -1
                         generic_type_name: -1
                       fun:
-                        kind: 5
-                        name: 74
+                        kind: 6
+                        name: 75
                         value: -1
                         raw: -1
-                        pkg: 7
-                        type: 54
-                        position: 75
+                        pkg: 8
+                        type: 55
+                        position: 76
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
                       pkg: -1
                       type: -1
-                      position: 73
+                      position: 74
                       resolved_type: -1
                       generic_type_name: -1
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 68
+                  position: 69
                   resolved_type: -1
                   generic_type_name: -1
                 raw: -1
                 pkg: -1
                 type: -1
-                position: 79
+                position: 80
                 resolved_type: -1
                 generic_type_name: -1
             returns:
-              - - kind: 77
+              - - kind: 78
                   name: -1
-                  value: 78
+                  value: 79
                   x:
-                    kind: 76
+                    kind: 77
                     name: -1
                     value: -1
                     x:
-                      kind: 5
-                      name: 60
+                      kind: 6
+                      name: 61
                       value: -1
                       raw: -1
-                      pkg: 7
-                      type: 60
-                      position: 68
+                      pkg: 8
+                      type: 61
+                      position: 69
                       resolved_type: -1
                       generic_type_name: -1
                     args:
-                      - kind: 72
+                      - kind: 73
                         name: -1
                         value: -1
                         x:
-                          kind: 5
-                          name: 43
+                          kind: 6
+                          name: 44
                           value: -1
                           raw: -1
-                          pkg: 7
-                          type: 35
-                          position: 69
+                          pkg: 8
+                          type: 36
+                          position: 70
                           resolved_type: -1
                           generic_type_name: -1
                         fun:
-                          kind: 5
-                          name: 70
+                          kind: 6
+                          name: 71
                           value: -1
                           raw: -1
-                          pkg: 7
-                          type: 35
-                          position: 71
+                          pkg: 8
+                          type: 36
+                          position: 72
                           resolved_type: -1
                           generic_type_name: -1
                         raw: -1
                         pkg: -1
                         type: -1
-                        position: 69
+                        position: 70
                         resolved_type: -1
                         generic_type_name: -1
-                      - kind: 72
+                      - kind: 73
                         name: -1
                         value: -1
                         x:
-                          kind: 5
-                          name: 53
+                          kind: 6
+                          name: 54
                           value: -1
                           raw: -1
-                          pkg: 7
-                          type: 54
-                          position: 73
+                          pkg: 8
+                          type: 55
+                          position: 74
                           resolved_type: -1
                           generic_type_name: -1
                         fun:
-                          kind: 5
-                          name: 74
+                          kind: 6
+                          name: 75
                           value: -1
                           raw: -1
-                          pkg: 7
-                          type: 54
-                          position: 75
+                          pkg: 8
+                          type: 55
+                          position: 76
                           resolved_type: -1
                           generic_type_name: -1
                         raw: -1
                         pkg: -1
                         type: -1
-                        position: 73
+                        position: 74
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
                     pkg: -1
                     type: -1
-                    position: 68
+                    position: 69
                     resolved_type: -1
                     generic_type_name: -1
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 79
+                  position: 80
                   resolved_type: -1
                   generic_type_name: -1
             end_line: 26
         struct_instances:
-          - type: 60
-            pkg: 7
-            position: 68
+          - type: 61
+            pkg: 8
+            position: 69
             fields:
-              43: 70
-              53: 74
+              44: 71
+              54: 75
         imports: {}
     types:
       User:
-        name: 60
-        pkg: 7
-        kind: 61
+        name: 61
+        pkg: 8
+        kind: 62
         implements:
-          - 172
+          - 173
         fields:
-          - name: 43
-            type: 35
-            tag: 62
-            scope: 49
-            comments: -1
-          - name: 53
-            type: 54
+          - name: 44
+            type: 36
             tag: 63
-            scope: 49
+            scope: 50
             comments: -1
-        scope: 49
+          - name: 54
+            type: 55
+            tag: 64
+            scope: 50
+            comments: -1
+        scope: 50
         methods:
-          - name: 45
-            receiver: 46
+          - name: 46
+            receiver: 47
             signature:
-              kind: 0
+              kind: 1
               name: -1
               value: -1
               fun:
-                kind: 1
+                kind: 2
                 name: -1
                 value: -1
                 args:
-                  - kind: 5
-                    name: 35
+                  - kind: 6
+                    name: 36
                     value: -1
                     raw: -1
                     pkg: -1
-                    type: 35
-                    position: 47
+                    type: 36
+                    position: 48
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -1030,229 +1031,195 @@ packages:
               pkg: -1
               type: -1
               position: -1
-              resolved_type: 35
+              resolved_type: 36
               generic_type_name: -1
-            signature_str: 51
-            position: 48
-            scope: 49
+            signature_str: 52
+            position: 49
+            scope: 50
             comments: -1
-            filename: 50
+            filename: 51
             return_vars:
-              - kind: 12
+              - kind: 13
                 name: -1
                 value: -1
                 x:
-                  kind: 5
-                  name: 41
+                  kind: 6
+                  name: 42
                   value: -1
                   raw: -1
-                  pkg: 7
-                  type: 14
-                  position: 42
+                  pkg: 8
+                  type: 15
+                  position: 43
                   resolved_type: -1
                   generic_type_name: -1
                 sel:
-                  kind: 5
-                  name: 43
+                  kind: 6
+                  name: 44
                   value: -1
                   raw: -1
-                  pkg: 7
-                  type: 35
-                  position: 44
+                  pkg: 8
+                  type: 36
+                  position: 45
                   resolved_type: -1
                   generic_type_name: -1
                 raw: -1
-                pkg: 7
-                type: 35
-                position: 42
+                pkg: 8
+                type: 36
+                position: 43
                 resolved_type: -1
                 generic_type_name: -1
             returns:
-              - - kind: 12
+              - - kind: 13
                   name: -1
                   value: -1
                   x:
-                    kind: 5
-                    name: 41
+                    kind: 6
+                    name: 42
                     value: -1
                     raw: -1
-                    pkg: 7
-                    type: 14
-                    position: 42
+                    pkg: 8
+                    type: 15
+                    position: 43
                     resolved_type: -1
                     generic_type_name: -1
                   sel:
-                    kind: 5
-                    name: 43
+                    kind: 6
+                    name: 44
                     value: -1
                     raw: -1
-                    pkg: 7
-                    type: 35
-                    position: 44
+                    pkg: 8
+                    type: 36
+                    position: 45
                     resolved_type: -1
                     generic_type_name: -1
                   raw: -1
-                  pkg: 7
-                  type: 35
-                  position: 42
+                  pkg: 8
+                  type: 36
+                  position: 43
                   resolved_type: -1
                   generic_type_name: -1
-          - name: 56
-            receiver: 46
+          - name: 57
+            receiver: 47
             signature:
-              kind: 0
+              kind: 1
               name: -1
               value: -1
               fun:
-                kind: 1
+                kind: 2
                 name: -1
                 value: -1
                 args:
-                  - kind: 5
+                  - kind: 6
+                    name: 55
+                    value: -1
+                    raw: -1
+                    pkg: -1
+                    type: 55
+                    position: 58
+                    resolved_type: -1
+                    generic_type_name: -1
+                raw: -1
+                pkg: -1
+                type: -1
+                position: -1
+                resolved_type: -1
+                generic_type_name: -1
+              raw: -1
+              pkg: -1
+              type: -1
+              position: -1
+              resolved_type: 55
+              generic_type_name: -1
+            signature_str: 60
+            position: 59
+            scope: 50
+            comments: -1
+            filename: 51
+            return_vars:
+              - kind: 13
+                name: -1
+                value: -1
+                x:
+                  kind: 6
+                  name: 42
+                  value: -1
+                  raw: -1
+                  pkg: 8
+                  type: 15
+                  position: 53
+                  resolved_type: -1
+                  generic_type_name: -1
+                sel:
+                  kind: 6
+                  name: 54
+                  value: -1
+                  raw: -1
+                  pkg: 8
+                  type: 55
+                  position: 56
+                  resolved_type: -1
+                  generic_type_name: -1
+                raw: -1
+                pkg: 8
+                type: 55
+                position: 53
+                resolved_type: -1
+                generic_type_name: -1
+            returns:
+              - - kind: 13
+                  name: -1
+                  value: -1
+                  x:
+                    kind: 6
+                    name: 42
+                    value: -1
+                    raw: -1
+                    pkg: 8
+                    type: 15
+                    position: 53
+                    resolved_type: -1
+                    generic_type_name: -1
+                  sel:
+                    kind: 6
                     name: 54
                     value: -1
                     raw: -1
-                    pkg: -1
-                    type: 54
-                    position: 57
-                    resolved_type: -1
-                    generic_type_name: -1
-                raw: -1
-                pkg: -1
-                type: -1
-                position: -1
-                resolved_type: -1
-                generic_type_name: -1
-              raw: -1
-              pkg: -1
-              type: -1
-              position: -1
-              resolved_type: 54
-              generic_type_name: -1
-            signature_str: 59
-            position: 58
-            scope: 49
-            comments: -1
-            filename: 50
-            return_vars:
-              - kind: 12
-                name: -1
-                value: -1
-                x:
-                  kind: 5
-                  name: 41
-                  value: -1
-                  raw: -1
-                  pkg: 7
-                  type: 14
-                  position: 52
-                  resolved_type: -1
-                  generic_type_name: -1
-                sel:
-                  kind: 5
-                  name: 53
-                  value: -1
-                  raw: -1
-                  pkg: 7
-                  type: 54
-                  position: 55
-                  resolved_type: -1
-                  generic_type_name: -1
-                raw: -1
-                pkg: 7
-                type: 54
-                position: 52
-                resolved_type: -1
-                generic_type_name: -1
-            returns:
-              - - kind: 12
-                  name: -1
-                  value: -1
-                  x:
-                    kind: 5
-                    name: 41
-                    value: -1
-                    raw: -1
-                    pkg: 7
-                    type: 14
-                    position: 52
-                    resolved_type: -1
-                    generic_type_name: -1
-                  sel:
-                    kind: 5
-                    name: 53
-                    value: -1
-                    raw: -1
-                    pkg: 7
-                    type: 54
-                    position: 55
+                    pkg: 8
+                    type: 55
+                    position: 56
                     resolved_type: -1
                     generic_type_name: -1
                   raw: -1
-                  pkg: 7
-                  type: 54
-                  position: 52
+                  pkg: 8
+                  type: 55
+                  position: 53
                   resolved_type: -1
                   generic_type_name: -1
         comments: -1
       UserInterface:
-        name: 65
-        pkg: 7
-        kind: 64
+        name: 66
+        pkg: 8
+        kind: 65
         implemented_by:
-          - 173
-        scope: 49
+          - 174
+        scope: 50
         methods:
-          - name: 45
+          - name: 46
             signature:
-              kind: 0
+              kind: 1
               name: -1
               value: -1
               fun:
-                kind: 1
+                kind: 2
                 name: -1
                 value: -1
                 args:
-                  - kind: 5
-                    name: 35
+                  - kind: 6
+                    name: 36
                     value: -1
                     raw: -1
                     pkg: -1
-                    type: 35
-                    position: 66
-                    resolved_type: -1
-                    generic_type_name: -1
-                raw: -1
-                pkg: -1
-                type: -1
-                position: -1
-                resolved_type: -1
-                generic_type_name: -1
-              raw: -1
-              pkg: -1
-              type: -1
-              position: -1
-              resolved_type: 35
-              generic_type_name: -1
-            signature_str: 51
-            scope: 49
-            comments: -1
-          - name: 56
-            signature:
-              kind: 0
-              name: -1
-              value: -1
-              fun:
-                kind: 1
-                name: -1
-                value: -1
-                args:
-                  - kind: 5
-                    name: 54
-                    value: -1
-                    raw: -1
-                    pkg: -1
-                    type: 54
+                    type: 36
                     position: 67
                     resolved_type: -1
                     generic_type_name: -1
@@ -1266,10 +1233,44 @@ packages:
               pkg: -1
               type: -1
               position: -1
-              resolved_type: 54
+              resolved_type: 36
               generic_type_name: -1
-            signature_str: 59
-            scope: 49
+            signature_str: 52
+            scope: 50
+            comments: -1
+          - name: 57
+            signature:
+              kind: 1
+              name: -1
+              value: -1
+              fun:
+                kind: 2
+                name: -1
+                value: -1
+                args:
+                  - kind: 6
+                    name: 55
+                    value: -1
+                    raw: -1
+                    pkg: -1
+                    type: 55
+                    position: 68
+                    resolved_type: -1
+                    generic_type_name: -1
+                raw: -1
+                pkg: -1
+                type: -1
+                position: -1
+                resolved_type: -1
+                generic_type_name: -1
+              raw: -1
+              pkg: -1
+              type: -1
+              position: -1
+              resolved_type: 55
+              generic_type_name: -1
+            signature_str: 60
+            scope: 50
             comments: -1
         comments: -1
   multipackage/services:
@@ -1277,35 +1278,35 @@ packages:
       multipackage/services/user_service.go:
         types:
           UserService:
-            name: 34
-            pkg: 21
-            kind: 61
+            name: 35
+            pkg: 22
+            kind: 62
             fields:
-              - name: 90
-                type: 35
+              - name: 91
+                type: 36
                 tag: -1
-                scope: 18
+                scope: 19
                 comments: -1
-            scope: 49
+            scope: 50
             methods:
-              - name: 31
-                receiver: 108
+              - name: 32
+                receiver: 109
                 signature:
-                  kind: 0
+                  kind: 1
                   name: -1
                   value: -1
                   fun:
-                    kind: 1
+                    kind: 2
                     name: -1
                     value: -1
                     args:
-                      - kind: 5
-                        name: 35
+                      - kind: 6
+                        name: 36
                         value: -1
                         raw: -1
                         pkg: -1
-                        type: 35
-                        position: 101
+                        type: 36
+                        position: 102
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
@@ -1315,397 +1316,397 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   args:
-                    - kind: 83
-                      name: 15
+                    - kind: 84
+                      name: 16
                       value: -1
                       x:
-                        kind: 12
+                        kind: 13
                         name: -1
                         value: -1
                         x:
-                          kind: 5
-                          name: 6
+                          kind: 6
+                          name: 7
                           value: -1
                           raw: -1
-                          pkg: 7
+                          pkg: 8
                           type: -1
-                          position: 98
-                          resolved_type: -1
-                          generic_type_name: -1
-                        sel:
-                          kind: 5
-                          name: 60
-                          value: -1
-                          raw: -1
-                          pkg: 7
-                          type: 60
                           position: 99
                           resolved_type: -1
                           generic_type_name: -1
+                        sel:
+                          kind: 6
+                          name: 61
+                          value: -1
+                          raw: -1
+                          pkg: 8
+                          type: 61
+                          position: 100
+                          resolved_type: -1
+                          generic_type_name: -1
                         raw: -1
-                        pkg: 7
-                        type: 60
-                        position: 98
+                        pkg: 8
+                        type: 61
+                        position: 99
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
                       pkg: -1
                       type: -1
-                      position: 100
+                      position: 101
                       resolved_type: -1
                       generic_type_name: -1
                   raw: -1
                   pkg: -1
                   type: -1
                   position: -1
-                  resolved_type: 35
+                  resolved_type: 36
                   generic_type_name: -1
-                signature_str: 111
-                position: 109
-                scope: 49
+                signature_str: 112
+                position: 110
+                scope: 50
                 comments: -1
-                filename: 110
+                filename: 111
                 return_vars:
-                  - kind: 13
+                  - kind: 14
                     name: -1
                     value: -1
                     fun:
-                      kind: 12
+                      kind: 13
                       name: -1
                       value: -1
                       x:
-                        kind: 5
-                        name: 40
+                        kind: 6
+                        name: 41
                         value: -1
                         raw: -1
-                        pkg: 40
+                        pkg: 41
                         type: -1
-                        position: 94
+                        position: 95
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 5
-                        name: 95
+                        kind: 6
+                        name: 96
                         value: -1
                         raw: -1
-                        pkg: 40
-                        type: 96
-                        position: 97
+                        pkg: 41
+                        type: 97
+                        position: 98
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 40
-                      type: 96
-                      position: 94
+                      pkg: 41
+                      type: 97
+                      position: 95
                       resolved_type: -1
                       generic_type_name: -1
                     args:
-                      - kind: 2
+                      - kind: 3
                         name: -1
-                        value: 87
+                        value: 88
                         raw: -1
                         pkg: -1
                         type: -1
                         position: -1
                         resolved_type: -1
                         generic_type_name: -1
-                      - kind: 12
+                      - kind: 13
                         name: -1
                         value: -1
                         x:
-                          kind: 5
-                          name: 88
+                          kind: 6
+                          name: 89
                           value: -1
                           raw: -1
-                          pkg: 21
-                          type: 26
-                          position: 89
+                          pkg: 22
+                          type: 27
+                          position: 90
                           resolved_type: -1
                           generic_type_name: -1
                         sel:
-                          kind: 5
-                          name: 90
+                          kind: 6
+                          name: 91
                           value: -1
                           raw: -1
-                          pkg: 21
-                          type: 35
-                          position: 91
+                          pkg: 22
+                          type: 36
+                          position: 92
                           resolved_type: -1
                           generic_type_name: -1
                         raw: -1
-                        pkg: 21
-                        type: 35
-                        position: 89
+                        pkg: 22
+                        type: 36
+                        position: 90
                         resolved_type: -1
                         generic_type_name: -1
-                      - kind: 5
-                        name: 70
+                      - kind: 6
+                        name: 71
                         value: -1
                         raw: -1
-                        pkg: 21
-                        type: 35
-                        position: 92
-                        resolved_type: -1
-                        generic_type_name: -1
-                      - kind: 5
-                        name: 74
-                        value: -1
-                        raw: -1
-                        pkg: 21
-                        type: 54
+                        pkg: 22
+                        type: 36
                         position: 93
+                        resolved_type: -1
+                        generic_type_name: -1
+                      - kind: 6
+                        name: 75
+                        value: -1
+                        raw: -1
+                        pkg: 22
+                        type: 55
+                        position: 94
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
                     pkg: -1
-                    type: 35
-                    position: 94
+                    type: 36
+                    position: 95
                     resolved_type: -1
                     generic_type_name: -1
                 returns:
-                  - - kind: 13
+                  - - kind: 14
                       name: -1
                       value: -1
                       fun:
-                        kind: 12
+                        kind: 13
                         name: -1
                         value: -1
                         x:
-                          kind: 5
-                          name: 40
+                          kind: 6
+                          name: 41
                           value: -1
                           raw: -1
-                          pkg: 40
+                          pkg: 41
                           type: -1
-                          position: 94
+                          position: 95
                           resolved_type: -1
                           generic_type_name: -1
                         sel:
-                          kind: 5
-                          name: 95
+                          kind: 6
+                          name: 96
                           value: -1
                           raw: -1
-                          pkg: 40
-                          type: 96
-                          position: 97
+                          pkg: 41
+                          type: 97
+                          position: 98
                           resolved_type: -1
                           generic_type_name: -1
                         raw: -1
-                        pkg: 40
-                        type: 96
-                        position: 94
+                        pkg: 41
+                        type: 97
+                        position: 95
                         resolved_type: -1
                         generic_type_name: -1
                       args:
-                        - kind: 2
+                        - kind: 3
                           name: -1
-                          value: 87
+                          value: 88
                           raw: -1
                           pkg: -1
                           type: -1
                           position: -1
                           resolved_type: -1
                           generic_type_name: -1
-                        - kind: 12
+                        - kind: 13
                           name: -1
                           value: -1
                           x:
-                            kind: 5
-                            name: 88
+                            kind: 6
+                            name: 89
                             value: -1
                             raw: -1
-                            pkg: 21
-                            type: 26
-                            position: 89
+                            pkg: 22
+                            type: 27
+                            position: 90
                             resolved_type: -1
                             generic_type_name: -1
                           sel:
-                            kind: 5
-                            name: 90
+                            kind: 6
+                            name: 91
                             value: -1
                             raw: -1
-                            pkg: 21
-                            type: 35
-                            position: 91
+                            pkg: 22
+                            type: 36
+                            position: 92
                             resolved_type: -1
                             generic_type_name: -1
                           raw: -1
-                          pkg: 21
-                          type: 35
-                          position: 89
+                          pkg: 22
+                          type: 36
+                          position: 90
                           resolved_type: -1
                           generic_type_name: -1
-                        - kind: 5
-                          name: 70
+                        - kind: 6
+                          name: 71
                           value: -1
                           raw: -1
-                          pkg: 21
-                          type: 35
-                          position: 92
-                          resolved_type: -1
-                          generic_type_name: -1
-                        - kind: 5
-                          name: 74
-                          value: -1
-                          raw: -1
-                          pkg: 21
-                          type: 54
+                          pkg: 22
+                          type: 36
                           position: 93
+                          resolved_type: -1
+                          generic_type_name: -1
+                        - kind: 6
+                          name: 75
+                          value: -1
+                          raw: -1
+                          pkg: 22
+                          type: 55
+                          position: 94
                           resolved_type: -1
                           generic_type_name: -1
                       raw: -1
                       pkg: -1
-                      type: 35
-                      position: 94
+                      type: 36
+                      position: 95
                       resolved_type: -1
                       generic_type_name: -1
                 assignments:
                   age:
-                    - variable_name: 74
-                      pkg: 21
-                      concrete_type: 54
-                      position: 107
-                      scope: 18
+                    - variable_name: 75
+                      pkg: 22
+                      concrete_type: 55
+                      position: 108
+                      scope: 19
                       value:
-                        kind: 13
+                        kind: 14
                         name: -1
                         value: -1
                         fun:
-                          kind: 12
+                          kind: 13
                           name: -1
                           value: -1
                           x:
-                            kind: 5
-                            name: 15
+                            kind: 6
+                            name: 16
                             value: -1
                             raw: -1
-                            pkg: 21
-                            type: 14
-                            position: 105
-                            resolved_type: -1
-                            generic_type_name: -1
-                          sel:
-                            kind: 5
-                            name: 56
-                            value: -1
-                            raw: -1
-                            pkg: 7
-                            type: 59
+                            pkg: 22
+                            type: 15
                             position: 106
                             resolved_type: -1
                             generic_type_name: -1
+                          sel:
+                            kind: 6
+                            name: 57
+                            value: -1
+                            raw: -1
+                            pkg: 8
+                            type: 60
+                            position: 107
+                            resolved_type: -1
+                            generic_type_name: -1
                           raw: -1
-                          pkg: 7
-                          type: 59
-                          position: 105
+                          pkg: 8
+                          type: 60
+                          position: 106
                           resolved_type: -1
                           generic_type_name: -1
                           receiver_type:
-                            kind: 5
-                            name: 60
+                            kind: 6
+                            name: 61
                             value: -1
                             raw: -1
-                            pkg: 7
-                            type: 60
+                            pkg: 8
+                            type: 61
                             position: -1
                             resolved_type: -1
                             generic_type_name: -1
                         raw: -1
                         pkg: -1
-                        type: 54
-                        position: 105
+                        type: 55
+                        position: 106
                         resolved_type: -1
                         generic_type_name: -1
                       lhs:
-                        kind: 5
-                        name: 74
+                        kind: 6
+                        name: 75
                         value: -1
                         raw: -1
-                        pkg: 21
-                        type: 54
-                        position: 107
+                        pkg: 22
+                        type: 55
+                        position: 108
                         resolved_type: -1
                         generic_type_name: -1
-                      func: 31
+                      func: 32
                       callee_func: GetAge
                       callee_pkg: multipackage/models
                   name:
-                    - variable_name: 70
-                      pkg: 21
-                      concrete_type: 35
-                      position: 104
-                      scope: 18
+                    - variable_name: 71
+                      pkg: 22
+                      concrete_type: 36
+                      position: 105
+                      scope: 19
                       value:
-                        kind: 13
+                        kind: 14
                         name: -1
                         value: -1
                         fun:
-                          kind: 12
+                          kind: 13
                           name: -1
                           value: -1
                           x:
-                            kind: 5
-                            name: 15
+                            kind: 6
+                            name: 16
                             value: -1
                             raw: -1
-                            pkg: 21
-                            type: 14
-                            position: 102
-                            resolved_type: -1
-                            generic_type_name: -1
-                          sel:
-                            kind: 5
-                            name: 45
-                            value: -1
-                            raw: -1
-                            pkg: 7
-                            type: 51
+                            pkg: 22
+                            type: 15
                             position: 103
                             resolved_type: -1
                             generic_type_name: -1
+                          sel:
+                            kind: 6
+                            name: 46
+                            value: -1
+                            raw: -1
+                            pkg: 8
+                            type: 52
+                            position: 104
+                            resolved_type: -1
+                            generic_type_name: -1
                           raw: -1
-                          pkg: 7
-                          type: 51
-                          position: 102
+                          pkg: 8
+                          type: 52
+                          position: 103
                           resolved_type: -1
                           generic_type_name: -1
                           receiver_type:
-                            kind: 5
-                            name: 60
+                            kind: 6
+                            name: 61
                             value: -1
                             raw: -1
-                            pkg: 7
-                            type: 60
+                            pkg: 8
+                            type: 61
                             position: -1
                             resolved_type: -1
                             generic_type_name: -1
                         raw: -1
                         pkg: -1
-                        type: 35
-                        position: 102
+                        type: 36
+                        position: 103
                         resolved_type: -1
                         generic_type_name: -1
                       lhs:
-                        kind: 5
-                        name: 70
+                        kind: 6
+                        name: 71
                         value: -1
                         raw: -1
-                        pkg: 21
-                        type: 35
-                        position: 104
+                        pkg: 22
+                        type: 36
+                        position: 105
                         resolved_type: -1
                         generic_type_name: -1
-                      func: 31
+                      func: 32
                       callee_func: GetName
                       callee_pkg: multipackage/models
-              - name: 117
-                receiver: 108
+              - name: 118
+                receiver: 109
                 signature:
-                  kind: 0
+                  kind: 1
                   name: -1
                   value: -1
                   fun:
-                    kind: 1
+                    kind: 2
                     name: -1
                     value: -1
                     raw: -1
@@ -1715,13 +1716,13 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   args:
-                    - kind: 5
-                      name: 90
+                    - kind: 6
+                      name: 91
                       value: -1
                       raw: -1
                       pkg: -1
-                      type: 35
-                      position: 112
+                      type: 36
+                      position: 113
                       resolved_type: -1
                       generic_type_name: -1
                   raw: -1
@@ -1730,89 +1731,89 @@ packages:
                   position: -1
                   resolved_type: -1
                   generic_type_name: -1
-                signature_str: 119
-                position: 118
-                scope: 49
+                signature_str: 120
+                position: 119
+                scope: 50
                 comments: -1
-                filename: 110
+                filename: 111
                 assignments:
                   multipackage/services.UserService.prefix:
-                    - variable_name: 115
-                      pkg: 21
-                      concrete_type: 35
-                      position: 113
-                      scope: 12
+                    - variable_name: 116
+                      pkg: 22
+                      concrete_type: 36
+                      position: 114
+                      scope: 13
                       value:
-                        kind: 5
-                        name: 90
+                        kind: 6
+                        name: 91
                         value: -1
                         raw: -1
-                        pkg: 21
-                        type: 35
-                        position: 116
+                        pkg: 22
+                        type: 36
+                        position: 117
                         resolved_type: -1
                         generic_type_name: -1
                       lhs:
-                        kind: 12
+                        kind: 13
                         name: -1
                         value: -1
                         x:
-                          kind: 5
-                          name: 88
+                          kind: 6
+                          name: 89
                           value: -1
                           raw: -1
-                          pkg: 21
-                          type: 26
-                          position: 113
-                          resolved_type: -1
-                          generic_type_name: -1
-                        sel:
-                          kind: 5
-                          name: 90
-                          value: -1
-                          raw: -1
-                          pkg: 21
-                          type: 35
+                          pkg: 22
+                          type: 27
                           position: 114
                           resolved_type: -1
                           generic_type_name: -1
+                        sel:
+                          kind: 6
+                          name: 91
+                          value: -1
+                          raw: -1
+                          pkg: 22
+                          type: 36
+                          position: 115
+                          resolved_type: -1
+                          generic_type_name: -1
                         raw: -1
-                        pkg: 21
-                        type: 35
-                        position: 113
+                        pkg: 22
+                        type: 36
+                        position: 114
                         resolved_type: -1
                         generic_type_name: -1
             comments: -1
         functions:
           NewUserService:
-            name: 23
-            pkg: 21
+            name: 24
+            pkg: 22
             signature:
-              kind: 0
+              kind: 1
               name: -1
               value: -1
               fun:
-                kind: 1
+                kind: 2
                 name: -1
                 value: -1
                 args:
-                  - kind: 83
+                  - kind: 84
                     name: -1
                     value: -1
                     x:
-                      kind: 5
-                      name: 34
+                      kind: 6
+                      name: 35
                       value: -1
                       raw: -1
-                      pkg: 21
-                      type: 34
-                      position: 124
+                      pkg: 22
+                      type: 35
+                      position: 125
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
                     pkg: -1
                     type: -1
-                    position: 125
+                    position: 126
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -1825,48 +1826,48 @@ packages:
               pkg: -1
               type: -1
               position: -1
-              resolved_type: 108
+              resolved_type: 109
               generic_type_name: -1
-            signature_str: 127
-            position: 126
-            scope: 49
+            signature_str: 128
+            position: 127
+            scope: 50
             comments: -1
             return_vars:
-              - kind: 77
+              - kind: 78
                 name: -1
-                value: 78
+                value: 79
                 x:
-                  kind: 76
+                  kind: 77
                   name: -1
                   value: -1
                   x:
-                    kind: 5
-                    name: 34
+                    kind: 6
+                    name: 35
                     value: -1
                     raw: -1
-                    pkg: 21
-                    type: 34
-                    position: 120
+                    pkg: 22
+                    type: 35
+                    position: 121
                     resolved_type: -1
                     generic_type_name: -1
                   args:
-                    - kind: 72
+                    - kind: 73
                       name: -1
                       value: -1
                       x:
-                        kind: 5
-                        name: 90
+                        kind: 6
+                        name: 91
                         value: -1
                         raw: -1
-                        pkg: 21
-                        type: 35
-                        position: 121
+                        pkg: 22
+                        type: 36
+                        position: 122
                         resolved_type: -1
                         generic_type_name: -1
                       fun:
-                        kind: 2
+                        kind: 3
                         name: -1
-                        value: 122
+                        value: 123
                         raw: -1
                         pkg: -1
                         type: -1
@@ -1876,57 +1877,57 @@ packages:
                       raw: -1
                       pkg: -1
                       type: -1
-                      position: 121
+                      position: 122
                       resolved_type: -1
                       generic_type_name: -1
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 120
+                  position: 121
                   resolved_type: -1
                   generic_type_name: -1
                 raw: -1
                 pkg: -1
                 type: -1
-                position: 123
+                position: 124
                 resolved_type: -1
                 generic_type_name: -1
             returns:
-              - - kind: 77
+              - - kind: 78
                   name: -1
-                  value: 78
+                  value: 79
                   x:
-                    kind: 76
+                    kind: 77
                     name: -1
                     value: -1
                     x:
-                      kind: 5
-                      name: 34
+                      kind: 6
+                      name: 35
                       value: -1
                       raw: -1
-                      pkg: 21
-                      type: 34
-                      position: 120
+                      pkg: 22
+                      type: 35
+                      position: 121
                       resolved_type: -1
                       generic_type_name: -1
                     args:
-                      - kind: 72
+                      - kind: 73
                         name: -1
                         value: -1
                         x:
-                          kind: 5
-                          name: 90
+                          kind: 6
+                          name: 91
                           value: -1
                           raw: -1
-                          pkg: 21
-                          type: 35
-                          position: 121
+                          pkg: 22
+                          type: 36
+                          position: 122
                           resolved_type: -1
                           generic_type_name: -1
                         fun:
-                          kind: 2
+                          kind: 3
                           name: -1
-                          value: 122
+                          value: 123
                           raw: -1
                           pkg: -1
                           type: -1
@@ -1936,62 +1937,62 @@ packages:
                         raw: -1
                         pkg: -1
                         type: -1
-                        position: 121
+                        position: 122
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
                     pkg: -1
                     type: -1
-                    position: 120
+                    position: 121
                     resolved_type: -1
                     generic_type_name: -1
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 123
+                  position: 124
                   resolved_type: -1
                   generic_type_name: -1
             end_line: 14
         struct_instances:
-          - type: 34
-            pkg: 21
-            position: 120
+          - type: 35
+            pkg: 22
+            position: 121
             fields:
-              90: 128
+              91: 129
         imports:
-          7: 7
-          40: 40
+          8: 8
+          41: 41
     types:
       UserService:
-        name: 34
-        pkg: 21
-        kind: 61
+        name: 35
+        pkg: 22
+        kind: 62
         fields:
-          - name: 90
-            type: 35
+          - name: 91
+            type: 36
             tag: -1
-            scope: 18
+            scope: 19
             comments: -1
-        scope: 49
+        scope: 50
         methods:
-          - name: 31
-            receiver: 108
+          - name: 32
+            receiver: 109
             signature:
-              kind: 0
+              kind: 1
               name: -1
               value: -1
               fun:
-                kind: 1
+                kind: 2
                 name: -1
                 value: -1
                 args:
-                  - kind: 5
-                    name: 35
+                  - kind: 6
+                    name: 36
                     value: -1
                     raw: -1
                     pkg: -1
-                    type: 35
-                    position: 101
+                    type: 36
+                    position: 102
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -2001,397 +2002,397 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 83
-                  name: 15
+                - kind: 84
+                  name: 16
                   value: -1
                   x:
-                    kind: 12
+                    kind: 13
                     name: -1
                     value: -1
                     x:
-                      kind: 5
-                      name: 6
+                      kind: 6
+                      name: 7
                       value: -1
                       raw: -1
-                      pkg: 7
+                      pkg: 8
                       type: -1
-                      position: 98
-                      resolved_type: -1
-                      generic_type_name: -1
-                    sel:
-                      kind: 5
-                      name: 60
-                      value: -1
-                      raw: -1
-                      pkg: 7
-                      type: 60
                       position: 99
                       resolved_type: -1
                       generic_type_name: -1
+                    sel:
+                      kind: 6
+                      name: 61
+                      value: -1
+                      raw: -1
+                      pkg: 8
+                      type: 61
+                      position: 100
+                      resolved_type: -1
+                      generic_type_name: -1
                     raw: -1
-                    pkg: 7
-                    type: 60
-                    position: 98
+                    pkg: 8
+                    type: 61
+                    position: 99
                     resolved_type: -1
                     generic_type_name: -1
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 100
+                  position: 101
                   resolved_type: -1
                   generic_type_name: -1
               raw: -1
               pkg: -1
               type: -1
               position: -1
-              resolved_type: 35
+              resolved_type: 36
               generic_type_name: -1
-            signature_str: 111
-            position: 109
-            scope: 49
+            signature_str: 112
+            position: 110
+            scope: 50
             comments: -1
-            filename: 110
+            filename: 111
             return_vars:
-              - kind: 13
+              - kind: 14
                 name: -1
                 value: -1
                 fun:
-                  kind: 12
+                  kind: 13
                   name: -1
                   value: -1
                   x:
-                    kind: 5
-                    name: 40
+                    kind: 6
+                    name: 41
                     value: -1
                     raw: -1
-                    pkg: 40
+                    pkg: 41
                     type: -1
-                    position: 94
+                    position: 95
                     resolved_type: -1
                     generic_type_name: -1
                   sel:
-                    kind: 5
-                    name: 95
+                    kind: 6
+                    name: 96
                     value: -1
                     raw: -1
-                    pkg: 40
-                    type: 96
-                    position: 97
+                    pkg: 41
+                    type: 97
+                    position: 98
                     resolved_type: -1
                     generic_type_name: -1
                   raw: -1
-                  pkg: 40
-                  type: 96
-                  position: 94
+                  pkg: 41
+                  type: 97
+                  position: 95
                   resolved_type: -1
                   generic_type_name: -1
                 args:
-                  - kind: 2
+                  - kind: 3
                     name: -1
-                    value: 87
+                    value: 88
                     raw: -1
                     pkg: -1
                     type: -1
                     position: -1
                     resolved_type: -1
                     generic_type_name: -1
-                  - kind: 12
+                  - kind: 13
                     name: -1
                     value: -1
                     x:
-                      kind: 5
-                      name: 88
+                      kind: 6
+                      name: 89
                       value: -1
                       raw: -1
-                      pkg: 21
-                      type: 26
-                      position: 89
+                      pkg: 22
+                      type: 27
+                      position: 90
                       resolved_type: -1
                       generic_type_name: -1
                     sel:
-                      kind: 5
-                      name: 90
+                      kind: 6
+                      name: 91
                       value: -1
                       raw: -1
-                      pkg: 21
-                      type: 35
-                      position: 91
+                      pkg: 22
+                      type: 36
+                      position: 92
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
-                    pkg: 21
-                    type: 35
-                    position: 89
+                    pkg: 22
+                    type: 36
+                    position: 90
                     resolved_type: -1
                     generic_type_name: -1
-                  - kind: 5
-                    name: 70
+                  - kind: 6
+                    name: 71
                     value: -1
                     raw: -1
-                    pkg: 21
-                    type: 35
-                    position: 92
-                    resolved_type: -1
-                    generic_type_name: -1
-                  - kind: 5
-                    name: 74
-                    value: -1
-                    raw: -1
-                    pkg: 21
-                    type: 54
+                    pkg: 22
+                    type: 36
                     position: 93
+                    resolved_type: -1
+                    generic_type_name: -1
+                  - kind: 6
+                    name: 75
+                    value: -1
+                    raw: -1
+                    pkg: 22
+                    type: 55
+                    position: 94
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
                 pkg: -1
-                type: 35
-                position: 94
+                type: 36
+                position: 95
                 resolved_type: -1
                 generic_type_name: -1
             returns:
-              - - kind: 13
+              - - kind: 14
                   name: -1
                   value: -1
                   fun:
-                    kind: 12
+                    kind: 13
                     name: -1
                     value: -1
                     x:
-                      kind: 5
-                      name: 40
+                      kind: 6
+                      name: 41
                       value: -1
                       raw: -1
-                      pkg: 40
+                      pkg: 41
                       type: -1
-                      position: 94
+                      position: 95
                       resolved_type: -1
                       generic_type_name: -1
                     sel:
-                      kind: 5
-                      name: 95
+                      kind: 6
+                      name: 96
                       value: -1
                       raw: -1
-                      pkg: 40
-                      type: 96
-                      position: 97
+                      pkg: 41
+                      type: 97
+                      position: 98
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
-                    pkg: 40
-                    type: 96
-                    position: 94
+                    pkg: 41
+                    type: 97
+                    position: 95
                     resolved_type: -1
                     generic_type_name: -1
                   args:
-                    - kind: 2
+                    - kind: 3
                       name: -1
-                      value: 87
+                      value: 88
                       raw: -1
                       pkg: -1
                       type: -1
                       position: -1
                       resolved_type: -1
                       generic_type_name: -1
-                    - kind: 12
+                    - kind: 13
                       name: -1
                       value: -1
                       x:
-                        kind: 5
-                        name: 88
+                        kind: 6
+                        name: 89
                         value: -1
                         raw: -1
-                        pkg: 21
-                        type: 26
-                        position: 89
+                        pkg: 22
+                        type: 27
+                        position: 90
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 5
-                        name: 90
+                        kind: 6
+                        name: 91
                         value: -1
                         raw: -1
-                        pkg: 21
-                        type: 35
-                        position: 91
+                        pkg: 22
+                        type: 36
+                        position: 92
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 21
-                      type: 35
-                      position: 89
+                      pkg: 22
+                      type: 36
+                      position: 90
                       resolved_type: -1
                       generic_type_name: -1
-                    - kind: 5
-                      name: 70
+                    - kind: 6
+                      name: 71
                       value: -1
                       raw: -1
-                      pkg: 21
-                      type: 35
-                      position: 92
-                      resolved_type: -1
-                      generic_type_name: -1
-                    - kind: 5
-                      name: 74
-                      value: -1
-                      raw: -1
-                      pkg: 21
-                      type: 54
+                      pkg: 22
+                      type: 36
                       position: 93
+                      resolved_type: -1
+                      generic_type_name: -1
+                    - kind: 6
+                      name: 75
+                      value: -1
+                      raw: -1
+                      pkg: 22
+                      type: 55
+                      position: 94
                       resolved_type: -1
                       generic_type_name: -1
                   raw: -1
                   pkg: -1
-                  type: 35
-                  position: 94
+                  type: 36
+                  position: 95
                   resolved_type: -1
                   generic_type_name: -1
             assignments:
               age:
-                - variable_name: 74
-                  pkg: 21
-                  concrete_type: 54
-                  position: 107
-                  scope: 18
+                - variable_name: 75
+                  pkg: 22
+                  concrete_type: 55
+                  position: 108
+                  scope: 19
                   value:
-                    kind: 13
+                    kind: 14
                     name: -1
                     value: -1
                     fun:
-                      kind: 12
+                      kind: 13
                       name: -1
                       value: -1
                       x:
-                        kind: 5
-                        name: 15
+                        kind: 6
+                        name: 16
                         value: -1
                         raw: -1
-                        pkg: 21
-                        type: 14
-                        position: 105
-                        resolved_type: -1
-                        generic_type_name: -1
-                      sel:
-                        kind: 5
-                        name: 56
-                        value: -1
-                        raw: -1
-                        pkg: 7
-                        type: 59
+                        pkg: 22
+                        type: 15
                         position: 106
                         resolved_type: -1
                         generic_type_name: -1
+                      sel:
+                        kind: 6
+                        name: 57
+                        value: -1
+                        raw: -1
+                        pkg: 8
+                        type: 60
+                        position: 107
+                        resolved_type: -1
+                        generic_type_name: -1
                       raw: -1
-                      pkg: 7
-                      type: 59
-                      position: 105
+                      pkg: 8
+                      type: 60
+                      position: 106
                       resolved_type: -1
                       generic_type_name: -1
                       receiver_type:
-                        kind: 5
-                        name: 60
+                        kind: 6
+                        name: 61
                         value: -1
                         raw: -1
-                        pkg: 7
-                        type: 60
+                        pkg: 8
+                        type: 61
                         position: -1
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
                     pkg: -1
-                    type: 54
-                    position: 105
+                    type: 55
+                    position: 106
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 5
-                    name: 74
+                    kind: 6
+                    name: 75
                     value: -1
                     raw: -1
-                    pkg: 21
-                    type: 54
-                    position: 107
+                    pkg: 22
+                    type: 55
+                    position: 108
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 31
+                  func: 32
                   callee_func: GetAge
                   callee_pkg: multipackage/models
               name:
-                - variable_name: 70
-                  pkg: 21
-                  concrete_type: 35
-                  position: 104
-                  scope: 18
+                - variable_name: 71
+                  pkg: 22
+                  concrete_type: 36
+                  position: 105
+                  scope: 19
                   value:
-                    kind: 13
+                    kind: 14
                     name: -1
                     value: -1
                     fun:
-                      kind: 12
+                      kind: 13
                       name: -1
                       value: -1
                       x:
-                        kind: 5
-                        name: 15
+                        kind: 6
+                        name: 16
                         value: -1
                         raw: -1
-                        pkg: 21
-                        type: 14
-                        position: 102
-                        resolved_type: -1
-                        generic_type_name: -1
-                      sel:
-                        kind: 5
-                        name: 45
-                        value: -1
-                        raw: -1
-                        pkg: 7
-                        type: 51
+                        pkg: 22
+                        type: 15
                         position: 103
                         resolved_type: -1
                         generic_type_name: -1
+                      sel:
+                        kind: 6
+                        name: 46
+                        value: -1
+                        raw: -1
+                        pkg: 8
+                        type: 52
+                        position: 104
+                        resolved_type: -1
+                        generic_type_name: -1
                       raw: -1
-                      pkg: 7
-                      type: 51
-                      position: 102
+                      pkg: 8
+                      type: 52
+                      position: 103
                       resolved_type: -1
                       generic_type_name: -1
                       receiver_type:
-                        kind: 5
-                        name: 60
+                        kind: 6
+                        name: 61
                         value: -1
                         raw: -1
-                        pkg: 7
-                        type: 60
+                        pkg: 8
+                        type: 61
                         position: -1
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
                     pkg: -1
-                    type: 35
-                    position: 102
+                    type: 36
+                    position: 103
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 5
-                    name: 70
+                    kind: 6
+                    name: 71
                     value: -1
                     raw: -1
-                    pkg: 21
-                    type: 35
-                    position: 104
+                    pkg: 22
+                    type: 36
+                    position: 105
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 31
+                  func: 32
                   callee_func: GetName
                   callee_pkg: multipackage/models
-          - name: 117
-            receiver: 108
+          - name: 118
+            receiver: 109
             signature:
-              kind: 0
+              kind: 1
               name: -1
               value: -1
               fun:
-                kind: 1
+                kind: 2
                 name: -1
                 value: -1
                 raw: -1
@@ -2401,13 +2402,13 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 5
-                  name: 90
+                - kind: 6
+                  name: 91
                   value: -1
                   raw: -1
                   pkg: -1
-                  type: 35
-                  position: 112
+                  type: 36
+                  position: 113
                   resolved_type: -1
                   generic_type_name: -1
               raw: -1
@@ -2416,56 +2417,56 @@ packages:
               position: -1
               resolved_type: -1
               generic_type_name: -1
-            signature_str: 119
-            position: 118
-            scope: 49
+            signature_str: 120
+            position: 119
+            scope: 50
             comments: -1
-            filename: 110
+            filename: 111
             assignments:
               multipackage/services.UserService.prefix:
-                - variable_name: 115
-                  pkg: 21
-                  concrete_type: 35
-                  position: 113
-                  scope: 12
+                - variable_name: 116
+                  pkg: 22
+                  concrete_type: 36
+                  position: 114
+                  scope: 13
                   value:
-                    kind: 5
-                    name: 90
+                    kind: 6
+                    name: 91
                     value: -1
                     raw: -1
-                    pkg: 21
-                    type: 35
-                    position: 116
+                    pkg: 22
+                    type: 36
+                    position: 117
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 12
+                    kind: 13
                     name: -1
                     value: -1
                     x:
-                      kind: 5
-                      name: 88
+                      kind: 6
+                      name: 89
                       value: -1
                       raw: -1
-                      pkg: 21
-                      type: 26
-                      position: 113
-                      resolved_type: -1
-                      generic_type_name: -1
-                    sel:
-                      kind: 5
-                      name: 90
-                      value: -1
-                      raw: -1
-                      pkg: 21
-                      type: 35
+                      pkg: 22
+                      type: 27
                       position: 114
                       resolved_type: -1
                       generic_type_name: -1
+                    sel:
+                      kind: 6
+                      name: 91
+                      value: -1
+                      raw: -1
+                      pkg: 22
+                      type: 36
+                      position: 115
+                      resolved_type: -1
+                      generic_type_name: -1
                     raw: -1
-                    pkg: 21
-                    type: 35
-                    position: 113
+                    pkg: 22
+                    type: 36
+                    position: 114
                     resolved_type: -1
                     generic_type_name: -1
         comments: -1
@@ -2474,24 +2475,24 @@ packages:
       multipackage/utils/helper.go:
         functions:
           FormatString:
-            name: 142
-            pkg: 132
+            name: 143
+            pkg: 133
             signature:
-              kind: 0
+              kind: 1
               name: -1
               value: -1
               fun:
-                kind: 1
+                kind: 2
                 name: -1
                 value: -1
                 args:
-                  - kind: 5
-                    name: 35
+                  - kind: 6
+                    name: 36
                     value: -1
                     raw: -1
                     pkg: -1
-                    type: 35
-                    position: 144
+                    type: 36
+                    position: 145
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -2501,225 +2502,225 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 5
-                  name: 131
+                - kind: 6
+                  name: 132
                   value: -1
                   raw: -1
                   pkg: -1
-                  type: 35
-                  position: 143
+                  type: 36
+                  position: 144
                   resolved_type: -1
                   generic_type_name: -1
               raw: -1
               pkg: -1
               type: -1
               position: -1
-              resolved_type: 35
+              resolved_type: 36
               generic_type_name: -1
-            signature_str: 146
-            position: 145
-            scope: 49
+            signature_str: 147
+            position: 146
+            scope: 50
             comments: -1
             return_vars:
-              - kind: 13
+              - kind: 14
                 name: -1
                 value: -1
                 fun:
-                  kind: 12
+                  kind: 13
                   name: -1
                   value: -1
                   x:
-                    kind: 5
-                    name: 134
+                    kind: 6
+                    name: 135
                     value: -1
                     raw: -1
-                    pkg: 134
+                    pkg: 135
                     type: -1
-                    position: 139
+                    position: 140
                     resolved_type: -1
                     generic_type_name: -1
                   sel:
-                    kind: 5
-                    name: 140
+                    kind: 6
+                    name: 141
                     value: -1
                     raw: -1
-                    pkg: 134
-                    type: 137
-                    position: 141
+                    pkg: 135
+                    type: 138
+                    position: 142
                     resolved_type: -1
                     generic_type_name: -1
                   raw: -1
-                  pkg: 134
-                  type: 137
-                  position: 139
+                  pkg: 135
+                  type: 138
+                  position: 140
                   resolved_type: -1
                   generic_type_name: -1
                 args:
-                  - kind: 13
+                  - kind: 14
                     name: -1
                     value: -1
                     fun:
-                      kind: 12
+                      kind: 13
                       name: -1
                       value: -1
                       x:
-                        kind: 5
-                        name: 134
+                        kind: 6
+                        name: 135
                         value: -1
                         raw: -1
-                        pkg: 134
+                        pkg: 135
                         type: -1
-                        position: 135
+                        position: 136
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 5
-                        name: 136
+                        kind: 6
+                        name: 137
                         value: -1
                         raw: -1
-                        pkg: 134
-                        type: 137
-                        position: 138
+                        pkg: 135
+                        type: 138
+                        position: 139
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 134
-                      type: 137
-                      position: 135
+                      pkg: 135
+                      type: 138
+                      position: 136
                       resolved_type: -1
                       generic_type_name: -1
                     args:
-                      - kind: 5
-                        name: 131
+                      - kind: 6
+                        name: 132
                         value: -1
                         raw: -1
-                        pkg: 132
-                        type: 35
-                        position: 133
+                        pkg: 133
+                        type: 36
+                        position: 134
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
                     pkg: -1
-                    type: 35
-                    position: 135
+                    type: 36
+                    position: 136
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
                 pkg: -1
-                type: 35
-                position: 139
+                type: 36
+                position: 140
                 resolved_type: -1
                 generic_type_name: -1
             returns:
-              - - kind: 13
+              - - kind: 14
                   name: -1
                   value: -1
                   fun:
-                    kind: 12
+                    kind: 13
                     name: -1
                     value: -1
                     x:
-                      kind: 5
-                      name: 134
+                      kind: 6
+                      name: 135
                       value: -1
                       raw: -1
-                      pkg: 134
+                      pkg: 135
                       type: -1
-                      position: 139
+                      position: 140
                       resolved_type: -1
                       generic_type_name: -1
                     sel:
-                      kind: 5
-                      name: 140
+                      kind: 6
+                      name: 141
                       value: -1
                       raw: -1
-                      pkg: 134
-                      type: 137
-                      position: 141
+                      pkg: 135
+                      type: 138
+                      position: 142
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
-                    pkg: 134
-                    type: 137
-                    position: 139
+                    pkg: 135
+                    type: 138
+                    position: 140
                     resolved_type: -1
                     generic_type_name: -1
                   args:
-                    - kind: 13
+                    - kind: 14
                       name: -1
                       value: -1
                       fun:
-                        kind: 12
+                        kind: 13
                         name: -1
                         value: -1
                         x:
-                          kind: 5
-                          name: 134
+                          kind: 6
+                          name: 135
                           value: -1
                           raw: -1
-                          pkg: 134
+                          pkg: 135
                           type: -1
-                          position: 135
+                          position: 136
                           resolved_type: -1
                           generic_type_name: -1
                         sel:
-                          kind: 5
-                          name: 136
+                          kind: 6
+                          name: 137
                           value: -1
                           raw: -1
-                          pkg: 134
-                          type: 137
-                          position: 138
+                          pkg: 135
+                          type: 138
+                          position: 139
                           resolved_type: -1
                           generic_type_name: -1
                         raw: -1
-                        pkg: 134
-                        type: 137
-                        position: 135
+                        pkg: 135
+                        type: 138
+                        position: 136
                         resolved_type: -1
                         generic_type_name: -1
                       args:
-                        - kind: 5
-                          name: 131
+                        - kind: 6
+                          name: 132
                           value: -1
                           raw: -1
-                          pkg: 132
-                          type: 35
-                          position: 133
+                          pkg: 133
+                          type: 36
+                          position: 134
                           resolved_type: -1
                           generic_type_name: -1
                       raw: -1
                       pkg: -1
-                      type: 35
-                      position: 135
+                      type: 36
+                      position: 136
                       resolved_type: -1
                       generic_type_name: -1
                   raw: -1
                   pkg: -1
-                  type: 35
-                  position: 139
+                  type: 36
+                  position: 140
                   resolved_type: -1
                   generic_type_name: -1
             end_line: 7
           ValidateAge:
-            name: 155
-            pkg: 132
+            name: 156
+            pkg: 133
             signature:
-              kind: 0
+              kind: 1
               name: -1
               value: -1
               fun:
-                kind: 1
+                kind: 2
                 name: -1
                 value: -1
                 args:
-                  - kind: 5
-                    name: 157
+                  - kind: 6
+                    name: 158
                     value: -1
                     raw: -1
                     pkg: -1
-                    type: 157
-                    position: 158
+                    type: 158
+                    position: 159
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -2729,47 +2730,47 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 5
-                  name: 74
+                - kind: 6
+                  name: 75
                   value: -1
                   raw: -1
                   pkg: -1
-                  type: 54
-                  position: 156
+                  type: 55
+                  position: 157
                   resolved_type: -1
                   generic_type_name: -1
               raw: -1
               pkg: -1
               type: -1
               position: -1
-              resolved_type: 157
+              resolved_type: 158
               generic_type_name: -1
-            signature_str: 160
-            position: 159
-            scope: 49
+            signature_str: 161
+            position: 160
+            scope: 50
             comments: -1
             return_vars:
-              - kind: 149
+              - kind: 150
                 name: -1
-                value: 154
+                value: 155
                 x:
-                  kind: 149
+                  kind: 150
                   name: -1
-                  value: 150
+                  value: 151
                   x:
-                    kind: 5
-                    name: 74
+                    kind: 6
+                    name: 75
                     value: -1
                     raw: -1
-                    pkg: 132
-                    type: 54
-                    position: 147
+                    pkg: 133
+                    type: 55
+                    position: 148
                     resolved_type: -1
                     generic_type_name: -1
                   fun:
-                    kind: 2
+                    kind: 3
                     name: -1
-                    value: 148
+                    value: 149
                     raw: -1
                     pkg: -1
                     type: -1
@@ -2779,27 +2780,27 @@ packages:
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 147
+                  position: 148
                   resolved_type: -1
                   generic_type_name: -1
                 fun:
-                  kind: 149
+                  kind: 150
                   name: -1
-                  value: 153
+                  value: 154
                   x:
-                    kind: 5
-                    name: 74
+                    kind: 6
+                    name: 75
                     value: -1
                     raw: -1
-                    pkg: 132
-                    type: 54
-                    position: 151
+                    pkg: 133
+                    type: 55
+                    position: 152
                     resolved_type: -1
                     generic_type_name: -1
                   fun:
-                    kind: 2
+                    kind: 3
                     name: -1
-                    value: 152
+                    value: 153
                     raw: -1
                     pkg: -1
                     type: -1
@@ -2809,37 +2810,37 @@ packages:
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 151
+                  position: 152
                   resolved_type: -1
                   generic_type_name: -1
                 raw: -1
                 pkg: -1
                 type: -1
-                position: 147
+                position: 148
                 resolved_type: -1
                 generic_type_name: -1
             returns:
-              - - kind: 149
+              - - kind: 150
                   name: -1
-                  value: 154
+                  value: 155
                   x:
-                    kind: 149
+                    kind: 150
                     name: -1
-                    value: 150
+                    value: 151
                     x:
-                      kind: 5
-                      name: 74
+                      kind: 6
+                      name: 75
                       value: -1
                       raw: -1
-                      pkg: 132
-                      type: 54
-                      position: 147
+                      pkg: 133
+                      type: 55
+                      position: 148
                       resolved_type: -1
                       generic_type_name: -1
                     fun:
-                      kind: 2
+                      kind: 3
                       name: -1
-                      value: 148
+                      value: 149
                       raw: -1
                       pkg: -1
                       type: -1
@@ -2849,27 +2850,27 @@ packages:
                     raw: -1
                     pkg: -1
                     type: -1
-                    position: 147
+                    position: 148
                     resolved_type: -1
                     generic_type_name: -1
                   fun:
-                    kind: 149
+                    kind: 150
                     name: -1
-                    value: 153
+                    value: 154
                     x:
-                      kind: 5
-                      name: 74
+                      kind: 6
+                      name: 75
                       value: -1
                       raw: -1
-                      pkg: 132
-                      type: 54
-                      position: 151
+                      pkg: 133
+                      type: 55
+                      position: 152
                       resolved_type: -1
                       generic_type_name: -1
                     fun:
-                      kind: 2
+                      kind: 3
                       name: -1
-                      value: 152
+                      value: 153
                       raw: -1
                       pkg: -1
                       type: -1
@@ -2879,77 +2880,68 @@ packages:
                     raw: -1
                     pkg: -1
                     type: -1
-                    position: 151
+                    position: 152
                     resolved_type: -1
                     generic_type_name: -1
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 147
+                  position: 148
                   resolved_type: -1
                   generic_type_name: -1
             end_line: 11
         variables:
           DefaultFormat:
-            name: 167
-            tok: 168
-            pkg: 132
+            name: 168
+            tok: 169
+            pkg: 133
             type: -1
-            value: 171
-            position: 169
+            value: 172
+            position: 170
             comments: -1
             group_index: 1
           MaxAge:
-            name: 165
-            tok: 162
-            pkg: 132
+            name: 166
+            tok: 163
+            pkg: 133
             type: -1
-            resolved_type: 164
-            value: 130
+            resolved_type: 165
+            value: 131
             computed_value: 149
-            position: 166
+            position: 167
             comments: -1
             group_index: 1
           MinAge:
-            name: 161
-            tok: 162
-            pkg: 132
+            name: 162
+            tok: 163
+            pkg: 133
             type: -1
-            resolved_type: 164
-            value: 129
+            resolved_type: 165
+            value: 130
             computed_value: 1
-            position: 163
+            position: 164
             comments: -1
             group_index: 1
         imports:
-          134: 134
+          135: 135
 call_graph:
   - caller:
-      name: 19
-      pkg: 16
+      name: 20
+      pkg: 17
       position: -1
       recv_type: -1
-      scope: 18
-      signature_str: 39
+      scope: 19
+      signature_str: 40
     callee:
-      name: 9
-      pkg: 7
-      position: 8
+      name: 10
+      pkg: 8
+      position: 9
       recv_type: -1
-      scope: 49
-      signature_str: 10
-    position: 8
+      scope: 50
+      signature_str: 11
+    position: 9
     args:
-      - kind: 2
-        name: -1
-        value: 3
-        raw: -1
-        pkg: -1
-        type: -1
-        position: -1
-        resolved_type: -1
-        generic_type_name: -1
-      - kind: 2
+      - kind: 3
         name: -1
         value: 4
         raw: -1
@@ -2958,58 +2950,58 @@ call_graph:
         position: -1
         resolved_type: -1
         generic_type_name: -1
+      - kind: 3
+        name: -1
+        value: 5
+        raw: -1
+        pkg: -1
+        type: -1
+        position: -1
+        resolved_type: -1
+        generic_type_name: -1
     assignments:
       user:
-        - variable_name: 15
-          pkg: 16
-          concrete_type: 14
-          position: 17
-          scope: 18
+        - variable_name: 16
+          pkg: 17
+          concrete_type: 15
+          position: 18
+          scope: 19
           value:
-            kind: 13
+            kind: 14
             name: -1
             value: -1
             fun:
-              kind: 12
+              kind: 13
               name: -1
               value: -1
               x:
-                kind: 5
-                name: 6
+                kind: 6
+                name: 7
                 value: -1
                 raw: -1
-                pkg: 7
+                pkg: 8
                 type: -1
-                position: 8
+                position: 9
                 resolved_type: -1
                 generic_type_name: -1
               sel:
-                kind: 5
-                name: 9
+                kind: 6
+                name: 10
                 value: -1
                 raw: -1
-                pkg: 7
-                type: 10
-                position: 11
+                pkg: 8
+                type: 11
+                position: 12
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
-              pkg: 7
-              type: 10
-              position: 8
+              pkg: 8
+              type: 11
+              position: 9
               resolved_type: -1
               generic_type_name: -1
             args:
-              - kind: 2
-                name: -1
-                value: 3
-                raw: -1
-                pkg: -1
-                type: -1
-                position: -1
-                resolved_type: -1
-                generic_type_name: -1
-              - kind: 2
+              - kind: 3
                 name: -1
                 value: 4
                 raw: -1
@@ -3018,28 +3010,47 @@ call_graph:
                 position: -1
                 resolved_type: -1
                 generic_type_name: -1
+              - kind: 3
+                name: -1
+                value: 5
+                raw: -1
+                pkg: -1
+                type: -1
+                position: -1
+                resolved_type: -1
+                generic_type_name: -1
             raw: -1
             pkg: -1
-            type: 14
-            position: 8
+            type: 15
+            position: 9
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 5
-            name: 15
+            kind: 6
+            name: 16
             value: -1
             raw: -1
-            pkg: 16
-            type: 14
-            position: 17
+            pkg: 17
+            type: 15
+            position: 18
             resolved_type: -1
             generic_type_name: -1
-          func: 19
+          func: 20
           callee_func: NewUser
           callee_pkg: multipackage/models
     param_arg_map:
       age:
-        kind: 2
+        kind: 3
+        name: -1
+        value: 5
+        raw: -1
+        pkg: -1
+        type: -1
+        position: -1
+        resolved_type: -1
+        generic_type_name: -1
+      name:
+        kind: 3
         name: -1
         value: 4
         raw: -1
@@ -3048,529 +3059,519 @@ call_graph:
         position: -1
         resolved_type: -1
         generic_type_name: -1
-      name:
-        kind: 2
-        name: -1
-        value: 3
-        raw: -1
-        pkg: -1
-        type: -1
-        position: -1
-        resolved_type: -1
-        generic_type_name: -1
     callee_recv_var_name: user
   - caller:
-      name: 19
-      pkg: 16
+      name: 20
+      pkg: 17
       position: -1
       recv_type: -1
-      scope: 18
-      signature_str: 39
+      scope: 19
+      signature_str: 40
     callee:
-      name: 23
-      pkg: 21
-      position: 22
+      name: 24
+      pkg: 22
+      position: 23
       recv_type: -1
-      scope: 49
-      signature_str: 24
-    position: 22
+      scope: 50
+      signature_str: 25
+    position: 23
     assignments:
       service:
-        - variable_name: 27
-          pkg: 16
-          concrete_type: 26
-          position: 28
-          scope: 18
+        - variable_name: 28
+          pkg: 17
+          concrete_type: 27
+          position: 29
+          scope: 19
           value:
-            kind: 13
+            kind: 14
             name: -1
             value: -1
             fun:
-              kind: 12
+              kind: 13
               name: -1
               value: -1
               x:
-                kind: 5
-                name: 20
+                kind: 6
+                name: 21
                 value: -1
                 raw: -1
-                pkg: 21
+                pkg: 22
                 type: -1
-                position: 22
+                position: 23
                 resolved_type: -1
                 generic_type_name: -1
               sel:
-                kind: 5
-                name: 23
+                kind: 6
+                name: 24
                 value: -1
                 raw: -1
-                pkg: 21
-                type: 24
-                position: 25
+                pkg: 22
+                type: 25
+                position: 26
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
-              pkg: 21
-              type: 24
-              position: 22
+              pkg: 22
+              type: 25
+              position: 23
               resolved_type: -1
               generic_type_name: -1
             raw: -1
             pkg: -1
-            type: 26
-            position: 22
+            type: 27
+            position: 23
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 5
-            name: 27
+            kind: 6
+            name: 28
             value: -1
             raw: -1
-            pkg: 16
-            type: 26
-            position: 28
+            pkg: 17
+            type: 27
+            position: 29
             resolved_type: -1
             generic_type_name: -1
-          func: 19
+          func: 20
           callee_func: NewUserService
           callee_pkg: multipackage/services
     callee_recv_var_name: service
   - caller:
-      name: 19
-      pkg: 16
+      name: 20
+      pkg: 17
       position: -1
       recv_type: -1
-      scope: 18
-      signature_str: 39
+      scope: 19
+      signature_str: 40
     callee:
-      name: 31
-      pkg: 21
-      position: 30
-      recv_type: 108
-      scope: 49
-      signature_str: 32
-    position: 30
+      name: 32
+      pkg: 22
+      position: 31
+      recv_type: 109
+      scope: 50
+      signature_str: 33
+    position: 31
     args:
-      - kind: 5
-        name: 15
+      - kind: 6
+        name: 16
         value: -1
         raw: -1
-        pkg: 16
-        type: 14
-        position: 29
+        pkg: 17
+        type: 15
+        position: 30
         resolved_type: -1
         generic_type_name: -1
     assignments:
       age:
-        - variable_name: 74
-          pkg: 21
-          concrete_type: 54
-          position: 107
-          scope: 18
+        - variable_name: 75
+          pkg: 22
+          concrete_type: 55
+          position: 108
+          scope: 19
           value:
-            kind: 13
+            kind: 14
             name: -1
             value: -1
             fun:
-              kind: 12
+              kind: 13
               name: -1
               value: -1
               x:
-                kind: 5
-                name: 15
+                kind: 6
+                name: 16
                 value: -1
                 raw: -1
-                pkg: 21
-                type: 14
-                position: 105
-                resolved_type: -1
-                generic_type_name: -1
-              sel:
-                kind: 5
-                name: 56
-                value: -1
-                raw: -1
-                pkg: 7
-                type: 59
+                pkg: 22
+                type: 15
                 position: 106
                 resolved_type: -1
                 generic_type_name: -1
+              sel:
+                kind: 6
+                name: 57
+                value: -1
+                raw: -1
+                pkg: 8
+                type: 60
+                position: 107
+                resolved_type: -1
+                generic_type_name: -1
               raw: -1
-              pkg: 7
-              type: 59
-              position: 105
+              pkg: 8
+              type: 60
+              position: 106
               resolved_type: -1
               generic_type_name: -1
               receiver_type:
-                kind: 5
-                name: 60
+                kind: 6
+                name: 61
                 value: -1
                 raw: -1
-                pkg: 7
-                type: 60
+                pkg: 8
+                type: 61
                 position: -1
                 resolved_type: -1
                 generic_type_name: -1
             raw: -1
             pkg: -1
-            type: 54
-            position: 105
+            type: 55
+            position: 106
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 5
-            name: 74
+            kind: 6
+            name: 75
             value: -1
             raw: -1
-            pkg: 21
-            type: 54
-            position: 107
+            pkg: 22
+            type: 55
+            position: 108
             resolved_type: -1
             generic_type_name: -1
-          func: 31
+          func: 32
           callee_func: GetAge
           callee_pkg: multipackage/models
       name:
-        - variable_name: 70
-          pkg: 21
-          concrete_type: 35
-          position: 104
-          scope: 18
+        - variable_name: 71
+          pkg: 22
+          concrete_type: 36
+          position: 105
+          scope: 19
           value:
-            kind: 13
+            kind: 14
             name: -1
             value: -1
             fun:
-              kind: 12
+              kind: 13
               name: -1
               value: -1
               x:
-                kind: 5
-                name: 15
+                kind: 6
+                name: 16
                 value: -1
                 raw: -1
-                pkg: 21
-                type: 14
-                position: 102
-                resolved_type: -1
-                generic_type_name: -1
-              sel:
-                kind: 5
-                name: 45
-                value: -1
-                raw: -1
-                pkg: 7
-                type: 51
+                pkg: 22
+                type: 15
                 position: 103
                 resolved_type: -1
                 generic_type_name: -1
+              sel:
+                kind: 6
+                name: 46
+                value: -1
+                raw: -1
+                pkg: 8
+                type: 52
+                position: 104
+                resolved_type: -1
+                generic_type_name: -1
               raw: -1
-              pkg: 7
-              type: 51
-              position: 102
+              pkg: 8
+              type: 52
+              position: 103
               resolved_type: -1
               generic_type_name: -1
               receiver_type:
-                kind: 5
-                name: 60
+                kind: 6
+                name: 61
                 value: -1
                 raw: -1
-                pkg: 7
-                type: 60
+                pkg: 8
+                type: 61
                 position: -1
                 resolved_type: -1
                 generic_type_name: -1
             raw: -1
             pkg: -1
-            type: 35
-            position: 102
+            type: 36
+            position: 103
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 5
-            name: 70
+            kind: 6
+            name: 71
             value: -1
             raw: -1
-            pkg: 21
-            type: 35
-            position: 104
+            pkg: 22
+            type: 36
+            position: 105
             resolved_type: -1
             generic_type_name: -1
-          func: 31
+          func: 32
           callee_func: GetName
           callee_pkg: multipackage/models
       result:
-        - variable_name: 36
-          pkg: 16
-          concrete_type: 35
-          position: 37
-          scope: 18
+        - variable_name: 37
+          pkg: 17
+          concrete_type: 36
+          position: 38
+          scope: 19
           value:
-            kind: 13
+            kind: 14
             name: -1
             value: -1
             fun:
-              kind: 12
+              kind: 13
               name: -1
               value: -1
               x:
-                kind: 5
-                name: 27
+                kind: 6
+                name: 28
                 value: -1
                 raw: -1
-                pkg: 16
-                type: 26
-                position: 30
+                pkg: 17
+                type: 27
+                position: 31
                 resolved_type: -1
                 generic_type_name: -1
               sel:
-                kind: 5
-                name: 31
+                kind: 6
+                name: 32
                 value: -1
                 raw: -1
-                pkg: 21
-                type: 32
-                position: 33
+                pkg: 22
+                type: 33
+                position: 34
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
-              pkg: 21
-              type: 32
-              position: 30
+              pkg: 22
+              type: 33
+              position: 31
               resolved_type: -1
               generic_type_name: -1
               receiver_type:
-                kind: 5
-                name: 34
+                kind: 6
+                name: 35
                 value: -1
                 raw: -1
-                pkg: 21
-                type: 34
+                pkg: 22
+                type: 35
                 position: -1
                 resolved_type: -1
                 generic_type_name: -1
             args:
-              - kind: 5
-                name: 15
+              - kind: 6
+                name: 16
                 value: -1
                 raw: -1
-                pkg: 16
-                type: 14
-                position: 29
+                pkg: 17
+                type: 15
+                position: 30
                 resolved_type: -1
                 generic_type_name: -1
             raw: -1
             pkg: -1
-            type: 35
-            position: 30
+            type: 36
+            position: 31
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 5
-            name: 36
+            kind: 6
+            name: 37
             value: -1
             raw: -1
-            pkg: 16
-            type: 35
-            position: 37
+            pkg: 17
+            type: 36
+            position: 38
             resolved_type: -1
             generic_type_name: -1
-          func: 19
+          func: 20
           callee_func: ProcessUser
           callee_pkg: multipackage/services
     param_arg_map:
       user:
-        kind: 5
-        name: 15
+        kind: 6
+        name: 16
         value: -1
         raw: -1
-        pkg: 16
-        type: 14
-        position: 29
+        pkg: 17
+        type: 15
+        position: 30
         resolved_type: -1
         generic_type_name: -1
     callee_var_name: service
     callee_recv_var_name: result
     chain_root: service
   - caller:
-      name: 19
-      pkg: 16
+      name: 20
+      pkg: 17
       position: -1
       recv_type: -1
-      scope: 18
-      signature_str: 39
+      scope: 19
+      signature_str: 40
     callee:
-      name: 176
-      pkg: 40
-      position: 175
+      name: 177
+      pkg: 41
+      position: 176
       recv_type: -1
-      scope: 49
-      signature_str: 177
-    position: 175
+      scope: 50
+      signature_str: 178
+    position: 176
     args:
-      - kind: 5
-        name: 36
+      - kind: 6
+        name: 37
         value: -1
         raw: -1
-        pkg: 16
-        type: 35
-        position: 174
+        pkg: 17
+        type: 36
+        position: 175
         resolved_type: -1
         generic_type_name: -1
     param_arg_map:
       a:
-        kind: 5
-        name: 36
+        kind: 6
+        name: 37
         value: -1
         raw: -1
-        pkg: 16
-        type: 35
-        position: 174
+        pkg: 17
+        type: 36
+        position: 175
         resolved_type: -1
         generic_type_name: -1
   - caller:
-      name: 31
-      pkg: 21
+      name: 32
+      pkg: 22
       position: -1
-      recv_type: 108
-      scope: 49
-      signature_str: 111
+      recv_type: 109
+      scope: 50
+      signature_str: 112
     callee:
-      name: 45
-      pkg: 7
-      position: 102
-      recv_type: 46
-      scope: 49
-      signature_str: 51
-    position: 102
+      name: 46
+      pkg: 8
+      position: 103
+      recv_type: 47
+      scope: 50
+      signature_str: 52
+    position: 103
     callee_var_name: user
     callee_recv_var_name: name
     chain_root: user
   - caller:
-      name: 31
-      pkg: 21
+      name: 32
+      pkg: 22
       position: -1
-      recv_type: 108
-      scope: 49
-      signature_str: 111
+      recv_type: 109
+      scope: 50
+      signature_str: 112
     callee:
-      name: 56
-      pkg: 7
-      position: 105
-      recv_type: 46
-      scope: 49
-      signature_str: 59
-    position: 105
+      name: 57
+      pkg: 8
+      position: 106
+      recv_type: 47
+      scope: 50
+      signature_str: 60
+    position: 106
     callee_var_name: user
     callee_recv_var_name: age
     chain_root: user
   - caller:
-      name: 31
-      pkg: 21
+      name: 32
+      pkg: 22
       position: -1
-      recv_type: 108
-      scope: 49
-      signature_str: 111
+      recv_type: 109
+      scope: 50
+      signature_str: 112
     callee:
-      name: 95
-      pkg: 40
-      position: 94
+      name: 96
+      pkg: 41
+      position: 95
       recv_type: -1
-      scope: 49
-      signature_str: 96
-    position: 94
+      scope: 50
+      signature_str: 97
+    position: 95
     args:
-      - kind: 2
+      - kind: 3
         name: -1
-        value: 87
+        value: 88
         raw: -1
         pkg: -1
         type: -1
         position: -1
         resolved_type: -1
         generic_type_name: -1
-      - kind: 12
+      - kind: 13
         name: -1
         value: -1
         x:
-          kind: 5
-          name: 88
+          kind: 6
+          name: 89
           value: -1
           raw: -1
-          pkg: 21
-          type: 26
-          position: 89
+          pkg: 22
+          type: 27
+          position: 90
           resolved_type: -1
           generic_type_name: -1
         sel:
-          kind: 5
-          name: 90
+          kind: 6
+          name: 91
           value: -1
           raw: -1
-          pkg: 21
-          type: 35
-          position: 91
+          pkg: 22
+          type: 36
+          position: 92
           resolved_type: -1
           generic_type_name: -1
         raw: -1
-        pkg: 21
-        type: 35
-        position: 89
+        pkg: 22
+        type: 36
+        position: 90
         resolved_type: -1
         generic_type_name: -1
-      - kind: 5
-        name: 70
+      - kind: 6
+        name: 71
         value: -1
         raw: -1
-        pkg: 21
-        type: 35
-        position: 92
-        resolved_type: -1
-        generic_type_name: -1
-      - kind: 5
-        name: 74
-        value: -1
-        raw: -1
-        pkg: 21
-        type: 54
+        pkg: 22
+        type: 36
         position: 93
+        resolved_type: -1
+        generic_type_name: -1
+      - kind: 6
+        name: 75
+        value: -1
+        raw: -1
+        pkg: 22
+        type: 55
+        position: 94
         resolved_type: -1
         generic_type_name: -1
     param_arg_map:
       a:
-        kind: 12
+        kind: 13
         name: -1
         value: -1
         x:
-          kind: 5
-          name: 88
+          kind: 6
+          name: 89
           value: -1
           raw: -1
-          pkg: 21
-          type: 26
-          position: 89
+          pkg: 22
+          type: 27
+          position: 90
           resolved_type: -1
           generic_type_name: -1
         sel:
-          kind: 5
-          name: 90
+          kind: 6
+          name: 91
           value: -1
           raw: -1
-          pkg: 21
-          type: 35
-          position: 91
+          pkg: 22
+          type: 36
+          position: 92
           resolved_type: -1
           generic_type_name: -1
         raw: -1
-        pkg: 21
-        type: 35
-        position: 89
+        pkg: 22
+        type: 36
+        position: 90
         resolved_type: -1
         generic_type_name: -1
       format:
-        kind: 2
+        kind: 3
         name: -1
-        value: 87
+        value: 88
         raw: -1
         pkg: -1
         type: -1
@@ -3578,154 +3579,154 @@ call_graph:
         resolved_type: -1
         generic_type_name: -1
   - caller:
-      name: 142
-      pkg: 132
+      name: 143
+      pkg: 133
       position: -1
       recv_type: -1
-      scope: 49
-      signature_str: 146
+      scope: 50
+      signature_str: 147
     callee:
-      name: 140
-      pkg: 134
-      position: 139
+      name: 141
+      pkg: 135
+      position: 140
       recv_type: -1
-      scope: 49
-      signature_str: 137
-    position: 139
+      scope: 50
+      signature_str: 138
+    position: 140
     args:
-      - kind: 13
+      - kind: 14
         name: -1
         value: -1
         fun:
-          kind: 12
+          kind: 13
           name: -1
           value: -1
           x:
-            kind: 5
-            name: 134
+            kind: 6
+            name: 135
             value: -1
             raw: -1
-            pkg: 134
+            pkg: 135
             type: -1
-            position: 135
+            position: 136
             resolved_type: -1
             generic_type_name: -1
           sel:
-            kind: 5
-            name: 136
+            kind: 6
+            name: 137
             value: -1
             raw: -1
-            pkg: 134
-            type: 137
-            position: 138
+            pkg: 135
+            type: 138
+            position: 139
             resolved_type: -1
             generic_type_name: -1
           raw: -1
-          pkg: 134
-          type: 137
-          position: 135
+          pkg: 135
+          type: 138
+          position: 136
           resolved_type: -1
           generic_type_name: -1
         args:
-          - kind: 5
-            name: 131
+          - kind: 6
+            name: 132
             value: -1
             raw: -1
-            pkg: 132
-            type: 35
-            position: 133
+            pkg: 133
+            type: 36
+            position: 134
             resolved_type: -1
             generic_type_name: -1
         raw: -1
         pkg: -1
-        type: 35
-        position: 135
+        type: 36
+        position: 136
         resolved_type: -1
         generic_type_name: -1
     param_arg_map:
       s:
-        kind: 13
+        kind: 14
         name: -1
         value: -1
         fun:
-          kind: 12
+          kind: 13
           name: -1
           value: -1
           x:
-            kind: 5
-            name: 134
+            kind: 6
+            name: 135
             value: -1
             raw: -1
-            pkg: 134
+            pkg: 135
             type: -1
-            position: 135
+            position: 136
             resolved_type: -1
             generic_type_name: -1
           sel:
-            kind: 5
-            name: 136
+            kind: 6
+            name: 137
             value: -1
             raw: -1
-            pkg: 134
-            type: 137
-            position: 138
+            pkg: 135
+            type: 138
+            position: 139
             resolved_type: -1
             generic_type_name: -1
           raw: -1
-          pkg: 134
-          type: 137
-          position: 135
+          pkg: 135
+          type: 138
+          position: 136
           resolved_type: -1
           generic_type_name: -1
         args:
-          - kind: 5
-            name: 131
+          - kind: 6
+            name: 132
             value: -1
             raw: -1
-            pkg: 132
-            type: 35
-            position: 133
+            pkg: 133
+            type: 36
+            position: 134
             resolved_type: -1
             generic_type_name: -1
         raw: -1
         pkg: -1
-        type: 35
-        position: 135
+        type: 36
+        position: 136
         resolved_type: -1
         generic_type_name: -1
   - caller:
-      name: 142
-      pkg: 132
+      name: 143
+      pkg: 133
       position: -1
       recv_type: -1
-      scope: 49
-      signature_str: 146
+      scope: 50
+      signature_str: 147
     callee:
-      name: 136
-      pkg: 134
-      position: 135
+      name: 137
+      pkg: 135
+      position: 136
       recv_type: -1
-      scope: 49
-      signature_str: 137
-    position: 135
+      scope: 50
+      signature_str: 138
+    position: 136
     args:
-      - kind: 5
-        name: 131
+      - kind: 6
+        name: 132
         value: -1
         raw: -1
-        pkg: 132
-        type: 35
-        position: 133
+        pkg: 133
+        type: 36
+        position: 134
         resolved_type: -1
         generic_type_name: -1
     param_arg_map:
       s:
-        kind: 5
-        name: 131
+        kind: 6
+        name: 132
         value: -1
         raw: -1
-        pkg: 132
-        type: 35
-        position: 133
+        pkg: 133
+        type: 36
+        position: 134
         resolved_type: -1
         generic_type_name: -1

--- a/internal/spec/visualization_test.go
+++ b/internal/spec/visualization_test.go
@@ -87,33 +87,32 @@ func TestDrawCallGraphCytoscape(t *testing.T) {
 }
 
 func TestBuildCallPathInfos(t *testing.T) {
-	// Create a simple metadata with call graph
+	// Intern first and use the indices Get hands back. Writing 0 and 1 here
+	// assumed the first string interned lands at slot 0, which is no longer
+	// true — slot 0 is the reserved empty string (#449) — and was never
+	// something a test needed to know.
+	pool := metadata.NewStringPool()
+	mainIdx := pool.Get("main")
+	fooIdx := pool.Get("foo")
+
 	meta := &metadata.Metadata{
-		StringPool: metadata.NewStringPool(),
+		StringPool: pool,
 		CallGraph: []metadata.CallGraphEdge{
 			{
 				Caller: metadata.Call{
-					Name:     0,   // "main" (function name) - index 0
-					Pkg:      0,   // "main" (package) - index 0
+					Name:     mainIdx,
+					Pkg:      mainIdx,
 					Position: -1,  // No position
 					Meta:     nil, // Will be set after metadata creation
 				},
 				Callee: metadata.Call{
-					Name: 1,   // "foo" (function name) - index 1
-					Pkg:  0,   // "main" (package) - index 0
+					Name: fooIdx,
+					Pkg:  mainIdx,
 					Meta: nil, // Will be set after metadata creation
 				},
 			},
 		},
 	}
-
-	// Add strings to string pool in the correct order
-	// Index 0: "main" (package)
-	// Index 1: "main" (function name)
-	// Index 2: "foo" (function name)
-	meta.StringPool.Get("main") // Index 0 - package
-	meta.StringPool.Get("main") // Index 1 - function name
-	meta.StringPool.Get("foo")  // Index 2 - function name
 
 	// Set Meta field on Call objects
 	meta.CallGraph[0].Caller.Meta = meta
@@ -142,27 +141,38 @@ func TestExtractParameterInfo(t *testing.T) {
 		StringPool: metadata.NewStringPool(),
 	}
 
+	// Intern first, then use the returned indices — see TestBuildCallPathInfos.
+	//
+	// Kind is set too, and that is the point of this comment: it used to be
+	// left at 0, so callArgToString fell to `default: return arg.GetRaw()` with
+	// Raw also 0 — which resolved to pool slot 0, the first string interned,
+	// which in this test happened to be "value1". The assertion below passed by
+	// reading a field the test never set. With slot 0 reserved (#449) an unset
+	// index reads as "", so the argument now has to say what it is: an ident
+	// named "value1" of type "string".
+	identIdx := meta.StringPool.Get(metadata.KindIdent)
+	valueIdx := meta.StringPool.Get("value1")
+	stringIdx := meta.StringPool.Get("string")
+	argIdx := meta.StringPool.Get("arg1")
+
 	// Create a call graph edge with parameter information
 	edge := &metadata.CallGraphEdge{
 		ParamArgMap: map[string]metadata.CallArgument{
 			"param1": {
-				Name: 0, // "value1"
-				Type: 1, // "string"
+				Kind: identIdx,
+				Name: valueIdx,
+				Type: stringIdx,
 				Meta: meta,
 			},
 		},
 		Args: []*metadata.CallArgument{
 			{
-				Name: 2, // "arg1"
+				Kind: identIdx,
+				Name: argIdx,
 				Meta: meta,
 			},
 		},
 	}
-
-	// Add strings to string pool
-	meta.StringPool.Get("value1")
-	meta.StringPool.Get("string")
-	meta.StringPool.Get("arg1")
 
 	paramTypes, passedParams := extractParameterInfo(edge)
 


### PR DESCRIPTION
Fixes #449. Follow-up to #448, which fixed one victim of this; this retires the
footgun.

## The problem

Pooled strings are stored by index. `0` was a valid index — the first string
interned in the run — and also the Go zero value of every pooled-index field
(`Comments`, `Name`, `Type`, `Kind`, `Raw`, ...). So a record that left a field
unset did not read as *absent*; it read as whatever that string happened to be.

The design is what made it silent: the junk is plausible prose, and it changes
with interning order, so an unchanged project appears to drift between
versions. That is exactly how #448 surfaced — as 213 CHANGED keys in a
comparison that had nothing to do with the code.

## The fix

Slot 0 holds `""`, so the zero value means "no string" by construction.
`reserveEmpty` is called from `Get` as well as the constructor (a pool built as
a struct literal would otherwise reintroduce it), and `UnmarshalYAML` skips
indexing `""` so a round-tripped pool behaves like a fresh one.

## Every index shifts by one — verified to be *only* that

The goldens are regenerated, which is why this is its own PR. The diff was
checked mechanically rather than eyeballed:

* for all six goldens, the pool is the old pool with `""` prepended — nothing
  reordered, nothing dropped;
* every changed scalar is an int that moved by **exactly +1**, and every field
  that moved is a pool-index field (`kind`, `position`, `pkg`, `name`, `type`,
  `scope`, `signature_str`, `value`, `tag`, `filename`, ...);
* the keys of index-keyed maps (`fields`, `imports`) shifted by +1 too;
* **no** line, column or count moved, and no value changed in any other way.

## Three live instances of the footgun turned up

1. The 211 junk schema descriptions of #448 — already fixed.
2. **`TestExtractParameterInfo` was passing by accident.** It left `Kind`
   unset, so `callArgToString` fell to `default: return arg.GetRaw()` with
   `Raw` unset too — resolving to slot 0, which in that test happened to be the
   exact string the assertion wanted. It was checking a field it never set. It
   now sets the fields it asserts.
3. **A real project emitted a header parameter as `name: func_type`.**
   Reserving the slot left it nameless, which is invalid OpenAPI, so
   `deduplicateParameters` now drops an inline parameter with no name (`$ref`
   parameters are exempt — their name lives in the component they point at).
   That is an output-validity guard, not a root-cause fix: why a parameter is
   recorded with no name is **#452**.

Probing #452 also turned up **#453** — a header name held in a local variable
is dropped while a literal resolves — filed rather than fixed here.

## Drift

| | result |
|---|---|
| 109 fixture specs | **byte-identical** to main |
| gitea, 899 paths | exactly one change: the bogus `func_type` parameter disappears; **no other operation, schema or path differs** |
| metadata goldens | regenerated; verified as a pure +1 re-index (above) |

Tests that hardcoded pool indices now take them from `Get`, so they no longer
depend on the pool's internal layout. Suite, `make lint` and the ratchet
(96.2%, floor 96) pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Metadata fields without string values are now correctly represented as absent instead of referencing an unrelated string.
  - OpenAPI output no longer includes inline parameters without names, preventing invalid parameter definitions.
  - Parameters defined through `$ref` continue to be preserved even when their local name is omitted.

- **Documentation**
  - Added unreleased changelog entries describing these metadata and OpenAPI output corrections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->