### PR TITLE
fix(spec): never render a path argument as a Go symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A path is never a rendered Go symbol.** When a path argument was a shape the
+  resolver had no case for — a selector such as `c.pattern` or `settings.Path` —
+  the argument was *rendered*, and rendering a selector yields a Go symbol. One
+  real project had **60 paths** reading
+  `/-/admin/auths/gitea.dev/modules/web.Combo.pattern`: endpoints that do not
+  exist, with nothing to warn a reader, so a consumer would call a URL that
+  404s. The internal type separator leaked too (`/recvfield-->Config.Path`).
+  Such an argument now goes through the same value-resolution ladder as any
+  other path, and becomes a declared `{placeholder}` when nothing resolves — the
+  route stays addressable and visibly incomplete instead of fabricated. A path
+  written as a literal is unaffected, which is 2389 of 2605 path arguments on
+  that project. (#461)
+
 - **operationIds are unique, and never prose.** An `operationId` identifies an
   operation and must be unique — a client generator turns it into a method name
   — but the fully-qualified handler symbol cannot carry that, because a shared

--- a/generator/testdata_receiver_field_path_test.go
+++ b/generator/testdata_receiver_field_path_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/spec"
+)
+
+// A path that cannot be resolved must never be RENDERED. Rendering an argument
+// yields a Go symbol, never a path: `resolvePathArg` had no case for a
+// selector, so `settings.Path` came out as the literal segment
+// `recvfield-->Config.Path` — internal separator included — and on a real
+// project 60 paths read `gitea.dev/modules/web.Combo.pattern` (issue #461).
+//
+// Such endpoints do not exist. A consumer would call a URL that 404s, with
+// nothing in the document to warn them, which is why this is worse than a
+// missing route.
+func TestTestdata_ReceiverFieldPath(t *testing.T) {
+	out := loadTestdata(t, "receiver_field_path", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+
+	for path := range out.Paths {
+		// The tells of a rendered Go value: a package/type qualifier, or the
+		// internal type separator.
+		if strings.Contains(path, spec.TypeSep) {
+			t.Errorf("path %q carries the internal type separator — an argument was rendered as a path", path)
+		}
+		for _, symbol := range []string{"recvfield", "Config.Path", ".pattern"} {
+			if strings.Contains(path, symbol) {
+				t.Errorf("path %q carries the Go symbol %q — an argument was rendered as a path", path, symbol)
+			}
+		}
+	}
+
+	// The literal route is unaffected: this must not cost the paths that do
+	// resolve.
+	if !hasPath(out, "/plain") {
+		t.Errorf("/plain missing; have %v", mapPathKeys(out.Paths))
+	}
+
+	// What replaces a fabricated segment is a declared placeholder, not a
+	// silent shortening — the route stays addressable and visibly incomplete
+	// (issue #34), and #428 reports the registration.
+	for path, item := range out.Paths {
+		item := item
+		op := firstOperation(&item)
+		if op == nil {
+			continue
+		}
+		for _, seg := range strings.Split(path, "/") {
+			if !strings.HasPrefix(seg, "{") {
+				continue
+			}
+			name := strings.Trim(seg, "{}")
+			declared := false
+			for _, p := range op.Parameters {
+				if p.Name == name || strings.HasSuffix(p.Ref, name) || strings.HasSuffix(p.Ref, name+"Param") {
+					declared = true
+				}
+			}
+			if !declared {
+				t.Errorf("%s: placeholder {%s} is not declared as a parameter — an undeclared placeholder is an invalid path template",
+					path, name)
+			}
+		}
+	}
+}

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -81,8 +81,27 @@ func (b *BasePatternMatcher) resolvePathArg(arg *metadata.CallArgument, node Tra
 		// it rather than emitting it.
 		value, name := b.resolvePathOperand(arg, node, 0)
 		return value, dynamicNameList(name)
+	case metadata.KindLiteral:
+		// The literal IS the path, and this is the overwhelmingly common case:
+		// 2389 of 2605 path arguments on a real project.
+		return b.contextProvider.GetArgumentInfo(arg), nil
 	}
-	return b.contextProvider.GetArgumentInfo(arg), nil
+	// Everything else — a selector (`c.pattern`, `settings.Path`), an index, a
+	// star — is answered by the same ladder, and becomes a {placeholder} when
+	// nothing resolves.
+	//
+	// It used to fall through to rendering the argument, and rendering a
+	// selector yields a Go SYMBOL, never a path. On one real project 216 path
+	// arguments took that branch, which put
+	// `gitea.dev/modules/web.Combo.pattern` into 60 paths as though it were a
+	// literal segment — endpoints that do not exist, with nothing to warn a
+	// reader (issue #461). The internal separator leaked too:
+	// `/recvfield-->Config.Path`.
+	//
+	// A placeholder is the honest answer instead, and #428 reports the
+	// registration rather than emitting a path built at runtime.
+	value, name := b.resolvePathOperand(arg, node, 0)
+	return value, dynamicNameList(name)
 }
 
 // dynamicNameList wraps a single synthesized name, or nil when there is none.

--- a/testdata/receiver_field_path/go.mod
+++ b/testdata/receiver_field_path/go.mod
@@ -1,0 +1,3 @@
+module recvfield
+
+go 1.26

