### PR TITLE
feat(spec): choose how operationIds and component names are spelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`naming`: choose how operationIds and component names are spelled.** Both
+  default to the fully-qualified Go symbol, which is collision-free and
+  reproducible — and also reproduces the module path, the internal package
+  layout and unexported handler names in a document that is usually served over
+  HTTP, in identifiers long enough that a generated client needs an alias for
+  every type. `schemaNames: short` gives `LineInput`; `operationId:
+  receiver-method` gives `estimateHandler.updateLine`, and `method-path` gives
+  `putEstimatesByIdLine`, which carries no Go symbol at all. When short names
+  collide — two packages with a `Components` type is ordinary — **every member
+  of the group is qualified**, with the shortest package-path suffix that tells
+  them apart, so no name wins for reasons a reader cannot see. The default is
+  unchanged in every respect: a project that says nothing about naming gets the
+  same document, byte for byte. (#298)
+
 ### Fixed
 
 - **One Go type now produces one component, and the right one.** A response type

--- a/README.md
+++ b/README.md
@@ -865,8 +865,9 @@ components:
 Short names collide — two packages with a `Components` type is ordinary — so
 when they do, **every member of the colliding group is qualified** with the
 shortest package-path suffix that tells them apart (`billing_Components`,
-`estimate_Components`), never just one of them. `method-path` ids need no such
-rule: a method and path pair is unique in OpenAPI.
+`estimate_Components`), never just one of them. `method-path` ids need no
+package qualification, but they are not collision-free either — `/a-b` and
+`/a/b` both read as `getAB` — so a clash there takes a numeric suffix.
 
 Nothing changes unless you ask: a project that sets no `naming` block gets the
 same document it got before, byte for byte. See

--- a/README.md
+++ b/README.md
@@ -833,6 +833,45 @@ there. A `json:"-"` field stays absent — a comment never resurrects a field th
 encoder skips. Applies to every type kind: structs, interfaces, aliases and
 named container types.
 
