### PR TITLE
fix(spec): make operationIds unique, and never prose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **operationIds are unique, and never prose.** An `operationId` identifies an
+  operation and must be unique — a client generator turns it into a method name
+  — but the fully-qualified handler symbol cannot carry that, because a shared
+  middleware or wrapper genuinely *is* the resolved handler for many routes. One
+  real project had **1109 operations under 700 ids**, `reqToken` alone
+  accounting for 46, and 153 operations whose id was the string `invalid type`
+  (go/types rendering a handler whose type did not check). A duplicated or
+  unusable id is now replaced — for **every** route holding it, not the
+  runners-up — by the operation's own method-and-path identity; an id that is
+  unique and usable is left exactly as it was. On that project 617 of 1109 ids
+  are untouched and the remaining 492 are repaired. A wrapped route and the same
+  handler registered directly therefore no longer share an id: attribution is
+  what the operation says (summary, request schema, responses), not its name.
+  (#459)
+
 - **One Go type now produces one component, and the right one.** A response type
   recovered from a call carried the package's *name* (`api.Issue`) while
   metadata's own type strings carry the import *path* (`example.com/api.Issue`),

--- a/generator/testdata_handler_wrapper_test.go
+++ b/generator/testdata_handler_wrapper_test.go
@@ -73,11 +73,30 @@ func TestTestdata_HandlerWrapperAttribution(t *testing.T) {
 						pair.method, pair.wrapped, pair.direct, mapPathKeys(out.Paths))
 				}
 