--- a/testdata/receiver_field_path/main.go
+++ b/testdata/receiver_field_path/main.go
@@ -1,0 +1,96 @@
+// Package main exercises a path held in a field of the RECEIVER.
+//
+// A combo builder — gitea's `web.Combo` is one — takes the path once and
+// registers several verbs from it:
+//
+//	r.Combo("/items").Get(list).Post(create)
+//
+// Inside Get/Post the path is `c.pattern`, a field read off the receiver. That
+// is not the shape the ladder's struct-field rung answers (a field off a struct
+// the CALLER passed), so nothing resolved — and the argument was rendered,
+// which put the Go symbol `recvfield.Combo.pattern` in the path as though it
+// were a literal segment. 60 paths on a real project looked like that
+// (issue #461).
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// Item is what these routes return.
+type Item struct {
+	ID string `json:"id"`
+}
+
+// Config holds a path in a field, which is how a house router or a settings
+// struct usually carries one.
+type Config struct{ Path string }
+
+// settings is a package-level value whose field is used as a path.
+var settings = Config{Path: "/from-field"}
+
+// Router is a thin house wrapper over ServeMux.
+type Router struct{ mux *http.ServeMux }
+
+// Combo carries the path so several verbs can be registered from it.
+type Combo struct {
+	r       *Router
+	pattern string
+}
+
+// Combo takes the path once. Every verb below reads it back off the receiver.
+func (r *Router) Combo(pattern string) *Combo { return &Combo{r, pattern} }
+
+func (c *Combo) Get(h http.HandlerFunc) *Combo {
+	c.r.mux.HandleFunc("GET "+c.pattern, h)
+	return c
+}
+
+func (c *Combo) Post(h http.HandlerFunc) *Combo {
+	c.r.mux.HandleFunc("POST "+c.pattern, h)
+	return c
+}
+
+// Handle passes the receiver field as the WHOLE path argument, with no literal
+// concatenated onto it. That is the shape that was rendered: a bare selector
+// reached resolvePathArg's default branch, which rendered the argument.
+func (c *Combo) Handle(h http.HandlerFunc) *Combo {
+	c.r.mux.HandleFunc(c.pattern, h)
+	return c
+}
+
+func listItems(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode([]Item{})
+}
+
+func createItem(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(Item{})
+}
+
+// plainList is registered directly, as the control: its path is a literal and
+// must be unaffected.
+func plainList(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode([]Item{})
+}
+
+func main() {
+	r := &Router{mux: http.NewServeMux()}
+
+	r.Combo("/items").Get(listItems).Post(createItem)
+
+	// The bare-selector shape, assigned first (a value created inside an
+	// argument list has no assignment to key on — golden rule #11).
+	things := r.Combo("/things")
+	things.Handle(listItems)
+
+	// A bare SELECTOR as the whole path argument. This is the shape that was
+	// rendered: `resolvePathArg` had no case for it, so the argument was
+	// stringified and a Go symbol became the path.
+	r.mux.HandleFunc(settings.Path, plainList)
+
+	r.mux.HandleFunc("GET /plain", plainList)
+
+	_ = http.ListenAndServe(":8080", r.mux)
+}


### PR DESCRIPTION
Addresses **point 2** of #461 — never render a path argument. Point 1 (resolve
the receiver field) is not in this PR; see the end.

## The bug

`resolvePathArg`'s switch covered binary, call, ident and type-conversion
arguments. Every other kind fell through to `GetArgumentInfo(arg)` — rendering
the argument. Rendering a **selector** yields a Go symbol, never a path:

```
/-/admin/auths/gitea.dev/modules/web.Combo.pattern
/_apis/pipelines/workflows/{run_id}/artifacts/gitea.dev/modules/web.Combo.pattern
```

60 such paths on gitea. Those endpoints do not exist, and nothing in the
document says so — a consumer calls a URL that 404s. That is worse than a
missing route, because it looks plausible. The internal type separator leaked
through the same branch: `/recvfield-->Config.Path`.

## Located by measurement, not reasoning

I instrumented the branch and ran it on the real project:

| argument kind reaching the render | count | rendering correct? |
|---|---|---|
| `literal` | **2389** | yes — the literal *is* the path |
| `selector` | **216** | never — it is a Go symbol |

So `KindLiteral` gets its own case, and everything else goes through the same
value-resolution ladder as any other path (#431, #433, #436), ending in a
declared `{placeholder}` when nothing resolves.

## Measured on gitea

| | before | after |
|---|---|---|
| paths | 899 | **899** |
| fabricated paths (Go symbol) | **60** | **0** |
| legitimate paths dropped | — | **0** |
| schemas | 242 | 242 |

The 60 fakes became honest placeholders — `/-/admin/auths/{pattern}` — with the
parameter declared, so each route stays addressable and visibly incomplete
(#34) rather than fabricated. **All 112 fixture specs byte-identical.**

## Reproduction took three tries, and the failures were informative

* `"GET "+c.pattern` — already correct: the concat resolves to a placeholder and
  #428 drops the route. The floor already worked for that shape.
* `Combo(...).Handle(h)`, chained and then assigned — not extracted at all. A
  receiver-resolution limit on builders, unrelated to this bug.
* A **bare selector as the whole path argument** — reproduced exactly:
  `POST '/recvfield-->Config.Path'`.

`testdata/receiver_field_path` is that shape. The guard checks the three tells
(a package qualifier, a `Type.Field` pair, the internal separator), asserts the
literal route still resolves, and asserts every remaining `{placeholder}` is
declared as a parameter — an undeclared one is an invalid path template. On
unfixed code it fails with
`path "/recvfield-->Config.Path" carries the internal type separator`.

## What this does not fix

#461's point 1: resolving a receiver field back through its constructor
argument, so `r.Combo("/items").Get(h)` documents `/items`. gitea's 60 routes
are now *honestly marked incomplete* rather than *correct*, which is an
improvement and not the end state — so **#461 stays open** for that half,
rather than being closed by this PR.

Suite, `make lint` and the ratchet (96.1%, floor 96) pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generated routes for unresolved selector-style path arguments.
  * Unresolvable path values now appear as declared `{placeholder}` parameters instead of fabricated Go symbols or internal type separators.
  * Literal paths remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->