### PR TITLE
fix(spec): one Go type, one component — and the right one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **One Go type now produces one component, and the right one.** A response type
+  recovered from a call carried the package's *name* (`api.Issue`) while
+  metadata's own type strings carry the import *path* (`example.com/api.Issue`),
+  so the same type became two components — and the short-named one resolved to a
+  **different type entirely**: its qualifier matches no package, so the lookup
+  fell back to a bare-name scan and returned the first same-named declaration in
+  package order. On gitea that was a migration's function-local
+  `type User struct`, so `GET /user/` documented a User with **1 of its 22
+  fields**; seven operations were affected and 31 duplicate or orphan schemas
+  were emitted. A package-name qualifier is now resolved to its import path
+  when exactly one package both ends in that name and declares the type;
+  anything ambiguous is left untouched rather than guessed. (#457)
+
 - **A parameter name held in a local variable is documented, not dropped.**
   `key := "X-Request-ID"; r.Header.Get(key)` produced no parameter at all, while
   the same name written as a literal produced one — so a header or query

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `type User struct`, so `GET /user/` documented a User with **1 of its 22
   fields**; seven operations were affected and 31 duplicate or orphan schemas
   were emitted. A package-name qualifier is now resolved to its import path
-  when exactly one package both ends in that name and declares the type;
-  anything ambiguous is left untouched rather than guessed. (#457)
+  when exactly one package declares that name and the type; anything ambiguous
+  is left untouched rather than guessed. Metadata now records each package's
+  declared name, because the import path does not carry it — a module major
+  version puts the package in a directory named `v2`, and `gopkg.in/yaml.v3`
+  declares `package yaml` — so reading the name off the path left every
+  versioned dependency broken. (#457)
 
 - **A parameter name held in a local variable is documented, not dropped.**
   `key := "X-Request-ID"; r.Header.Get(key)` produced no parameter at all, while

--- a/generator/testdata_one_type_one_component_test.go
+++ b/generator/testdata_one_type_one_component_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/spec"
+)
+
+// One Go type must produce ONE component, however its name reached the mapper.
+//
+// A response type recovered from a call carries the package's NAME
+// ("api.Issue"); metadata's own strings carry the import PATH
+// ("twoname/api.Issue"). Both used to become separate components, and the
+// short-keyed one resolved to a DIFFERENT type entirely — a migration's
+// function-local `type Issue struct`, found by a bare-name scan over sorted
+// packages — so an endpoint documented one field instead of four (issue #457).
+func TestTestdata_OneTypeOneComponent(t *testing.T) {
+	out := loadTestdata(t, "one_type_one_component", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+	noUnresolvedPlaceholders(t, out)
+
+	// Exactly one component for Issue, and it is the fully-qualified one.
+	var issueComps []string
+	for name := range out.Components.Schemas {
+		if strings.HasSuffix(name, "Issue") {
+			issueComps = append(issueComps, name)
+		}
+	}
+	if len(issueComps) != 1 {
+		t.Fatalf("want exactly one Issue component, got %v", issueComps)
+	}
+	comp := issueComps[0]
+	if !strings.Contains(comp, "twoname_api") {
+		t.Errorf("Issue component is %q, want the import-path-qualified name", comp)
+	}
+
+	// The real type has four fields; the migration's throwaway struct has one,
+	// so this is what catches a resolution that picked the wrong declaration.
+	schema := out.Components.Schemas[comp]
+	if schema == nil {
+		t.Fatalf("component %q missing", comp)
+	}
+	if got := len(schema.Properties); got != 4 {
+		t.Errorf("%s has %d properties, want 4 (%v) — a wrong-package resolution looks exactly like this",
+			comp, got, mapSchemaPropKeys(schema.Properties))
+	}
+	if _, ok := schema.Properties["OnlyColumn"]; ok {
+		t.Errorf("%s carries the migration struct's field: resolved the wrong Issue", comp)
+	}
+
+	// Every route that can resolve a body points at that one component.
+	for _, path := range []string{"/direct", "/viaconcrete", "/viapointer", "/viavar", "/viawrapper"} {
+		item, ok := out.Paths[path]
+		if !ok {
+			t.Errorf("missing path %q; have %v", path, mapPathKeys(out.Paths))
+			continue
+		}
+		op := firstOperation(&item)
+		if op == nil {
+			t.Errorf("%s: no operation", path)
+			continue
+		}
+		found := ""
+		for _, resp := range op.Responses {
+			for _, media := range resp.Content {
+				if media.Schema != nil && media.Schema.Ref != "" {
+					found = media.Schema.Ref
+				}
+			}
+		}
+		if !strings.HasSuffix(found, comp) {
+			t.Errorf("%s response schema is %q, want a $ref to %s", path, found, comp)
+		}
+	}
+
+	// /viaany stays unresolved on purpose: the concrete type is not recoverable
+	// from an `any` return, and guessing one is worse than documenting none.
+	if item, ok := out.Paths["/viaany"]; ok {
+		if op := firstOperation(&item); op != nil {
+			for _, resp := range op.Responses {
+				for _, media := range resp.Content {
+					if media.Schema != nil && strings.HasSuffix(media.Schema.Ref, comp) {
+						t.Errorf("/viaany resolved to %s — an `any` return should not be guessed", comp)
+					}
+				}
+			}
+		}
+	}
+}
+
+// mapSchemaPropKeys lists a schema's property names for a failure message.
+func mapSchemaPropKeys(props map[string]*spec.Schema) []string {
+	out := make([]string, 0, len(props))
+	for k := range props {
+		out = append(out, k)
+	}
+	return out
+}

--- a/generator/testdata_one_type_one_component_test.go
+++ b/generator/testdata_one_type_one_component_test.go
@@ -63,6 +63,28 @@ func TestTestdata_OneTypeOneComponent(t *testing.T) {
 		t.Errorf("%s carries the migration struct's field: resolved the wrong Issue", comp)
 	}
 
+	// A package whose declared name differs from its path's last segment (a
+	// module major version, `thing` under thing/v2) must resolve to the real
+	// type. Reading the name off the path answers "v2", so this route used to
+	// document aaamig's one-field struct instead.
+	var thingComps []string
+	for name := range out.Components.Schemas {
+		if strings.HasSuffix(name, "Thing") {
+			thingComps = append(thingComps, name)
+		}
+	}
+	if len(thingComps) != 1 {
+		t.Fatalf("want exactly one Thing component, got %v", thingComps)
+	}
+	thingSchema := out.Components.Schemas[thingComps[0]]
+	if thingSchema == nil || len(thingSchema.Properties) != 3 {
+		t.Errorf("%s has %d properties, want 3 — the version-suffixed package resolved to the wrong type",
+			thingComps[0], len(thingSchema.Properties))
+	}
+	if _, bad := thingSchema.Properties["OnlyColumn"]; bad {
+		t.Errorf("%s carries the migration struct's field", thingComps[0])
+	}
+
 	// Every route that can resolve a body points at that one component.
 	for _, path := range []string{"/direct", "/viaconcrete", "/viapointer", "/viavar", "/viawrapper"} {
 		item, ok := out.Paths[path]
@@ -90,14 +112,27 @@ func TestTestdata_OneTypeOneComponent(t *testing.T) {
 
 	// /viaany stays unresolved on purpose: the concrete type is not recoverable
 	// from an `any` return, and guessing one is worse than documenting none.
-	if item, ok := out.Paths["/viaany"]; ok {
-		if op := firstOperation(&item); op != nil {
-			for _, resp := range op.Responses {
-				for _, media := range resp.Content {
-					if media.Schema != nil && strings.HasSuffix(media.Schema.Ref, comp) {
-						t.Errorf("/viaany resolved to %s — an `any` return should not be guessed", comp)
-					}
-				}
+	//
+	// Required, not conditional: if the route or its response disappears, this
+	// fixture silently stops testing the behavior it exists for. And ANY $ref
+	// fails it, not just one to the Issue component — resolving `any` to some
+	// other component would be the same mistake wearing a different name.
+	item, ok := out.Paths["/viaany"]
+	if !ok {
+		t.Fatalf("/viaany missing; have %v", mapPathKeys(out.Paths))
+	}
+	op := firstOperation(&item)
+	if op == nil {
+		t.Fatal("/viaany has no operation")
+	}
+	if len(op.Responses) == 0 {
+		t.Fatal("/viaany has no response, so the unresolved-any guard checked nothing")
+	}
+	for status, resp := range op.Responses {
+		for ct, media := range resp.Content {
+			if media.Schema != nil && media.Schema.Ref != "" {
+				t.Errorf("/viaany %s %s resolved to %q — an `any` return must not be guessed",
+					status, ct, media.Schema.Ref)
 			}
 		}
 	}

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -264,6 +264,16 @@ func GenerateMetadataWithLogger(pkgs map[string]map[string]*ast.File, fileToInfo
 		pkg := &Package{
 			Files: make(map[string]*File),
 		}
+		// The declared name comes from the source itself (`package thing`), so
+		// it is a fact rather than a convention read off the path. Every file
+		// of a package declares the same one, so the first sorted file settles
+		// it deterministically.
+		for _, fileName := range sortedFileNames {
+			if f := files[fileName]; f != nil && f.Name != nil {
+				pkg.Name = metadata.StringPool.Get(f.Name.Name)
+				break
+			}
+		}
 
 		// Collect methods for types
 		allTypeMethods := make(map[string][]Method)

--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -541,6 +541,16 @@ func (m *Metadata) SortedTypeNames(pkgName, fileName string) []string {
 // path that falls back to scanning all packages (issue #322). The scan order is
 // preserved exactly: the index is filled in sorted-file order and an earlier
 // file wins, so a name declared twice resolves to the same type it did before.
+// PackageDeclaredName returns a package's declared name, or "" when metadata
+// did not record one (a pool written before the field existed).
+func (m *Metadata) PackageDeclaredName(pkgPath string) string {
+	pkg, ok := m.Packages[pkgPath]
+	if !ok || pkg == nil || pkg.Name <= 0 {
+		return ""
+	}
+	return m.StringPool.GetString(pkg.Name)
+}
+
 func (m *Metadata) TypeInPackage(pkgName, typeName string) *Type {
 	pkg, ok := m.Packages[pkgName]
 	if !ok || pkg == nil {
@@ -911,6 +921,12 @@ func (m *Metadata) CallGraphRoots() []*CallGraphEdge {
 type Package struct {
 	Files map[string]*File `yaml:"files,omitempty"`
 	Types map[string]*Type `yaml:"types,omitempty"`
+	// Name is the package's DECLARED name (the identifier after `package`),
+	// which is not recoverable from the import path that keys this map: a
+	// module major version puts the package in a directory named v2, and
+	// gopkg.in/yaml.v3 declares `package yaml`. The spec layer needs it to
+	// resolve a type qualified by package name back to its path (#457).
+	Name int `yaml:"name,omitempty"`
 }
 
 // File represents a Go source file

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -131,7 +131,7 @@ func canonicalPackageQualifier(goType string, meta *metadata.Metadata) string {
 	}
 	full, matches := "", 0
 	for _, pkg := range meta.SortedPackageNames() {
-		if pkg == core.Pkg || packageBaseName(pkg) != core.Pkg {
+		if pkg == core.Pkg || !packageDeclares(meta, pkg, core.Pkg) {
 			continue
 		}
 		if meta.TypeInPackage(pkg, core.Name) == nil {
@@ -149,9 +149,29 @@ func canonicalPackageQualifier(goType string, meta *metadata.Metadata) string {
 	return c.String()
 }
 
-// packageBaseName is the last segment of an import path, which is the package
-// name for all but the versioned-path minority (gopkg.in/yaml.v3). Those simply
-// fail to match, which leaves the name untouched rather than wrong.
+// packageDeclares reports whether the package at pkgPath is the one a type
+// qualified by `name` refers to.
+//
+// It asks metadata for the DECLARED package name, because the import path does
+// not carry it: a module major version puts the package in a directory named
+// v2 (github.com/go-chi/chi/v5 declares `package chi`), and gopkg.in/yaml.v3
+// declares `package yaml`. Matching the path's last segment would answer "v5"
+// and "yaml.v3" for those, so a qualifier could never be resolved and the type
+// would keep falling into the bare-name scan this whole change exists to avoid
+// — measurably: a package laid out under a v2 directory documented a
+// migration's throwaway struct instead of the real type.
+//
+// The last segment is the fallback for metadata deserialized before the
+// declared name was recorded, where it is the best available answer and right
+// for every unversioned path.
+func packageDeclares(meta *metadata.Metadata, pkgPath, name string) bool {
+	if declared := meta.PackageDeclaredName(pkgPath); declared != "" {
+		return declared == name
+	}
+	return packageBaseName(pkgPath) == name
+}
+
+// packageBaseName is the last segment of an import path.
 func packageBaseName(pkgPath string) string {
 	if i := strings.LastIndex(pkgPath, "/"); i >= 0 {
 		return pkgPath[i+1:]

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -97,6 +97,68 @@ func mapGoTypeForRoute(usedTypes map[string]*Schema, goType string, meta *metada
 	return schema
 }
 
+// canonicalPackageQualifier rewrites a type qualified by a package NAME
+// ("structs.User") into one qualified by its import PATH
+// ("gitea.dev/modules/structs.User"), when metadata names exactly one package
+// that fits.
+//
+// Both forms arrive here for the same type. Metadata's own type strings come
+// from go/types and always carry the full path, but a type recovered by
+// RENDERING an argument carries CallArgument.Pkg, which is the package's name —
+// deliberate naming behavior (golden rule #3), not a bug in itself. The bug was
+// that each form became its own schema key, so one Go type produced two
+// components. On a real project twelve types were emitted twice, and the
+// short-keyed copy was also WRONG: its qualifier matches no package key, so
+// typeByName fell through to a bare-name scan over sorted packages and returned
+// the first same-named type it found — a migration's function-local
+// `type User struct` beat modules/structs.User, and an endpoint documented a
+// User with one of its twenty-two fields (issue #457).
+//
+// Nothing is guessed. A candidate package must both end in that name AND
+// declare the type, and the match must be unique; otherwise the name is left
+// exactly as it came (golden rule #7). Resolution is over SortedPackageNames so
+// the answer cannot depend on map order (golden rule #1).
+func canonicalPackageQualifier(goType string, meta *metadata.Metadata) string {
+	// Cheap gate first: this runs for every type mapped. Only a dotted name
+	// with no slash can be qualified by a bare package name.
+	if meta == nil || goType == "" || strings.Contains(goType, "/") || !strings.Contains(goType, ".") {
+		return goType
+	}
+	ref := typemodel.Parse(goType)
+	core := ref.Core()
+	if core == nil || !core.IsNamed() || core.Pkg == "" || strings.Contains(core.Pkg, "/") {
+		return goType
+	}
+	full, matches := "", 0
+	for _, pkg := range meta.SortedPackageNames() {
+		if pkg == core.Pkg || packageBaseName(pkg) != core.Pkg {
+			continue
+		}
+		if meta.TypeInPackage(pkg, core.Name) == nil {
+			continue
+		}
+		full = pkg
+		matches++
+	}
+	if matches != 1 {
+		return goType
+	}
+	// Clone before mutating: TypeRefs are shared (golden rule #2).
+	c := ref.Clone()
+	c.Core().Pkg = full
+	return c.String()
+}
+
+// packageBaseName is the last segment of an import path, which is the package
+// name for all but the versioned-path minority (gopkg.in/yaml.v3). Those simply
+// fail to match, which leaves the name untouched rather than wrong.
+func packageBaseName(pkgPath string) string {
+	if i := strings.LastIndex(pkgPath, "/"); i >= 0 {
+		return pkgPath[i+1:]
+	}
+	return pkgPath
+}
+
 // untypedConstantDefault maps go/types' rendering of an untyped constant to the
 // type it defaults to. Go defines these exactly (spec, "Constants"), so `true`
 // in a response body is a bool and the schema is derived, not guessed. Without
@@ -1292,10 +1354,44 @@ func generateComponentSchemas(meta *metadata.Metadata, cfg *APISpecConfig, route
 	// Collect all types used in routes
 	usedTypes := collectUsedTypesFromRoutes(routes)
 
+	// One Go type, one key: fold a key qualified by a package NAME into the
+	// same type's import-path-qualified key before anything is emitted.
+	mergeShortQualifiedKeys(usedTypes, meta)
+
 	// Generate schemas for used types
 	generateSchemas(usedTypes, cfg, components, meta)
 
 	return components, usedTypes
+}
+
+// mergeShortQualifiedKeys folds a used-type key qualified by a package NAME
+// into the same type's import-path-qualified key, so one Go type yields one
+// component.
+//
+// Both spellings arrive for the same type (see canonicalPackageQualifier) and
+// each used to produce its own entry here. Canonicalising at the mapping entry
+// already sends every $ref to the import-path name, which left the short-keyed
+// components as ORPHANS — 15 of them on a real project, referenced by nothing —
+// so folding the keys is what stops them being emitted at all.
+//
+// Iterates in sorted order: a merge decides which schema survives when both
+// keys carry one, and map order must not (golden rule #1).
+func mergeShortQualifiedKeys(usedTypes map[string]*Schema, meta *metadata.Metadata) {
+	if meta == nil {
+		return
+	}
+	for _, name := range slices.Sorted(maps.Keys(usedTypes)) {
+		canon := canonicalPackageQualifier(name, meta)
+		if canon == name {
+			continue
+		}
+		// A resolved schema wins over an unresolved placeholder; otherwise the
+		// canonical entry stands, since it is the one every $ref now names.
+		if existing, ok := usedTypes[canon]; !ok || existing == nil {
+			usedTypes[canon] = usedTypes[name]
+		}
+		delete(usedTypes, name)
+	}
 }
 
 func generateSchemas(usedTypes map[string]*Schema, cfg *APISpecConfig, components Components, meta *metadata.Metadata) {
@@ -3167,6 +3263,7 @@ func mapGoTypeToOpenAPISchema(usedTypes map[string]*Schema, goType string, meta 
 		goType = def
 	}
 	goType = unqualifyContainer(goType)
+	goType = canonicalPackageQualifier(goType, meta)
 
 	isPrimitive := metadata.IsPrimitiveType(goType)
 

--- a/internal/spec/tests/complex.yaml
+++ b/internal/spec/tests/complex.yaml
@@ -1,8 +1,8 @@
 string_pool:
   - ""
+  - complex
   - ident
   - s
-  - complex
   - '*complex.Service'
   - complex/service.go:10:9
   - name
@@ -116,7 +116,7 @@ packages:
         types:
           Handler:
             name: 61
-            pkg: 3
+            pkg: 1
             kind: 59
             fields:
               - name: 43
@@ -143,7 +143,7 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   args:
-                    - kind: 1
+                    - kind: 2
                       name: 39
                       value: -1
                       raw: -1
@@ -166,7 +166,7 @@ packages:
                 assignments:
                   name:
                     - variable_name: 6
-                      pkg: 3
+                      pkg: 1
                       concrete_type: 7
                       position: 47
                       scope: 34
@@ -183,53 +183,53 @@ packages:
                             name: -1
                             value: -1
                             x:
-                              kind: 1
+                              kind: 2
                               name: 40
                               value: -1
                               raw: -1
-                              pkg: 3
+                              pkg: 1
                               type: 41
                               position: 42
                               resolved_type: -1
                               generic_type_name: -1
                             sel:
-                              kind: 1
+                              kind: 2
                               name: 43
                               value: -1
                               raw: -1
-                              pkg: 3
+                              pkg: 1
                               type: 4
                               position: 44
                               resolved_type: -1
                               generic_type_name: -1
                             raw: -1
-                            pkg: 3
+                            pkg: 1
                             type: 4
                             position: 42
                             resolved_type: -1
                             generic_type_name: -1
                           sel:
-                            kind: 1
+                            kind: 2
                             name: 10
                             value: -1
                             raw: -1
-                            pkg: 3
+                            pkg: 1
                             type: 18
                             position: 45
                             resolved_type: -1
                             generic_type_name: -1
                           raw: -1
-                          pkg: 3
+                          pkg: 1
                           type: 18
                           position: 42
                           resolved_type: -1
                           generic_type_name: -1
                           receiver_type:
-                            kind: 1
+                            kind: 2
                             name: 46
                             value: -1
                             raw: -1
-                            pkg: 3
+                            pkg: 1
                             type: 46
                             position: -1
                             resolved_type: -1
@@ -241,11 +241,11 @@ packages:
                         resolved_type: -1
                         generic_type_name: -1
                       lhs:
-                        kind: 1
+                        kind: 2
                         name: 6
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 7
                         position: 47
                         resolved_type: -1
@@ -255,7 +255,7 @@ packages:
                       callee_pkg: complex
                   processed:
                     - variable_name: 54
-                      pkg: 3
+                      pkg: 1
                       concrete_type: 7
                       position: 55
                       scope: 34
@@ -272,63 +272,63 @@ packages:
                             name: -1
                             value: -1
                             x:
-                              kind: 1
+                              kind: 2
                               name: 40
                               value: -1
                               raw: -1
-                              pkg: 3
+                              pkg: 1
                               type: 41
                               position: 50
                               resolved_type: -1
                               generic_type_name: -1
                             sel:
-                              kind: 1
+                              kind: 2
                               name: 43
                               value: -1
                               raw: -1
-                              pkg: 3
+                              pkg: 1
                               type: 4
                               position: 51
                               resolved_type: -1
                               generic_type_name: -1
                             raw: -1
-                            pkg: 3
+                            pkg: 1
                             type: 4
                             position: 50
                             resolved_type: -1
                             generic_type_name: -1
                           sel:
-                            kind: 1
+                            kind: 2
                             name: 35
                             value: -1
                             raw: -1
-                            pkg: 3
+                            pkg: 1
                             type: 52
                             position: 53
                             resolved_type: -1
                             generic_type_name: -1
                           raw: -1
-                          pkg: 3
+                          pkg: 1
                           type: 52
                           position: 50
                           resolved_type: -1
                           generic_type_name: -1
                           receiver_type:
-                            kind: 1
+                            kind: 2
                             name: 46
                             value: -1
                             raw: -1
-                            pkg: 3
+                            pkg: 1
                             type: 46
                             position: -1
                             resolved_type: -1
                             generic_type_name: -1
                         args:
-                          - kind: 1
+                          - kind: 2
                             name: 39
                             value: -1
                             raw: -1
-                            pkg: 3
+                            pkg: 1
                             type: 7
                             position: 49
                             resolved_type: -1
@@ -340,11 +340,11 @@ packages:
                         resolved_type: -1
                         generic_type_name: -1
                       lhs:
-                        kind: 1
+                        kind: 2
                         name: 54
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 7
                         position: 55
                         resolved_type: -1
@@ -355,7 +355,7 @@ packages:
             comments: -1
           Service:
             name: 46
-            pkg: 3
+            pkg: 1
             kind: 59
             fields:
               - name: 6
@@ -376,7 +376,7 @@ packages:
                     name: -1
                     value: -1
                     args:
-                      - kind: 1
+                      - kind: 2
                         name: 7
                         value: -1
                         raw: -1
@@ -407,27 +407,27 @@ packages:
                     name: -1
                     value: -1
                     x:
-                      kind: 1
-                      name: 2
+                      kind: 2
+                      name: 3
                       value: -1
                       raw: -1
-                      pkg: 3
+                      pkg: 1
                       type: 4
                       position: 5
                       resolved_type: -1
                       generic_type_name: -1
                     sel:
-                      kind: 1
+                      kind: 2
                       name: 6
                       value: -1
                       raw: -1
-                      pkg: 3
+                      pkg: 1
                       type: 7
                       position: 8
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 7
                     position: 5
                     resolved_type: -1
@@ -437,27 +437,27 @@ packages:
                       name: -1
                       value: -1
                       x:
-                        kind: 1
-                        name: 2
+                        kind: 2
+                        name: 3
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 4
                         position: 5
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 1
+                        kind: 2
                         name: 6
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 7
                         position: 8
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 3
+                      pkg: 1
                       type: 7
                       position: 5
                       resolved_type: -1
@@ -473,7 +473,7 @@ packages:
                     name: -1
                     value: -1
                     args:
-                      - kind: 1
+                      - kind: 2
                         name: 7
                         value: -1
                         raw: -1
@@ -489,7 +489,7 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   args:
-                    - kind: 1
+                    - kind: 2
                       name: 22
                       value: -1
                       raw: -1
@@ -510,21 +510,21 @@ packages:
                 comments: -1
                 filename: 17
                 return_vars:
-                  - kind: 1
+                  - kind: 2
                     name: 19
                     value: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 7
                     position: 20
                     resolved_type: -1
                     generic_type_name: -1
                 returns:
-                  - - kind: 1
+                  - - kind: 2
                       name: 19
                       value: -1
                       raw: -1
-                      pkg: 3
+                      pkg: 1
                       type: 7
                       position: 20
                       resolved_type: -1
@@ -532,7 +532,7 @@ packages:
                 assignments:
                   result:
                     - variable_name: 19
-                      pkg: 3
+                      pkg: 1
                       concrete_type: 7
                       position: 33
                       scope: 34
@@ -545,7 +545,7 @@ packages:
                           name: -1
                           value: -1
                           x:
-                            kind: 1
+                            kind: 2
                             name: 27
                             value: -1
                             raw: -1
@@ -555,7 +555,7 @@ packages:
                             resolved_type: -1
                             generic_type_name: -1
                           sel:
-                            kind: 1
+                            kind: 2
                             name: 29
                             value: -1
                             raw: -1
@@ -580,11 +580,11 @@ packages:
                             position: -1
                             resolved_type: -1
                             generic_type_name: -1
-                          - kind: 1
+                          - kind: 2
                             name: 22
                             value: -1
                             raw: -1
-                            pkg: 3
+                            pkg: 1
                             type: 7
                             position: 26
                             resolved_type: -1
@@ -596,11 +596,11 @@ packages:
                         resolved_type: -1
                         generic_type_name: -1
                       lhs:
-                        kind: 1
+                        kind: 2
                         name: 19
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 7
                         position: 33
                         resolved_type: -1
@@ -612,7 +612,7 @@ packages:
         functions:
           NewHandler:
             name: 82
-            pkg: 3
+            pkg: 1
             signature:
               kind: 13
               name: -1
@@ -626,11 +626,11 @@ packages:
                     name: -1
                     value: -1
                     x:
-                      kind: 1
+                      kind: 2
                       name: 61
                       value: -1
                       raw: -1
-                      pkg: 3
+                      pkg: 1
                       type: 61
                       position: 85
                       resolved_type: -1
@@ -652,11 +652,11 @@ packages:
                   name: 79
                   value: -1
                   x:
-                    kind: 1
+                    kind: 2
                     name: 46
                     value: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 46
                     position: 83
                     resolved_type: -1
@@ -686,11 +686,11 @@ packages:
                   name: -1
                   value: -1
                   x:
-                    kind: 1
+                    kind: 2
                     name: 61
                     value: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 61
                     position: 77
                     resolved_type: -1
@@ -700,21 +700,21 @@ packages:
                       name: -1
                       value: -1
                       x:
-                        kind: 1
+                        kind: 2
                         name: 43
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 4
                         position: 78
                         resolved_type: -1
                         generic_type_name: -1
                       fun:
-                        kind: 1
+                        kind: 2
                         name: 79
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 4
                         position: 80
                         resolved_type: -1
@@ -746,11 +746,11 @@ packages:
                     name: -1
                     value: -1
                     x:
-                      kind: 1
+                      kind: 2
                       name: 61
                       value: -1
                       raw: -1
-                      pkg: 3
+                      pkg: 1
                       type: 61
                       position: 77
                       resolved_type: -1
@@ -760,21 +760,21 @@ packages:
                         name: -1
                         value: -1
                         x:
-                          kind: 1
+                          kind: 2
                           name: 43
                           value: -1
                           raw: -1
-                          pkg: 3
+                          pkg: 1
                           type: 4
                           position: 78
                           resolved_type: -1
                           generic_type_name: -1
                         fun:
-                          kind: 1
+                          kind: 2
                           name: 79
                           value: -1
                           raw: -1
-                          pkg: 3
+                          pkg: 1
                           type: 4
                           position: 80
                           resolved_type: -1
@@ -800,7 +800,7 @@ packages:
             end_line: 34
           NewService:
             name: 70
-            pkg: 3
+            pkg: 1
             signature:
               kind: 13
               name: -1
@@ -814,11 +814,11 @@ packages:
                     name: -1
                     value: -1
                     x:
-                      kind: 1
+                      kind: 2
                       name: 46
                       value: -1
                       raw: -1
-                      pkg: 3
+                      pkg: 1
                       type: 46
                       position: 72
                       resolved_type: -1
@@ -836,7 +836,7 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 1
+                - kind: 2
                   name: 6
                   value: -1
                   raw: -1
@@ -864,11 +864,11 @@ packages:
                   name: -1
                   value: -1
                   x:
-                    kind: 1
+                    kind: 2
                     name: 46
                     value: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 46
                     position: 62
                     resolved_type: -1
@@ -878,21 +878,21 @@ packages:
                       name: -1
                       value: -1
                       x:
-                        kind: 1
+                        kind: 2
                         name: 6
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 7
                         position: 63
                         resolved_type: -1
                         generic_type_name: -1
                       fun:
-                        kind: 1
+                        kind: 2
                         name: 6
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 7
                         position: 64
                         resolved_type: -1
@@ -924,11 +924,11 @@ packages:
                     name: -1
                     value: -1
                     x:
-                      kind: 1
+                      kind: 2
                       name: 46
                       value: -1
                       raw: -1
-                      pkg: 3
+                      pkg: 1
                       type: 46
                       position: 62
                       resolved_type: -1
@@ -938,21 +938,21 @@ packages:
                         name: -1
                         value: -1
                         x:
-                          kind: 1
+                          kind: 2
                           name: 6
                           value: -1
                           raw: -1
-                          pkg: 3
+                          pkg: 1
                           type: 7
                           position: 63
                           resolved_type: -1
                           generic_type_name: -1
                         fun:
-                          kind: 1
+                          kind: 2
                           name: 6
                           value: -1
                           raw: -1
-                          pkg: 3
+                          pkg: 1
                           type: 7
                           position: 64
                           resolved_type: -1
@@ -978,7 +978,7 @@ packages:
             end_line: 30
           main:
             name: 93
-            pkg: 3
+            pkg: 1
             signature:
               kind: 13
               name: -1
@@ -1006,7 +1006,7 @@ packages:
             assignments:
               handler:
                 - variable_name: 97
-                  pkg: 3
+                  pkg: 1
                   concrete_type: 41
                   position: 98
                   scope: 34
@@ -1015,21 +1015,21 @@ packages:
                     name: -1
                     value: -1
                     fun:
-                      kind: 1
+                      kind: 2
                       name: 82
                       value: -1
                       raw: -1
-                      pkg: 3
+                      pkg: 1
                       type: 95
                       position: 96
                       resolved_type: -1
                       generic_type_name: -1
                     args:
-                      - kind: 1
+                      - kind: 2
                         name: 79
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 4
                         position: 94
                         resolved_type: -1
@@ -1041,11 +1041,11 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 1
+                    kind: 2
                     name: 97
                     value: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 41
                     position: 98
                     resolved_type: -1
@@ -1055,7 +1055,7 @@ packages:
                   callee_pkg: complex
               svc:
                 - variable_name: 79
-                  pkg: 3
+                  pkg: 1
                   concrete_type: 4
                   position: 92
                   scope: 34
@@ -1064,11 +1064,11 @@ packages:
                     name: -1
                     value: -1
                     fun:
-                      kind: 1
+                      kind: 2
                       name: 70
                       value: -1
                       raw: -1
-                      pkg: 3
+                      pkg: 1
                       type: 90
                       position: 91
                       resolved_type: -1
@@ -1090,11 +1090,11 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 1
+                    kind: 2
                     name: 79
                     value: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 4
                     position: 92
                     resolved_type: -1
@@ -1105,12 +1105,12 @@ packages:
             end_line: 40
         struct_instances:
           - type: 46
-            pkg: 3
+            pkg: 1
             position: 62
             fields:
               6: 6
           - type: 61
-            pkg: 3
+            pkg: 1
             position: 77
             fields:
               43: 79
@@ -1119,7 +1119,7 @@ packages:
     types:
       Handler:
         name: 61
-        pkg: 3
+        pkg: 1
         kind: 59
         fields:
           - name: 43
@@ -1146,7 +1146,7 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 1
+                - kind: 2
                   name: 39
                   value: -1
                   raw: -1
@@ -1169,7 +1169,7 @@ packages:
             assignments:
               name:
                 - variable_name: 6
-                  pkg: 3
+                  pkg: 1
                   concrete_type: 7
                   position: 47
                   scope: 34
@@ -1186,53 +1186,53 @@ packages:
                         name: -1
                         value: -1
                         x:
-                          kind: 1
+                          kind: 2
                           name: 40
                           value: -1
                           raw: -1
-                          pkg: 3
+                          pkg: 1
                           type: 41
                           position: 42
                           resolved_type: -1
                           generic_type_name: -1
                         sel:
-                          kind: 1
+                          kind: 2
                           name: 43
                           value: -1
                           raw: -1
-                          pkg: 3
+                          pkg: 1
                           type: 4
                           position: 44
                           resolved_type: -1
                           generic_type_name: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 4
                         position: 42
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 1
+                        kind: 2
                         name: 10
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 18
                         position: 45
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 3
+                      pkg: 1
                       type: 18
                       position: 42
                       resolved_type: -1
                       generic_type_name: -1
                       receiver_type:
-                        kind: 1
+                        kind: 2
                         name: 46
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 46
                         position: -1
                         resolved_type: -1
@@ -1244,11 +1244,11 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 1
+                    kind: 2
                     name: 6
                     value: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 7
                     position: 47
                     resolved_type: -1
@@ -1258,7 +1258,7 @@ packages:
                   callee_pkg: complex
               processed:
                 - variable_name: 54
-                  pkg: 3
+                  pkg: 1
                   concrete_type: 7
                   position: 55
                   scope: 34
@@ -1275,63 +1275,63 @@ packages:
                         name: -1
                         value: -1
                         x:
-                          kind: 1
+                          kind: 2
                           name: 40
                           value: -1
                           raw: -1
-                          pkg: 3
+                          pkg: 1
                           type: 41
                           position: 50
                           resolved_type: -1
                           generic_type_name: -1
                         sel:
-                          kind: 1
+                          kind: 2
                           name: 43
                           value: -1
                           raw: -1
-                          pkg: 3
+                          pkg: 1
                           type: 4
                           position: 51
                           resolved_type: -1
                           generic_type_name: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 4
                         position: 50
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 1
+                        kind: 2
                         name: 35
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 52
                         position: 53
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 3
+                      pkg: 1
                       type: 52
                       position: 50
                       resolved_type: -1
                       generic_type_name: -1
                       receiver_type:
-                        kind: 1
+                        kind: 2
                         name: 46
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 46
                         position: -1
                         resolved_type: -1
                         generic_type_name: -1
                     args:
-                      - kind: 1
+                      - kind: 2
                         name: 39
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 7
                         position: 49
                         resolved_type: -1
@@ -1343,11 +1343,11 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 1
+                    kind: 2
                     name: 54
                     value: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 7
                     position: 55
                     resolved_type: -1
@@ -1358,7 +1358,7 @@ packages:
         comments: -1
       Service:
         name: 46
-        pkg: 3
+        pkg: 1
         kind: 59
         fields:
           - name: 6
@@ -1379,7 +1379,7 @@ packages:
                 name: -1
                 value: -1
                 args:
-                  - kind: 1
+                  - kind: 2
                     name: 7
                     value: -1
                     raw: -1
@@ -1410,27 +1410,27 @@ packages:
                 name: -1
                 value: -1
                 x:
-                  kind: 1
-                  name: 2
+                  kind: 2
+                  name: 3
                   value: -1
                   raw: -1
-                  pkg: 3
+                  pkg: 1
                   type: 4
                   position: 5
                   resolved_type: -1
                   generic_type_name: -1
                 sel:
-                  kind: 1
+                  kind: 2
                   name: 6
                   value: -1
                   raw: -1
-                  pkg: 3
+                  pkg: 1
                   type: 7
                   position: 8
                   resolved_type: -1
                   generic_type_name: -1
                 raw: -1
-                pkg: 3
+                pkg: 1
                 type: 7
                 position: 5
                 resolved_type: -1
@@ -1440,27 +1440,27 @@ packages:
                   name: -1
                   value: -1
                   x:
-                    kind: 1
-                    name: 2
+                    kind: 2
+                    name: 3
                     value: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 4
                     position: 5
                     resolved_type: -1
                     generic_type_name: -1
                   sel:
-                    kind: 1
+                    kind: 2
                     name: 6
                     value: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 7
                     position: 8
                     resolved_type: -1
                     generic_type_name: -1
                   raw: -1
-                  pkg: 3
+                  pkg: 1
                   type: 7
                   position: 5
                   resolved_type: -1
@@ -1476,7 +1476,7 @@ packages:
                 name: -1
                 value: -1
                 args:
-                  - kind: 1
+                  - kind: 2
                     name: 7
                     value: -1
                     raw: -1
@@ -1492,7 +1492,7 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 1
+                - kind: 2
                   name: 22
                   value: -1
                   raw: -1
@@ -1513,21 +1513,21 @@ packages:
             comments: -1
             filename: 17
             return_vars:
-              - kind: 1
+              - kind: 2
                 name: 19
                 value: -1
                 raw: -1
-                pkg: 3
+                pkg: 1
                 type: 7
                 position: 20
                 resolved_type: -1
                 generic_type_name: -1
             returns:
-              - - kind: 1
+              - - kind: 2
                   name: 19
                   value: -1
                   raw: -1
-                  pkg: 3
+                  pkg: 1
                   type: 7
                   position: 20
                   resolved_type: -1
@@ -1535,7 +1535,7 @@ packages:
             assignments:
               result:
                 - variable_name: 19
-                  pkg: 3
+                  pkg: 1
                   concrete_type: 7
                   position: 33
                   scope: 34
@@ -1548,7 +1548,7 @@ packages:
                       name: -1
                       value: -1
                       x:
-                        kind: 1
+                        kind: 2
                         name: 27
                         value: -1
                         raw: -1
@@ -1558,7 +1558,7 @@ packages:
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 1
+                        kind: 2
                         name: 29
                         value: -1
                         raw: -1
@@ -1583,11 +1583,11 @@ packages:
                         position: -1
                         resolved_type: -1
                         generic_type_name: -1
-                      - kind: 1
+                      - kind: 2
                         name: 22
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 7
                         position: 26
                         resolved_type: -1
@@ -1599,11 +1599,11 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 1
+                    kind: 2
                     name: 19
                     value: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 7
                     position: 33
                     resolved_type: -1
@@ -1612,10 +1612,11 @@ packages:
                   callee_func: Sprintf
                   callee_pkg: fmt
         comments: -1
+    name: 1
 call_graph:
   - caller:
       name: 35
-      pkg: 3
+      pkg: 1
       position: -1
       recv_type: 11
       scope: 16
@@ -1638,22 +1639,22 @@ call_graph:
         position: -1
         resolved_type: -1
         generic_type_name: -1
-      - kind: 1
+      - kind: 2
         name: 22
         value: -1
         raw: -1
-        pkg: 3
+        pkg: 1
         type: 7
         position: 26
         resolved_type: -1
         generic_type_name: -1
     param_arg_map:
       a:
-        kind: 1
+        kind: 2
         name: 22
         value: -1
         raw: -1
-        pkg: 3
+        pkg: 1
         type: 7
         position: 26
         resolved_type: -1
@@ -1671,14 +1672,14 @@ call_graph:
     callee_recv_var_name: result
   - caller:
       name: 48
-      pkg: 3
+      pkg: 1
       position: -1
       recv_type: 56
       scope: 16
       signature_str: 58
     callee:
       name: 10
-      pkg: 3
+      pkg: 1
       position: 42
       recv_type: 11
       scope: 16
@@ -1687,25 +1688,25 @@ call_graph:
     callee_recv_var_name: name
   - caller:
       name: 48
-      pkg: 3
+      pkg: 1
       position: -1
       recv_type: 56
       scope: 16
       signature_str: 58
     callee:
       name: 35
-      pkg: 3
+      pkg: 1
       position: 50
       recv_type: 11
       scope: 16
       signature_str: 52
     position: 50
     args:
-      - kind: 1
+      - kind: 2
         name: 39
         value: -1
         raw: -1
-        pkg: 3
+        pkg: 1
         type: 7
         position: 49
         resolved_type: -1
@@ -1713,7 +1714,7 @@ call_graph:
     assignments:
       result:
         - variable_name: 19
-          pkg: 3
+          pkg: 1
           concrete_type: 7
           position: 33
           scope: 34
@@ -1726,7 +1727,7 @@ call_graph:
               name: -1
               value: -1
               x:
-                kind: 1
+                kind: 2
                 name: 27
                 value: -1
                 raw: -1
@@ -1736,7 +1737,7 @@ call_graph:
                 resolved_type: -1
                 generic_type_name: -1
               sel:
-                kind: 1
+                kind: 2
                 name: 29
                 value: -1
                 raw: -1
@@ -1761,11 +1762,11 @@ call_graph:
                 position: -1
                 resolved_type: -1
                 generic_type_name: -1
-              - kind: 1
+              - kind: 2
                 name: 22
                 value: -1
                 raw: -1
-                pkg: 3
+                pkg: 1
                 type: 7
                 position: 26
                 resolved_type: -1
@@ -1777,11 +1778,11 @@ call_graph:
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 1
+            kind: 2
             name: 19
             value: -1
             raw: -1
-            pkg: 3
+            pkg: 1
             type: 7
             position: 33
             resolved_type: -1
@@ -1791,11 +1792,11 @@ call_graph:
           callee_pkg: fmt
     param_arg_map:
       data:
-        kind: 1
+        kind: 2
         name: 39
         value: -1
         raw: -1
-        pkg: 3
+        pkg: 1
         type: 7
         position: 49
         resolved_type: -1
@@ -1803,7 +1804,7 @@ call_graph:
     callee_recv_var_name: processed
   - caller:
       name: 48
-      pkg: 3
+      pkg: 1
       position: -1
       recv_type: 56
       scope: 16
@@ -1826,31 +1827,31 @@ call_graph:
         position: -1
         resolved_type: -1
         generic_type_name: -1
-      - kind: 1
+      - kind: 2
         name: 6
         value: -1
         raw: -1
-        pkg: 3
+        pkg: 1
         type: 7
         position: 102
         resolved_type: -1
         generic_type_name: -1
-      - kind: 1
+      - kind: 2
         name: 54
         value: -1
         raw: -1
-        pkg: 3
+        pkg: 1
         type: 7
         position: 103
         resolved_type: -1
         generic_type_name: -1
     param_arg_map:
       a:
-        kind: 1
+        kind: 2
         name: 6
         value: -1
         raw: -1
-        pkg: 3
+        pkg: 1
         type: 7
         position: 102
         resolved_type: -1
@@ -1867,14 +1868,14 @@ call_graph:
         generic_type_name: -1
   - caller:
       name: 93
-      pkg: 3
+      pkg: 1
       position: -1
       recv_type: -1
       scope: 34
       signature_str: 100
     callee:
       name: 70
-      pkg: 3
+      pkg: 1
       position: 91
       recv_type: -1
       scope: 16
@@ -1893,7 +1894,7 @@ call_graph:
     assignments:
       svc:
         - variable_name: 79
-          pkg: 3
+          pkg: 1
           concrete_type: 4
           position: 92
           scope: 34
@@ -1902,11 +1903,11 @@ call_graph:
             name: -1
             value: -1
             fun:
-              kind: 1
+              kind: 2
               name: 70
               value: -1
               raw: -1
-              pkg: 3
+              pkg: 1
               type: 90
               position: 91
               resolved_type: -1
@@ -1928,11 +1929,11 @@ call_graph:
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 1
+            kind: 2
             name: 79
             value: -1
             raw: -1
-            pkg: 3
+            pkg: 1
             type: 4
             position: 92
             resolved_type: -1
@@ -1954,25 +1955,25 @@ call_graph:
     callee_recv_var_name: svc
   - caller:
       name: 93
-      pkg: 3
+      pkg: 1
       position: -1
       recv_type: -1
       scope: 34
       signature_str: 100
     callee:
       name: 82
-      pkg: 3
+      pkg: 1
       position: 96
       recv_type: -1
       scope: 16
       signature_str: 95
     position: 96
     args:
-      - kind: 1
+      - kind: 2
         name: 79
         value: -1
         raw: -1
-        pkg: 3
+        pkg: 1
         type: 4
         position: 94
         resolved_type: -1
@@ -1980,7 +1981,7 @@ call_graph:
     assignments:
       handler:
         - variable_name: 97
-          pkg: 3
+          pkg: 1
           concrete_type: 41
           position: 98
           scope: 34
@@ -1989,21 +1990,21 @@ call_graph:
             name: -1
             value: -1
             fun:
-              kind: 1
+              kind: 2
               name: 82
               value: -1
               raw: -1
-              pkg: 3
+              pkg: 1
               type: 95
               position: 96
               resolved_type: -1
               generic_type_name: -1
             args:
-              - kind: 1
+              - kind: 2
                 name: 79
                 value: -1
                 raw: -1
-                pkg: 3
+                pkg: 1
                 type: 4
                 position: 94
                 resolved_type: -1
@@ -2015,11 +2016,11 @@ call_graph:
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 1
+            kind: 2
             name: 97
             value: -1
             raw: -1
-            pkg: 3
+            pkg: 1
             type: 41
             position: 98
             resolved_type: -1
@@ -2029,11 +2030,11 @@ call_graph:
           callee_pkg: complex
     param_arg_map:
       svc:
-        kind: 1
+        kind: 2
         name: 79
         value: -1
         raw: -1
-        pkg: 3
+        pkg: 1
         type: 4
         position: 94
         resolved_type: -1
@@ -2041,14 +2042,14 @@ call_graph:
     callee_recv_var_name: handler
   - caller:
       name: 93
-      pkg: 3
+      pkg: 1
       position: -1
       recv_type: -1
       scope: 34
       signature_str: 100
     callee:
       name: 48
-      pkg: 3
+      pkg: 1
       position: 108
       recv_type: 56
       scope: 16
@@ -2067,7 +2068,7 @@ call_graph:
     assignments:
       name:
         - variable_name: 6
-          pkg: 3
+          pkg: 1
           concrete_type: 7
           position: 47
           scope: 34
@@ -2084,53 +2085,53 @@ call_graph:
                 name: -1
                 value: -1
                 x:
-                  kind: 1
+                  kind: 2
                   name: 40
                   value: -1
                   raw: -1
-                  pkg: 3
+                  pkg: 1
                   type: 41
                   position: 42
                   resolved_type: -1
                   generic_type_name: -1
                 sel:
-                  kind: 1
+                  kind: 2
                   name: 43
                   value: -1
                   raw: -1
-                  pkg: 3
+                  pkg: 1
                   type: 4
                   position: 44
                   resolved_type: -1
                   generic_type_name: -1
                 raw: -1
-                pkg: 3
+                pkg: 1
                 type: 4
                 position: 42
                 resolved_type: -1
                 generic_type_name: -1
               sel:
-                kind: 1
+                kind: 2
                 name: 10
                 value: -1
                 raw: -1
-                pkg: 3
+                pkg: 1
                 type: 18
                 position: 45
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
-              pkg: 3
+              pkg: 1
               type: 18
               position: 42
               resolved_type: -1
               generic_type_name: -1
               receiver_type:
-                kind: 1
+                kind: 2
                 name: 46
                 value: -1
                 raw: -1
-                pkg: 3
+                pkg: 1
                 type: 46
                 position: -1
                 resolved_type: -1
@@ -2142,11 +2143,11 @@ call_graph:
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 1
+            kind: 2
             name: 6
             value: -1
             raw: -1
-            pkg: 3
+            pkg: 1
             type: 7
             position: 47
             resolved_type: -1
@@ -2156,7 +2157,7 @@ call_graph:
           callee_pkg: complex
       processed:
         - variable_name: 54
-          pkg: 3
+          pkg: 1
           concrete_type: 7
           position: 55
           scope: 34
@@ -2173,63 +2174,63 @@ call_graph:
                 name: -1
                 value: -1
                 x:
-                  kind: 1
+                  kind: 2
                   name: 40
                   value: -1
                   raw: -1
-                  pkg: 3
+                  pkg: 1
                   type: 41
                   position: 50
                   resolved_type: -1
                   generic_type_name: -1
                 sel:
-                  kind: 1
+                  kind: 2
                   name: 43
                   value: -1
                   raw: -1
-                  pkg: 3
+                  pkg: 1
                   type: 4
                   position: 51
                   resolved_type: -1
                   generic_type_name: -1
                 raw: -1
-                pkg: 3
+                pkg: 1
                 type: 4
                 position: 50
                 resolved_type: -1
                 generic_type_name: -1
               sel:
-                kind: 1
+                kind: 2
                 name: 35
                 value: -1
                 raw: -1
-                pkg: 3
+                pkg: 1
                 type: 52
                 position: 53
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
-              pkg: 3
+              pkg: 1
               type: 52
               position: 50
               resolved_type: -1
               generic_type_name: -1
               receiver_type:
-                kind: 1
+                kind: 2
                 name: 46
                 value: -1
                 raw: -1
-                pkg: 3
+                pkg: 1
                 type: 46
                 position: -1
                 resolved_type: -1
                 generic_type_name: -1
             args:
-              - kind: 1
+              - kind: 2
                 name: 39
                 value: -1
                 raw: -1
-                pkg: 3
+                pkg: 1
                 type: 7
                 position: 49
                 resolved_type: -1
@@ -2241,11 +2242,11 @@ call_graph:
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 1
+            kind: 2
             name: 54
             value: -1
             raw: -1
-            pkg: 3
+            pkg: 1
             type: 7
             position: 55
             resolved_type: -1

--- a/internal/spec/tests/constants.yaml
+++ b/internal/spec/tests/constants.yaml
@@ -1,5 +1,6 @@
 string_pool:
   - ""
+  - constants
   - literal
   - "100"
   - '"test"'
@@ -10,7 +11,6 @@ string_pool:
   - ident
   - string
   - Message
-  - constants
   - constants/const.go:15:2
   - exported
   - init
@@ -49,13 +49,13 @@ packages:
         functions:
           UseConstants:
             name: 24
-            pkg: 11
+            pkg: 1
             signature:
-              kind: 5
+              kind: 6
               name: -1
               value: -1
               fun:
-                kind: 6
+                kind: 7
                 name: -1
                 value: -1
                 raw: -1
@@ -77,53 +77,53 @@ packages:
             assignments:
               name:
                 - variable_name: 28
-                  pkg: 11
-                  concrete_type: 9
+                  pkg: 1
+                  concrete_type: 10
                   position: 29
                   scope: 16
                   value:
-                    kind: 8
+                    kind: 9
                     name: 25
-                    value: 3
+                    value: 4
                     raw: -1
-                    pkg: 11
+                    pkg: 1
                     type: 26
                     position: 27
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 8
+                    kind: 9
                     name: 28
                     value: -1
                     raw: -1
-                    pkg: 11
-                    type: 9
+                    pkg: 1
+                    type: 10
                     position: 29
                     resolved_type: -1
                     generic_type_name: -1
                   func: 24
               size:
                 - variable_name: 22
-                  pkg: 11
+                  pkg: 1
                   concrete_type: 21
                   position: 23
                   scope: 16
                   value:
-                    kind: 8
+                    kind: 9
                     name: 18
                     value: -1
                     raw: -1
-                    pkg: 11
+                    pkg: 1
                     type: 19
                     position: 20
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 8
+                    kind: 9
                     name: 22
                     value: -1
                     raw: -1
-                    pkg: 11
+                    pkg: 1
                     type: 21
                     position: 23
                     resolved_type: -1
@@ -132,13 +132,13 @@ packages:
             end_line: 23
           init:
             name: 14
-            pkg: 11
+            pkg: 1
             signature:
-              kind: 5
+              kind: 6
               name: -1
               value: -1
               fun:
-                kind: 6
+                kind: 7
                 name: -1
                 value: -1
                 raw: -1
@@ -159,15 +159,15 @@ packages:
             comments: -1
             assignments:
               Message:
-                - variable_name: 10
-                  pkg: 11
-                  concrete_type: 9
+                - variable_name: 11
+                  pkg: 1
+                  concrete_type: 10
                   position: 12
                   scope: 13
                   value:
-                    kind: 1
+                    kind: 2
                     name: -1
-                    value: 7
+                    value: 8
                     raw: -1
                     pkg: -1
                     type: -1
@@ -175,12 +175,12 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 8
-                    name: 10
+                    kind: 9
+                    name: 11
                     value: -1
                     raw: -1
-                    pkg: 11
-                    type: 9
+                    pkg: 1
+                    type: 10
                     position: 12
                     resolved_type: -1
                     generic_type_name: -1
@@ -190,7 +190,7 @@ packages:
           GlobalVar:
             name: 38
             tok: 39
-            pkg: 11
+            pkg: 1
             type: 21
             value: 41
             position: 40
@@ -199,26 +199,26 @@ packages:
           MaxSize:
             name: 18
             tok: 31
-            pkg: 11
+            pkg: 1
             type: -1
             resolved_type: 19
-            value: 2
+            value: 3
             computed_value: 100
             position: 32
             comments: -1
             group_index: 1
           Message:
-            name: 10
+            name: 11
             tok: 39
-            pkg: 11
-            type: 9
+            pkg: 1
+            type: 10
             position: 42
             comments: -1
             group_index: 1
           Name:
             name: 25
             tok: 31
-            pkg: 11
+            pkg: 1
             type: -1
             resolved_type: 26
             value: 34
@@ -229,12 +229,13 @@ packages:
           Pi:
             name: 35
             tok: 31
-            pkg: 11
+            pkg: 1
             type: -1
             resolved_type: 37
-            value: 4
+            value: 5
             computed_value: {}
             position: 36
             comments: -1
             group_index: 1
         imports: {}
+    name: 1

--- a/internal/spec/tests/example.yaml
+++ b/internal/spec/tests/example.yaml
@@ -1,8 +1,8 @@
 string_pool:
   - ""
+  - example
   - ident
   - u
-  - example
   - '*example.User'
   - example/types.go:21:9
   - Name
@@ -93,7 +93,7 @@ packages:
         types:
           Ager:
             name: 37
-            pkg: 3
+            pkg: 1
             kind: 34
             implemented_by:
               - 78
@@ -115,7 +115,7 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   args:
-                    - kind: 1
+                    - kind: 2
                       name: 21
                       value: -1
                       raw: -1
@@ -136,7 +136,7 @@ packages:
             comments: -1
           Namer:
             name: 35
-            pkg: 3
+            pkg: 1
             kind: 34
             implemented_by:
               - 78
@@ -152,7 +152,7 @@ packages:
                     name: -1
                     value: -1
                     args:
-                      - kind: 1
+                      - kind: 2
                         name: 7
                         value: -1
                         raw: -1
@@ -179,7 +179,7 @@ packages:
             comments: -1
           Phoner:
             name: 39
-            pkg: 3
+            pkg: 1
             kind: 34
             scope: 16
             methods:
@@ -199,7 +199,7 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   args:
-                    - kind: 1
+                    - kind: 2
                       name: 42
                       value: -1
                       raw: -1
@@ -220,7 +220,7 @@ packages:
             comments: -1
           User:
             name: 30
-            pkg: 3
+            pkg: 1
             kind: 31
             implements:
               - 77
@@ -249,7 +249,7 @@ packages:
                     name: -1
                     value: -1
                     args:
-                      - kind: 1
+                      - kind: 2
                         name: 7
                         value: -1
                         raw: -1
@@ -280,27 +280,27 @@ packages:
                     name: -1
                     value: -1
                     x:
-                      kind: 1
-                      name: 2
+                      kind: 2
+                      name: 3
                       value: -1
                       raw: -1
-                      pkg: 3
+                      pkg: 1
                       type: 4
                       position: 5
                       resolved_type: -1
                       generic_type_name: -1
                     sel:
-                      kind: 1
+                      kind: 2
                       name: 6
                       value: -1
                       raw: -1
-                      pkg: 3
+                      pkg: 1
                       type: 7
                       position: 8
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 7
                     position: 5
                     resolved_type: -1
@@ -310,27 +310,27 @@ packages:
                       name: -1
                       value: -1
                       x:
-                        kind: 1
-                        name: 2
+                        kind: 2
+                        name: 3
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 4
                         position: 5
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 1
+                        kind: 2
                         name: 6
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 7
                         position: 8
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 3
+                      pkg: 1
                       type: 7
                       position: 5
                       resolved_type: -1
@@ -352,7 +352,7 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   args:
-                    - kind: 1
+                    - kind: 2
                       name: 21
                       value: -1
                       raw: -1
@@ -375,16 +375,16 @@ packages:
                 assignments:
                   example.User.Age:
                     - variable_name: 25
-                      pkg: 3
+                      pkg: 1
                       concrete_type: 19
                       position: 22
                       scope: 9
                       value:
-                        kind: 1
+                        kind: 2
                         name: 21
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 19
                         position: 26
                         resolved_type: -1
@@ -394,27 +394,27 @@ packages:
                         name: -1
                         value: -1
                         x:
-                          kind: 1
-                          name: 2
+                          kind: 2
+                          name: 3
                           value: -1
                           raw: -1
-                          pkg: 3
+                          pkg: 1
                           type: 4
                           position: 22
                           resolved_type: -1
                           generic_type_name: -1
                         sel:
-                          kind: 1
+                          kind: 2
                           name: 23
                           value: -1
                           raw: -1
-                          pkg: 3
+                          pkg: 1
                           type: 19
                           position: 24
                           resolved_type: -1
                           generic_type_name: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 19
                         position: 22
                         resolved_type: -1
@@ -423,7 +423,7 @@ packages:
         functions:
           NewUser:
             name: 63
-            pkg: 3
+            pkg: 1
             signature:
               kind: 13
               name: -1
@@ -437,11 +437,11 @@ packages:
                     name: -1
                     value: -1
                     x:
-                      kind: 1
+                      kind: 2
                       name: 30
                       value: -1
                       raw: -1
-                      pkg: 3
+                      pkg: 1
                       type: 30
                       position: 48
                       resolved_type: -1
@@ -459,7 +459,7 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 1
+                - kind: 2
                   name: 46
                   value: -1
                   raw: -1
@@ -468,7 +468,7 @@ packages:
                   position: 45
                   resolved_type: -1
                   generic_type_name: -1
-                - kind: 1
+                - kind: 2
                   name: 21
                   value: -1
                   raw: -1
@@ -488,29 +488,29 @@ packages:
             scope: 16
             comments: -1
             return_vars:
-              - kind: 1
-                name: 2
+              - kind: 2
+                name: 3
                 value: -1
                 raw: -1
-                pkg: 3
+                pkg: 1
                 type: 4
                 position: 44
                 resolved_type: -1
                 generic_type_name: -1
             returns:
-              - - kind: 1
-                  name: 2
+              - - kind: 2
+                  name: 3
                   value: -1
                   raw: -1
-                  pkg: 3
+                  pkg: 1
                   type: 4
                   position: 44
                   resolved_type: -1
                   generic_type_name: -1
             assignments:
               u:
-                - variable_name: 2
-                  pkg: 3
+                - variable_name: 3
+                  pkg: 1
                   concrete_type: 4
                   position: 61
                   scope: 62
@@ -523,11 +523,11 @@ packages:
                       name: -1
                       value: -1
                       x:
-                        kind: 1
+                        kind: 2
                         name: 30
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 30
                         position: 51
                         resolved_type: -1
@@ -537,21 +537,21 @@ packages:
                           name: -1
                           value: -1
                           x:
-                            kind: 1
+                            kind: 2
                             name: 6
                             value: -1
                             raw: -1
-                            pkg: 3
+                            pkg: 1
                             type: 7
                             position: 52
                             resolved_type: -1
                             generic_type_name: -1
                           fun:
-                            kind: 1
+                            kind: 2
                             name: 46
                             value: -1
                             raw: -1
-                            pkg: 3
+                            pkg: 1
                             type: 7
                             position: 53
                             resolved_type: -1
@@ -566,21 +566,21 @@ packages:
                           name: -1
                           value: -1
                           x:
-                            kind: 1
+                            kind: 2
                             name: 23
                             value: -1
                             raw: -1
-                            pkg: 3
+                            pkg: 1
                             type: 19
                             position: 55
                             resolved_type: -1
                             generic_type_name: -1
                           fun:
-                            kind: 1
+                            kind: 2
                             name: 21
                             value: -1
                             raw: -1
-                            pkg: 3
+                            pkg: 1
                             type: 19
                             position: 56
                             resolved_type: -1
@@ -604,11 +604,11 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 1
-                    name: 2
+                    kind: 2
+                    name: 3
                     value: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 4
                     position: 61
                     resolved_type: -1
@@ -617,7 +617,7 @@ packages:
             end_line: 37
           main:
             name: 74
-            pkg: 3
+            pkg: 1
             signature:
               kind: 13
               name: -1
@@ -645,7 +645,7 @@ packages:
             assignments:
               user:
                 - variable_name: 72
-                  pkg: 3
+                  pkg: 1
                   concrete_type: 4
                   position: 73
                   scope: 62
@@ -654,11 +654,11 @@ packages:
                     name: -1
                     value: -1
                     fun:
-                      kind: 1
+                      kind: 2
                       name: 63
                       value: -1
                       raw: -1
-                      pkg: 3
+                      pkg: 1
                       type: 69
                       position: 70
                       resolved_type: -1
@@ -689,11 +689,11 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 1
+                    kind: 2
                     name: 72
                     value: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 4
                     position: 73
                     resolved_type: -1
@@ -704,7 +704,7 @@ packages:
             end_line: 42
         struct_instances:
           - type: 30
-            pkg: 3
+            pkg: 1
             position: 51
             fields:
               6: 46
@@ -713,7 +713,7 @@ packages:
     types:
       Ager:
         name: 37
-        pkg: 3
+        pkg: 1
         kind: 34
         implemented_by:
           - 78
@@ -735,7 +735,7 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 1
+                - kind: 2
                   name: 21
                   value: -1
                   raw: -1
@@ -756,7 +756,7 @@ packages:
         comments: -1
       Namer:
         name: 35
-        pkg: 3
+        pkg: 1
         kind: 34
         implemented_by:
           - 78
@@ -772,7 +772,7 @@ packages:
                 name: -1
                 value: -1
                 args:
-                  - kind: 1
+                  - kind: 2
                     name: 7
                     value: -1
                     raw: -1
@@ -799,7 +799,7 @@ packages:
         comments: -1
       Phoner:
         name: 39
-        pkg: 3
+        pkg: 1
         kind: 34
         scope: 16
         methods:
@@ -819,7 +819,7 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 1
+                - kind: 2
                   name: 42
                   value: -1
                   raw: -1
@@ -840,7 +840,7 @@ packages:
         comments: -1
       User:
         name: 30
-        pkg: 3
+        pkg: 1
         kind: 31
         implements:
           - 77
@@ -869,7 +869,7 @@ packages:
                 name: -1
                 value: -1
                 args:
-                  - kind: 1
+                  - kind: 2
                     name: 7
                     value: -1
                     raw: -1
@@ -900,27 +900,27 @@ packages:
                 name: -1
                 value: -1
                 x:
-                  kind: 1
-                  name: 2
+                  kind: 2
+                  name: 3
                   value: -1
                   raw: -1
-                  pkg: 3
+                  pkg: 1
                   type: 4
                   position: 5
                   resolved_type: -1
                   generic_type_name: -1
                 sel:
-                  kind: 1
+                  kind: 2
                   name: 6
                   value: -1
                   raw: -1
-                  pkg: 3
+                  pkg: 1
                   type: 7
                   position: 8
                   resolved_type: -1
                   generic_type_name: -1
                 raw: -1
-                pkg: 3
+                pkg: 1
                 type: 7
                 position: 5
                 resolved_type: -1
@@ -930,27 +930,27 @@ packages:
                   name: -1
                   value: -1
                   x:
-                    kind: 1
-                    name: 2
+                    kind: 2
+                    name: 3
                     value: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 4
                     position: 5
                     resolved_type: -1
                     generic_type_name: -1
                   sel:
-                    kind: 1
+                    kind: 2
                     name: 6
                     value: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 7
                     position: 8
                     resolved_type: -1
                     generic_type_name: -1
                   raw: -1
-                  pkg: 3
+                  pkg: 1
                   type: 7
                   position: 5
                   resolved_type: -1
@@ -972,7 +972,7 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 1
+                - kind: 2
                   name: 21
                   value: -1
                   raw: -1
@@ -995,16 +995,16 @@ packages:
             assignments:
               example.User.Age:
                 - variable_name: 25
-                  pkg: 3
+                  pkg: 1
                   concrete_type: 19
                   position: 22
                   scope: 9
                   value:
-                    kind: 1
+                    kind: 2
                     name: 21
                     value: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 19
                     position: 26
                     resolved_type: -1
@@ -1014,54 +1014,55 @@ packages:
                     name: -1
                     value: -1
                     x:
-                      kind: 1
-                      name: 2
+                      kind: 2
+                      name: 3
                       value: -1
                       raw: -1
-                      pkg: 3
+                      pkg: 1
                       type: 4
                       position: 22
                       resolved_type: -1
                       generic_type_name: -1
                     sel:
-                      kind: 1
+                      kind: 2
                       name: 23
                       value: -1
                       raw: -1
-                      pkg: 3
+                      pkg: 1
                       type: 19
                       position: 24
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 19
                     position: 22
                     resolved_type: -1
                     generic_type_name: -1
         comments: -1
+    name: 1
 call_graph:
   - caller:
       name: 63
-      pkg: 3
+      pkg: 1
       position: -1
       recv_type: -1
       scope: 16
       signature_str: 65
     callee:
       name: 27
-      pkg: 3
+      pkg: 1
       position: 81
       recv_type: 11
       scope: 16
       signature_str: 82
     position: 81
     args:
-      - kind: 1
+      - kind: 2
         name: 21
         value: -1
         raw: -1
-        pkg: 3
+        pkg: 1
         type: 19
         position: 80
         resolved_type: -1
@@ -1069,16 +1070,16 @@ call_graph:
     assignments:
       example.User.Age:
         - variable_name: 25
-          pkg: 3
+          pkg: 1
           concrete_type: 19
           position: 22
           scope: 9
           value:
-            kind: 1
+            kind: 2
             name: 21
             value: -1
             raw: -1
-            pkg: 3
+            pkg: 1
             type: 19
             position: 26
             resolved_type: -1
@@ -1088,38 +1089,38 @@ call_graph:
             name: -1
             value: -1
             x:
-              kind: 1
-              name: 2
+              kind: 2
+              name: 3
               value: -1
               raw: -1
-              pkg: 3
+              pkg: 1
               type: 4
               position: 22
               resolved_type: -1
               generic_type_name: -1
             sel:
-              kind: 1
+              kind: 2
               name: 23
               value: -1
               raw: -1
-              pkg: 3
+              pkg: 1
               type: 19
               position: 24
               resolved_type: -1
               generic_type_name: -1
             raw: -1
-            pkg: 3
+            pkg: 1
             type: 19
             position: 22
             resolved_type: -1
             generic_type_name: -1
     param_arg_map:
       age:
-        kind: 1
+        kind: 2
         name: 21
         value: -1
         raw: -1
-        pkg: 3
+        pkg: 1
         type: 19
         position: 80
         resolved_type: -1
@@ -1129,14 +1130,14 @@ call_graph:
     chain_root: u
   - caller:
       name: 74
-      pkg: 3
+      pkg: 1
       position: -1
       recv_type: -1
       scope: 62
       signature_str: 76
     callee:
       name: 63
-      pkg: 3
+      pkg: 1
       position: 70
       recv_type: -1
       scope: 16
@@ -1163,8 +1164,8 @@ call_graph:
         generic_type_name: -1
     assignments:
       u:
-        - variable_name: 2
-          pkg: 3
+        - variable_name: 3
+          pkg: 1
           concrete_type: 4
           position: 61
           scope: 62
@@ -1177,11 +1178,11 @@ call_graph:
               name: -1
               value: -1
               x:
-                kind: 1
+                kind: 2
                 name: 30
                 value: -1
                 raw: -1
-                pkg: 3
+                pkg: 1
                 type: 30
                 position: 51
                 resolved_type: -1
@@ -1191,21 +1192,21 @@ call_graph:
                   name: -1
                   value: -1
                   x:
-                    kind: 1
+                    kind: 2
                     name: 6
                     value: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 7
                     position: 52
                     resolved_type: -1
                     generic_type_name: -1
                   fun:
-                    kind: 1
+                    kind: 2
                     name: 46
                     value: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 7
                     position: 53
                     resolved_type: -1
@@ -1220,21 +1221,21 @@ call_graph:
                   name: -1
                   value: -1
                   x:
-                    kind: 1
+                    kind: 2
                     name: 23
                     value: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 19
                     position: 55
                     resolved_type: -1
                     generic_type_name: -1
                   fun:
-                    kind: 1
+                    kind: 2
                     name: 21
                     value: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 19
                     position: 56
                     resolved_type: -1
@@ -1258,11 +1259,11 @@ call_graph:
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 1
-            name: 2
+            kind: 2
+            name: 3
             value: -1
             raw: -1
-            pkg: 3
+            pkg: 1
             type: 4
             position: 61
             resolved_type: -1
@@ -1270,7 +1271,7 @@ call_graph:
           func: 63
       user:
         - variable_name: 72
-          pkg: 3
+          pkg: 1
           concrete_type: 4
           position: 73
           scope: 62
@@ -1279,11 +1280,11 @@ call_graph:
             name: -1
             value: -1
             fun:
-              kind: 1
+              kind: 2
               name: 63
               value: -1
               raw: -1
-              pkg: 3
+              pkg: 1
               type: 69
               position: 70
               resolved_type: -1
@@ -1314,11 +1315,11 @@ call_graph:
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 1
+            kind: 2
             name: 72
             value: -1
             raw: -1
-            pkg: 3
+            pkg: 1
             type: 4
             position: 73
             resolved_type: -1
@@ -1350,14 +1351,14 @@ call_graph:
     callee_recv_var_name: user
   - caller:
       name: 74
-      pkg: 3
+      pkg: 1
       position: -1
       recv_type: -1
       scope: 62
       signature_str: 76
     callee:
       name: 86
-      pkg: 3
+      pkg: 1
       position: 85
       recv_type: -1
       scope: 16
@@ -1368,11 +1369,11 @@ call_graph:
         name: -1
         value: -1
         x:
-          kind: 1
+          kind: 2
           name: 72
           value: -1
           raw: -1
-          pkg: 3
+          pkg: 1
           type: 4
           position: 83
           resolved_type: -1

--- a/internal/spec/tests/generic.yaml
+++ b/internal/spec/tests/generic.yaml
@@ -1,8 +1,8 @@
 string_pool:
   - ""
+  - generic
   - ident
   - c
-  - generic
   - '*generic.Container[T]'
   - generic/generic.go:8:9
   - Value
@@ -113,7 +113,7 @@ packages:
         types:
           Container:
             name: 28
-            pkg: 3
+            pkg: 1
             kind: 29
             fields:
               - name: 6
@@ -134,11 +134,11 @@ packages:
                     name: -1
                     value: -1
                     args:
-                      - kind: 1
+                      - kind: 2
                         name: 7
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 7
                         position: 12
                         resolved_type: -1
@@ -165,27 +165,27 @@ packages:
                     name: -1
                     value: -1
                     x:
-                      kind: 1
-                      name: 2
+                      kind: 2
+                      name: 3
                       value: -1
                       raw: -1
-                      pkg: 3
+                      pkg: 1
                       type: 4
                       position: 5
                       resolved_type: -1
                       generic_type_name: -1
                     sel:
-                      kind: 1
+                      kind: 2
                       name: 6
                       value: -1
                       raw: -1
-                      pkg: 3
+                      pkg: 1
                       type: 7
                       position: 8
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 7
                     position: 5
                     resolved_type: -1
@@ -195,27 +195,27 @@ packages:
                       name: -1
                       value: -1
                       x:
-                        kind: 1
-                        name: 2
+                        kind: 2
+                        name: 3
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 4
                         position: 5
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 1
+                        kind: 2
                         name: 6
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 7
                         position: 8
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 3
+                      pkg: 1
                       type: 7
                       position: 5
                       resolved_type: -1
@@ -237,11 +237,11 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   args:
-                    - kind: 1
+                    - kind: 2
                       name: 20
                       value: -1
                       raw: -1
-                      pkg: 3
+                      pkg: 1
                       type: 7
                       position: 19
                       resolved_type: -1
@@ -260,16 +260,16 @@ packages:
                 assignments:
                   generic.Container[T].Value:
                     - variable_name: 23
-                      pkg: 3
+                      pkg: 1
                       concrete_type: 7
                       position: 21
                       scope: 9
                       value:
-                        kind: 1
+                        kind: 2
                         name: 20
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 7
                         position: 24
                         resolved_type: -1
@@ -279,27 +279,27 @@ packages:
                         name: -1
                         value: -1
                         x:
-                          kind: 1
-                          name: 2
+                          kind: 2
+                          name: 3
                           value: -1
                           raw: -1
-                          pkg: 3
+                          pkg: 1
                           type: 4
                           position: 21
                           resolved_type: -1
                           generic_type_name: -1
                         sel:
-                          kind: 1
+                          kind: 2
                           name: 6
                           value: -1
                           raw: -1
-                          pkg: 3
+                          pkg: 1
                           type: 7
                           position: 22
                           resolved_type: -1
                           generic_type_name: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 7
                         position: 21
                         resolved_type: -1
@@ -310,7 +310,7 @@ packages:
         functions:
           NewContainer:
             name: 42
-            pkg: 3
+            pkg: 1
             signature:
               kind: 13
               name: -1
@@ -328,21 +328,21 @@ packages:
                       name: -1
                       value: -1
                       x:
-                        kind: 1
+                        kind: 2
                         name: 28
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 31
                         position: 46
                         resolved_type: -1
                         generic_type_name: -1
                       fun:
-                        kind: 1
+                        kind: 2
                         name: 7
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 7
                         position: 47
                         resolved_type: -1
@@ -366,17 +366,17 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 1
+                - kind: 2
                   name: 20
                   value: -1
                   raw: -1
-                  pkg: 3
+                  pkg: 1
                   type: 7
                   position: 43
                   resolved_type: -1
                   generic_type_name: -1
               tparams:
-                - kind: 1
+                - kind: 2
                   name: 7
                   value: -1
                   raw: -1
@@ -410,21 +410,21 @@ packages:
                     name: -1
                     value: -1
                     x:
-                      kind: 1
+                      kind: 2
                       name: 28
                       value: -1
                       raw: -1
-                      pkg: 3
+                      pkg: 1
                       type: 31
                       position: 32
                       resolved_type: -1
                       generic_type_name: -1
                     fun:
-                      kind: 1
+                      kind: 2
                       name: 7
                       value: -1
                       raw: -1
-                      pkg: 3
+                      pkg: 1
                       type: 7
                       position: 33
                       resolved_type: -1
@@ -440,21 +440,21 @@ packages:
                       name: -1
                       value: -1
                       x:
-                        kind: 1
+                        kind: 2
                         name: 6
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 7
                         position: 35
                         resolved_type: -1
                         generic_type_name: -1
                       fun:
-                        kind: 1
+                        kind: 2
                         name: 20
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 7
                         position: 36
                         resolved_type: -1
@@ -490,21 +490,21 @@ packages:
                       name: -1
                       value: -1
                       x:
-                        kind: 1
+                        kind: 2
                         name: 28
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 31
                         position: 32
                         resolved_type: -1
                         generic_type_name: -1
                       fun:
-                        kind: 1
+                        kind: 2
                         name: 7
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 7
                         position: 33
                         resolved_type: -1
@@ -520,21 +520,21 @@ packages:
                         name: -1
                         value: -1
                         x:
-                          kind: 1
+                          kind: 2
                           name: 6
                           value: -1
                           raw: -1
-                          pkg: 3
+                          pkg: 1
                           type: 7
                           position: 35
                           resolved_type: -1
                           generic_type_name: -1
                         fun:
-                          kind: 1
+                          kind: 2
                           name: 20
                           value: -1
                           raw: -1
-                          pkg: 3
+                          pkg: 1
                           type: 7
                           position: 36
                           resolved_type: -1
@@ -560,7 +560,7 @@ packages:
             end_line: 17
           Process:
             name: 59
-            pkg: 3
+            pkg: 1
             signature:
               kind: 13
               name: -1
@@ -570,11 +570,11 @@ packages:
                 name: -1
                 value: -1
                 args:
-                  - kind: 1
+                  - kind: 2
                     name: 7
                     value: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 7
                     position: 65
                     resolved_type: -1
@@ -590,11 +590,11 @@ packages:
                   name: 54
                   value: -1
                   x:
-                    kind: 1
+                    kind: 2
                     name: 7
                     value: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 7
                     position: 60
                     resolved_type: -1
@@ -606,7 +606,7 @@ packages:
                   resolved_type: -1
                   generic_type_name: -1
               tparams:
-                - kind: 1
+                - kind: 2
                   name: 7
                   value: -1
                   raw: -1
@@ -628,21 +628,21 @@ packages:
             type_params:
               - T
             return_vars:
-              - kind: 1
+              - kind: 2
                 name: 52
                 value: -1
                 raw: -1
-                pkg: 3
+                pkg: 1
                 type: 7
                 position: 53
                 resolved_type: -1
                 generic_type_name: -1
             returns:
-              - - kind: 1
+              - - kind: 2
                   name: 52
                   value: -1
                   raw: -1
-                  pkg: 3
+                  pkg: 1
                   type: 7
                   position: 53
                   resolved_type: -1
@@ -651,11 +651,11 @@ packages:
                   name: -1
                   value: -1
                   x:
-                    kind: 1
+                    kind: 2
                     name: 54
                     value: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 55
                     position: 56
                     resolved_type: -1
@@ -687,7 +687,7 @@ packages:
                 group: 1
           main:
             name: 77
-            pkg: 3
+            pkg: 1
             signature:
               kind: 13
               name: -1
@@ -714,8 +714,8 @@ packages:
             comments: -1
             assignments:
               c:
-                - variable_name: 2
-                  pkg: 3
+                - variable_name: 3
+                  pkg: 1
                   concrete_type: 74
                   position: 75
                   scope: 76
@@ -728,17 +728,17 @@ packages:
                       name: -1
                       value: -1
                       x:
-                        kind: 1
+                        kind: 2
                         name: 42
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 69
                         position: 70
                         resolved_type: -1
                         generic_type_name: -1
                       fun:
-                        kind: 1
+                        kind: 2
                         name: 71
                         value: -1
                         raw: -1
@@ -770,11 +770,11 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 1
-                    name: 2
+                    kind: 2
+                    name: 3
                     value: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 74
                     position: 75
                     resolved_type: -1
@@ -784,7 +784,7 @@ packages:
                   callee_pkg: generic
               result:
                 - variable_name: 92
-                  pkg: 3
+                  pkg: 1
                   concrete_type: 84
                   position: 93
                   scope: 76
@@ -797,17 +797,17 @@ packages:
                       name: -1
                       value: -1
                       x:
-                        kind: 1
+                        kind: 2
                         name: 59
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 89
                         position: 90
                         resolved_type: -1
                         generic_type_name: -1
                       fun:
-                        kind: 1
+                        kind: 2
                         name: 84
                         value: -1
                         raw: -1
@@ -831,7 +831,7 @@ packages:
                           name: -1
                           value: -1
                           x:
-                            kind: 1
+                            kind: 2
                             name: 84
                             value: -1
                             raw: -1
@@ -878,11 +878,11 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 1
+                    kind: 2
                     name: 92
                     value: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 84
                     position: 93
                     resolved_type: -1
@@ -892,7 +892,7 @@ packages:
                   callee_pkg: generic
               val:
                 - variable_name: 82
-                  pkg: 3
+                  pkg: 1
                   concrete_type: 71
                   position: 83
                   scope: 76
@@ -905,37 +905,37 @@ packages:
                       name: -1
                       value: -1
                       x:
-                        kind: 1
-                        name: 2
+                        kind: 2
+                        name: 3
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 74
                         position: 78
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 1
+                        kind: 2
                         name: 10
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 79
                         position: 80
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 3
+                      pkg: 1
                       type: 79
                       position: 78
                       resolved_type: -1
                       generic_type_name: -1
                       receiver_type:
-                        kind: 1
+                        kind: 2
                         name: 81
                         value: -1
                         raw: -1
-                        pkg: 3
+                        pkg: 1
                         type: 81
                         position: -1
                         resolved_type: -1
@@ -947,11 +947,11 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 1
+                    kind: 2
                     name: 82
                     value: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 71
                     position: 83
                     resolved_type: -1
@@ -962,18 +962,18 @@ packages:
             end_line: 35
         struct_instances:
           - type: 96
-            pkg: 3
+            pkg: 1
             position: 32
             fields:
               6: 20
           - type: 97
-            pkg: 3
+            pkg: 1
             position: 86
         imports: {}
     types:
       Container:
         name: 28
-        pkg: 3
+        pkg: 1
         kind: 29
         fields:
           - name: 6
@@ -994,11 +994,11 @@ packages:
                 name: -1
                 value: -1
                 args:
-                  - kind: 1
+                  - kind: 2
                     name: 7
                     value: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 7
                     position: 12
                     resolved_type: -1
@@ -1025,27 +1025,27 @@ packages:
                 name: -1
                 value: -1
                 x:
-                  kind: 1
-                  name: 2
+                  kind: 2
+                  name: 3
                   value: -1
                   raw: -1
-                  pkg: 3
+                  pkg: 1
                   type: 4
                   position: 5
                   resolved_type: -1
                   generic_type_name: -1
                 sel:
-                  kind: 1
+                  kind: 2
                   name: 6
                   value: -1
                   raw: -1
-                  pkg: 3
+                  pkg: 1
                   type: 7
                   position: 8
                   resolved_type: -1
                   generic_type_name: -1
                 raw: -1
-                pkg: 3
+                pkg: 1
                 type: 7
                 position: 5
                 resolved_type: -1
@@ -1055,27 +1055,27 @@ packages:
                   name: -1
                   value: -1
                   x:
-                    kind: 1
-                    name: 2
+                    kind: 2
+                    name: 3
                     value: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 4
                     position: 5
                     resolved_type: -1
                     generic_type_name: -1
                   sel:
-                    kind: 1
+                    kind: 2
                     name: 6
                     value: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 7
                     position: 8
                     resolved_type: -1
                     generic_type_name: -1
                   raw: -1
-                  pkg: 3
+                  pkg: 1
                   type: 7
                   position: 5
                   resolved_type: -1
@@ -1097,11 +1097,11 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 1
+                - kind: 2
                   name: 20
                   value: -1
                   raw: -1
-                  pkg: 3
+                  pkg: 1
                   type: 7
                   position: 19
                   resolved_type: -1
@@ -1120,16 +1120,16 @@ packages:
             assignments:
               generic.Container[T].Value:
                 - variable_name: 23
-                  pkg: 3
+                  pkg: 1
                   concrete_type: 7
                   position: 21
                   scope: 9
                   value:
-                    kind: 1
+                    kind: 2
                     name: 20
                     value: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 7
                     position: 24
                     resolved_type: -1
@@ -1139,27 +1139,27 @@ packages:
                     name: -1
                     value: -1
                     x:
-                      kind: 1
-                      name: 2
+                      kind: 2
+                      name: 3
                       value: -1
                       raw: -1
-                      pkg: 3
+                      pkg: 1
                       type: 4
                       position: 21
                       resolved_type: -1
                       generic_type_name: -1
                     sel:
-                      kind: 1
+                      kind: 2
                       name: 6
                       value: -1
                       raw: -1
-                      pkg: 3
+                      pkg: 1
                       type: 7
                       position: 22
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
-                    pkg: 3
+                    pkg: 1
                     type: 7
                     position: 21
                     resolved_type: -1
@@ -1167,28 +1167,29 @@ packages:
         comments: -1
         type_params:
           - T
+    name: 1
 call_graph:
   - caller:
       name: 59
-      pkg: 3
+      pkg: 1
       position: -1
       recv_type: -1
       scope: 16
       signature_str: 67
     callee:
       name: 100
-      pkg: 3
+      pkg: 1
       position: 99
       recv_type: -1
       scope: 76
       signature_str: 101
     position: 99
     args:
-      - kind: 1
+      - kind: 2
         name: 54
         value: -1
         raw: -1
-        pkg: 3
+        pkg: 1
         type: 55
         position: 98
         resolved_type: -1
@@ -1196,14 +1197,14 @@ call_graph:
     callee_recv_var_name: generic.Container[T].Value
   - caller:
       name: 77
-      pkg: 3
+      pkg: 1
       position: -1
       recv_type: -1
       scope: 76
       signature_str: 95
     callee:
       name: 42
-      pkg: 3
+      pkg: 1
       position: 70
       recv_type: -1
       scope: 16
@@ -1221,8 +1222,8 @@ call_graph:
         generic_type_name: -1
     assignments:
       c:
-        - variable_name: 2
-          pkg: 3
+        - variable_name: 3
+          pkg: 1
           concrete_type: 74
           position: 75
           scope: 76
@@ -1235,17 +1236,17 @@ call_graph:
               name: -1
               value: -1
               x:
-                kind: 1
+                kind: 2
                 name: 42
                 value: -1
                 raw: -1
-                pkg: 3
+                pkg: 1
                 type: 69
                 position: 70
                 resolved_type: -1
                 generic_type_name: -1
               fun:
-                kind: 1
+                kind: 2
                 name: 71
                 value: -1
                 raw: -1
@@ -1277,11 +1278,11 @@ call_graph:
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 1
-            name: 2
+            kind: 2
+            name: 3
             value: -1
             raw: -1
-            pkg: 3
+            pkg: 1
             type: 74
             position: 75
             resolved_type: -1
@@ -1305,14 +1306,14 @@ call_graph:
     callee_recv_var_name: c
   - caller:
       name: 77
-      pkg: 3
+      pkg: 1
       position: -1
       recv_type: -1
       scope: 76
       signature_str: 95
     callee:
       name: 10
-      pkg: 3
+      pkg: 1
       position: 78
       recv_type: 102
       scope: 16
@@ -1321,7 +1322,7 @@ call_graph:
     assignments:
       val:
         - variable_name: 82
-          pkg: 3
+          pkg: 1
           concrete_type: 71
           position: 83
           scope: 76
@@ -1334,37 +1335,37 @@ call_graph:
               name: -1
               value: -1
               x:
-                kind: 1
-                name: 2
+                kind: 2
+                name: 3
                 value: -1
                 raw: -1
-                pkg: 3
+                pkg: 1
                 type: 74
                 position: 78
                 resolved_type: -1
                 generic_type_name: -1
               sel:
-                kind: 1
+                kind: 2
                 name: 10
                 value: -1
                 raw: -1
-                pkg: 3
+                pkg: 1
                 type: 79
                 position: 80
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
-              pkg: 3
+              pkg: 1
               type: 79
               position: 78
               resolved_type: -1
               generic_type_name: -1
               receiver_type:
-                kind: 1
+                kind: 2
                 name: 81
                 value: -1
                 raw: -1
-                pkg: 3
+                pkg: 1
                 type: 81
                 position: -1
                 resolved_type: -1
@@ -1376,11 +1377,11 @@ call_graph:
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 1
+            kind: 2
             name: 82
             value: -1
             raw: -1
-            pkg: 3
+            pkg: 1
             type: 71
             position: 83
             resolved_type: -1
@@ -1393,14 +1394,14 @@ call_graph:
     chain_root: c
   - caller:
       name: 77
-      pkg: 3
+      pkg: 1
       position: -1
       recv_type: -1
       scope: 76
       signature_str: 95
     callee:
       name: 25
-      pkg: 3
+      pkg: 1
       position: 104
       recv_type: 102
       scope: 16
@@ -1431,14 +1432,14 @@ call_graph:
     chain_root: c
   - caller:
       name: 77
-      pkg: 3
+      pkg: 1
       position: -1
       recv_type: -1
       scope: 76
       signature_str: 95
     callee:
       name: 59
-      pkg: 3
+      pkg: 1
       position: 90
       recv_type: -1
       scope: 16
@@ -1453,7 +1454,7 @@ call_graph:
           name: -1
           value: -1
           x:
-            kind: 1
+            kind: 2
             name: 84
             value: -1
             raw: -1
@@ -1496,7 +1497,7 @@ call_graph:
     assignments:
       result:
         - variable_name: 92
-          pkg: 3
+          pkg: 1
           concrete_type: 84
           position: 93
           scope: 76
@@ -1509,17 +1510,17 @@ call_graph:
               name: -1
               value: -1
               x:
-                kind: 1
+                kind: 2
                 name: 59
                 value: -1
                 raw: -1
-                pkg: 3
+                pkg: 1
                 type: 89
                 position: 90
                 resolved_type: -1
                 generic_type_name: -1
               fun:
-                kind: 1
+                kind: 2
                 name: 84
                 value: -1
                 raw: -1
@@ -1543,7 +1544,7 @@ call_graph:
                   name: -1
                   value: -1
                   x:
-                    kind: 1
+                    kind: 2
                     name: 84
                     value: -1
                     raw: -1
@@ -1590,11 +1591,11 @@ call_graph:
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 1
+            kind: 2
             name: 92
             value: -1
             raw: -1
-            pkg: 3
+            pkg: 1
             type: 84
             position: 93
             resolved_type: -1
@@ -1612,7 +1613,7 @@ call_graph:
           name: -1
           value: -1
           x:
-            kind: 1
+            kind: 2
             name: 84
             value: -1
             raw: -1

--- a/internal/spec/tests/main.yaml
+++ b/internal/spec/tests/main.yaml
@@ -1,5 +1,6 @@
 string_pool:
   - ""
+  - main
   - func_type
   - func_results
   - literal
@@ -7,7 +8,6 @@ string_pool:
   - ident
   - int
   - x
-  - main
   - main/test.go:9:2
   - unexported
   - '"hello"'
@@ -43,14 +43,14 @@ packages:
       main/test.go:
         functions:
           main:
-            name: 8
-            pkg: 8
+            name: 1
+            pkg: 1
             signature:
-              kind: 1
+              kind: 2
               name: -1
               value: -1
               fun:
-                kind: 2
+                kind: 3
                 name: -1
                 value: -1
                 raw: -1
@@ -71,15 +71,15 @@ packages:
             comments: -1
             assignments:
               x:
-                - variable_name: 7
-                  pkg: 8
-                  concrete_type: 6
+                - variable_name: 8
+                  pkg: 1
+                  concrete_type: 7
                   position: 9
                   scope: 10
                   value:
-                    kind: 3
+                    kind: 4
                     name: -1
-                    value: 4
+                    value: 5
                     raw: -1
                     pkg: -1
                     type: -1
@@ -87,24 +87,24 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 5
-                    name: 7
+                    kind: 6
+                    name: 8
                     value: -1
                     raw: -1
-                    pkg: 8
-                    type: 6
+                    pkg: 1
+                    type: 7
                     position: 9
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 8
+                  func: 1
               "y":
                 - variable_name: 13
-                  pkg: 8
+                  pkg: 1
                   concrete_type: 12
                   position: 14
                   scope: 10
                   value:
-                    kind: 3
+                    kind: 4
                     name: -1
                     value: 11
                     raw: -1
@@ -114,19 +114,19 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 5
+                    kind: 6
                     name: 13
                     value: -1
                     raw: -1
-                    pkg: 8
+                    pkg: 1
                     type: 12
                     position: 14
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 8
+                  func: 1
               z:
                 - variable_name: 24
-                  pkg: 8
+                  pkg: 1
                   concrete_type: 12
                   position: 25
                   scope: 10
@@ -139,7 +139,7 @@ packages:
                       name: -1
                       value: -1
                       x:
-                        kind: 5
+                        kind: 6
                         name: 17
                         value: -1
                         raw: -1
@@ -149,7 +149,7 @@ packages:
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 5
+                        kind: 6
                         name: 19
                         value: -1
                         raw: -1
@@ -165,7 +165,7 @@ packages:
                       resolved_type: -1
                       generic_type_name: -1
                     args:
-                      - kind: 3
+                      - kind: 4
                         name: -1
                         value: 15
                         raw: -1
@@ -174,12 +174,12 @@ packages:
                         position: -1
                         resolved_type: -1
                         generic_type_name: -1
-                      - kind: 5
-                        name: 7
+                      - kind: 6
+                        name: 8
                         value: -1
                         raw: -1
-                        pkg: 8
-                        type: 6
+                        pkg: 1
+                        type: 7
                         position: 16
                         resolved_type: -1
                         generic_type_name: -1
@@ -190,26 +190,27 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 5
+                    kind: 6
                     name: 24
                     value: -1
                     raw: -1
-                    pkg: 8
+                    pkg: 1
                     type: 12
                     position: 25
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 8
+                  func: 1
                   callee_func: Sprintf
                   callee_pkg: fmt
             end_line: 14
         imports:
           17: 17
           28: 28
+    name: 1
 call_graph:
   - caller:
-      name: 8
-      pkg: 8
+      name: 1
+      pkg: 1
       position: -1
       recv_type: -1
       scope: 10
@@ -223,7 +224,7 @@ call_graph:
       signature_str: 20
     position: 18
     args:
-      - kind: 3
+      - kind: 4
         name: -1
         value: 15
         raw: -1
@@ -232,19 +233,19 @@ call_graph:
         position: -1
         resolved_type: -1
         generic_type_name: -1
-      - kind: 5
-        name: 7
+      - kind: 6
+        name: 8
         value: -1
         raw: -1
-        pkg: 8
-        type: 6
+        pkg: 1
+        type: 7
         position: 16
         resolved_type: -1
         generic_type_name: -1
     assignments:
       z:
         - variable_name: 24
-          pkg: 8
+          pkg: 1
           concrete_type: 12
           position: 25
           scope: 10
@@ -257,7 +258,7 @@ call_graph:
               name: -1
               value: -1
               x:
-                kind: 5
+                kind: 6
                 name: 17
                 value: -1
                 raw: -1
@@ -267,7 +268,7 @@ call_graph:
                 resolved_type: -1
                 generic_type_name: -1
               sel:
-                kind: 5
+                kind: 6
                 name: 19
                 value: -1
                 raw: -1
@@ -283,7 +284,7 @@ call_graph:
               resolved_type: -1
               generic_type_name: -1
             args:
-              - kind: 3
+              - kind: 4
                 name: -1
                 value: 15
                 raw: -1
@@ -292,12 +293,12 @@ call_graph:
                 position: -1
                 resolved_type: -1
                 generic_type_name: -1
-              - kind: 5
-                name: 7
+              - kind: 6
+                name: 8
                 value: -1
                 raw: -1
-                pkg: 8
-                type: 6
+                pkg: 1
+                type: 7
                 position: 16
                 resolved_type: -1
                 generic_type_name: -1
@@ -308,31 +309,31 @@ call_graph:
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 5
+            kind: 6
             name: 24
             value: -1
             raw: -1
-            pkg: 8
+            pkg: 1
             type: 12
             position: 25
             resolved_type: -1
             generic_type_name: -1
-          func: 8
+          func: 1
           callee_func: Sprintf
           callee_pkg: fmt
     param_arg_map:
       a:
-        kind: 5
-        name: 7
+        kind: 6
+        name: 8
         value: -1
         raw: -1
-        pkg: 8
-        type: 6
+        pkg: 1
+        type: 7
         position: 16
         resolved_type: -1
         generic_type_name: -1
       format:
-        kind: 3
+        kind: 4
         name: -1
         value: 15
         raw: -1
@@ -343,8 +344,8 @@ call_graph:
         generic_type_name: -1
     callee_recv_var_name: z
   - caller:
-      name: 8
-      pkg: 8
+      name: 1
+      pkg: 1
       position: -1
       recv_type: -1
       scope: 10
@@ -358,29 +359,29 @@ call_graph:
       signature_str: 33
     position: 31
     args:
-      - kind: 5
+      - kind: 6
         name: 24
         value: -1
         raw: -1
-        pkg: 8
+        pkg: 1
         type: 12
         position: 30
         resolved_type: -1
         generic_type_name: -1
     param_arg_map:
       a:
-        kind: 5
+        kind: 6
         name: 24
         value: -1
         raw: -1
-        pkg: 8
+        pkg: 1
         type: 12
         position: 30
         resolved_type: -1
         generic_type_name: -1
   - caller:
-      name: 8
-      pkg: 8
+      name: 1
+      pkg: 1
       position: -1
       recv_type: -1
       scope: 10
@@ -394,22 +395,22 @@ call_graph:
       signature_str: 37
     position: 35
     args:
-      - kind: 5
+      - kind: 6
         name: 13
         value: -1
         raw: -1
-        pkg: 8
+        pkg: 1
         type: 12
         position: 34
         resolved_type: -1
         generic_type_name: -1
     param_arg_map:
       s:
-        kind: 5
+        kind: 6
         name: 13
         value: -1
         raw: -1
-        pkg: 8
+        pkg: 1
         type: 12
         position: 34
         resolved_type: -1

--- a/internal/spec/tests/multipackage.yaml
+++ b/internal/spec/tests/multipackage.yaml
@@ -1,5 +1,6 @@
 string_pool:
   - ""
+  - main
   - func_type
   - func_results
   - literal
@@ -19,7 +20,6 @@ string_pool:
   - multipackage
   - multipackage/main.go:10:2
   - unexported
-  - main
   - services
   - multipackage/services
   - multipackage/main.go:11:13
@@ -129,6 +129,7 @@ string_pool:
   - multipackage/services/user_service.go:12:1
   - func() *UserService
   - 'User:'
+  - utils
   - "1"
   - "149"
   - input
@@ -184,14 +185,14 @@ packages:
       multipackage/main.go:
         functions:
           main:
-            name: 20
-            pkg: 17
+            name: 1
+            pkg: 18
             signature:
-              kind: 1
+              kind: 2
               name: -1
               value: -1
               fun:
-                kind: 2
+                kind: 3
                 name: -1
                 value: -1
                 raw: -1
@@ -208,35 +209,35 @@ packages:
               generic_type_name: -1
             signature_str: 40
             position: 39
-            scope: 19
+            scope: 20
             comments: -1
             assignments:
               result:
                 - variable_name: 37
-                  pkg: 17
+                  pkg: 18
                   concrete_type: 36
                   position: 38
-                  scope: 19
+                  scope: 20
                   value:
-                    kind: 14
+                    kind: 15
                     name: -1
                     value: -1
                     fun:
-                      kind: 13
+                      kind: 14
                       name: -1
                       value: -1
                       x:
-                        kind: 6
+                        kind: 7
                         name: 28
                         value: -1
                         raw: -1
-                        pkg: 17
+                        pkg: 18
                         type: 27
                         position: 31
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 6
+                        kind: 7
                         name: 32
                         value: -1
                         raw: -1
@@ -252,7 +253,7 @@ packages:
                       resolved_type: -1
                       generic_type_name: -1
                       receiver_type:
-                        kind: 6
+                        kind: 7
                         name: 35
                         value: -1
                         raw: -1
@@ -262,12 +263,12 @@ packages:
                         resolved_type: -1
                         generic_type_name: -1
                     args:
-                      - kind: 6
-                        name: 16
+                      - kind: 7
+                        name: 17
                         value: -1
                         raw: -1
-                        pkg: 17
-                        type: 15
+                        pkg: 18
+                        type: 16
                         position: 30
                         resolved_type: -1
                         generic_type_name: -1
@@ -278,34 +279,34 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 6
+                    kind: 7
                     name: 37
                     value: -1
                     raw: -1
-                    pkg: 17
+                    pkg: 18
                     type: 36
                     position: 38
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 20
+                  func: 1
                   callee_func: ProcessUser
                   callee_pkg: multipackage/services
               service:
                 - variable_name: 28
-                  pkg: 17
+                  pkg: 18
                   concrete_type: 27
                   position: 29
-                  scope: 19
+                  scope: 20
                   value:
-                    kind: 14
+                    kind: 15
                     name: -1
                     value: -1
                     fun:
-                      kind: 13
+                      kind: 14
                       name: -1
                       value: -1
                       x:
-                        kind: 6
+                        kind: 7
                         name: 21
                         value: -1
                         raw: -1
@@ -315,7 +316,7 @@ packages:
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 6
+                        kind: 7
                         name: 24
                         value: -1
                         raw: -1
@@ -337,69 +338,60 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 6
+                    kind: 7
                     name: 28
                     value: -1
                     raw: -1
-                    pkg: 17
+                    pkg: 18
                     type: 27
                     position: 29
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 20
+                  func: 1
                   callee_func: NewUserService
                   callee_pkg: multipackage/services
               user:
-                - variable_name: 16
-                  pkg: 17
-                  concrete_type: 15
-                  position: 18
-                  scope: 19
+                - variable_name: 17
+                  pkg: 18
+                  concrete_type: 16
+                  position: 19
+                  scope: 20
                   value:
-                    kind: 14
+                    kind: 15
                     name: -1
                     value: -1
                     fun:
-                      kind: 13
+                      kind: 14
                       name: -1
                       value: -1
                       x:
-                        kind: 6
-                        name: 7
+                        kind: 7
+                        name: 8
                         value: -1
                         raw: -1
-                        pkg: 8
+                        pkg: 9
                         type: -1
-                        position: 9
+                        position: 10
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 6
-                        name: 10
+                        kind: 7
+                        name: 11
                         value: -1
                         raw: -1
-                        pkg: 8
-                        type: 11
-                        position: 12
+                        pkg: 9
+                        type: 12
+                        position: 13
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 8
-                      type: 11
-                      position: 9
+                      pkg: 9
+                      type: 12
+                      position: 10
                       resolved_type: -1
                       generic_type_name: -1
                     args:
-                      - kind: 3
-                        name: -1
-                        value: 4
-                        raw: -1
-                        pkg: -1
-                        type: -1
-                        position: -1
-                        resolved_type: -1
-                        generic_type_name: -1
-                      - kind: 3
+                      - kind: 4
                         name: -1
                         value: 5
                         raw: -1
@@ -408,40 +400,50 @@ packages:
                         position: -1
                         resolved_type: -1
                         generic_type_name: -1
+                      - kind: 4
+                        name: -1
+                        value: 6
+                        raw: -1
+                        pkg: -1
+                        type: -1
+                        position: -1
+                        resolved_type: -1
+                        generic_type_name: -1
                     raw: -1
                     pkg: -1
-                    type: 15
-                    position: 9
+                    type: 16
+                    position: 10
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 6
-                    name: 16
+                    kind: 7
+                    name: 17
                     value: -1
                     raw: -1
-                    pkg: 17
-                    type: 15
-                    position: 18
+                    pkg: 18
+                    type: 16
+                    position: 19
                     resolved_type: -1
                     generic_type_name: -1
-                  func: 20
+                  func: 1
                   callee_func: NewUser
                   callee_pkg: multipackage/models
             end_line: 15
         imports:
-          8: 8
+          9: 9
           22: 22
           41: 41
+    name: 1
   multipackage/models:
     files:
       multipackage/models/user.go:
         types:
           User:
             name: 61
-            pkg: 8
+            pkg: 9
             kind: 62
             implements:
-              - 173
+              - 174
             fields:
               - name: 44
                 type: 36
@@ -458,15 +460,15 @@ packages:
               - name: 46
                 receiver: 47
                 signature:
-                  kind: 1
+                  kind: 2
                   name: -1
                   value: -1
                   fun:
-                    kind: 2
+                    kind: 3
                     name: -1
                     value: -1
                     args:
-                      - kind: 6
+                      - kind: 7
                         name: 36
                         value: -1
                         raw: -1
@@ -493,61 +495,61 @@ packages:
                 comments: -1
                 filename: 51
                 return_vars:
-                  - kind: 13
+                  - kind: 14
                     name: -1
                     value: -1
                     x:
-                      kind: 6
+                      kind: 7
                       name: 42
                       value: -1
                       raw: -1
-                      pkg: 8
-                      type: 15
+                      pkg: 9
+                      type: 16
                       position: 43
                       resolved_type: -1
                       generic_type_name: -1
                     sel:
-                      kind: 6
+                      kind: 7
                       name: 44
                       value: -1
                       raw: -1
-                      pkg: 8
+                      pkg: 9
                       type: 36
                       position: 45
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
-                    pkg: 8
+                    pkg: 9
                     type: 36
                     position: 43
                     resolved_type: -1
                     generic_type_name: -1
                 returns:
-                  - - kind: 13
+                  - - kind: 14
                       name: -1
                       value: -1
                       x:
-                        kind: 6
+                        kind: 7
                         name: 42
                         value: -1
                         raw: -1
-                        pkg: 8
-                        type: 15
+                        pkg: 9
+                        type: 16
                         position: 43
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 6
+                        kind: 7
                         name: 44
                         value: -1
                         raw: -1
-                        pkg: 8
+                        pkg: 9
                         type: 36
                         position: 45
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 8
+                      pkg: 9
                       type: 36
                       position: 43
                       resolved_type: -1
@@ -555,15 +557,15 @@ packages:
               - name: 57
                 receiver: 47
                 signature:
-                  kind: 1
+                  kind: 2
                   name: -1
                   value: -1
                   fun:
-                    kind: 2
+                    kind: 3
                     name: -1
                     value: -1
                     args:
-                      - kind: 6
+                      - kind: 7
                         name: 55
                         value: -1
                         raw: -1
@@ -590,61 +592,61 @@ packages:
                 comments: -1
                 filename: 51
                 return_vars:
-                  - kind: 13
+                  - kind: 14
                     name: -1
                     value: -1
                     x:
-                      kind: 6
+                      kind: 7
                       name: 42
                       value: -1
                       raw: -1
-                      pkg: 8
-                      type: 15
+                      pkg: 9
+                      type: 16
                       position: 53
                       resolved_type: -1
                       generic_type_name: -1
                     sel:
-                      kind: 6
+                      kind: 7
                       name: 54
                       value: -1
                       raw: -1
-                      pkg: 8
+                      pkg: 9
                       type: 55
                       position: 56
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
-                    pkg: 8
+                    pkg: 9
                     type: 55
                     position: 53
                     resolved_type: -1
                     generic_type_name: -1
                 returns:
-                  - - kind: 13
+                  - - kind: 14
                       name: -1
                       value: -1
                       x:
-                        kind: 6
+                        kind: 7
                         name: 42
                         value: -1
                         raw: -1
-                        pkg: 8
-                        type: 15
+                        pkg: 9
+                        type: 16
                         position: 53
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 6
+                        kind: 7
                         name: 54
                         value: -1
                         raw: -1
-                        pkg: 8
+                        pkg: 9
                         type: 55
                         position: 56
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 8
+                      pkg: 9
                       type: 55
                       position: 53
                       resolved_type: -1
@@ -652,23 +654,23 @@ packages:
             comments: -1
           UserInterface:
             name: 66
-            pkg: 8
+            pkg: 9
             kind: 65
             implemented_by:
-              - 174
+              - 175
             scope: 50
             methods:
               - name: 46
                 signature:
-                  kind: 1
+                  kind: 2
                   name: -1
                   value: -1
                   fun:
-                    kind: 2
+                    kind: 3
                     name: -1
                     value: -1
                     args:
-                      - kind: 6
+                      - kind: 7
                         name: 36
                         value: -1
                         raw: -1
@@ -694,15 +696,15 @@ packages:
                 comments: -1
               - name: 57
                 signature:
-                  kind: 1
+                  kind: 2
                   name: -1
                   value: -1
                   fun:
-                    kind: 2
+                    kind: 3
                     name: -1
                     value: -1
                     args:
-                      - kind: 6
+                      - kind: 7
                         name: 55
                         value: -1
                         raw: -1
@@ -729,14 +731,14 @@ packages:
             comments: -1
         functions:
           NewUser:
-            name: 10
-            pkg: 8
+            name: 11
+            pkg: 9
             signature:
-              kind: 1
+              kind: 2
               name: -1
               value: -1
               fun:
-                kind: 2
+                kind: 3
                 name: -1
                 value: -1
                 args:
@@ -744,11 +746,11 @@ packages:
                     name: -1
                     value: -1
                     x:
-                      kind: 6
+                      kind: 7
                       name: 61
                       value: -1
                       raw: -1
-                      pkg: 8
+                      pkg: 9
                       type: 61
                       position: 83
                       resolved_type: -1
@@ -766,7 +768,7 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 6
+                - kind: 7
                   name: 71
                   value: -1
                   raw: -1
@@ -775,7 +777,7 @@ packages:
                   position: 81
                   resolved_type: -1
                   generic_type_name: -1
-                - kind: 6
+                - kind: 7
                   name: 75
                   value: -1
                   raw: -1
@@ -803,11 +805,11 @@ packages:
                   name: -1
                   value: -1
                   x:
-                    kind: 6
+                    kind: 7
                     name: 61
                     value: -1
                     raw: -1
-                    pkg: 8
+                    pkg: 9
                     type: 61
                     position: 69
                     resolved_type: -1
@@ -817,21 +819,21 @@ packages:
                       name: -1
                       value: -1
                       x:
-                        kind: 6
+                        kind: 7
                         name: 44
                         value: -1
                         raw: -1
-                        pkg: 8
+                        pkg: 9
                         type: 36
                         position: 70
                         resolved_type: -1
                         generic_type_name: -1
                       fun:
-                        kind: 6
+                        kind: 7
                         name: 71
                         value: -1
                         raw: -1
-                        pkg: 8
+                        pkg: 9
                         type: 36
                         position: 72
                         resolved_type: -1
@@ -846,21 +848,21 @@ packages:
                       name: -1
                       value: -1
                       x:
-                        kind: 6
+                        kind: 7
                         name: 54
                         value: -1
                         raw: -1
-                        pkg: 8
+                        pkg: 9
                         type: 55
                         position: 74
                         resolved_type: -1
                         generic_type_name: -1
                       fun:
-                        kind: 6
+                        kind: 7
                         name: 75
                         value: -1
                         raw: -1
-                        pkg: 8
+                        pkg: 9
                         type: 55
                         position: 76
                         resolved_type: -1
@@ -892,11 +894,11 @@ packages:
                     name: -1
                     value: -1
                     x:
-                      kind: 6
+                      kind: 7
                       name: 61
                       value: -1
                       raw: -1
-                      pkg: 8
+                      pkg: 9
                       type: 61
                       position: 69
                       resolved_type: -1
@@ -906,21 +908,21 @@ packages:
                         name: -1
                         value: -1
                         x:
-                          kind: 6
+                          kind: 7
                           name: 44
                           value: -1
                           raw: -1
-                          pkg: 8
+                          pkg: 9
                           type: 36
                           position: 70
                           resolved_type: -1
                           generic_type_name: -1
                         fun:
-                          kind: 6
+                          kind: 7
                           name: 71
                           value: -1
                           raw: -1
-                          pkg: 8
+                          pkg: 9
                           type: 36
                           position: 72
                           resolved_type: -1
@@ -935,21 +937,21 @@ packages:
                         name: -1
                         value: -1
                         x:
-                          kind: 6
+                          kind: 7
                           name: 54
                           value: -1
                           raw: -1
-                          pkg: 8
+                          pkg: 9
                           type: 55
                           position: 74
                           resolved_type: -1
                           generic_type_name: -1
                         fun:
-                          kind: 6
+                          kind: 7
                           name: 75
                           value: -1
                           raw: -1
-                          pkg: 8
+                          pkg: 9
                           type: 55
                           position: 76
                           resolved_type: -1
@@ -975,7 +977,7 @@ packages:
             end_line: 26
         struct_instances:
           - type: 61
-            pkg: 8
+            pkg: 9
             position: 69
             fields:
               44: 71
@@ -984,10 +986,10 @@ packages:
     types:
       User:
         name: 61
-        pkg: 8
+        pkg: 9
         kind: 62
         implements:
-          - 173
+          - 174
         fields:
           - name: 44
             type: 36
@@ -1004,15 +1006,15 @@ packages:
           - name: 46
             receiver: 47
             signature:
-              kind: 1
+              kind: 2
               name: -1
               value: -1
               fun:
-                kind: 2
+                kind: 3
                 name: -1
                 value: -1
                 args:
-                  - kind: 6
+                  - kind: 7
                     name: 36
                     value: -1
                     raw: -1
@@ -1039,61 +1041,61 @@ packages:
             comments: -1
             filename: 51
             return_vars:
-              - kind: 13
+              - kind: 14
                 name: -1
                 value: -1
                 x:
-                  kind: 6
+                  kind: 7
                   name: 42
                   value: -1
                   raw: -1
-                  pkg: 8
-                  type: 15
+                  pkg: 9
+                  type: 16
                   position: 43
                   resolved_type: -1
                   generic_type_name: -1
                 sel:
-                  kind: 6
+                  kind: 7
                   name: 44
                   value: -1
                   raw: -1
-                  pkg: 8
+                  pkg: 9
                   type: 36
                   position: 45
                   resolved_type: -1
                   generic_type_name: -1
                 raw: -1
-                pkg: 8
+                pkg: 9
                 type: 36
                 position: 43
                 resolved_type: -1
                 generic_type_name: -1
             returns:
-              - - kind: 13
+              - - kind: 14
                   name: -1
                   value: -1
                   x:
-                    kind: 6
+                    kind: 7
                     name: 42
                     value: -1
                     raw: -1
-                    pkg: 8
-                    type: 15
+                    pkg: 9
+                    type: 16
                     position: 43
                     resolved_type: -1
                     generic_type_name: -1
                   sel:
-                    kind: 6
+                    kind: 7
                     name: 44
                     value: -1
                     raw: -1
-                    pkg: 8
+                    pkg: 9
                     type: 36
                     position: 45
                     resolved_type: -1
                     generic_type_name: -1
                   raw: -1
-                  pkg: 8
+                  pkg: 9
                   type: 36
                   position: 43
                   resolved_type: -1
@@ -1101,15 +1103,15 @@ packages:
           - name: 57
             receiver: 47
             signature:
-              kind: 1
+              kind: 2
               name: -1
               value: -1
               fun:
-                kind: 2
+                kind: 3
                 name: -1
                 value: -1
                 args:
-                  - kind: 6
+                  - kind: 7
                     name: 55
                     value: -1
                     raw: -1
@@ -1136,61 +1138,61 @@ packages:
             comments: -1
             filename: 51
             return_vars:
-              - kind: 13
+              - kind: 14
                 name: -1
                 value: -1
                 x:
-                  kind: 6
+                  kind: 7
                   name: 42
                   value: -1
                   raw: -1
-                  pkg: 8
-                  type: 15
+                  pkg: 9
+                  type: 16
                   position: 53
                   resolved_type: -1
                   generic_type_name: -1
                 sel:
-                  kind: 6
+                  kind: 7
                   name: 54
                   value: -1
                   raw: -1
-                  pkg: 8
+                  pkg: 9
                   type: 55
                   position: 56
                   resolved_type: -1
                   generic_type_name: -1
                 raw: -1
-                pkg: 8
+                pkg: 9
                 type: 55
                 position: 53
                 resolved_type: -1
                 generic_type_name: -1
             returns:
-              - - kind: 13
+              - - kind: 14
                   name: -1
                   value: -1
                   x:
-                    kind: 6
+                    kind: 7
                     name: 42
                     value: -1
                     raw: -1
-                    pkg: 8
-                    type: 15
+                    pkg: 9
+                    type: 16
                     position: 53
                     resolved_type: -1
                     generic_type_name: -1
                   sel:
-                    kind: 6
+                    kind: 7
                     name: 54
                     value: -1
                     raw: -1
-                    pkg: 8
+                    pkg: 9
                     type: 55
                     position: 56
                     resolved_type: -1
                     generic_type_name: -1
                   raw: -1
-                  pkg: 8
+                  pkg: 9
                   type: 55
                   position: 53
                   resolved_type: -1
@@ -1198,23 +1200,23 @@ packages:
         comments: -1
       UserInterface:
         name: 66
-        pkg: 8
+        pkg: 9
         kind: 65
         implemented_by:
-          - 174
+          - 175
         scope: 50
         methods:
           - name: 46
             signature:
-              kind: 1
+              kind: 2
               name: -1
               value: -1
               fun:
-                kind: 2
+                kind: 3
                 name: -1
                 value: -1
                 args:
-                  - kind: 6
+                  - kind: 7
                     name: 36
                     value: -1
                     raw: -1
@@ -1240,15 +1242,15 @@ packages:
             comments: -1
           - name: 57
             signature:
-              kind: 1
+              kind: 2
               name: -1
               value: -1
               fun:
-                kind: 2
+                kind: 3
                 name: -1
                 value: -1
                 args:
-                  - kind: 6
+                  - kind: 7
                     name: 55
                     value: -1
                     raw: -1
@@ -1273,6 +1275,7 @@ packages:
             scope: 50
             comments: -1
         comments: -1
+    name: 8
   multipackage/services:
     files:
       multipackage/services/user_service.go:
@@ -1285,22 +1288,22 @@ packages:
               - name: 91
                 type: 36
                 tag: -1
-                scope: 19
+                scope: 20
                 comments: -1
             scope: 50
             methods:
               - name: 32
                 receiver: 109
                 signature:
-                  kind: 1
+                  kind: 2
                   name: -1
                   value: -1
                   fun:
-                    kind: 2
+                    kind: 3
                     name: -1
                     value: -1
                     args:
-                      - kind: 6
+                      - kind: 7
                         name: 36
                         value: -1
                         raw: -1
@@ -1317,34 +1320,34 @@ packages:
                     generic_type_name: -1
                   args:
                     - kind: 84
-                      name: 16
+                      name: 17
                       value: -1
                       x:
-                        kind: 13
+                        kind: 14
                         name: -1
                         value: -1
                         x:
-                          kind: 6
-                          name: 7
+                          kind: 7
+                          name: 8
                           value: -1
                           raw: -1
-                          pkg: 8
+                          pkg: 9
                           type: -1
                           position: 99
                           resolved_type: -1
                           generic_type_name: -1
                         sel:
-                          kind: 6
+                          kind: 7
                           name: 61
                           value: -1
                           raw: -1
-                          pkg: 8
+                          pkg: 9
                           type: 61
                           position: 100
                           resolved_type: -1
                           generic_type_name: -1
                         raw: -1
-                        pkg: 8
+                        pkg: 9
                         type: 61
                         position: 99
                         resolved_type: -1
@@ -1367,15 +1370,15 @@ packages:
                 comments: -1
                 filename: 111
                 return_vars:
-                  - kind: 14
+                  - kind: 15
                     name: -1
                     value: -1
                     fun:
-                      kind: 13
+                      kind: 14
                       name: -1
                       value: -1
                       x:
-                        kind: 6
+                        kind: 7
                         name: 41
                         value: -1
                         raw: -1
@@ -1385,7 +1388,7 @@ packages:
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 6
+                        kind: 7
                         name: 96
                         value: -1
                         raw: -1
@@ -1401,7 +1404,7 @@ packages:
                       resolved_type: -1
                       generic_type_name: -1
                     args:
-                      - kind: 3
+                      - kind: 4
                         name: -1
                         value: 88
                         raw: -1
@@ -1410,11 +1413,11 @@ packages:
                         position: -1
                         resolved_type: -1
                         generic_type_name: -1
-                      - kind: 13
+                      - kind: 14
                         name: -1
                         value: -1
                         x:
-                          kind: 6
+                          kind: 7
                           name: 89
                           value: -1
                           raw: -1
@@ -1424,7 +1427,7 @@ packages:
                           resolved_type: -1
                           generic_type_name: -1
                         sel:
-                          kind: 6
+                          kind: 7
                           name: 91
                           value: -1
                           raw: -1
@@ -1439,7 +1442,7 @@ packages:
                         position: 90
                         resolved_type: -1
                         generic_type_name: -1
-                      - kind: 6
+                      - kind: 7
                         name: 71
                         value: -1
                         raw: -1
@@ -1448,7 +1451,7 @@ packages:
                         position: 93
                         resolved_type: -1
                         generic_type_name: -1
-                      - kind: 6
+                      - kind: 7
                         name: 75
                         value: -1
                         raw: -1
@@ -1464,15 +1467,15 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                 returns:
-                  - - kind: 14
+                  - - kind: 15
                       name: -1
                       value: -1
                       fun:
-                        kind: 13
+                        kind: 14
                         name: -1
                         value: -1
                         x:
-                          kind: 6
+                          kind: 7
                           name: 41
                           value: -1
                           raw: -1
@@ -1482,7 +1485,7 @@ packages:
                           resolved_type: -1
                           generic_type_name: -1
                         sel:
-                          kind: 6
+                          kind: 7
                           name: 96
                           value: -1
                           raw: -1
@@ -1498,7 +1501,7 @@ packages:
                         resolved_type: -1
                         generic_type_name: -1
                       args:
-                        - kind: 3
+                        - kind: 4
                           name: -1
                           value: 88
                           raw: -1
@@ -1507,11 +1510,11 @@ packages:
                           position: -1
                           resolved_type: -1
                           generic_type_name: -1
-                        - kind: 13
+                        - kind: 14
                           name: -1
                           value: -1
                           x:
-                            kind: 6
+                            kind: 7
                             name: 89
                             value: -1
                             raw: -1
@@ -1521,7 +1524,7 @@ packages:
                             resolved_type: -1
                             generic_type_name: -1
                           sel:
-                            kind: 6
+                            kind: 7
                             name: 91
                             value: -1
                             raw: -1
@@ -1536,7 +1539,7 @@ packages:
                           position: 90
                           resolved_type: -1
                           generic_type_name: -1
-                        - kind: 6
+                        - kind: 7
                           name: 71
                           value: -1
                           raw: -1
@@ -1545,7 +1548,7 @@ packages:
                           position: 93
                           resolved_type: -1
                           generic_type_name: -1
-                        - kind: 6
+                        - kind: 7
                           name: 75
                           value: -1
                           raw: -1
@@ -1566,47 +1569,47 @@ packages:
                       pkg: 22
                       concrete_type: 55
                       position: 108
-                      scope: 19
+                      scope: 20
                       value:
-                        kind: 14
+                        kind: 15
                         name: -1
                         value: -1
                         fun:
-                          kind: 13
+                          kind: 14
                           name: -1
                           value: -1
                           x:
-                            kind: 6
-                            name: 16
+                            kind: 7
+                            name: 17
                             value: -1
                             raw: -1
                             pkg: 22
-                            type: 15
+                            type: 16
                             position: 106
                             resolved_type: -1
                             generic_type_name: -1
                           sel:
-                            kind: 6
+                            kind: 7
                             name: 57
                             value: -1
                             raw: -1
-                            pkg: 8
+                            pkg: 9
                             type: 60
                             position: 107
                             resolved_type: -1
                             generic_type_name: -1
                           raw: -1
-                          pkg: 8
+                          pkg: 9
                           type: 60
                           position: 106
                           resolved_type: -1
                           generic_type_name: -1
                           receiver_type:
-                            kind: 6
+                            kind: 7
                             name: 61
                             value: -1
                             raw: -1
-                            pkg: 8
+                            pkg: 9
                             type: 61
                             position: -1
                             resolved_type: -1
@@ -1618,7 +1621,7 @@ packages:
                         resolved_type: -1
                         generic_type_name: -1
                       lhs:
-                        kind: 6
+                        kind: 7
                         name: 75
                         value: -1
                         raw: -1
@@ -1635,47 +1638,47 @@ packages:
                       pkg: 22
                       concrete_type: 36
                       position: 105
-                      scope: 19
+                      scope: 20
                       value:
-                        kind: 14
+                        kind: 15
                         name: -1
                         value: -1
                         fun:
-                          kind: 13
+                          kind: 14
                           name: -1
                           value: -1
                           x:
-                            kind: 6
-                            name: 16
+                            kind: 7
+                            name: 17
                             value: -1
                             raw: -1
                             pkg: 22
-                            type: 15
+                            type: 16
                             position: 103
                             resolved_type: -1
                             generic_type_name: -1
                           sel:
-                            kind: 6
+                            kind: 7
                             name: 46
                             value: -1
                             raw: -1
-                            pkg: 8
+                            pkg: 9
                             type: 52
                             position: 104
                             resolved_type: -1
                             generic_type_name: -1
                           raw: -1
-                          pkg: 8
+                          pkg: 9
                           type: 52
                           position: 103
                           resolved_type: -1
                           generic_type_name: -1
                           receiver_type:
-                            kind: 6
+                            kind: 7
                             name: 61
                             value: -1
                             raw: -1
-                            pkg: 8
+                            pkg: 9
                             type: 61
                             position: -1
                             resolved_type: -1
@@ -1687,7 +1690,7 @@ packages:
                         resolved_type: -1
                         generic_type_name: -1
                       lhs:
-                        kind: 6
+                        kind: 7
                         name: 71
                         value: -1
                         raw: -1
@@ -1702,11 +1705,11 @@ packages:
               - name: 118
                 receiver: 109
                 signature:
-                  kind: 1
+                  kind: 2
                   name: -1
                   value: -1
                   fun:
-                    kind: 2
+                    kind: 3
                     name: -1
                     value: -1
                     raw: -1
@@ -1716,7 +1719,7 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   args:
-                    - kind: 6
+                    - kind: 7
                       name: 91
                       value: -1
                       raw: -1
@@ -1742,9 +1745,9 @@ packages:
                       pkg: 22
                       concrete_type: 36
                       position: 114
-                      scope: 13
+                      scope: 14
                       value:
-                        kind: 6
+                        kind: 7
                         name: 91
                         value: -1
                         raw: -1
@@ -1754,11 +1757,11 @@ packages:
                         resolved_type: -1
                         generic_type_name: -1
                       lhs:
-                        kind: 13
+                        kind: 14
                         name: -1
                         value: -1
                         x:
-                          kind: 6
+                          kind: 7
                           name: 89
                           value: -1
                           raw: -1
@@ -1768,7 +1771,7 @@ packages:
                           resolved_type: -1
                           generic_type_name: -1
                         sel:
-                          kind: 6
+                          kind: 7
                           name: 91
                           value: -1
                           raw: -1
@@ -1789,11 +1792,11 @@ packages:
             name: 24
             pkg: 22
             signature:
-              kind: 1
+              kind: 2
               name: -1
               value: -1
               fun:
-                kind: 2
+                kind: 3
                 name: -1
                 value: -1
                 args:
@@ -1801,7 +1804,7 @@ packages:
                     name: -1
                     value: -1
                     x:
-                      kind: 6
+                      kind: 7
                       name: 35
                       value: -1
                       raw: -1
@@ -1841,7 +1844,7 @@ packages:
                   name: -1
                   value: -1
                   x:
-                    kind: 6
+                    kind: 7
                     name: 35
                     value: -1
                     raw: -1
@@ -1855,7 +1858,7 @@ packages:
                       name: -1
                       value: -1
                       x:
-                        kind: 6
+                        kind: 7
                         name: 91
                         value: -1
                         raw: -1
@@ -1865,7 +1868,7 @@ packages:
                         resolved_type: -1
                         generic_type_name: -1
                       fun:
-                        kind: 3
+                        kind: 4
                         name: -1
                         value: 123
                         raw: -1
@@ -1901,7 +1904,7 @@ packages:
                     name: -1
                     value: -1
                     x:
-                      kind: 6
+                      kind: 7
                       name: 35
                       value: -1
                       raw: -1
@@ -1915,7 +1918,7 @@ packages:
                         name: -1
                         value: -1
                         x:
-                          kind: 6
+                          kind: 7
                           name: 91
                           value: -1
                           raw: -1
@@ -1925,7 +1928,7 @@ packages:
                           resolved_type: -1
                           generic_type_name: -1
                         fun:
-                          kind: 3
+                          kind: 4
                           name: -1
                           value: 123
                           raw: -1
@@ -1960,7 +1963,7 @@ packages:
             fields:
               91: 129
         imports:
-          8: 8
+          9: 9
           41: 41
     types:
       UserService:
@@ -1971,22 +1974,22 @@ packages:
           - name: 91
             type: 36
             tag: -1
-            scope: 19
+            scope: 20
             comments: -1
         scope: 50
         methods:
           - name: 32
             receiver: 109
             signature:
-              kind: 1
+              kind: 2
               name: -1
               value: -1
               fun:
-                kind: 2
+                kind: 3
                 name: -1
                 value: -1
                 args:
-                  - kind: 6
+                  - kind: 7
                     name: 36
                     value: -1
                     raw: -1
@@ -2003,34 +2006,34 @@ packages:
                 generic_type_name: -1
               args:
                 - kind: 84
-                  name: 16
+                  name: 17
                   value: -1
                   x:
-                    kind: 13
+                    kind: 14
                     name: -1
                     value: -1
                     x:
-                      kind: 6
-                      name: 7
+                      kind: 7
+                      name: 8
                       value: -1
                       raw: -1
-                      pkg: 8
+                      pkg: 9
                       type: -1
                       position: 99
                       resolved_type: -1
                       generic_type_name: -1
                     sel:
-                      kind: 6
+                      kind: 7
                       name: 61
                       value: -1
                       raw: -1
-                      pkg: 8
+                      pkg: 9
                       type: 61
                       position: 100
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
-                    pkg: 8
+                    pkg: 9
                     type: 61
                     position: 99
                     resolved_type: -1
@@ -2053,15 +2056,15 @@ packages:
             comments: -1
             filename: 111
             return_vars:
-              - kind: 14
+              - kind: 15
                 name: -1
                 value: -1
                 fun:
-                  kind: 13
+                  kind: 14
                   name: -1
                   value: -1
                   x:
-                    kind: 6
+                    kind: 7
                     name: 41
                     value: -1
                     raw: -1
@@ -2071,7 +2074,7 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   sel:
-                    kind: 6
+                    kind: 7
                     name: 96
                     value: -1
                     raw: -1
@@ -2087,7 +2090,7 @@ packages:
                   resolved_type: -1
                   generic_type_name: -1
                 args:
-                  - kind: 3
+                  - kind: 4
                     name: -1
                     value: 88
                     raw: -1
@@ -2096,11 +2099,11 @@ packages:
                     position: -1
                     resolved_type: -1
                     generic_type_name: -1
-                  - kind: 13
+                  - kind: 14
                     name: -1
                     value: -1
                     x:
-                      kind: 6
+                      kind: 7
                       name: 89
                       value: -1
                       raw: -1
@@ -2110,7 +2113,7 @@ packages:
                       resolved_type: -1
                       generic_type_name: -1
                     sel:
-                      kind: 6
+                      kind: 7
                       name: 91
                       value: -1
                       raw: -1
@@ -2125,7 +2128,7 @@ packages:
                     position: 90
                     resolved_type: -1
                     generic_type_name: -1
-                  - kind: 6
+                  - kind: 7
                     name: 71
                     value: -1
                     raw: -1
@@ -2134,7 +2137,7 @@ packages:
                     position: 93
                     resolved_type: -1
                     generic_type_name: -1
-                  - kind: 6
+                  - kind: 7
                     name: 75
                     value: -1
                     raw: -1
@@ -2150,15 +2153,15 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
             returns:
-              - - kind: 14
+              - - kind: 15
                   name: -1
                   value: -1
                   fun:
-                    kind: 13
+                    kind: 14
                     name: -1
                     value: -1
                     x:
-                      kind: 6
+                      kind: 7
                       name: 41
                       value: -1
                       raw: -1
@@ -2168,7 +2171,7 @@ packages:
                       resolved_type: -1
                       generic_type_name: -1
                     sel:
-                      kind: 6
+                      kind: 7
                       name: 96
                       value: -1
                       raw: -1
@@ -2184,7 +2187,7 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   args:
-                    - kind: 3
+                    - kind: 4
                       name: -1
                       value: 88
                       raw: -1
@@ -2193,11 +2196,11 @@ packages:
                       position: -1
                       resolved_type: -1
                       generic_type_name: -1
-                    - kind: 13
+                    - kind: 14
                       name: -1
                       value: -1
                       x:
-                        kind: 6
+                        kind: 7
                         name: 89
                         value: -1
                         raw: -1
@@ -2207,7 +2210,7 @@ packages:
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 6
+                        kind: 7
                         name: 91
                         value: -1
                         raw: -1
@@ -2222,7 +2225,7 @@ packages:
                       position: 90
                       resolved_type: -1
                       generic_type_name: -1
-                    - kind: 6
+                    - kind: 7
                       name: 71
                       value: -1
                       raw: -1
@@ -2231,7 +2234,7 @@ packages:
                       position: 93
                       resolved_type: -1
                       generic_type_name: -1
-                    - kind: 6
+                    - kind: 7
                       name: 75
                       value: -1
                       raw: -1
@@ -2252,47 +2255,47 @@ packages:
                   pkg: 22
                   concrete_type: 55
                   position: 108
-                  scope: 19
+                  scope: 20
                   value:
-                    kind: 14
+                    kind: 15
                     name: -1
                     value: -1
                     fun:
-                      kind: 13
+                      kind: 14
                       name: -1
                       value: -1
                       x:
-                        kind: 6
-                        name: 16
+                        kind: 7
+                        name: 17
                         value: -1
                         raw: -1
                         pkg: 22
-                        type: 15
+                        type: 16
                         position: 106
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 6
+                        kind: 7
                         name: 57
                         value: -1
                         raw: -1
-                        pkg: 8
+                        pkg: 9
                         type: 60
                         position: 107
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 8
+                      pkg: 9
                       type: 60
                       position: 106
                       resolved_type: -1
                       generic_type_name: -1
                       receiver_type:
-                        kind: 6
+                        kind: 7
                         name: 61
                         value: -1
                         raw: -1
-                        pkg: 8
+                        pkg: 9
                         type: 61
                         position: -1
                         resolved_type: -1
@@ -2304,7 +2307,7 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 6
+                    kind: 7
                     name: 75
                     value: -1
                     raw: -1
@@ -2321,47 +2324,47 @@ packages:
                   pkg: 22
                   concrete_type: 36
                   position: 105
-                  scope: 19
+                  scope: 20
                   value:
-                    kind: 14
+                    kind: 15
                     name: -1
                     value: -1
                     fun:
-                      kind: 13
+                      kind: 14
                       name: -1
                       value: -1
                       x:
-                        kind: 6
-                        name: 16
+                        kind: 7
+                        name: 17
                         value: -1
                         raw: -1
                         pkg: 22
-                        type: 15
+                        type: 16
                         position: 103
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 6
+                        kind: 7
                         name: 46
                         value: -1
                         raw: -1
-                        pkg: 8
+                        pkg: 9
                         type: 52
                         position: 104
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 8
+                      pkg: 9
                       type: 52
                       position: 103
                       resolved_type: -1
                       generic_type_name: -1
                       receiver_type:
-                        kind: 6
+                        kind: 7
                         name: 61
                         value: -1
                         raw: -1
-                        pkg: 8
+                        pkg: 9
                         type: 61
                         position: -1
                         resolved_type: -1
@@ -2373,7 +2376,7 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 6
+                    kind: 7
                     name: 71
                     value: -1
                     raw: -1
@@ -2388,11 +2391,11 @@ packages:
           - name: 118
             receiver: 109
             signature:
-              kind: 1
+              kind: 2
               name: -1
               value: -1
               fun:
-                kind: 2
+                kind: 3
                 name: -1
                 value: -1
                 raw: -1
@@ -2402,7 +2405,7 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 6
+                - kind: 7
                   name: 91
                   value: -1
                   raw: -1
@@ -2428,9 +2431,9 @@ packages:
                   pkg: 22
                   concrete_type: 36
                   position: 114
-                  scope: 13
+                  scope: 14
                   value:
-                    kind: 6
+                    kind: 7
                     name: 91
                     value: -1
                     raw: -1
@@ -2440,11 +2443,11 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
                   lhs:
-                    kind: 13
+                    kind: 14
                     name: -1
                     value: -1
                     x:
-                      kind: 6
+                      kind: 7
                       name: 89
                       value: -1
                       raw: -1
@@ -2454,7 +2457,7 @@ packages:
                       resolved_type: -1
                       generic_type_name: -1
                     sel:
-                      kind: 6
+                      kind: 7
                       name: 91
                       value: -1
                       raw: -1
@@ -2470,29 +2473,30 @@ packages:
                     resolved_type: -1
                     generic_type_name: -1
         comments: -1
+    name: 21
   multipackage/utils:
     files:
       multipackage/utils/helper.go:
         functions:
           FormatString:
-            name: 143
-            pkg: 133
+            name: 144
+            pkg: 134
             signature:
-              kind: 1
+              kind: 2
               name: -1
               value: -1
               fun:
-                kind: 2
+                kind: 3
                 name: -1
                 value: -1
                 args:
-                  - kind: 6
+                  - kind: 7
                     name: 36
                     value: -1
                     raw: -1
                     pkg: -1
                     type: 36
-                    position: 145
+                    position: 146
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -2502,13 +2506,13 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 6
-                  name: 132
+                - kind: 7
+                  name: 133
                   value: -1
                   raw: -1
                   pkg: -1
                   type: 36
-                  position: 144
+                  position: 145
                   resolved_type: -1
                   generic_type_name: -1
               raw: -1
@@ -2517,210 +2521,210 @@ packages:
               position: -1
               resolved_type: 36
               generic_type_name: -1
-            signature_str: 147
-            position: 146
+            signature_str: 148
+            position: 147
             scope: 50
             comments: -1
             return_vars:
-              - kind: 14
+              - kind: 15
                 name: -1
                 value: -1
                 fun:
-                  kind: 13
+                  kind: 14
                   name: -1
                   value: -1
                   x:
-                    kind: 6
-                    name: 135
+                    kind: 7
+                    name: 136
                     value: -1
                     raw: -1
-                    pkg: 135
+                    pkg: 136
                     type: -1
-                    position: 140
+                    position: 141
                     resolved_type: -1
                     generic_type_name: -1
                   sel:
-                    kind: 6
-                    name: 141
+                    kind: 7
+                    name: 142
                     value: -1
                     raw: -1
-                    pkg: 135
-                    type: 138
-                    position: 142
+                    pkg: 136
+                    type: 139
+                    position: 143
                     resolved_type: -1
                     generic_type_name: -1
                   raw: -1
-                  pkg: 135
-                  type: 138
-                  position: 140
+                  pkg: 136
+                  type: 139
+                  position: 141
                   resolved_type: -1
                   generic_type_name: -1
                 args:
-                  - kind: 14
+                  - kind: 15
                     name: -1
                     value: -1
                     fun:
-                      kind: 13
+                      kind: 14
                       name: -1
                       value: -1
                       x:
-                        kind: 6
-                        name: 135
+                        kind: 7
+                        name: 136
                         value: -1
                         raw: -1
-                        pkg: 135
+                        pkg: 136
                         type: -1
-                        position: 136
+                        position: 137
                         resolved_type: -1
                         generic_type_name: -1
                       sel:
-                        kind: 6
-                        name: 137
+                        kind: 7
+                        name: 138
                         value: -1
                         raw: -1
-                        pkg: 135
-                        type: 138
-                        position: 139
+                        pkg: 136
+                        type: 139
+                        position: 140
                         resolved_type: -1
                         generic_type_name: -1
                       raw: -1
-                      pkg: 135
-                      type: 138
-                      position: 136
+                      pkg: 136
+                      type: 139
+                      position: 137
                       resolved_type: -1
                       generic_type_name: -1
                     args:
-                      - kind: 6
-                        name: 132
+                      - kind: 7
+                        name: 133
                         value: -1
                         raw: -1
-                        pkg: 133
+                        pkg: 134
                         type: 36
-                        position: 134
+                        position: 135
                         resolved_type: -1
                         generic_type_name: -1
                     raw: -1
                     pkg: -1
                     type: 36
-                    position: 136
+                    position: 137
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
                 pkg: -1
                 type: 36
-                position: 140
+                position: 141
                 resolved_type: -1
                 generic_type_name: -1
             returns:
-              - - kind: 14
+              - - kind: 15
                   name: -1
                   value: -1
                   fun:
-                    kind: 13
+                    kind: 14
                     name: -1
                     value: -1
                     x:
-                      kind: 6
-                      name: 135
+                      kind: 7
+                      name: 136
                       value: -1
                       raw: -1
-                      pkg: 135
+                      pkg: 136
                       type: -1
-                      position: 140
+                      position: 141
                       resolved_type: -1
                       generic_type_name: -1
                     sel:
-                      kind: 6
-                      name: 141
+                      kind: 7
+                      name: 142
                       value: -1
                       raw: -1
-                      pkg: 135
-                      type: 138
-                      position: 142
+                      pkg: 136
+                      type: 139
+                      position: 143
                       resolved_type: -1
                       generic_type_name: -1
                     raw: -1
-                    pkg: 135
-                    type: 138
-                    position: 140
+                    pkg: 136
+                    type: 139
+                    position: 141
                     resolved_type: -1
                     generic_type_name: -1
                   args:
-                    - kind: 14
+                    - kind: 15
                       name: -1
                       value: -1
                       fun:
-                        kind: 13
+                        kind: 14
                         name: -1
                         value: -1
                         x:
-                          kind: 6
-                          name: 135
+                          kind: 7
+                          name: 136
                           value: -1
                           raw: -1
-                          pkg: 135
+                          pkg: 136
                           type: -1
-                          position: 136
+                          position: 137
                           resolved_type: -1
                           generic_type_name: -1
                         sel:
-                          kind: 6
-                          name: 137
+                          kind: 7
+                          name: 138
                           value: -1
                           raw: -1
-                          pkg: 135
-                          type: 138
-                          position: 139
+                          pkg: 136
+                          type: 139
+                          position: 140
                           resolved_type: -1
                           generic_type_name: -1
                         raw: -1
-                        pkg: 135
-                        type: 138
-                        position: 136
+                        pkg: 136
+                        type: 139
+                        position: 137
                         resolved_type: -1
                         generic_type_name: -1
                       args:
-                        - kind: 6
-                          name: 132
+                        - kind: 7
+                          name: 133
                           value: -1
                           raw: -1
-                          pkg: 133
+                          pkg: 134
                           type: 36
-                          position: 134
+                          position: 135
                           resolved_type: -1
                           generic_type_name: -1
                       raw: -1
                       pkg: -1
                       type: 36
-                      position: 136
+                      position: 137
                       resolved_type: -1
                       generic_type_name: -1
                   raw: -1
                   pkg: -1
                   type: 36
-                  position: 140
+                  position: 141
                   resolved_type: -1
                   generic_type_name: -1
             end_line: 7
           ValidateAge:
-            name: 156
-            pkg: 133
+            name: 157
+            pkg: 134
             signature:
-              kind: 1
+              kind: 2
               name: -1
               value: -1
               fun:
-                kind: 2
+                kind: 3
                 name: -1
                 value: -1
                 args:
-                  - kind: 6
-                    name: 158
+                  - kind: 7
+                    name: 159
                     value: -1
                     raw: -1
                     pkg: -1
-                    type: 158
-                    position: 159
+                    type: 159
+                    position: 160
                     resolved_type: -1
                     generic_type_name: -1
                 raw: -1
@@ -2730,47 +2734,47 @@ packages:
                 resolved_type: -1
                 generic_type_name: -1
               args:
-                - kind: 6
+                - kind: 7
                   name: 75
                   value: -1
                   raw: -1
                   pkg: -1
                   type: 55
-                  position: 157
+                  position: 158
                   resolved_type: -1
                   generic_type_name: -1
               raw: -1
               pkg: -1
               type: -1
               position: -1
-              resolved_type: 158
+              resolved_type: 159
               generic_type_name: -1
-            signature_str: 161
-            position: 160
+            signature_str: 162
+            position: 161
             scope: 50
             comments: -1
             return_vars:
-              - kind: 150
+              - kind: 151
                 name: -1
-                value: 155
+                value: 156
                 x:
-                  kind: 150
+                  kind: 151
                   name: -1
-                  value: 151
+                  value: 152
                   x:
-                    kind: 6
+                    kind: 7
                     name: 75
                     value: -1
                     raw: -1
-                    pkg: 133
+                    pkg: 134
                     type: 55
-                    position: 148
+                    position: 149
                     resolved_type: -1
                     generic_type_name: -1
                   fun:
-                    kind: 3
+                    kind: 4
                     name: -1
-                    value: 149
+                    value: 150
                     raw: -1
                     pkg: -1
                     type: -1
@@ -2780,27 +2784,27 @@ packages:
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 148
+                  position: 149
                   resolved_type: -1
                   generic_type_name: -1
                 fun:
-                  kind: 150
+                  kind: 151
                   name: -1
-                  value: 154
+                  value: 155
                   x:
-                    kind: 6
+                    kind: 7
                     name: 75
                     value: -1
                     raw: -1
-                    pkg: 133
+                    pkg: 134
                     type: 55
-                    position: 152
+                    position: 153
                     resolved_type: -1
                     generic_type_name: -1
                   fun:
-                    kind: 3
+                    kind: 4
                     name: -1
-                    value: 153
+                    value: 154
                     raw: -1
                     pkg: -1
                     type: -1
@@ -2810,37 +2814,37 @@ packages:
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 152
+                  position: 153
                   resolved_type: -1
                   generic_type_name: -1
                 raw: -1
                 pkg: -1
                 type: -1
-                position: 148
+                position: 149
                 resolved_type: -1
                 generic_type_name: -1
             returns:
-              - - kind: 150
+              - - kind: 151
                   name: -1
-                  value: 155
+                  value: 156
                   x:
-                    kind: 150
+                    kind: 151
                     name: -1
-                    value: 151
+                    value: 152
                     x:
-                      kind: 6
+                      kind: 7
                       name: 75
                       value: -1
                       raw: -1
-                      pkg: 133
+                      pkg: 134
                       type: 55
-                      position: 148
+                      position: 149
                       resolved_type: -1
                       generic_type_name: -1
                     fun:
-                      kind: 3
+                      kind: 4
                       name: -1
-                      value: 149
+                      value: 150
                       raw: -1
                       pkg: -1
                       type: -1
@@ -2850,27 +2854,27 @@ packages:
                     raw: -1
                     pkg: -1
                     type: -1
-                    position: 148
+                    position: 149
                     resolved_type: -1
                     generic_type_name: -1
                   fun:
-                    kind: 150
+                    kind: 151
                     name: -1
-                    value: 154
+                    value: 155
                     x:
-                      kind: 6
+                      kind: 7
                       name: 75
                       value: -1
                       raw: -1
-                      pkg: 133
+                      pkg: 134
                       type: 55
-                      position: 152
+                      position: 153
                       resolved_type: -1
                       generic_type_name: -1
                     fun:
-                      kind: 3
+                      kind: 4
                       name: -1
-                      value: 153
+                      value: 154
                       raw: -1
                       pkg: -1
                       type: -1
@@ -2880,79 +2884,80 @@ packages:
                     raw: -1
                     pkg: -1
                     type: -1
-                    position: 152
+                    position: 153
                     resolved_type: -1
                     generic_type_name: -1
                   raw: -1
                   pkg: -1
                   type: -1
-                  position: 148
+                  position: 149
                   resolved_type: -1
                   generic_type_name: -1
             end_line: 11
         variables:
           DefaultFormat:
-            name: 168
-            tok: 169
-            pkg: 133
+            name: 169
+            tok: 170
+            pkg: 134
             type: -1
-            value: 172
-            position: 170
+            value: 173
+            position: 171
             comments: -1
             group_index: 1
           MaxAge:
-            name: 166
-            tok: 163
-            pkg: 133
+            name: 167
+            tok: 164
+            pkg: 134
             type: -1
-            resolved_type: 165
-            value: 131
+            resolved_type: 166
+            value: 132
             computed_value: 149
-            position: 167
+            position: 168
             comments: -1
             group_index: 1
           MinAge:
-            name: 162
-            tok: 163
-            pkg: 133
+            name: 163
+            tok: 164
+            pkg: 134
             type: -1
-            resolved_type: 165
-            value: 130
+            resolved_type: 166
+            value: 131
             computed_value: 1
-            position: 164
+            position: 165
             comments: -1
             group_index: 1
         imports:
-          135: 135
+          136: 136
+    name: 130
 call_graph:
   - caller:
-      name: 20
-      pkg: 17
+      name: 1
+      pkg: 18
       position: -1
       recv_type: -1
-      scope: 19
+      scope: 20
       signature_str: 40
     callee:
-      name: 10
-      pkg: 8
-      position: 9
+      name: 11
+      pkg: 9
+      position: 10
       recv_type: -1
       scope: 50
-      signature_str: 11
-    position: 9
+      signature_str: 12
+    position: 10
     args:
-      - kind: 3
+      - kind: 4
         name: -1
-        value: 4
+        value: 5
         raw: -1
         pkg: -1
         type: -1
         position: -1
         resolved_type: -1
         generic_type_name: -1
-      - kind: 3
+      - kind: 4
         name: -1
-        value: 5
+        value: 6
         raw: -1
         pkg: -1
         type: -1
@@ -2961,56 +2966,47 @@ call_graph:
         generic_type_name: -1
     assignments:
       user:
-        - variable_name: 16
-          pkg: 17
-          concrete_type: 15
-          position: 18
-          scope: 19
+        - variable_name: 17
+          pkg: 18
+          concrete_type: 16
+          position: 19
+          scope: 20
           value:
-            kind: 14
+            kind: 15
             name: -1
             value: -1
             fun:
-              kind: 13
+              kind: 14
               name: -1
               value: -1
               x:
-                kind: 6
-                name: 7
+                kind: 7
+                name: 8
                 value: -1
                 raw: -1
-                pkg: 8
+                pkg: 9
                 type: -1
-                position: 9
+                position: 10
                 resolved_type: -1
                 generic_type_name: -1
               sel:
-                kind: 6
-                name: 10
+                kind: 7
+                name: 11
                 value: -1
                 raw: -1
-                pkg: 8
-                type: 11
-                position: 12
+                pkg: 9
+                type: 12
+                position: 13
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
-              pkg: 8
-              type: 11
-              position: 9
+              pkg: 9
+              type: 12
+              position: 10
               resolved_type: -1
               generic_type_name: -1
             args:
-              - kind: 3
-                name: -1
-                value: 4
-                raw: -1
-                pkg: -1
-                type: -1
-                position: -1
-                resolved_type: -1
-                generic_type_name: -1
-              - kind: 3
+              - kind: 4
                 name: -1
                 value: 5
                 raw: -1
@@ -3019,28 +3015,47 @@ call_graph:
                 position: -1
                 resolved_type: -1
                 generic_type_name: -1
+              - kind: 4
+                name: -1
+                value: 6
+                raw: -1
+                pkg: -1
+                type: -1
+                position: -1
+                resolved_type: -1
+                generic_type_name: -1
             raw: -1
             pkg: -1
-            type: 15
-            position: 9
+            type: 16
+            position: 10
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 6
-            name: 16
+            kind: 7
+            name: 17
             value: -1
             raw: -1
-            pkg: 17
-            type: 15
-            position: 18
+            pkg: 18
+            type: 16
+            position: 19
             resolved_type: -1
             generic_type_name: -1
-          func: 20
+          func: 1
           callee_func: NewUser
           callee_pkg: multipackage/models
     param_arg_map:
       age:
-        kind: 3
+        kind: 4
+        name: -1
+        value: 6
+        raw: -1
+        pkg: -1
+        type: -1
+        position: -1
+        resolved_type: -1
+        generic_type_name: -1
+      name:
+        kind: 4
         name: -1
         value: 5
         raw: -1
@@ -3049,23 +3064,13 @@ call_graph:
         position: -1
         resolved_type: -1
         generic_type_name: -1
-      name:
-        kind: 3
-        name: -1
-        value: 4
-        raw: -1
-        pkg: -1
-        type: -1
-        position: -1
-        resolved_type: -1
-        generic_type_name: -1
     callee_recv_var_name: user
   - caller:
-      name: 20
-      pkg: 17
+      name: 1
+      pkg: 18
       position: -1
       recv_type: -1
-      scope: 19
+      scope: 20
       signature_str: 40
     callee:
       name: 24
@@ -3078,20 +3083,20 @@ call_graph:
     assignments:
       service:
         - variable_name: 28
-          pkg: 17
+          pkg: 18
           concrete_type: 27
           position: 29
-          scope: 19
+          scope: 20
           value:
-            kind: 14
+            kind: 15
             name: -1
             value: -1
             fun:
-              kind: 13
+              kind: 14
               name: -1
               value: -1
               x:
-                kind: 6
+                kind: 7
                 name: 21
                 value: -1
                 raw: -1
@@ -3101,7 +3106,7 @@ call_graph:
                 resolved_type: -1
                 generic_type_name: -1
               sel:
-                kind: 6
+                kind: 7
                 name: 24
                 value: -1
                 raw: -1
@@ -3123,25 +3128,25 @@ call_graph:
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 6
+            kind: 7
             name: 28
             value: -1
             raw: -1
-            pkg: 17
+            pkg: 18
             type: 27
             position: 29
             resolved_type: -1
             generic_type_name: -1
-          func: 20
+          func: 1
           callee_func: NewUserService
           callee_pkg: multipackage/services
     callee_recv_var_name: service
   - caller:
-      name: 20
-      pkg: 17
+      name: 1
+      pkg: 18
       position: -1
       recv_type: -1
-      scope: 19
+      scope: 20
       signature_str: 40
     callee:
       name: 32
@@ -3152,12 +3157,12 @@ call_graph:
       signature_str: 33
     position: 31
     args:
-      - kind: 6
-        name: 16
+      - kind: 7
+        name: 17
         value: -1
         raw: -1
-        pkg: 17
-        type: 15
+        pkg: 18
+        type: 16
         position: 30
         resolved_type: -1
         generic_type_name: -1
@@ -3167,47 +3172,47 @@ call_graph:
           pkg: 22
           concrete_type: 55
           position: 108
-          scope: 19
+          scope: 20
           value:
-            kind: 14
+            kind: 15
             name: -1
             value: -1
             fun:
-              kind: 13
+              kind: 14
               name: -1
               value: -1
               x:
-                kind: 6
-                name: 16
+                kind: 7
+                name: 17
                 value: -1
                 raw: -1
                 pkg: 22
-                type: 15
+                type: 16
                 position: 106
                 resolved_type: -1
                 generic_type_name: -1
               sel:
-                kind: 6
+                kind: 7
                 name: 57
                 value: -1
                 raw: -1
-                pkg: 8
+                pkg: 9
                 type: 60
                 position: 107
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
-              pkg: 8
+              pkg: 9
               type: 60
               position: 106
               resolved_type: -1
               generic_type_name: -1
               receiver_type:
-                kind: 6
+                kind: 7
                 name: 61
                 value: -1
                 raw: -1
-                pkg: 8
+                pkg: 9
                 type: 61
                 position: -1
                 resolved_type: -1
@@ -3219,7 +3224,7 @@ call_graph:
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 6
+            kind: 7
             name: 75
             value: -1
             raw: -1
@@ -3236,47 +3241,47 @@ call_graph:
           pkg: 22
           concrete_type: 36
           position: 105
-          scope: 19
+          scope: 20
           value:
-            kind: 14
+            kind: 15
             name: -1
             value: -1
             fun:
-              kind: 13
+              kind: 14
               name: -1
               value: -1
               x:
-                kind: 6
-                name: 16
+                kind: 7
+                name: 17
                 value: -1
                 raw: -1
                 pkg: 22
-                type: 15
+                type: 16
                 position: 103
                 resolved_type: -1
                 generic_type_name: -1
               sel:
-                kind: 6
+                kind: 7
                 name: 46
                 value: -1
                 raw: -1
-                pkg: 8
+                pkg: 9
                 type: 52
                 position: 104
                 resolved_type: -1
                 generic_type_name: -1
               raw: -1
-              pkg: 8
+              pkg: 9
               type: 52
               position: 103
               resolved_type: -1
               generic_type_name: -1
               receiver_type:
-                kind: 6
+                kind: 7
                 name: 61
                 value: -1
                 raw: -1
-                pkg: 8
+                pkg: 9
                 type: 61
                 position: -1
                 resolved_type: -1
@@ -3288,7 +3293,7 @@ call_graph:
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 6
+            kind: 7
             name: 71
             value: -1
             raw: -1
@@ -3302,30 +3307,30 @@ call_graph:
           callee_pkg: multipackage/models
       result:
         - variable_name: 37
-          pkg: 17
+          pkg: 18
           concrete_type: 36
           position: 38
-          scope: 19
+          scope: 20
           value:
-            kind: 14
+            kind: 15
             name: -1
             value: -1
             fun:
-              kind: 13
+              kind: 14
               name: -1
               value: -1
               x:
-                kind: 6
+                kind: 7
                 name: 28
                 value: -1
                 raw: -1
-                pkg: 17
+                pkg: 18
                 type: 27
                 position: 31
                 resolved_type: -1
                 generic_type_name: -1
               sel:
-                kind: 6
+                kind: 7
                 name: 32
                 value: -1
                 raw: -1
@@ -3341,7 +3346,7 @@ call_graph:
               resolved_type: -1
               generic_type_name: -1
               receiver_type:
-                kind: 6
+                kind: 7
                 name: 35
                 value: -1
                 raw: -1
@@ -3351,12 +3356,12 @@ call_graph:
                 resolved_type: -1
                 generic_type_name: -1
             args:
-              - kind: 6
-                name: 16
+              - kind: 7
+                name: 17
                 value: -1
                 raw: -1
-                pkg: 17
-                type: 15
+                pkg: 18
+                type: 16
                 position: 30
                 resolved_type: -1
                 generic_type_name: -1
@@ -3367,26 +3372,26 @@ call_graph:
             resolved_type: -1
             generic_type_name: -1
           lhs:
-            kind: 6
+            kind: 7
             name: 37
             value: -1
             raw: -1
-            pkg: 17
+            pkg: 18
             type: 36
             position: 38
             resolved_type: -1
             generic_type_name: -1
-          func: 20
+          func: 1
           callee_func: ProcessUser
           callee_pkg: multipackage/services
     param_arg_map:
       user:
-        kind: 6
-        name: 16
+        kind: 7
+        name: 17
         value: -1
         raw: -1
-        pkg: 17
-        type: 15
+        pkg: 18
+        type: 16
         position: 30
         resolved_type: -1
         generic_type_name: -1
@@ -3394,39 +3399,39 @@ call_graph:
     callee_recv_var_name: result
     chain_root: service
   - caller:
-      name: 20
-      pkg: 17
+      name: 1
+      pkg: 18
       position: -1
       recv_type: -1
-      scope: 19
+      scope: 20
       signature_str: 40
     callee:
-      name: 177
+      name: 178
       pkg: 41
-      position: 176
+      position: 177
       recv_type: -1
       scope: 50
-      signature_str: 178
-    position: 176
+      signature_str: 179
+    position: 177
     args:
-      - kind: 6
+      - kind: 7
         name: 37
         value: -1
         raw: -1
-        pkg: 17
+        pkg: 18
         type: 36
-        position: 175
+        position: 176
         resolved_type: -1
         generic_type_name: -1
     param_arg_map:
       a:
-        kind: 6
+        kind: 7
         name: 37
         value: -1
         raw: -1
-        pkg: 17
+        pkg: 18
         type: 36
-        position: 175
+        position: 176
         resolved_type: -1
         generic_type_name: -1
   - caller:
@@ -3438,7 +3443,7 @@ call_graph:
       signature_str: 112
     callee:
       name: 46
-      pkg: 8
+      pkg: 9
       position: 103
       recv_type: 47
       scope: 50
@@ -3456,7 +3461,7 @@ call_graph:
       signature_str: 112
     callee:
       name: 57
-      pkg: 8
+      pkg: 9
       position: 106
       recv_type: 47
       scope: 50
@@ -3481,7 +3486,7 @@ call_graph:
       signature_str: 97
     position: 95
     args:
-      - kind: 3
+      - kind: 4
         name: -1
         value: 88
         raw: -1
@@ -3490,11 +3495,11 @@ call_graph:
         position: -1
         resolved_type: -1
         generic_type_name: -1
-      - kind: 13
+      - kind: 14
         name: -1
         value: -1
         x:
-          kind: 6
+          kind: 7
           name: 89
           value: -1
           raw: -1
@@ -3504,7 +3509,7 @@ call_graph:
           resolved_type: -1
           generic_type_name: -1
         sel:
-          kind: 6
+          kind: 7
           name: 91
           value: -1
           raw: -1
@@ -3519,7 +3524,7 @@ call_graph:
         position: 90
         resolved_type: -1
         generic_type_name: -1
-      - kind: 6
+      - kind: 7
         name: 71
         value: -1
         raw: -1
@@ -3528,7 +3533,7 @@ call_graph:
         position: 93
         resolved_type: -1
         generic_type_name: -1
-      - kind: 6
+      - kind: 7
         name: 75
         value: -1
         raw: -1
@@ -3539,11 +3544,11 @@ call_graph:
         generic_type_name: -1
     param_arg_map:
       a:
-        kind: 13
+        kind: 14
         name: -1
         value: -1
         x:
-          kind: 6
+          kind: 7
           name: 89
           value: -1
           raw: -1
@@ -3553,7 +3558,7 @@ call_graph:
           resolved_type: -1
           generic_type_name: -1
         sel:
-          kind: 6
+          kind: 7
           name: 91
           value: -1
           raw: -1
@@ -3569,7 +3574,7 @@ call_graph:
         resolved_type: -1
         generic_type_name: -1
       format:
-        kind: 3
+        kind: 4
         name: -1
         value: 88
         raw: -1
@@ -3579,154 +3584,154 @@ call_graph:
         resolved_type: -1
         generic_type_name: -1
   - caller:
-      name: 143
-      pkg: 133
+      name: 144
+      pkg: 134
       position: -1
       recv_type: -1
       scope: 50
-      signature_str: 147
+      signature_str: 148
     callee:
-      name: 141
-      pkg: 135
-      position: 140
+      name: 142
+      pkg: 136
+      position: 141
       recv_type: -1
       scope: 50
-      signature_str: 138
-    position: 140
+      signature_str: 139
+    position: 141
     args:
-      - kind: 14
+      - kind: 15
         name: -1
         value: -1
         fun:
-          kind: 13
+          kind: 14
           name: -1
           value: -1
           x:
-            kind: 6
-            name: 135
+            kind: 7
+            name: 136
             value: -1
             raw: -1
-            pkg: 135
+            pkg: 136
             type: -1
-            position: 136
+            position: 137
             resolved_type: -1
             generic_type_name: -1
           sel:
-            kind: 6
-            name: 137
+            kind: 7
+            name: 138
             value: -1
             raw: -1
-            pkg: 135
-            type: 138
-            position: 139
+            pkg: 136
+            type: 139
+            position: 140
             resolved_type: -1
             generic_type_name: -1
           raw: -1
-          pkg: 135
-          type: 138
-          position: 136
+          pkg: 136
+          type: 139
+          position: 137
           resolved_type: -1
           generic_type_name: -1
         args:
-          - kind: 6
-            name: 132
+          - kind: 7
+            name: 133
             value: -1
             raw: -1
-            pkg: 133
+            pkg: 134
             type: 36
-            position: 134
+            position: 135
             resolved_type: -1
             generic_type_name: -1
         raw: -1
         pkg: -1
         type: 36
-        position: 136
+        position: 137
         resolved_type: -1
         generic_type_name: -1
     param_arg_map:
       s:
-        kind: 14
+        kind: 15
         name: -1
         value: -1
         fun:
-          kind: 13
+          kind: 14
           name: -1
           value: -1
           x:
-            kind: 6
-            name: 135
+            kind: 7
+            name: 136
             value: -1
             raw: -1
-            pkg: 135
+            pkg: 136
             type: -1
-            position: 136
+            position: 137
             resolved_type: -1
             generic_type_name: -1
           sel:
-            kind: 6
-            name: 137
+            kind: 7
+            name: 138
             value: -1
             raw: -1
-            pkg: 135
-            type: 138
-            position: 139
+            pkg: 136
+            type: 139
+            position: 140
             resolved_type: -1
             generic_type_name: -1
           raw: -1
-          pkg: 135
-          type: 138
-          position: 136
+          pkg: 136
+          type: 139
+          position: 137
           resolved_type: -1
           generic_type_name: -1
         args:
-          - kind: 6
-            name: 132
+          - kind: 7
+            name: 133
             value: -1
             raw: -1
-            pkg: 133
+            pkg: 134
             type: 36
-            position: 134
+            position: 135
             resolved_type: -1
             generic_type_name: -1
         raw: -1
         pkg: -1
         type: 36
-        position: 136
+        position: 137
         resolved_type: -1
         generic_type_name: -1
   - caller:
-      name: 143
-      pkg: 133
+      name: 144
+      pkg: 134
       position: -1
       recv_type: -1
       scope: 50
-      signature_str: 147
+      signature_str: 148
     callee:
-      name: 137
-      pkg: 135
-      position: 136
+      name: 138
+      pkg: 136
+      position: 137
       recv_type: -1
       scope: 50
-      signature_str: 138
-    position: 136
+      signature_str: 139
+    position: 137
     args:
-      - kind: 6
-        name: 132
+      - kind: 7
+        name: 133
         value: -1
         raw: -1
-        pkg: 133
+        pkg: 134
         type: 36
-        position: 134
+        position: 135
         resolved_type: -1
         generic_type_name: -1
     param_arg_map:
       s:
-        kind: 6
-        name: 132
+        kind: 7
+        name: 133
         value: -1
         raw: -1
-        pkg: 133
+        pkg: 134
         type: 36
-        position: 134
+        position: 135
         resolved_type: -1
         generic_type_name: -1

--- a/testdata/one_type_one_component/aaamig/mig.go
+++ b/testdata/one_type_one_component/aaamig/mig.go
@@ -9,3 +9,10 @@ func Migrate() any {
 	type Issue struct{ OnlyColumn string }
 	return new(Issue)
 }
+
+// MigrateThing is the same trap for the version-suffixed package.
+func MigrateThing() any {
+	// Thing see thing/v2
+	type Thing struct{ OnlyColumn string }
+	return new(Thing)
+}

--- a/testdata/one_type_one_component/aaamig/mig.go
+++ b/testdata/one_type_one_component/aaamig/mig.go
@@ -1,0 +1,11 @@
+package aaamig
+
+// Migrate declares a throwaway struct named like the API type, the way a schema
+// migration declares only the columns it touches. The package is named so that
+// it sorts BEFORE the real one: that is what decides which type a bare-name
+// scan finds first.
+func Migrate() any {
+	// Issue see api/issue.go
+	type Issue struct{ OnlyColumn string }
+	return new(Issue)
+}

--- a/testdata/one_type_one_component/api/issue.go
+++ b/testdata/one_type_one_component/api/issue.go
@@ -1,0 +1,9 @@
+package api
+
+// Issue is the real API type.
+type Issue struct {
+	ID    int64  `json:"id"`
+	Title string `json:"title"`
+	Body  string `json:"body"`
+	State string `json:"state"`
+}

--- a/testdata/one_type_one_component/go.mod
+++ b/testdata/one_type_one_component/go.mod
@@ -1,0 +1,3 @@
+module twoname
+
+go 1.26

--- a/testdata/one_type_one_component/main.go
+++ b/testdata/one_type_one_component/main.go
@@ -17,16 +17,19 @@ import (
 
 	"twoname/aaamig"
 	"twoname/api"
+	thing "twoname/thing/v2"
 )
 
 func mkConcrete() api.Issue { return api.Issue{} }
 func mkPointer() *api.Issue { return &api.Issue{} }
 func mkAny() any            { return api.Issue{} }
+func mkThing() thing.Thing  { return thing.Thing{} }
 
 func respond(w http.ResponseWriter, v any) { _ = json.NewEncoder(w).Encode(v) }
 
 func main() {
 	_ = aaamig.Migrate()
+	_ = aaamig.MigrateThing()
 
 	// A composite literal: the type string comes from metadata, fully qualified.
 	http.HandleFunc("GET /direct", func(w http.ResponseWriter, r *http.Request) {
@@ -53,6 +56,12 @@ func main() {
 	// Passed to a wrapper, resolved at the wrapper's call site.
 	http.HandleFunc("GET /viawrapper", func(w http.ResponseWriter, r *http.Request) {
 		respond(w, api.Issue{})
+	})
+
+	// A package whose declared name differs from its path's last segment,
+	// which is what a module major version looks like.
+	http.HandleFunc("GET /viaversioned", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(mkThing())
 	})
 
 	// An `any`-returning helper stays unresolved: the concrete type is not

--- a/testdata/one_type_one_component/main.go
+++ b/testdata/one_type_one_component/main.go
@@ -1,0 +1,66 @@
+// Package main exercises the rule that one Go type produces one component.
+//
+// A response type recovered from a CALL carries the package's NAME
+// ("api.Issue"), while metadata's own type strings carry the import PATH
+// ("twoname/api.Issue"). Both spellings used to become their own component, and
+// the short-keyed one resolved WRONGLY: its qualifier matches no package key,
+// so the lookup fell back to a bare-name scan over sorted packages and returned
+// aaamig's function-local `type Issue struct` — one field instead of four
+// (issue #457).
+//
+// Every route below must reference the SAME component, with all four fields.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"twoname/aaamig"
+	"twoname/api"
+)
+
+func mkConcrete() api.Issue { return api.Issue{} }
+func mkPointer() *api.Issue { return &api.Issue{} }
+func mkAny() any            { return api.Issue{} }
+
+func respond(w http.ResponseWriter, v any) { _ = json.NewEncoder(w).Encode(v) }
+
+func main() {
+	_ = aaamig.Migrate()
+
+	// A composite literal: the type string comes from metadata, fully qualified.
+	http.HandleFunc("GET /direct", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.Issue{})
+	})
+
+	// A direct call: the return type is recovered from the call and arrives
+	// qualified by the package NAME. This is the shape that broke.
+	http.HandleFunc("GET /viaconcrete", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(mkConcrete())
+	})
+
+	// The same through a pointer return.
+	http.HandleFunc("GET /viapointer", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(mkPointer())
+	})
+
+	// Assigned first, which resolves through the variable and was never broken.
+	http.HandleFunc("GET /viavar", func(w http.ResponseWriter, r *http.Request) {
+		v := mkConcrete()
+		_ = json.NewEncoder(w).Encode(v)
+	})
+
+	// Passed to a wrapper, resolved at the wrapper's call site.
+	http.HandleFunc("GET /viawrapper", func(w http.ResponseWriter, r *http.Request) {
+		respond(w, api.Issue{})
+	})
+
+	// An `any`-returning helper stays unresolved: the concrete type is not
+	// recoverable from the signature, and guessing one would be worse than
+	// documenting none (golden rule #7).
+	http.HandleFunc("GET /viaany", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(mkAny())
+	})
+
+	_ = http.ListenAndServe(":8080", nil)
+}

--- a/testdata/one_type_one_component/thing/v2/thing.go
+++ b/testdata/one_type_one_component/thing/v2/thing.go
@@ -1,0 +1,13 @@
+// Package thing sits in a directory named v2, the way a module major version is
+// laid out: the DECLARED package name is "thing" while the path's last segment
+// is "v2". Reading the name off the path answers "v2", so a `thing.`-qualified
+// type could never be resolved and fell back to a bare-name scan — which found
+// aaamig's throwaway struct instead (issue #457).
+package thing
+
+// Thing is the real type behind a version-suffixed path.
+type Thing struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
+	Kind string `json:"kind"`
+}


### PR DESCRIPTION
Fixes #457. Also the reproduction #447 was waiting for — see the end.

## The bug

A response type recovered from a **call** carries the package's *name*
(`api.Issue`); metadata's own type strings come from go/types and carry the
import *path* (`twoname/api.Issue`). Both spellings reached the mapper for the
same type, and each became its own schema key.

Duplication was the visible half. The silent half: the short key also resolved
**wrongly** — its qualifier matches no package key, so `typeByName` fell
through to a bare-name scan over sorted packages and returned the first
same-named declaration. On gitea that is a *migration's function-local*
`type User struct` (migrations declare only the columns they touch, and
`gitea.dev/modelmigration` sorts before `gitea.dev/modules/structs`):

```yaml
# GET /user/  ->  structs_User
structs_User:
  properties:
    EmailNotificationsPreference: {type: string}     # 1 field

gitea_dev_modules_structs_User:                      # 22 fields, 38 refs
  properties: {id, login, email, avatar_url, ...}
```

The Go field name rather than the `json:` tag was the tell: the two components
came from different *views of different types*, not one truncated walk.

## The fix — two pieces, both at the schema boundary

* **`canonicalPackageQualifier`** rewrites a package-name qualifier to the
  import path, joining the normalisations already applied before the type
  string is read. A candidate package must end in that name **and** declare the
  type, and the match must be **unique**; anything else is left exactly as it
  came (golden rule #7). Resolution runs over `SortedPackageNames`, so it
  cannot depend on map order (golden rule #1).
* **`mergeShortQualifiedKeys`** folds short used-type keys into the canonical
  one. Canonicalising alone already redirects every `$ref`, which left the
  short-keyed components as **orphans** (15 on gitea, referenced by nothing) —
  folding the keys is what stops them being emitted.

The renderer that produces the short form is **not** changed: qualifying by
package name is deliberate (golden rule #3). What was wrong is that the schema
boundary treated two spellings of one type as two types.

## Fixture

`testdata/one_type_one_component` pins six handler shapes side by side:

| route | shape | before |
|---|---|---|
| `/viaconcrete` | `Encode(mkConcrete())` | **broken** — 1-field twin |
| `/viapointer` | `Encode(mkPointer())` | **broken** — 1-field twin |
| `/direct` | `Encode(api.Issue{})` | correct |
| `/viavar` | `v := mkConcrete()` | correct |
| `/viawrapper` | `respond(w, api.Issue{})` | correct |
| `/viaany` | `Encode(mkAny())` (`any` return) | unresolved, **and must stay so** |

Its migration package is named to sort first, because that ordering is what
decided the wrong answer. On unfixed code the test fails with
`want exactly one Issue component, got [api_Issue twoname_api_Issue]`.

## Measured

| | before | after |
|---|---|---|
| gitea paths | 899 | **899** |
| gitea schemas | 273 | **242** |
| short `structs_*` components | 19 | **0** |
| dangling `$ref`s | — | **none** (227 distinct refs resolve) |
| the 7 impoverished operations | 1–3 props | **full qualified schema** |
| 110 existing fixture specs | — | **byte-identical** |
| a 280-path service | — | **unchanged** (never produced the short form) |

Suite, `make lint` and the ratchet (96.2%, floor 96) pass.

## On #447

#447 was filed as "cannot reproduce the trigger" — the honest state at the
time. This is that trigger: a qualifier the lookup cannot match, sending
`typeByName` into its bare-name fallback, which returns *whatever* same-named
type sorts first. #447 is the case where that lands on an unrelated package's
type; this is the case where it lands on a weaker view of the right name.

This PR removes the *cause* for the short-qualifier path, so the fallback fires
far less often. I am deliberately **not** also changing the fallback itself
here: refusing an ambiguous bare-name substitution is a behavior change with
its own risk surface, and it deserves its own measured PR now that a
reproduction exists. #447 stays open with this evidence added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed OpenAPI schema generation for package-qualified types when package names and import paths differ.
  - Prevented duplicate or incorrect schemas from being generated when multiple types share similar names.
  - Ensured affected routes reference the correct, complete component schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->