-				// Same handler ⇒ same operationId, modulo the path it was
-				// registered at (operationIds carry the handler, not the route).
-				if wrapped.OperationID != direct.OperationID {
-					t.Errorf("%s %s: operationId %q, but the same handler registered directly is %q — the wrapper replaced it",
-						pair.method, pair.wrapped, wrapped.OperationID, direct.OperationID)
+				// Attribution is asserted by what the operation SAYS — summary,
+				// request schema, responses, below — not by a shared
+				// operationId.
+				//
+				// This used to require the wrapped and direct routes to carry
+				// the SAME operationId, on the reasoning that an operationId
+				// carries the handler rather than the route. That is what
+				// OpenAPI forbids: an operationId identifies an operation and
+				// must be unique across the document, so two distinct
+				// operations sharing one is a spec violation, and a client
+				// generator cannot give two methods a single name. A real
+				// project reached 700 ids for 1109 operations this way
+				// (issue #459).
+				//
+				// So the invariant is inverted: distinct operations must have
+				// distinct ids, and neither may be empty.
+				if wrapped.OperationID == direct.OperationID {
+					t.Errorf("%s %s: wrapped and direct share operationId %q — distinct operations need distinct ids",
+						pair.method, pair.wrapped, wrapped.OperationID)
+				}
+				for label, op := range map[string]*intspec.Operation{"wrapped": wrapped, "direct": direct} {
+					if op.OperationID == "" {
+						t.Errorf("%s %s: %s operation has no operationId", pair.method, pair.wrapped, label)
+					}
 				}
 				if wrapped.Summary != direct.Summary {
 					t.Errorf("%s %s: summary %q, want the handler's %q",

--- a/generator/testdata_shared_handler_ids_test.go
+++ b/generator/testdata_shared_handler_ids_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/spec"
+)
+
+// An operationId must be unique across the document, and a shared handler's
+// symbol cannot be: it is genuinely the resolved handler for several routes.
+// A duplicated id is replaced for EVERY holder by the operation's own
+// method-and-path identity; a handler used once keeps its symbol (issue #459).
+func TestTestdata_SharedHandlerOperationIDs(t *testing.T) {
+	out := loadTestdata(t, "shared_handler_ids", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+
+	got := map[string]string{} // "METHOD path" -> operationId
+	seen := map[string]string{}
+	for path, item := range out.Paths {
+		item := item
+		for method, op := range map[string]*spec.Operation{
+			"GET": item.Get, "POST": item.Post, "PUT": item.Put, "DELETE": item.Delete,
+		} {
+			if op == nil {
+				continue
+			}
+			key := method + " " + path
+			got[key] = op.OperationID
+			if op.OperationID == "" {
+				t.Errorf("%s: empty operationId", key)
+				continue
+			}
+			if prev, dup := seen[op.OperationID]; dup {
+				t.Errorf("operationId %q shared by %s and %s — distinct operations need distinct ids",
+					op.OperationID, prev, key)
+			}
+			seen[op.OperationID] = key
+		}
+	}
+
+	// The three routes sharing serveItem take their identity from the
+	// operation, since the symbol describes none of them.
+	for key, want := range map[string]string{
+		"GET /items/{id}":   "getItemsById",
+		"GET /widgets/{id}": "getWidgetsById",
+		"POST /items":       "postItems",
+	} {
+		if got[key] != want {
+			t.Errorf("%s: operationId %q, want %q", key, got[key], want)
+		}
+	}
+
+	// A handler used once still identifies its operation, so it is untouched —
+	// the repair must be surgical, not a wholesale renaming.
+	if id := got["GET /catalogue"]; !strings.HasSuffix(id, "listOnce") {
+		t.Errorf("GET /catalogue: operationId %q, want the handler symbol (…listOnce) kept", id)
+	}
+}

--- a/internal/spec/naming.go
+++ b/internal/spec/naming.go
@@ -53,12 +53,88 @@ func applyNaming(spec *OpenAPISpec, cfg *APISpecConfig, usedTypes map[string]*Sc
 	}
 	switch cfg.Naming.OperationID {
 	case "", NamingFull:
+		repairOperationIDs(spec)
 	case NamingReceiverMethod, NamingMethodPath:
 		applyOperationIDs(spec, cfg.Naming.OperationID)
 	default:
 		log.Printf("[naming] unknown operationId %q, keeping %q", cfg.Naming.OperationID, NamingFull)
+		repairOperationIDs(spec)
 	}
 }
+
+// repairOperationIDs replaces the operationIds that cannot serve as one, and
+// leaves every other id exactly as it was.
+//
+// An operationId must be unique across the document — a client generator keys
+// its method names on it — and the fully-qualified handler symbol is not, for
+// a reason no amount of resolution fixes: a shared middleware or wrapper IS the
+// resolved handler for many routes. On gitea that put 1109 operations under 700
+// ids, `reqToken` alone accounting for 46 (issue #459).
+//
+// Two kinds of id are replaced:
+//
+//   - one claimed by more than one operation. ALL of its holders are replaced,
+//     not the runners-up: the symbol has been shown not to identify an
+//     operation, so keeping it for whichever route sorted first would be
+//     arbitrary in a way a reader cannot see.
+//   - one that is not an identifier at all. `invalid type` is go/types
+//     rendering Typ[Invalid] — a handler whose type did not check — and it
+//     reached 153 operations on gitea. It says nothing and cannot be dropped
+//     into generated code.
+//
+// The replacement is the operation's own method-and-path identity, which is
+// derived from the document rather than from the code, so it exists for every
+// operation and describes the one thing that is unique about it. Assignment is
+// in sorted (path, method) order and skips ids already spoken for, so the
+// result is a pure function of the document (golden rule #1).
+func repairOperationIDs(spec *OpenAPISpec) {
+	ops := sortedOperations(spec)
+	if len(ops) == 0 {
+		return
+	}
+
+	counts := map[string]int{}
+	for _, o := range ops {
+		counts[o.op.OperationID]++
+	}
+
+	// Ids that stay are spoken for, so a replacement never lands on one.
+	taken := map[string]bool{}
+	for _, o := range ops {
+		if id := o.op.OperationID; counts[id] == 1 && usableOperationID(id) {
+			taken[id] = true
+		}
+	}
+
+	for _, o := range ops {
+		id := o.op.OperationID
+		if counts[id] == 1 && usableOperationID(id) {
+			continue
+		}
+		for _, want := range operationIDCandidates(NamingMethodPath, o.method, o.path, id, len(ops)) {
+			if want == "" || taken[want] {
+				continue
+			}
+			taken[want] = true
+			o.op.OperationID = want
+			break
+		}
+	}
+}
+
+// usableOperationID reports whether an id can serve as an operationId at all.
+//
+// "invalid type" is go/types' rendering of Typ[Invalid], which reaches the
+// handler identity when a package does not type-check; it is prose, not a
+// name. An empty id is no better.
+func usableOperationID(id string) bool {
+	return id != "" && !strings.Contains(id, invalidTypeRendering)
+}
+
+// invalidTypeRendering is what go/types prints for Typ[Invalid]. Matched as a
+// string because that is the only form it arrives in here — the spec layer sees
+// a rendered name, not a types.Type.
+const invalidTypeRendering = "invalid type"
 
 // shortEntry is one component considered for shortening: the key it has now,
 // the import path of its Go type, and the unqualified rendering of that type.
@@ -251,22 +327,7 @@ func applySchemaRenames(spec *OpenAPISpec, renames map[string]string) {
 // unreachable belt-and-braces. Operations are visited in sorted (path, method) order, so which one
 // takes the plain name is decided by the document, not by map order.
 func applyOperationIDs(spec *OpenAPISpec, style string) {
-	type opRef struct {
-		path, method string
-		op           *Operation
-	}
-	var ops []opRef
-	for _, path := range slices.Sorted(maps.Keys(spec.Paths)) {
-		item := spec.Paths[path]
-		byMethod := operationsByMethod(&item)
-		for _, method := range slices.Sorted(maps.Keys(byMethod)) {
-			if op := byMethod[method]; op != nil {
-				ops = append(ops, opRef{path: path, method: method, op: op})
-			}
-		}
-		spec.Paths[path] = item
-	}
-
+	ops := sortedOperations(spec)
 	taken := map[string]bool{}
 	for _, o := range ops {
 		for _, want := range operationIDCandidates(style, o.method, o.path, o.op.OperationID, len(ops)) {
@@ -407,4 +468,30 @@ func operationsByMethod(item *PathItem) map[string]*Operation {
 		}
 	}
 	return out
+}
+
+// opRef is one operation with the path and method that identify it.
+type opRef struct {
+	path, method string
+	op           *Operation
+}
+
+// sortedOperations lists every operation in (path, method) order, so a pass
+// that assigns names cannot depend on map order (golden rule #1).
+func sortedOperations(spec *OpenAPISpec) []opRef {
+	if spec == nil {
+		return nil
+	}
+	var ops []opRef
+	for _, path := range slices.Sorted(maps.Keys(spec.Paths)) {
+		item := spec.Paths[path]
+		byMethod := operationsByMethod(&item)
+		for _, method := range slices.Sorted(maps.Keys(byMethod)) {
+			if op := byMethod[method]; op != nil {
+				ops = append(ops, opRef{path: path, method: method, op: op})
+			}
+		}
+		spec.Paths[path] = item
+	}
+	return ops
 }

--- a/internal/spec/naming_test.go
+++ b/internal/spec/naming_test.go
@@ -271,3 +271,71 @@ func TestApplyOperationIDsFallbackScalesWithOperationCount(t *testing.T) {
 		t.Errorf("got %d distinct ids for %d operations", len(seen), n)
 	}
 }
+
+// "invalid type" is go/types rendering Typ[Invalid] — a handler whose type did
+// not check. It reached 153 operationIds on a real project (issue #459). It is
+// prose, not a name, so it is replaced even when it is not duplicated.
+func TestRepairOperationIDsReplacesUnusableIDs(t *testing.T) {
+	spec := &OpenAPISpec{Paths: map[string]PathItem{
+		"/a": {Get: &Operation{OperationID: "invalid type"}},
+		"/b": {Get: &Operation{OperationID: ""}},
+		"/c": {Get: &Operation{OperationID: "pkg.realHandler"}},
+	}}
+
+	repairOperationIDs(spec)
+
+	if got := spec.Paths["/a"].Get.OperationID; got != "getA" {
+		t.Errorf("/a: operationId %q, want %q", got, "getA")
+	}
+	if got := spec.Paths["/b"].Get.OperationID; got != "getB" {
+		t.Errorf("/b: operationId %q, want %q", got, "getB")
+	}
+	// Unique and usable: left exactly as it was.
+	if got := spec.Paths["/c"].Get.OperationID; got != "pkg.realHandler" {
+		t.Errorf("/c: operationId %q, want it untouched", got)
+	}
+}
+
+// Every holder of a duplicated id is replaced, not the runners-up: keeping it
+// for whichever route sorted first would be arbitrary in a way a reader cannot
+// see.
+func TestRepairOperationIDsReplacesEveryHolderOfADuplicate(t *testing.T) {
+	spec := &OpenAPISpec{Paths: map[string]PathItem{
+		"/x": {Get: &Operation{OperationID: "pkg.shared"}},
+		"/y": {Get: &Operation{OperationID: "pkg.shared"}},
+		"/z": {Get: &Operation{OperationID: "pkg.unique"}},
+	}}
+
+	repairOperationIDs(spec)
+
+	for path, want := range map[string]string{"/x": "getX", "/y": "getY", "/z": "pkg.unique"} {
+		if got := spec.Paths[path].Get.OperationID; got != want {
+			t.Errorf("%s: operationId %q, want %q", path, got, want)
+		}
+	}
+}
+
+// A replacement never lands on an id that a kept operation already holds.
+func TestRepairOperationIDsAvoidsKeptIDs(t *testing.T) {
+	spec := &OpenAPISpec{Paths: map[string]PathItem{
+		// Both duplicates normalize to "getA"...
+		"/a-": {Get: &Operation{OperationID: "pkg.shared"}},
+		"/a":  {Get: &Operation{OperationID: "pkg.shared"}},
+		// ...and this operation already owns "getA" outright.
+		"/A": {Get: &Operation{OperationID: "getA"}},
+	}}
+
+	repairOperationIDs(spec)
+
+	seen := map[string]string{}
+	for path, item := range spec.Paths {
+		id := item.Get.OperationID
+		if prev, dup := seen[id]; dup {
+			t.Errorf("operationId %q shared by %s and %s", id, prev, path)
+		}
+		seen[id] = path
+	}
+	if got := spec.Paths["/A"].Get.OperationID; got != "getA" {
+		t.Errorf("/A: operationId %q, want it untouched", got)
+	}
+}

--- a/testdata/shared_handler_ids/go.mod
+++ b/testdata/shared_handler_ids/go.mod
@@ -1,0 +1,3 @@
+module sharedids
+
+go 1.26

--- a/testdata/shared_handler_ids/main.go
+++ b/testdata/shared_handler_ids/main.go
@@ -1,0 +1,50 @@
+// Package main exercises operationId uniqueness when one handler serves many
+// routes.
+//
+// An operationId identifies an OPERATION and must be unique across the
+// document — a client generator turns it into a method name. The
+// fully-qualified handler symbol cannot carry that: a shared handler or
+// middleware is genuinely the resolved handler for several routes, and on a
+// real project that put 1109 operations under 700 ids (issue #459).
+//
+// So a duplicated id is replaced, for every route holding it, by the
+// operation's own method-and-path identity. A handler used once keeps its
+// symbol.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// Item is the payload every route here returns.
+type Item struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// serveItem is registered at three different paths, so its symbol identifies
+// none of them.
+func serveItem(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode(Item{})
+}
+
+// listOnce is registered exactly once, so its symbol still identifies its
+// operation and must be left alone.
+func listOnce(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode([]Item{})
+}
+
+func main() {
+	mux := http.NewServeMux()
+
+	// One handler, three operations.
+	mux.HandleFunc("GET /items/{id}", serveItem)
+	mux.HandleFunc("GET /widgets/{id}", serveItem)
+	mux.HandleFunc("POST /items", serveItem)
+
+	// One handler, one operation.
+	mux.HandleFunc("GET /catalogue", listOnce)
+
+	_ = http.ListenAndServe(":8080", mux)
+}


### PR DESCRIPTION
Fixes #459.

An `operationId` identifies an operation and must be unique across the document
— a client generator turns it into a method name. The fully-qualified handler
symbol cannot carry that, for a reason no amount of resolution fixes: **a shared
middleware or wrapper genuinely is the resolved handler for many routes.**

## Measured on gitea (899 paths, 1109 operations)

| | before | after |
|---|---|---|
| distinct operationIds | **700 / 1109** | **1109 / 1109** |
| `invalid type` as an id | **153** | **0** |
| ids left untouched | — | **617** |
| ids repaired | — | 492 |

`reqToken` accounted for 46 duplicates on its own, `RepoRefByType` 34. And
`invalid type` is `go/types` rendering `Typ[Invalid]` — a handler whose type did
not check — which is prose, not a name.

## The rule

An id that is **duplicated** or **unusable** (empty, or `invalid type`) is
replaced by the operation's own method-and-path identity: derived from the
document rather than the code, so it exists for every operation and describes
the one thing that is unique about it. An id that is unique and usable is left
exactly as it was — the repair is surgical, not a wholesale renaming.

**Every holder of a duplicated id is replaced, not the runners-up.** Keeping the
symbol for whichever route sorted first would decide by something a reader
cannot see; if a symbol has been shown not to identify an operation, it does not
identify the first one either.

## An invariant this inverts, deliberately

`TestTestdata_HandlerWrapperAttribution` asserted that a wrapped route and the
same handler registered directly carry the **same** operationId, on the
reasoning that "operationIds carry the handler, not the route". That is what
OpenAPI forbids: two distinct operations cannot share an id, and a generator
cannot give two methods one name.

The attribution that test exists for is untouched and still asserted — by
summary, request schema, responses and params, which is where attribution
belongs. The id assertion is now "distinct, and non-empty".

If you want the handler symbol to remain visible on repaired operations, the
natural follow-up is an `x-` extension carrying it; I left that out as scope
creep rather than deciding it here.

## Drift

* **103 fixture specs byte-identical.**
* **8 differ, and every one differs in `operationId` lines only** — verified by
  counting non-id changed lines per fixture (all zero), not by reading the diff.
  Those 8 are the fixtures where one handler serves several routes:
  `handler_wrapper_attribution`, `mount_via_helper`, `dynamic_mount_prefix`,
  `variable_path`, `helper_response_body`, `chi_middleware_recv_shadow`,
  `auth_echo_keylookup`, and the chi variant.

(My first A/B run reported a ninth fixture with 28 non-id changes. That was a
stale baseline binary predating #458 and #460, not this change; rebuilt against
current main and re-measured.)

## Tests

`testdata/shared_handler_ids` registers one handler at three paths and another
at one. The three take path-derived ids; the single-use handler keeps its
symbol, which is what pins the repair as surgical. It fails on unfixed code with
`operationId "sharedids.serveItem" shared by GET /items/{id} and GET /widgets/{id}`.

Unit tests cover the three rules separately: unusable ids replaced even when
unique, every holder of a duplicate replaced, and a replacement never landing on
an id a kept operation already owns.

## Found by this change, filed not folded in

**#461** — because repaired ids derive from the path, they made it obvious that
**60 of gitea's 899 paths are fabricated**:

```
/-/admin/auths/gitea.dev/modules/web.Combo.pattern
```

gitea's `Combo` builder holds the path in a receiver field; the resolution
ladder handles a field off a *caller-passed* struct, so this fell through and
the argument was **rendered** — a Go symbol concatenated as a path segment.
Those endpoints do not exist, and nothing warns. That is a path-resolution fix
with its own risk surface, so it is not in this PR.