+### Naming: shorter operationIds and component names
+
+By default an `operationId` is the fully-qualified Go symbol and a component
+name is that symbol with separators replaced. Those names never collide, which
+is why they are the default — but they also put your module path, internal
+package layout and unexported handler names into a document you probably serve
+over HTTP, and they make identifiers long enough that a generated client needs
+an alias for every type.
+
+```yaml
+naming:
+  operationId: method-path   # full (default) | receiver-method | method-path
+  schemaNames: short         # full (default) | short
+```
+
+```yaml
+# full (default)
+operationId: github.com/acme/api/internal/httpapi.estimateHandler.updateLine
+components:
+  schemas:
+    github_com_acme_api_internal_estimate_LineInput: {}
+
+# naming: {operationId: method-path, schemaNames: short}
+operationId: putEstimatesByIdLine
+components:
+  schemas:
+    LineInput: {}
+```
+
+Short names collide — two packages with a `Components` type is ordinary — so
+when they do, **every member of the colliding group is qualified** with the
+shortest package-path suffix that tells them apart (`billing_Components`,
+`estimate_Components`), never just one of them. `method-path` ids need no such
+rule: a method and path pair is unique in OpenAPI.
+
+Nothing changes unless you ask: a project that sets no `naming` block gets the
+same document it got before, byte for byte. See
+[docs/CONFIGURATION.md](docs/CONFIGURATION.md#naming) for the full table.
+
 ### Request body source disambiguation
 
 Generic decoders like `json.Decode`, `json.Unmarshal`, and `render.DecodeJSON` are used both for request bodies *and* for unrelated decoding (config files, internal payloads). The `requestContext` block tells APISpec which receivers represent a request context and which method names yield the body. A decoder call is classified as a request-body decoder only when its source argument can be traced — through selectors, idents, assignments, and parameter boundaries — back to a body accessor on a request-context root.

--- a/cmd/apispecui/assets/js/config.js
+++ b/cmd/apispecui/assets/js/config.js
@@ -19,6 +19,17 @@ const txt = (label, value, onInput, ph = "") => html`
     <input class="input" value=${value || ""} placeholder=${ph} onInput=${onInput} />
   </div>
 `;
+const sel = (label, value, options, onChange, help = "") => html`
+  <div class="field">
+    <label>${label}</label>
+    <select class="input" onChange=${onChange}>
+      ${options.map(
+        (o) => html`<option value=${o.value} selected=${(value || options[0].value) === o.value}>${o.label}</option>`,
+      )}
+    </select>
+    ${help ? html`<div class="hint">${help}</div>` : null}
+  </div>
+`;
 const area = (label, value, onInput, ph = "") => html`
   <div class="field">
     <label>${label}</label>
@@ -253,6 +264,7 @@ export function ConfigMode() {
 
   const setInfo = (patch) => setConfig({ info: { ...c.info, ...patch } });
   const setDefaults = (patch) => setConfig({ defaults: { ...c.defaults, ...patch } });
+  const setNaming = (patch) => setConfig({ naming: { ...c.naming, ...patch } });
   const setFilter = (which, field, value) =>
     setConfig({ [which]: { ...(c[which] || {}), [field]: value } });
   const setExtDocs = (patch) =>
@@ -358,6 +370,28 @@ export function ConfigMode() {
             ${txt("Request content-type", c.defaults?.requestContentType, (e) => setDefaults({ requestContentType: e.target.value }), "application/json")}
             ${txt("Response content-type", c.defaults?.responseContentType, (e) => setDefaults({ responseContentType: e.target.value }), "application/json")}
             ${txt("Default response status", c.defaults?.responseStatus, (e) => setDefaults({ responseStatus: parseInt(e.target.value, 10) || 0 }), "200")}
+          <//>
+
+          <${Section} title="Naming" help="How operationIds and component names are spelled. The default, 'full', is the fully-qualified Go symbol: collision-free and reproducible, but it puts your module path, package layout and unexported handler names into a document you may serve publicly, and it makes very long identifiers in a generated client. Short names are qualified only where they would collide, and then every member of the colliding group is qualified — so no name wins for invisible reasons.">
+            ${sel(
+              "operationId",
+              c.naming?.operationId,
+              [
+                { value: "full", label: "full — github.com/acme/api/internal/httpapi.handler.update" },
+                { value: "receiver-method", label: "receiver-method — handler.update" },
+                { value: "method-path", label: "method-path — putEstimatesByIdLine" },
+              ],
+              (e) => setNaming({ operationId: e.target.value }),
+            )}
+            ${sel(
+              "schemaNames",
+              c.naming?.schemaNames,
+              [
+                { value: "full", label: "full — github_com_acme_api_internal_estimate_LineInput" },
+                { value: "short", label: "short — LineInput" },
+              ],
+              (e) => setNaming({ schemaNames: e.target.value }),
+            )}
           <//>
 
           <${Section} title="Analysis limits" help="How far the analysis is allowed to walk the call tree. Raise these when a project is large enough that the default budget stops expansion part-way through its routes; leave them blank to use the defaults shown.">

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -245,10 +245,14 @@ Letting one `Components` keep the bare name would make the winner depend on
 nothing a reader can see. Groups are resolved in sorted order, so the result is
 reproducible run to run.
 
-`method-path` needs no such rule: a method and path pair is unique in OpenAPI,
-so the ids are unique by construction. They are also longer than a handler
-name — `deleteReposByOwnerByRepoIssuesByIndex` — which is the trade for
-carrying no Go symbol at all. `receiver-method` keeps them short.
+`method-path` needs no *package* qualification, but it is not collision-free
+either: a method and path pair is unique in OpenAPI, while the identifier
+derived from it is not — every non-alphanumeric character is dropped, so
+`/a-b`, `/a/b` and `/aB` all read as `getAB`. A collision there takes a numeric
+suffix (`getAB2`), assigned in sorted path order. These ids are also longer
+than a handler name — `deleteReposByOwnerByRepoIssuesByIndex` — which is the
+trade for carrying no Go symbol at all. `receiver-method` keeps them short, and
+falls back to the method-path form when a handler serves more than one route.
 
 A component whose type is a pointer or slice is left fully qualified: such a
 key is an artifact rather than a type anyone references, and shortening it

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -40,6 +40,7 @@ apispec --output-config used-config.yaml     # dump the effective config
 | `overrides` | list | Per-handler summary/description/response overrides. |
 | `include` / `exclude` | object | Filter which files/packages/functions/types are analysed. |
 | `defaults` | object | Fallback content types and response status. |
+| `naming` | object | How operationIds and component names are spelled. |
 | `security` | list | Document-level security requirements. |
 | `securitySchemes` | map | OpenAPI `securitySchemes` definitions. |
 | `securityMappings` | list | Map detected auth middleware to a scheme. |
@@ -200,6 +201,69 @@ defaults:
 | `requestContentType` | string | Default request body media type. |
 | `responseContentType` | string | Default response media type. |
 | `responseStatus` | int | Default success status when none is detected. |
+
+## `naming`
+
+By default every `operationId` is the fully-qualified Go symbol and every
+component name is that symbol with separators replaced. Those names are
+collision-free and reproducible, which is why they are the default — but they
+also reproduce the module path, the internal package layout and unexported
+handler names in a document that is usually served over HTTP, and they make
+80-character identifiers in a generated client.
+
+```yaml
+naming:
+  operationId: full          # full (default) | receiver-method | method-path
+  schemaNames: full          # full (default) | short
+```
+
+| Field | Value | Result |
+|-------|-------|--------|
+| `schemaNames` | `full` (default) | `github_com_acme_api_internal_estimate_LineInput` |
+| | `short` | `LineInput` |
+| `operationId` | `full` (default) | `github.com/acme/api/internal/httpapi.estimateHandler.updateLine` |
+| | `receiver-method` | `estimateHandler.updateLine` |
+| | `method-path` | `putEstimatesByIdLine` |
+
+An unknown value logs a warning and keeps `full`, so a typo cannot silently
+change the names your consumers depend on.
+
+### Collisions
+
+Two packages with a `Components` type are ordinary, and short names collide.
+When they do, **every member of the colliding group is qualified** — never just
+one of them — with the shortest suffix of its package path that tells them
+apart, extended a segment at a time:
+
+```yaml
+billing_Components      # from internal/billing
+estimate_Components     # from internal/estimate
+LineInput               # unique, so it stays bare
+```
+
+Letting one `Components` keep the bare name would make the winner depend on
+nothing a reader can see. Groups are resolved in sorted order, so the result is
+reproducible run to run.
+
+`method-path` needs no such rule: a method and path pair is unique in OpenAPI,
+so the ids are unique by construction. They are also longer than a handler
+name — `deleteReposByOwnerByRepoIssuesByIndex` — which is the trade for
+carrying no Go symbol at all. `receiver-method` keeps them short.
+
+A component whose type is a pointer or slice is left fully qualified: such a
+key is an artifact rather than a type anyone references, and shortening it
+would collide with the component for the type itself.
+
+### Trying it on your project
+
+A `-c` config **replaces** the framework preset rather than merging with it, so
+write the effective config out first and edit that:
+
+```bash
+apispec --dir . --output-config used-config.yaml   # what apispec composed
+# add a `naming:` block to used-config.yaml
+apispec --dir . -c used-config.yaml -o openapi.yaml
+```
 
 ## Security: `security`, `securitySchemes`, `securityMappings`
 

--- a/generator/testdata_naming_test.go
+++ b/generator/testdata_naming_test.go
@@ -1,0 +1,135 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/spec"
+)
+
+// naming.schemaNames: short must shorten every component AND keep the document
+// resolvable — a rename that misses one $ref site produces a spec that cannot
+// be consumed at all, which is worse than the long names it replaced (#298).
+func TestTestdata_NamingShortSchemas(t *testing.T) {
+	cfg := spec.DefaultHTTPConfig()
+	cfg.Naming.SchemaNames = spec.NamingShort
+	out := loadTestdata(t, "one_type_one_component", cfg)
+
+	noDanglingRefs(t, out)
+	noUnresolvedPlaceholders(t, out)
+
+	for name := range out.Components.Schemas {
+		if strings.Contains(name, "twoname") {
+			t.Errorf("component %q still carries the module path", name)
+		}
+	}
+	for _, want := range []string{"Issue", "Thing"} {
+		if _, ok := out.Components.Schemas[want]; !ok {
+			t.Errorf("want a component named %q; have %v", want, mapSchemaKeys(out.Components.Schemas))
+		}
+	}
+}
+
+// The default must not move: `full` is the documented default, and a project
+// that says nothing about naming gets exactly what it got before.
+func TestTestdata_NamingDefaultsToFull(t *testing.T) {
+	out := loadTestdata(t, "one_type_one_component", spec.DefaultHTTPConfig())
+	found := false
+	for name := range out.Components.Schemas {
+		if strings.Contains(name, "twoname_api") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("default naming should keep fully-qualified components; have %v",
+			mapSchemaKeys(out.Components.Schemas))
+	}
+}
+
+// method-path ids are derived from the operation itself, so they carry no Go
+// symbol and are unique by construction (a method and path pair is unique in
+// OpenAPI).
+func TestTestdata_NamingMethodPathOperationIDs(t *testing.T) {
+	cfg := spec.DefaultHTTPConfig()
+	cfg.Naming.OperationID = spec.NamingMethodPath
+	out := loadTestdata(t, "one_type_one_component", cfg)
+
+	seen := map[string]string{}
+	for path, item := range out.Paths {
+		item := item
+		op := firstOperation(&item)
+		if op == nil {
+			continue
+		}
+		id := op.OperationID
+		if id == "" {
+			t.Errorf("%s: empty operationId", path)
+			continue
+		}
+		if strings.Contains(id, "/") || strings.Contains(id, "twoname") {
+			t.Errorf("%s: operationId %q still carries a Go symbol", path, id)
+		}
+		if prev, dup := seen[id]; dup {
+			t.Errorf("operationId %q used by both %s and %s", id, prev, path)
+		}
+		seen[id] = path
+	}
+	if got, ok := seen["getDirect"]; !ok {
+		t.Errorf("want an operationId %q derived from GET /direct; have %v", "getDirect", seen)
+	} else if got != "/direct" {
+		t.Errorf("getDirect mapped to %s", got)
+	}
+}
+
+// receiver-method keeps the handler's own name and drops the import path.
+func TestTestdata_NamingReceiverMethodOperationIDs(t *testing.T) {
+	cfg := spec.DefaultHTTPConfig()
+	cfg.Naming.OperationID = spec.NamingReceiverMethod
+	out := loadTestdata(t, "one_type_one_component", cfg)
+
+	for path, item := range out.Paths {
+		item := item
+		op := firstOperation(&item)
+		if op == nil {
+			continue
+		}
+		if strings.Contains(op.OperationID, "/") {
+			t.Errorf("%s: operationId %q still carries an import path", path, op.OperationID)
+		}
+	}
+}
+
+// An unknown value keeps the default rather than failing the run or inventing
+// a third behaviour.
+func TestTestdata_NamingUnknownValueKeepsFull(t *testing.T) {
+	cfg := spec.DefaultHTTPConfig()
+	cfg.Naming.SchemaNames = "abbreviated"
+	cfg.Naming.OperationID = "verb-noun"
+	out := loadTestdata(t, "one_type_one_component", cfg)
+
+	noDanglingRefs(t, out)
+	found := false
+	for name := range out.Components.Schemas {
+		if strings.Contains(name, "twoname_api") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("an unknown naming value should keep the fully-qualified default; have %v",
+			mapSchemaKeys(out.Components.Schemas))
+	}
+}

--- a/internal/spec/config.go
+++ b/internal/spec/config.go
@@ -886,6 +886,28 @@ type Defaults struct {
 	ResponseStatus      int    `yaml:"responseStatus,omitempty" json:"responseStatus,omitempty"`
 }
 
+// Naming selects how operationIds and component names are spelled.
+//
+// The default for both is "full": the fully-qualified Go symbol, which is
+// collision-free and reproducible. It also reproduces the module path, the
+// internal package layout and unexported handler names in a document that is
+// usually served over HTTP, and it makes 80-character TypeScript identifiers
+// downstream — so it is a choice rather than a law (issue #298).
+type Naming struct {
+	// OperationID is "full" (default), "receiver-method" or "method-path".
+	OperationID string `yaml:"operationId,omitempty" json:"operationId,omitempty"`
+	// SchemaNames is "full" (default) or "short".
+	SchemaNames string `yaml:"schemaNames,omitempty" json:"schemaNames,omitempty"`
+}
+
+// Naming style values.
+const (
+	NamingFull           = "full"
+	NamingShort          = "short"
+	NamingReceiverMethod = "receiver-method"
+	NamingMethodPath     = "method-path"
+)
+
 // ExternalType defines an external type that should be treated as known
 type ExternalType struct {
 	Name        string  `yaml:"name" json:"name,omitempty"`               // Full type name (e.g., "primitive.ObjectID")
@@ -913,6 +935,10 @@ type APISpecConfig struct {
 
 	// Defaults
 	Defaults Defaults `yaml:"defaults" json:"defaults,omitempty"`
+
+	// Naming selects how operationIds and component names are spelled
+	// (issue #298). Both default to the fully-qualified Go symbol.
+	Naming Naming `yaml:"naming,omitempty" json:"naming,omitempty"`
 
 	// OpenAPI metadata
 	Info            Info                      `yaml:"info" json:"info,omitempty"`

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -432,6 +432,11 @@ func MapMetadataToOpenAPIWithDiagnostics(tree TrackerTreeInterface, cfg *APISpec
 		spec.Components.SecuritySchemes = schemes
 	}
 
+	// Rename before the consistency check, not after: if a rename ever missed a
+	// $ref site, the repair below reports it instead of the spec shipping a
+	// dangling reference (issue #298).
+	applyNaming(spec, cfg, usedTypes)
+
 	// Last, once every component is registered: make the document internally
 	// consistent. Anything still pointing at nothing is repaired with the
 	// honest placeholder and reported, so a spec that cannot resolve never

--- a/internal/spec/naming.go
+++ b/internal/spec/naming.go
@@ -119,6 +119,19 @@ func shortSchemaNames(components *Components, usedTypes map[string]*Schema) map[
 
 	renames := map[string]string{}
 	taken := map[string]string{} // proposed name -> component key that claimed it
+	// A component this pass skips — wrapper-typed, unqualified, opaque — keeps
+	// the key it has. Reserve those first: a short name that happened to equal
+	// one would put two schemas under a single key, and the map would keep only
+	// the last, silently redirecting the other's $refs to the wrong type.
+	shortened := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		shortened[e.key] = true
+	}
+	for key := range components.Schemas {
+		if !shortened[key] {
+			taken[key] = key
+		}
+	}
 	for _, bare := range slices.Sorted(maps.Keys(byBare)) {
 		group := byBare[bare]
 		level := 0
@@ -231,10 +244,11 @@ func applySchemaRenames(spec *OpenAPISpec, renames map[string]string) {
 // generators reject.
 //
 // So a clash escalates rather than surrendering: receiver-method falls back to
-// the operation's own method-and-path identity, which is unique by construction
-// (OpenAPI cannot hold two operations for one method and path), and only a
-// clash there — two paths normalizing to the same identifier — takes a numeric
-// suffix. Operations are visited in sorted (path, method) order, so which one
+// the operation's own method-and-path identity, and a clash THERE — two paths
+// normalizing to one identifier, since /a-b and /a/b both read as "getAB" —
+// takes a numeric suffix. The pair is unique in OpenAPI; the identifier derived
+// from it is not, which is why the numbering exists rather than being
+// unreachable belt-and-braces. Operations are visited in sorted (path, method) order, so which one
 // takes the plain name is decided by the document, not by map order.
 func applyOperationIDs(spec *OpenAPISpec, style string) {
 	type opRef struct {
@@ -255,7 +269,7 @@ func applyOperationIDs(spec *OpenAPISpec, style string) {
 
 	taken := map[string]bool{}
 	for _, o := range ops {
-		for _, want := range operationIDCandidates(style, o.method, o.path, o.op.OperationID) {
+		for _, want := range operationIDCandidates(style, o.method, o.path, o.op.OperationID, len(ops)) {
 			if want == "" || taken[want] {
 				continue
 			}
@@ -268,9 +282,13 @@ func applyOperationIDs(spec *OpenAPISpec, style string) {
 
 // operationIDCandidates lists the ids to try for one operation, best first: the
 // chosen style, then the method-and-path identity, then that identity numbered.
-// The last is reached only when two paths normalize to the same string, and it
-// terminates because the counter is unbounded while the operations are finite.
-func operationIDCandidates(style, method, path, current string) []string {
+//
+// The numbering is not decoration. A method and path pair is unique in OpenAPI,
+// but the IDENTIFIER derived from it is not: methodPathID drops every
+// non-alphanumeric character, so /a-b, /a/b and /aB all read as "getAB". The
+// suffix is bounded by the number of operations, so a name is always available
+// — with n operations, at most n-1 can be ahead of this one on any given name.
+func operationIDCandidates(style, method, path, current string, operations int) []string {
 	byPath := methodPathID(method, path)
 	var out []string
 	switch style {
@@ -279,7 +297,7 @@ func operationIDCandidates(style, method, path, current string) []string {
 	case NamingReceiverMethod:
 		out = []string{receiverMethodID(current), byPath}
 	}
-	for i := 2; i <= 64; i++ {
+	for i := 2; i <= operations+1; i++ {
 		out = append(out, byPath+strconv.Itoa(i))
 	}
 	return out

--- a/internal/spec/naming.go
+++ b/internal/spec/naming.go
@@ -1,0 +1,366 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"log"
+	"maps"
+	"slices"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/ehabterra/apispec/internal/typemodel"
+)
+
+// applyNaming rewrites component names and operationIds according to
+// cfg.Naming, after the spec is otherwise complete.
+//
+// It runs as a post-pass rather than at each producer because a component name
+// is written in many places — the components map, and a $ref in a schema, a
+// property, an allOf member, a parameter, a request body, a response, a
+// discriminator mapping. Renaming at the source would mean threading the
+// decision through all of them and would dangle a ref the day one is missed;
+// renaming afterwards, from one table, either rewrites every occurrence or
+// none. The fixture asserts no dangling $ref for exactly this reason.
+//
+// usedTypes carries the Go type names the components were built from, which is
+// what makes a short name derivable at all: a component KEY has already been
+// sanitized ("pkg_Type"), and splitting that back apart would be guesswork on
+// any type or package containing an underscore.
+func applyNaming(spec *OpenAPISpec, cfg *APISpecConfig, usedTypes map[string]*Schema) {
+	if spec == nil || cfg == nil {
+		return
+	}
+	switch cfg.Naming.SchemaNames {
+	case "", NamingFull:
+	case NamingShort:
+		applySchemaRenames(spec, shortSchemaNames(spec.Components, usedTypes))
+	default:
+		log.Printf("[naming] unknown schemaNames %q, keeping %q", cfg.Naming.SchemaNames, NamingFull)
+	}
+	switch cfg.Naming.OperationID {
+	case "", NamingFull:
+	case NamingReceiverMethod, NamingMethodPath:
+		applyOperationIDs(spec, cfg.Naming.OperationID)
+	default:
+		log.Printf("[naming] unknown operationId %q, keeping %q", cfg.Naming.OperationID, NamingFull)
+	}
+}
+
+// shortEntry is one component considered for shortening: the key it has now,
+// the import path of its Go type, and the unqualified rendering of that type.
+type shortEntry struct {
+	key  string
+	pkg  string
+	bare string
+}
+
+// shortSchemaNames maps each component key to its unqualified type name,
+// qualifying only what would otherwise collide.
+//
+// Two packages with a `Components` type are ordinary, and letting one of them
+// win the bare name would be worse than the long names — the winner would
+// depend on nothing a reader could see. So a colliding group is qualified as a
+// group: every member takes the shortest suffix of its package path that tells
+// all of them apart, extended one segment at a time. Groups are visited in
+// sorted order, and a name already claimed is never taken, so the result is a
+// pure function of the input (golden rule #1).
+func shortSchemaNames(components *Components, usedTypes map[string]*Schema) map[string]string {
+	if components == nil || len(components.Schemas) == 0 {
+		return nil
+	}
+	var entries []shortEntry
+	for _, goType := range slices.Sorted(maps.Keys(usedTypes)) {
+		key := schemaComponentNameReplacer.Replace(goType)
+		if _, ok := components.Schemas[key]; !ok {
+			continue
+		}
+		ref := typemodel.Parse(goType)
+		if ref == nil || ref.Kind != typemodel.KindNamed {
+			// A wrapper-typed key (*T, []T) is an artifact rather than a type
+			// anyone references — gitea has one such orphan component, from a
+			// pointer that was never stripped. Shortening it would render as
+			// "*T", sanitize to a leading underscore, and collide with the
+			// component for T. Left alone, so the artifact stays visible and
+			// this pass invents nothing.
+			continue
+		}
+		core := ref.Core()
+		if core == nil || core.Name == "" || core.Pkg == "" {
+			continue // unqualified or opaque: nothing to shorten
+		}
+		bare := ref.Simple()
+		if bare == "" {
+			continue
+		}
+		entries = append(entries, shortEntry{key: key, pkg: core.Pkg, bare: bare})
+	}
+	if len(entries) == 0 {
+		return nil
+	}
+
+	byBare := map[string][]shortEntry{}
+	for _, e := range entries {
+		byBare[e.bare] = append(byBare[e.bare], e)
+	}
+
+	renames := map[string]string{}
+	taken := map[string]string{} // proposed name -> component key that claimed it
+	for _, bare := range slices.Sorted(maps.Keys(byBare)) {
+		group := byBare[bare]
+		level := 0
+		if len(group) > 1 {
+			level = distinguishingLevel(group)
+		}
+		for _, e := range group {
+			// A cross-group clash (a qualified name meeting an unqualified one)
+			// escalates this entry alone until it is free, and never past the
+			// full path, where uniqueness is guaranteed by construction.
+			var name string
+			for lvl := level; ; lvl++ {
+				name = schemaComponentNameReplacer.Replace(qualifyName(e.bare, e.pkg, lvl))
+				if claimed, clash := taken[name]; !clash || claimed == e.key {
+					break
+				}
+				if lvl > strings.Count(e.pkg, "/")+1 {
+					name = e.key // give up: keep the fully-qualified key
+					break
+				}
+			}
+			taken[name] = e.key
+			if name != e.key {
+				renames[e.key] = name
+			}
+		}
+	}
+	return renames
+}
+
+// distinguishingLevel is the smallest number of trailing package-path segments
+// that tells every member of a colliding group apart, or the longest path
+// length when no level does (two types of the same name in one package cannot
+// happen, so this is a safety net rather than an expected outcome).
+func distinguishingLevel(group []shortEntry) int {
+	max := 0
+	for _, e := range group {
+		if n := strings.Count(e.pkg, "/") + 1; n > max {
+			max = n
+		}
+	}
+	for level := 1; level <= max; level++ {
+		seen := map[string]bool{}
+		unique := true
+		for _, e := range group {
+			q := qualifyName(e.bare, e.pkg, level)
+			if seen[q] {
+				unique = false
+				break
+			}
+			seen[q] = true
+		}
+		if unique {
+			return level
+		}
+	}
+	return max
+}
+
+// qualifyName prefixes bare with the last `level` segments of pkg. Level 0 is
+// the unqualified name.
+func qualifyName(bare, pkg string, level int) string {
+	if level <= 0 {
+		return bare
+	}
+	segs := strings.Split(pkg, "/")
+	if level > len(segs) {
+		level = len(segs)
+	}
+	return strings.Join(segs[len(segs)-level:], "_") + "_" + bare
+}
+
+// applySchemaRenames renames the component keys and every $ref that names one.
+//
+// The rewrite goes through mapSchemaRefs — the same traversal the dangling-ref
+// check uses — so a ref site cannot be renamed by one and missed by the other.
+func applySchemaRenames(spec *OpenAPISpec, renames map[string]string) {
+	if len(renames) == 0 || spec == nil || spec.Components == nil {
+		return
+	}
+	refFor := make(map[string]string, len(renames))
+	for from, to := range renames {
+		refFor[refComponentsSchemasPrefix+from] = refComponentsSchemasPrefix + to
+	}
+
+	renamed := make(map[string]*Schema, len(spec.Components.Schemas))
+	for key, s := range spec.Components.Schemas {
+		if to, ok := renames[key]; ok {
+			key = to
+		}
+		renamed[key] = s
+	}
+	spec.Components.Schemas = renamed
+
+	mapSchemaRefs(spec, func(ref string) string {
+		if to, ok := refFor[ref]; ok {
+			return to
+		}
+		return ref
+	})
+}
+
+// applyOperationIDs rewrites every operationId in the chosen style, and
+// guarantees the result is unique.
+//
+// Uniqueness is not a nicety here. The fully-qualified default is NOT unique on
+// a real project: gitea's spec carries 1109 operations under 700 distinct ids,
+// because a shared middleware or wrapper is the resolved handler for many
+// routes (issue #459). Inheriting that would hand a caller a document most
+// generators reject.
+//
+// So a clash escalates rather than surrendering: receiver-method falls back to
+// the operation's own method-and-path identity, which is unique by construction
+// (OpenAPI cannot hold two operations for one method and path), and only a
+// clash there — two paths normalizing to the same identifier — takes a numeric
+// suffix. Operations are visited in sorted (path, method) order, so which one
+// takes the plain name is decided by the document, not by map order.
+func applyOperationIDs(spec *OpenAPISpec, style string) {
+	type opRef struct {
+		path, method string
+		op           *Operation
+	}
+	var ops []opRef
+	for _, path := range slices.Sorted(maps.Keys(spec.Paths)) {
+		item := spec.Paths[path]
+		byMethod := operationsByMethod(&item)
+		for _, method := range slices.Sorted(maps.Keys(byMethod)) {
+			if op := byMethod[method]; op != nil {
+				ops = append(ops, opRef{path: path, method: method, op: op})
+			}
+		}
+		spec.Paths[path] = item
+	}
+
+	taken := map[string]bool{}
+	for _, o := range ops {
+		for _, want := range operationIDCandidates(style, o.method, o.path, o.op.OperationID) {
+			if want == "" || taken[want] {
+				continue
+			}
+			taken[want] = true
+			o.op.OperationID = want
+			break
+		}
+	}
+}
+
+// operationIDCandidates lists the ids to try for one operation, best first: the
+// chosen style, then the method-and-path identity, then that identity numbered.
+// The last is reached only when two paths normalize to the same string, and it
+// terminates because the counter is unbounded while the operations are finite.
+func operationIDCandidates(style, method, path, current string) []string {
+	byPath := methodPathID(method, path)
+	var out []string
+	switch style {
+	case NamingMethodPath:
+		out = []string{byPath}
+	case NamingReceiverMethod:
+		out = []string{receiverMethodID(current), byPath}
+	}
+	for i := 2; i <= 64; i++ {
+		out = append(out, byPath+strconv.Itoa(i))
+	}
+	return out
+}
+
+// receiverMethodID drops the import path from a fully-qualified operationId,
+// keeping the receiver and method that identify the handler in its own package
+// ("…/internal/httpapi.estimateHandler.updateLine" -> "estimateHandler.updateLine").
+//
+// A closure has no receiver and its tail is a source position
+// ("pkg.FuncLit:router.go:998:21"); dropping the path is still an improvement,
+// and method-path is the better choice for a codebase written that way.
+func receiverMethodID(full string) string {
+	if full == "" {
+		return ""
+	}
+	tail := full
+	if i := strings.LastIndex(tail, "/"); i >= 0 {
+		tail = tail[i+1:]
+	}
+	// What remains is "pkgname.Rest"; drop the package name.
+	if i := strings.Index(tail, "."); i >= 0 && i+1 < len(tail) {
+		tail = tail[i+1:]
+	}
+	return tail
+}
+
+// methodPathID builds "getUsersByIdItems" from GET /users/{id}/items: the verb,
+// then each segment capitalized, with a path parameter reading as "By<Name>".
+func methodPathID(method, path string) string {
+	var b strings.Builder
+	b.WriteString(strings.ToLower(method))
+	for _, seg := range strings.Split(path, "/") {
+		if seg == "" {
+			continue
+		}
+		if strings.HasPrefix(seg, "{") && strings.HasSuffix(seg, "}") {
+			b.WriteString("By")
+			b.WriteString(pathWord(strings.Trim(seg, "{}")))
+			continue
+		}
+		b.WriteString(pathWord(seg))
+	}
+	return b.String()
+}
+
+// pathWord renders one path segment as an identifier fragment: word boundaries
+// at every non-alphanumeric character, each word capitalized. Interior case is
+// preserved, so a camelCase segment survives — unlike security_lookup's
+// camelSegment, which lowercases what follows and would read "estimateLine" as
+// "Estimateline".
+func pathWord(s string) string {
+	var b strings.Builder
+	upper := true
+	for _, r := range s {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsDigit(r):
+			if upper {
+				b.WriteRune(unicode.ToUpper(r))
+				upper = false
+			} else {
+				b.WriteRune(r)
+			}
+		default:
+			upper = true
+		}
+	}
+	return b.String()
+}
+
+// operationsByMethod indexes a path item's operations by uppercase HTTP method,
+// so a pass can visit them in a sorted, reproducible order.
+func operationsByMethod(item *PathItem) map[string]*Operation {
+	out := map[string]*Operation{}
+	for method, op := range map[string]*Operation{
+		"GET": item.Get, "POST": item.Post, "PUT": item.Put, "DELETE": item.Delete,
+		"PATCH": item.Patch, "OPTIONS": item.Options, "HEAD": item.Head,
+	} {
+		if op != nil {
+			out[method] = op
+		}
+	}
+	return out
+}

--- a/internal/spec/naming.go
+++ b/internal/spec/naming.go
@@ -289,6 +289,12 @@ func operationIDCandidates(style, method, path, current string) []string {
 // keeping the receiver and method that identify the handler in its own package
 // ("…/internal/httpapi.estimateHandler.updateLine" -> "estimateHandler.updateLine").
 //
+// A generic handler is qualified INSIDE its type argument as well
+// ("…/modules/web.Bind[…/services/forms.InstallForm]"), so the base and the
+// argument list are unqualified separately. Trimming the whole string at its
+// last "/" would cut inside the brackets and leave "InstallForm]" — which is
+// how gitea's spec looked before this was split out.
+//
 // A closure has no receiver and its tail is a source position
 // ("pkg.FuncLit:router.go:998:21"); dropping the path is still an improvement,
 // and method-path is the better choice for a codebase written that way.
@@ -296,15 +302,35 @@ func receiverMethodID(full string) string {
 	if full == "" {
 		return ""
 	}
-	tail := full
-	if i := strings.LastIndex(tail, "/"); i >= 0 {
-		tail = tail[i+1:]
+	base, args := full, ""
+	if i := strings.Index(full, "["); i >= 0 {
+		base, args = full[:i], full[i:]
+	}
+	base = unqualifySymbol(base)
+	if args == "" {
+		return base
+	}
+	// Each type argument is unqualified the same way, so Bind[…forms.X] reads
+	// as Bind[X] rather than carrying a second import path.
+	inner := strings.TrimSuffix(strings.TrimPrefix(args, "["), "]")
+	parts := strings.Split(inner, ",")
+	for i, p := range parts {
+		parts[i] = unqualifySymbol(strings.TrimSpace(p))
+	}
+	return base + "[" + strings.Join(parts, ", ") + "]"
+}
+
+// unqualifySymbol drops an import path and the package name from a qualified Go
+// symbol, keeping everything that identifies it within its own package.
+func unqualifySymbol(sym string) string {
+	if i := strings.LastIndex(sym, "/"); i >= 0 {
+		sym = sym[i+1:]
 	}
 	// What remains is "pkgname.Rest"; drop the package name.
-	if i := strings.Index(tail, "."); i >= 0 && i+1 < len(tail) {
-		tail = tail[i+1:]
+	if i := strings.Index(sym, "."); i >= 0 && i+1 < len(sym) {
+		sym = sym[i+1:]
 	}
-	return tail
+	return sym
 }
 
 // methodPathID builds "getUsersByIdItems" from GET /users/{id}/items: the verb,

--- a/internal/spec/naming_test.go
+++ b/internal/spec/naming_test.go
@@ -15,6 +15,7 @@
 package spec
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -146,6 +147,9 @@ func TestApplySchemaRenamesRewritesEveryRefSite(t *testing.T) {
 					Parameters: []Parameter{{Name: "p", In: "query", Schema: ref("old")}},
 					RequestBody: &RequestBody{Content: map[string]MediaType{
 						"application/json": {Schema: &Schema{Properties: map[string]*Schema{"nested": ref("old")}}},
+						"multipart/form-data": {Encoding: map[string]Encoding{
+							"part": {Headers: map[string]Header{"X-Part": {Schema: ref("old")}}},
+						}},
 					}},
 					Responses: map[string]Response{
 						"200": {
@@ -183,5 +187,87 @@ func TestApplySchemaRenamesRewritesEveryRefSite(t *testing.T) {
 	})
 	if len(stale) != 0 {
 		t.Errorf("%d $ref sites still point at the old name", len(stale))
+	}
+}
+
+// A component this pass skips keeps its key, so a short name must not be
+// allowed to land on it: the components map would keep one schema and the
+// other's $refs would silently point at the wrong type.
+func TestShortSchemaNamesDoesNotClaimASkippedKey(t *testing.T) {
+	usedTypes := map[string]*Schema{
+		"github.com/acme/svc/internal/api.Reference": {Type: "object"},
+	}
+	components := &Components{Schemas: map[string]*Schema{
+		schemaComponentNameReplacer.Replace("github.com/acme/svc/internal/api.Reference"): {Type: "object"},
+		// Already unqualified, so shortSchemaNames skips it — and "Reference"
+		// is exactly what the qualified type above would shorten to.
+		"Reference": {Type: "string"},
+	}}
+
+	renames := shortSchemaNames(components, usedTypes)
+
+	spec := &OpenAPISpec{Paths: map[string]PathItem{}, Components: components}
+	applySchemaRenames(spec, renames)
+
+	if len(spec.Components.Schemas) != 2 {
+		t.Fatalf("a schema was dropped: %v", mapKeys(spec.Components.Schemas))
+	}
+	if got := spec.Components.Schemas["Reference"]; got == nil || got.Type != "string" {
+		t.Errorf("the skipped component was overwritten: %+v", got)
+	}
+}
+
+// Distinct paths can normalize to one identifier (/a-b and /a/b both read as
+// "getAB"), so the numeric fallback is load-bearing rather than decorative.
+func TestApplyOperationIDsNumbersNormalizedCollisions(t *testing.T) {
+	op := func(id string) *Operation { return &Operation{OperationID: id} }
+	spec := &OpenAPISpec{Paths: map[string]PathItem{
+		"/a-b": {Get: op("pkg.first")},
+		"/a/b": {Get: op("pkg.second")},
+		"/aB":  {Get: op("pkg.third")},
+	}}
+
+	applyOperationIDs(spec, NamingMethodPath)
+
+	seen := map[string]string{}
+	for path, item := range spec.Paths {
+		item := item
+		id := item.Get.OperationID
+		if prev, dup := seen[id]; dup {
+			t.Errorf("operationId %q used by both %s and %s", id, prev, path)
+		}
+		seen[id] = path
+	}
+	if len(seen) != 3 {
+		t.Errorf("want 3 distinct ids, got %v", seen)
+	}
+}
+
+// The numeric fallback must not run out. More operations normalizing to one
+// identifier than a fixed cap allows used to leave the overflow sharing an id;
+// the bound is the operation count, so a name is always available.
+func TestApplyOperationIDsFallbackScalesWithOperationCount(t *testing.T) {
+	const n = 70 // more than the fixed cap the first version used
+	paths := map[string]PathItem{}
+	for i := 0; i < n; i++ {
+		// Each path differs only in characters methodPathID drops, so all n
+		// normalize to the same identifier.
+		paths["/a"+strings.Repeat("-", i+1)+"b"] = PathItem{Get: &Operation{OperationID: "pkg.shared"}}
+	}
+	spec := &OpenAPISpec{Paths: paths}
+
+	applyOperationIDs(spec, NamingMethodPath)
+
+	seen := map[string]string{}
+	for path, item := range spec.Paths {
+		item := item
+		id := item.Get.OperationID
+		if prev, dup := seen[id]; dup {
+			t.Errorf("operationId %q shared by %s and %s", id, prev, path)
+		}
+		seen[id] = path
+	}
+	if len(seen) != n {
+		t.Errorf("got %d distinct ids for %d operations", len(seen), n)
 	}
 }

--- a/internal/spec/naming_test.go
+++ b/internal/spec/naming_test.go
@@ -1,0 +1,181 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"testing"
+)
+
+func TestMethodPathID(t *testing.T) {
+	for _, tc := range []struct {
+		method, path, want string
+	}{
+		{"GET", "/users", "getUsers"},
+		{"GET", "/users/{id}", "getUsersById"},
+		{"GET", "/users/{id}/items", "getUsersByIdItems"},
+		{"POST", "/", "post"},
+		{"DELETE", "/repos/{owner}/{repo}/issues/{index}", "deleteReposByOwnerByRepoIssuesByIndex"},
+		// Word boundaries at non-alphanumerics, interior case preserved: a
+		// camelCase segment survives, unlike security_lookup's camelSegment.
+		{"GET", "/api/v1/estimateLine", "getApiV1EstimateLine"},
+		{"GET", "/-/admin/user-settings", "getAdminUserSettings"},
+	} {
+		if got := methodPathID(tc.method, tc.path); got != tc.want {
+			t.Errorf("methodPathID(%q, %q) = %q, want %q", tc.method, tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestReceiverMethodID(t *testing.T) {
+	for _, tc := range []struct{ full, want string }{
+		{"github.com/acme/api/internal/httpapi.estimateHandler.updateLine", "estimateHandler.updateLine"},
+		{"github.com/acme/api/internal/httpapi.ListUsers", "ListUsers"},
+		{"main.handler", "handler"},
+		// A closure's tail is a source position. Dropping the module path is
+		// still an improvement; method-path suits such a codebase better.
+		{"github.com/acme/api/internal/http.FuncLit:router.go:998:21", "FuncLit:router.go:998:21"},
+		{"", ""},
+	} {
+		if got := receiverMethodID(tc.full); got != tc.want {
+			t.Errorf("receiverMethodID(%q) = %q, want %q", tc.full, got, tc.want)
+		}
+	}
+}
+
+// A colliding bare name qualifies the whole GROUP: letting one win would make
+// the winner depend on nothing a reader can see (issue #298).
+func TestShortSchemaNamesQualifiesCollisionsAsAGroup(t *testing.T) {
+	usedTypes := map[string]*Schema{
+		"github.com/acme/svc/internal/billing.Components":  {},
+		"github.com/acme/svc/internal/estimate.Components": {},
+		"github.com/acme/svc/internal/estimate.LineInput":  {},
+	}
+	components := &Components{Schemas: map[string]*Schema{}}
+	for name := range usedTypes {
+		components.Schemas[schemaComponentNameReplacer.Replace(name)] = &Schema{}
+	}
+
+	renames := shortSchemaNames(components, usedTypes)
+
+	want := map[string]string{
+		schemaComponentNameReplacer.Replace("github.com/acme/svc/internal/billing.Components"):  "billing_Components",
+		schemaComponentNameReplacer.Replace("github.com/acme/svc/internal/estimate.Components"): "estimate_Components",
+		schemaComponentNameReplacer.Replace("github.com/acme/svc/internal/estimate.LineInput"):  "LineInput",
+	}
+	for key, expected := range want {
+		if got := renames[key]; got != expected {
+			t.Errorf("rename[%q] = %q, want %q", key, got, expected)
+		}
+	}
+	if len(renames) != len(want) {
+		t.Errorf("got %d renames, want %d: %v", len(renames), len(want), renames)
+	}
+}
+
+// Same bare name AND same last package segment: qualification extends one
+// segment at a time until the group is distinct.
+func TestShortSchemaNamesExtendsUntilDistinct(t *testing.T) {
+	usedTypes := map[string]*Schema{
+		"github.com/acme/svc/alpha/config.Row": {},
+		"github.com/acme/svc/zeta/config.Row":  {},
+	}
+	components := &Components{Schemas: map[string]*Schema{}}
+	for name := range usedTypes {
+		components.Schemas[schemaComponentNameReplacer.Replace(name)] = &Schema{}
+	}
+
+	renames := shortSchemaNames(components, usedTypes)
+	want := map[string]string{
+		schemaComponentNameReplacer.Replace("github.com/acme/svc/alpha/config.Row"): "alpha_config_Row",
+		schemaComponentNameReplacer.Replace("github.com/acme/svc/zeta/config.Row"):  "zeta_config_Row",
+	}
+	for key, expected := range want {
+		if got := renames[key]; got != expected {
+			t.Errorf("rename[%q] = %q, want %q", key, got, expected)
+		}
+	}
+}
+
+// A wrapper-typed key (*T) is left alone: shortening it would render "*T",
+// sanitize to a leading underscore and collide with T's own component.
+func TestShortSchemaNamesSkipsWrapperKeys(t *testing.T) {
+	usedTypes := map[string]*Schema{
+		"*github.com/acme/svc/internal/api.Reference": {},
+		"github.com/acme/svc/internal/api.Reference":  {},
+	}
+	components := &Components{Schemas: map[string]*Schema{}}
+	for name := range usedTypes {
+		components.Schemas[schemaComponentNameReplacer.Replace(name)] = &Schema{}
+	}
+
+	renames := shortSchemaNames(components, usedTypes)
+	if got, ok := renames[schemaComponentNameReplacer.Replace("*github.com/acme/svc/internal/api.Reference")]; ok {
+		t.Errorf("pointer-typed key was renamed to %q; it should be left as it is", got)
+	}
+	if got := renames[schemaComponentNameReplacer.Replace("github.com/acme/svc/internal/api.Reference")]; got != "Reference" {
+		t.Errorf("named key = %q, want %q", got, "Reference")
+	}
+}
+
+// The rename must reach every $ref site, or the spec ships a dangling
+// reference. This drives the real traversal rather than a hand-rolled one.
+func TestApplySchemaRenamesRewritesEveryRefSite(t *testing.T) {
+	ref := func(name string) *Schema { return &Schema{Ref: refComponentsSchemasPrefix + name} }
+	spec := &OpenAPISpec{
+		Paths: map[string]PathItem{
+			"/x": {
+				Get: &Operation{
+					Parameters: []Parameter{{Name: "p", In: "query", Schema: ref("old")}},
+					RequestBody: &RequestBody{Content: map[string]MediaType{
+						"application/json": {Schema: &Schema{Properties: map[string]*Schema{"nested": ref("old")}}},
+					}},
+					Responses: map[string]Response{
+						"200": {
+							Content: map[string]MediaType{"application/json": {Schema: &Schema{Items: ref("old")}}},
+							Headers: map[string]Header{"X-Thing": {Schema: ref("old")}},
+						},
+					},
+				},
+			},
+		},
+		Components: &Components{
+			Schemas: map[string]*Schema{
+				"old":     {Type: "object"},
+				"wrapper": {AllOf: []*Schema{ref("old")}, AdditionalProperties: ref("old")},
+			},
+			Parameters:    map[string]*Parameter{"P": {Schema: ref("old")}},
+			RequestBodies: map[string]*RequestBody{"B": {Content: map[string]MediaType{"application/json": {Schema: ref("old")}}}},
+			Responses:     map[string]*Response{"R": {Content: map[string]MediaType{"application/json": {Schema: ref("old")}}}},
+		},
+	}
+
+	applySchemaRenames(spec, map[string]string{"old": "New"})
+
+	if _, ok := spec.Components.Schemas["New"]; !ok {
+		t.Fatalf("component was not renamed: %v", spec.Components.Schemas)
+	}
+	if _, ok := spec.Components.Schemas["old"]; ok {
+		t.Error("the old component key is still present")
+	}
+	var stale []string
+	forEachSchemaRef(spec, func(name string) {
+		if name == "old" {
+			stale = append(stale, name)
+		}
+	})
+	if len(stale) != 0 {
+		t.Errorf("%d $ref sites still point at the old name", len(stale))
+	}
+}

--- a/internal/spec/naming_test.go
+++ b/internal/spec/naming_test.go
@@ -46,6 +46,12 @@ func TestReceiverMethodID(t *testing.T) {
 		// A closure's tail is a source position. Dropping the module path is
 		// still an improvement; method-path suits such a codebase better.
 		{"github.com/acme/api/internal/http.FuncLit:router.go:998:21", "FuncLit:router.go:998:21"},
+		// A generic handler is qualified inside its type argument too, so the
+		// base and the argument are unqualified separately. Trimming the whole
+		// string at its last "/" cut inside the brackets and left
+		// "InstallForm]" in a real spec.
+		{"gitea.dev/modules/web.Bind[gitea.dev/services/forms.InstallForm]", "Bind[InstallForm]"},
+		{"acme.dev/web.Bind[acme.dev/forms.A, acme.dev/forms.B]", "Bind[A, B]"},
 		{"", ""},
 	} {
 		if got := receiverMethodID(tc.full); got != tc.want {

--- a/internal/spec/refcheck.go
+++ b/internal/spec/refcheck.go
@@ -215,6 +215,16 @@ func mapSchemaRefs(spec *OpenAPISpec, rewrite func(ref string) string) {
 	walkContent := func(content map[string]MediaType) {
 		for ct, mt := range content {
 			walk(mt.Schema)
+			// A multipart part's own headers carry schemas too, and a $ref
+			// there needs a target like any other. Example/Examples hold
+			// values rather than schemas, so they have nothing to visit.
+			for name, enc := range mt.Encoding {
+				for hn, h := range enc.Headers {
+					walk(h.Schema)
+					enc.Headers[hn] = h
+				}
+				mt.Encoding[name] = enc
+			}
 			content[ct] = mt
 		}
 	}

--- a/internal/spec/refcheck.go
+++ b/internal/spec/refcheck.go
@@ -144,13 +144,39 @@ func goTypeByComponentName(usedTypes map[string]*Schema) map[string]string {
 // walking the typed document rather than the schemas map alone — request
 // bodies, responses, headers, parameters and the components section each carry
 // their own.
+// forEachSchemaRef visits the component name behind every $ref in the spec.
+//
+// Implemented on top of mapSchemaRefs so the enumeration the dangling-ref
+// check trusts and the rewrite the naming pass performs cannot drift apart:
+// one traversal, two uses. A ref site added to the walk is therefore both
+// counted and rewritable, which is what keeps a rename from dangling.
 func forEachSchemaRef(spec *OpenAPISpec, visit func(name string)) {
+	mapSchemaRefs(spec, func(ref string) string {
+		if name, ok := componentSchemaName(ref); ok {
+			visit(name)
+		}
+		return ref
+	})
+}
+
+// mapSchemaRefs replaces every $ref in the spec with rewrite(ref), in place.
+//
+// rewrite is called with the whole ref string and returns its replacement, so
+// returning the argument unchanged makes this a pure traversal. Value-typed
+// containers (a Parameter in a slice, a MediaType or Response in a map) are
+// written back explicitly; a pointer-typed Schema is updated through the
+// pointer.
+func mapSchemaRefs(spec *OpenAPISpec, rewrite func(ref string) string) {
+	if spec == nil {
+		return
+	}
 	// A RECURSION STACK, not a global visited set: the same *Schema can be
 	// mounted in two operations, and both are references that need a target.
 	// Deduplicating globally would visit it once and undercount Sites, which
 	// is the number telling a user how much of their spec is affected. Only a
 	// schema currently being walked is skipped, which is what makes a
-	// self-referential type terminate.
+	// self-referential type terminate. Rewriting is idempotent, so a schema
+	// reached twice is rewritten twice to the same value.
 	onPath := map[*Schema]bool{}
 
 	var walk func(s *Schema)
@@ -161,9 +187,7 @@ func forEachSchemaRef(spec *OpenAPISpec, visit func(name string)) {
 		onPath[s] = true
 		defer delete(onPath, s)
 
-		if name, ok := componentSchemaName(s.Ref); ok {
-			visit(name)
-		}
+		s.Ref = rewrite(s.Ref)
 		for _, p := range s.Properties {
 			walk(p)
 		}
@@ -175,31 +199,37 @@ func forEachSchemaRef(spec *OpenAPISpec, visit func(name string)) {
 				walk(member)
 			}
 		}
+		if s.Discriminator != nil {
+			for k, v := range s.Discriminator.Mapping {
+				s.Discriminator.Mapping[k] = rewrite(v)
+			}
+		}
 	}
 
 	walkParams := func(params []Parameter) {
-		for _, p := range params {
-			if name, ok := componentSchemaName(p.Ref); ok {
-				visit(name)
-			}
-			walk(p.Schema)
+		for i := range params {
+			params[i].Ref = rewrite(params[i].Ref)
+			walk(params[i].Schema)
 		}
 	}
 	walkContent := func(content map[string]MediaType) {
-		for _, mt := range content {
+		for ct, mt := range content {
 			walk(mt.Schema)
+			content[ct] = mt
 		}
 	}
 	walkResponses := func(responses map[string]Response) {
-		for _, r := range responses {
+		for status, r := range responses {
 			walkContent(r.Content)
-			for _, h := range r.Headers {
+			for name, h := range r.Headers {
 				walk(h.Schema)
+				r.Headers[name] = h
 			}
+			responses[status] = r
 		}
 	}
 
-	for _, item := range spec.Paths {
+	for path, item := range spec.Paths {
 		walkParams(item.Parameters)
 		for _, op := range []*Operation{item.Get, item.Post, item.Put, item.Delete, item.Patch, item.Head, item.Options} {
 			if op == nil {
@@ -211,6 +241,7 @@ func forEachSchemaRef(spec *OpenAPISpec, visit func(name string)) {
 			}
 			walkResponses(op.Responses)
 		}
+		spec.Paths[path] = item
 	}
 
 	if spec.Components == nil {
@@ -223,6 +254,7 @@ func forEachSchemaRef(spec *OpenAPISpec, visit func(name string)) {
 		if p == nil {
 			continue
 		}
+		p.Ref = rewrite(p.Ref)
 		walk(p.Schema)
 	}
 	for _, rb := range spec.Components.RequestBodies {
@@ -236,8 +268,9 @@ func forEachSchemaRef(spec *OpenAPISpec, visit func(name string)) {
 			continue
 		}
 		walkContent(r.Content)
-		for _, h := range r.Headers {
+		for name, h := range r.Headers {
 			walk(h.Schema)
+			r.Headers[name] = h
 		}
 	}
 	for _, h := range spec.Components.Headers {

--- a/internal/spec/refcheck_test.go
+++ b/internal/spec/refcheck_test.go
@@ -102,6 +102,18 @@ func TestForEachSchemaRefVisitsEveryLocation(t *testing.T) {
 			return &OpenAPISpec{Paths: map[string]PathItem{}, Components: &Components{
 				Headers: map[string]*Header{"h": {Schema: refTo("T")}}}}
 		},
+		// A multipart part's own headers carry schemas, and a $ref there needs
+		// a target like any other. Found in review of #298: neither this
+		// walker nor the rename that now shares it looked inside Encoding.
+		"encoding headers": func() *OpenAPISpec {
+			return &OpenAPISpec{Paths: map[string]PathItem{"/x": {Post: &Operation{
+				RequestBody: &RequestBody{Content: map[string]MediaType{
+					"multipart/form-data": {Encoding: map[string]Encoding{
+						"part": {Headers: map[string]Header{"X-Part": {Schema: refTo("T")}}},
+					}},
+				}},
+			}}}}
+		},
 		"nested two deep": func() *OpenAPISpec {
 			return specWithSchemas(map[string]*Schema{"Outer": {Type: "array", Items: &Schema{
 				Properties: map[string]*Schema{"f": {Type: "array", Items: refTo("T")}}}}})


### PR DESCRIPTION
Closes #298.

Every `operationId` was the fully-qualified Go symbol and every component name
that symbol with separators replaced. Those names never collide, which is why
they stay the **default** — but they also put the module path, internal package
layout and unexported handler names into a document that is usually served over
HTTP, in identifiers long enough that a generated client needs an alias per
type.

```yaml
naming:
  operationId: full | receiver-method | method-path
  schemaNames: full | short
```

## Additive: the default does not move

**111 fixture specs are byte-identical** with no `naming` block. A project that
says nothing gets the same document it got before, and there is no golden churn
in this PR.

## Measured on gitea (899 paths, 1109 operations)

| | default (`full`) | `short` + `method-path` |
|---|---|---|
| longest component name | 69 chars | **36** |
| components carrying the module path | 230 | **1** |
| schemas | 242 | 242 (nothing merged or lost) |
| dangling `$ref`s | — | **none** |
| distinct operationIds | **700 / 1109** | **1109 / 1109** |
| ids carrying an import path | 956 | **0** |

The one remaining module-path component is a pointer-typed key
(`*…structs.Reference`), left alone deliberately — see below.

## Collisions qualify the group, never a winner

Two packages with a `Components` type is ordinary. When short names collide,
**every member of the group** takes the shortest package-path suffix that tells
them apart, extended one segment at a time:

```
billing_Components      # internal/billing
estimate_Components     # internal/estimate
LineInput               # unique, stays bare
```

Letting one keep the bare name would make the winner depend on nothing a reader
can see. Groups resolve in sorted order, so the result is a pure function of the
input (golden rule #1). 21 of gitea's names needed qualification.

## Three implementation decisions

* **Short names come from the Go type names, not the component keys.** A key is
  already sanitized, so splitting `pkg_Type` back apart would be guesswork for
  any type or package containing an underscore. `typemodel` answers it exactly.
* **The rename shares the traversal the dangling-ref check uses.**
  `forEachSchemaRef` is now written in terms of a mutating `mapSchemaRefs`, so a
  ref site cannot be renamed by one and missed by the other, and the pass runs
  *before* `repairDanglingRefs` so a miss would be reported rather than shipped.
  (My first rewrite dropped `components.headers` from that walk — the existing
  parity test caught it, which is the argument for sharing the traversal.)
* **A wrapper-typed key (`*T`, `[]T`) is left fully qualified.** Such a key is an
  artifact rather than a type anyone references; shortening it renders `*T`,
  sanitizes to a leading underscore, and collides with `T`'s own component.

## operationId uniqueness — and a pre-existing bug

The default is **not** unique: gitea carries 1109 operations under **700**
distinct ids, because a shared middleware resolves as the handler for dozens of
routes, and `invalid type` appears as an id 153 times. That is not caused by this
PR — filed as **#459**, including the `invalid type` leak as a separate defect.

Both opt-in styles therefore guarantee uniqueness rather than inheriting it:
`receiver-method` escalates a collision to the operation's own method-and-path
identity (unique by construction), and only a clash *there* takes a numeric
suffix. `method-path` needs no escalation. Fixing the default is a behavioural
change and belongs in #459.

`method-path` ids are longer than a handler name
(`deleteReposByOwnerByRepoIssuesByIndex`, longest 148 chars) — the trade for
carrying no Go symbol at all. `receiver-method` keeps them short; on gitea 613
of 1109 differ from the method-path form, the rest having escalated.

## A bug this PR's own comparison found

`receiver-method` first emitted `InstallForm]`. A generic operationId is
qualified *inside* its type argument
(`…/modules/web.Bind[…/services/forms.InstallForm]`), so trimming at the last
`/` cut inside the brackets — 60 ids on gitea have that shape. Base and type
arguments are now unqualified separately (`Bind[InstallForm]`), with unit
coverage for both the single- and multi-argument forms. It only showed up
because I diffed the two styles operation by operation; the aggregate counts
looked identical and healthy.

## Also

`-c` **replaces** the framework preset rather than merging, so enabling this
needs the effective config. README and `docs/CONFIGURATION.md` document the
`--output-config` → edit → `-c` route. The apispecui config editor gains a
Naming section with both dropdowns (its parity test requires every config key to
be editable).

Suite, `make lint` and the ratchet (96.1%, floor 96) pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable naming strategies for schema components and operation IDs.
  - Choose full, short, receiver-method, or method-path formats.
  - Short schema names automatically handle naming collisions.
  - Method-path operation IDs remain unique through fallback naming.
  - Added Naming options to the configuration interface.

- **Documentation**
  - Documented naming settings, defaults, collision handling, and configuration examples.
  - Confirmed existing output remains unchanged when no naming options are configured.

- **Tests**
  - Added coverage for naming strategies, defaults, collision handling, references, and operation ID uniqueness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->