### PR TITLE
feat(spec): resolve a path held on a builder's receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A path held on a builder's receiver is resolved, not just reported.** The
+  builder shape gives the path once, to a constructor, and reads it back off the
+  receiver for each verb — `r.Combo("/items").Get(list).Post(create)` — so the
+  registration itself has no path to read. #463 stopped the argument being
+  rendered as a Go symbol, which left an honest `{pattern}`; this resolves what
+  it stood for, by following the call chain back to the call that BUILT the
+  receiver and reading the field out of the literal it returns. On a real
+  project that recovered **33 endpoints** (899 paths → 932), turning collapsed
+  placeholders into real routes like `/-/admin/auths/new` and
+  `/notifications/threads/{id}`. Nothing is matched by name: a candidate call
+  qualifies only by returning a composite literal of the receiver's type
+  declaring that field, positional literals are matched against the struct's
+  declared field order, and the value must resolve to a constant or to the
+  argument bound to the parameter the literal stores — anything else stays a
+  placeholder. (#461)
+
 - **A path is never a rendered Go symbol.** When a path argument was a shape the
   resolver had no case for — a selector such as `c.pattern` or `settings.Path` —
   the argument was *rendered*, and rendering a selector yields a Go symbol. One

--- a/generator/testdata_receiver_field_path_test.go
+++ b/generator/testdata_receiver_field_path_test.go
@@ -53,6 +53,26 @@ func TestTestdata_ReceiverFieldPath(t *testing.T) {
 		t.Errorf("/plain missing; have %v", mapPathKeys(out.Paths))
 	}
 
+	// The builder's real path is RECOVERED, not merely left honest: the path was
+	// given once to the constructor (`r.Combo("/items")`) and each verb reads it
+	// back off the receiver, so it is resolved by following the chain to the call
+	// that built the receiver and reading the field out of the literal it
+	// returns (issue #461).
+	//
+	// Both verbs must appear, which is what pins the chain WALK: `.Post` links
+	// to `.Get`, not to the constructor, and a verb returns its receiver rather
+	// than a literal, so a single hop would recover only the first.
+	item, ok := out.Paths["/items"]
+	if !ok {
+		t.Fatalf("/items missing — the builder's path was not recovered; have %v", mapPathKeys(out.Paths))
+	}
+	if item.Get == nil {
+		t.Error("/items has no GET (r.Combo(\"/items\").Get)")
+	}
+	if item.Post == nil {
+		t.Error("/items has no POST — the chained verb links to Get, not to the constructor")
+	}
+
 	// What replaces a fabricated segment is a declared placeholder, not a
 	// silent shortening — the route stays addressable and visibly incomplete
 	// (issue #34), and #428 reports the registration.

--- a/generator/testdata_unresolved_path_test.go
+++ b/generator/testdata_unresolved_path_test.go
@@ -127,8 +127,26 @@ func TestTestdata_ChainedWrapper(t *testing.T) {
 	if _, ok := out.Paths["/{pattern}"]; ok {
 		t.Error("the chained registration must not be documented under its placeholder path")
 	}
-	if _, ok := out.Paths["/items"]; ok {
-		t.Error("the chained pattern is not readable at the framework call; documenting /items would be a guess")
+
+	// /items is now DERIVED, not guessed, so this expectation is inverted.
+	//
+	// It used to assert the opposite — "documenting /items would be a guess" —
+	// and that was right while the pattern was unreadable at the framework
+	// call. It is readable now: the chain leads back to the call that built the
+	// receiver (`Combo("/items")`), whose returned literal stores the
+	// constructor's parameter, and the argument bound to that parameter is
+	// recorded. Every step is a fact metadata holds, which is what separates
+	// this from a guess (issue #461).
+	items, ok := out.Paths["/items"]
+	if !ok {
+		t.Fatalf("the chained pattern is readable through the constructor; /items should be documented. have %v",
+			mapPathKeys(out.Paths))
+	}
+	if opFor(items, "GET") == nil {
+		t.Error("GET /items missing (Combo(\"/items\").Get)")
+	}
+	if opFor(items, "POST") == nil {
+		t.Error("POST /items missing — the chained verb links to Get rather than to the constructor, so the walk must continue past it")
 	}
 
 	// The ordinary method on the same router still resolves: what is unsupported
@@ -141,8 +159,10 @@ func TestTestdata_ChainedWrapper(t *testing.T) {
 		t.Error("GET /health missing")
 	}
 
-	// Both chained calls are reported.
-	if reports := gen.UnresolvedPaths(); len(reports) != 2 {
-		t.Errorf("want the chained Get and Post reported, got %d: %+v", len(reports), reports)
+	// Nothing is left to report: both chained calls resolve, so neither is an
+	// unresolved path any more. This is the other half of the inversion — the
+	// reports were the honest answer while the value was unreachable.
+	if reports := gen.UnresolvedPaths(); len(reports) != 0 {
+		t.Errorf("want no unresolved-path reports now that the chain resolves, got %d: %+v", len(reports), reports)
 	}
 }

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -242,6 +242,13 @@ func (b *BasePatternMatcher) resolvePathOperand(arg *metadata.CallArgument, node
 	if v, ok := b.paramValueFromCallSites(arg, node, depth); ok {
 		return v, ""
 	}
+	// A field of the RECEIVER, resolved through the call that constructed it —
+	// the builder shape `r.Combo("/items").Get(h)`, where the path was given to
+	// the constructor and every verb reads it back (issue #461). Last, so it is
+	// only asked once everything else has failed.
+	if v, ok := b.receiverFieldValue(arg, node); ok && v != "" {
+		return v, ""
+	}
 	return placeholderFor(arg)
 }
 

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -246,7 +246,12 @@ func (b *BasePatternMatcher) resolvePathOperand(arg *metadata.CallArgument, node
 	// the builder shape `r.Combo("/items").Get(h)`, where the path was given to
 	// the constructor and every verb reads it back (issue #461). Last, so it is
 	// only asked once everything else has failed.
-	if v, ok := b.receiverFieldValue(arg, node); ok && v != "" {
+	if v, ok := b.receiverFieldValue(arg, node); ok {
+		// `ok` already distinguishes "resolved" from "unresolved", so an empty
+		// value is honoured rather than turned into a placeholder: a builder
+		// constructed with "" contributes nothing to the path, exactly as a
+		// zero-value struct field does one rung above. Testing v != "" here
+		// would emit {pattern} for a path that IS resolved.
 		return v, ""
 	}
 	return placeholderFor(arg)

--- a/internal/spec/receiver_field.go
+++ b/internal/spec/receiver_field.go
@@ -73,6 +73,32 @@ func (b *BasePatternMatcher) receiverFieldValue(arg *metadata.CallArgument, node
 	if recvName == "" {
 		return "", false
 	}
+	// The base must BE the receiver, checked by type. Without this, any
+	// identifier selector entered the walk: an unrelated `other.pattern` inside
+	// a builder method would resolve `pattern` from the builder's constructor
+	// and fabricate a route from a value that has nothing to do with it.
+	//
+	// By type rather than by name, because the receiver's variable name is not
+	// recorded — CalleeRecvVarName is the receiver expression at the CALL site
+	// and is empty for a chained call, so comparing names would decline every
+	// case this rung exists for. The base's own type is recorded, and it is the
+	// fact that matters.
+	//
+	// Two limits this leaves, both measured rather than assumed:
+	//
+	//   - a different value of the SAME builder type passes the check, and is
+	//     read from this chain's constructor. Narrowing that needs the
+	//     receiver's identity, which metadata does not carry.
+	//   - when one registration serves SEVERAL builder chains
+	//     (`r.Combo("/alpha").Get(a)` and `r.Combo("/beta").Get(b)` share the
+	//     call site inside Get), the extractor collapses them into ONE route
+	//     before this rung is asked — the floor reports a single unresolved
+	//     registration for the pair, not two — so the value resolved here is
+	//     the first chain's, and the others were already lost upstream. That
+	//     collapse is #465, not something this rung can see.
+	if bareTypeName(arg.X.GetType()) != recvName {
+		return "", false
+	}
 	for e, hops := inv.ChainParent, 0; e != nil && hops < maxChainHops; e, hops = e.ChainParent, hops+1 {
 		if value, ok := b.fieldFromReturnedLiteral(e, field, recvPkg, recvName); ok {
 			return value, true

--- a/internal/spec/receiver_field.go
+++ b/internal/spec/receiver_field.go
@@ -1,0 +1,201 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// receiverFieldValue resolves `c.field` where `c` is the receiver of the method
+// the registration is written in, by following the call chain to the call that
+// CONSTRUCTED that receiver and reading the field out of the composite literal
+// it returns.
+//
+// This is the builder shape, and gitea has 60 routes of it:
+//
+//	r.Combo("/items").Get(list).Post(create)
+//
+// The path is given once, to the constructor, and each verb reads it back off
+// the receiver — so the registration itself has no path to read. Before this it
+// resolved to nothing: #463 stopped the argument being rendered as the Go symbol
+// `gitea.dev/modules/web.Combo.pattern`, which left an honest `{pattern}`
+// placeholder; this resolves the value it stands for (issue #461).
+//
+// Nothing here matches on names, and nothing is guessed:
+//
+//   - a candidate call qualifies only by RETURNING a composite literal of a type
+//     that declares the field, so the value read is the one that call put there;
+//   - the chain is walked until such a call is found, because a chained verb
+//     (`.Get(...).Post(...)`) links to the previous verb rather than to the
+//     constructor, and a verb returns its receiver rather than a literal;
+//   - the field's value must resolve to a constant, either directly or through
+//     the constructor's own argument for the parameter it names. Anything else
+//     stays unresolved, and the caller falls back to the placeholder
+//     (golden rule #7).
+func (b *BasePatternMatcher) receiverFieldValue(arg *metadata.CallArgument, node TrackerNodeInterface) (string, bool) {
+	if arg == nil || arg.GetKind() != metadata.KindSelector || arg.X == nil || arg.Sel == nil {
+		return "", false
+	}
+	field := arg.Sel.GetName()
+	if field == "" || arg.X.GetKind() != metadata.KindIdent {
+		return "", false
+	}
+	if node == nil || b.metadata() == nil {
+		return "", false
+	}
+	// The enclosing method's own invocation is the parent frame; its chain
+	// parent is the call the receiver came from.
+	parent := node.GetParent()
+	if parent == nil {
+		return "", false
+	}
+	inv := parent.GetEdge()
+	if inv == nil {
+		return "", false
+	}
+	// The field belongs to the RECEIVER's type, which the invocation records —
+	// the constructor's literal carries no type of its own. If the constructor
+	// had built a different type, the receiver would not have this one.
+	recvPkg := b.contextProvider.GetString(inv.Callee.Pkg)
+	recvName := bareTypeName(b.contextProvider.GetString(inv.Callee.RecvType))
+	if recvName == "" {
+		return "", false
+	}
+	for e, hops := inv.ChainParent, 0; e != nil && hops < maxChainHops; e, hops = e.ChainParent, hops+1 {
+		if value, ok := b.fieldFromReturnedLiteral(e, field, recvPkg, recvName); ok {
+			return value, true
+		}
+	}
+	return "", false
+}
+
+// maxChainHops bounds the walk back along a method chain. A builder chain is a
+// handful of links (`.Get().Post().Patch()`); the bound is what keeps a cyclic
+// ChainParent from being a hang rather than a wrong answer.
+const maxChainHops = 32
+
+// fieldFromReturnedLiteral reads `field` out of the composite literal that
+// edge's callee returns, resolving the element through that call's own
+// arguments when the literal stores a parameter.
+func (b *BasePatternMatcher) fieldFromReturnedLiteral(edge *metadata.CallGraphEdge, field, typePkg, typeName string) (string, bool) {
+	meta := b.metadata()
+	for _, ret := range b.calleeReturnVars(edge) {
+		ret := ret
+		lit := unwrapComposite(&ret)
+		if lit == nil || lit.GetKind() != metadata.KindCompositeLit {
+			continue
+		}
+		elt, ok := literalFieldElement(meta, lit, field, typePkg, typeName)
+		if !ok {
+			continue
+		}
+		if value, ok := b.contextProvider.ConstantValue(elt); ok {
+			return value, true
+		}
+		// The literal stores one of the constructor's parameters, which is the
+		// whole point of a builder: `&Combo{r, pattern}` holds what the caller
+		// passed for `pattern`.
+		if elt.GetKind() == metadata.KindIdent {
+			if bound, exists := edge.ParamArgMap[elt.GetName()]; exists {
+				if value, ok := b.contextProvider.ConstantValue(&bound); ok {
+					return value, true
+				}
+			}
+		}
+	}
+	return "", false
+}
+
+// calleeReturnVars returns the callee's recorded return values, whether it is a
+// method (`(r *Router) Combo`) or a plain function (`NewCombo`).
+func (b *BasePatternMatcher) calleeReturnVars(edge *metadata.CallGraphEdge) []metadata.CallArgument {
+	meta := b.metadata()
+	if meta == nil || edge == nil {
+		return nil
+	}
+	name := b.contextProvider.GetString(edge.Callee.Name)
+	pkg := b.contextProvider.GetString(edge.Callee.Pkg)
+	if name == "" {
+		return nil
+	}
+	if recv := b.contextProvider.GetString(edge.Callee.RecvType); recv != "" {
+		typ := typeByName(pkg, bareTypeName(recv), meta)
+		if typ == nil {
+			return nil
+		}
+		for i := range typ.Methods {
+			if getStringFromPool(meta, typ.Methods[i].Name) == name {
+				return typ.Methods[i].ReturnVars
+			}
+		}
+		return nil
+	}
+	if fn := findFunctionByName(meta, pkg, name); fn != nil {
+		return fn.ReturnVars
+	}
+	return nil
+}
+
+// literalFieldElement returns the element of a composite literal that sets
+// `field`, keyed or positional.
+//
+// A positional literal (`&Combo{r, pattern}`) names no fields, so the element is
+// found by matching the index against the STRUCT's field order — which is a fact
+// metadata records, not an assumption about argument order. Without that, the
+// builder shape resolves nothing: a constructor almost always writes its literal
+// positionally.
+func literalFieldElement(meta *metadata.Metadata, lit *metadata.CallArgument, field, typePkg, typeName string) (*metadata.CallArgument, bool) {
+	keyed := false
+	for _, elt := range lit.Args {
+		if elt == nil {
+			continue
+		}
+		if elt.GetKind() != metadata.KindKeyValue {
+			continue
+		}
+		keyed = true
+		if elt.X != nil && elt.X.GetName() == field && elt.Fun != nil {
+			return elt.Fun, true
+		}
+	}
+	if keyed {
+		// Keyed and not among the keys: the field is at its zero value, which
+		// is not a path. Reported as unresolved rather than as "".
+		return nil, false
+	}
+	idx, ok := structFieldIndex(meta, typePkg, typeName, field)
+	if !ok || idx < 0 || idx >= len(lit.Args) {
+		return nil, false
+	}
+	return lit.Args[idx], lit.Args[idx] != nil
+}
+
+// structFieldIndex is the declaration index of `field` in the named struct, or
+// false when the type or the field cannot be found.
+func structFieldIndex(meta *metadata.Metadata, pkg, name, field string) (int, bool) {
+	if meta == nil || name == "" {
+		return 0, false
+	}
+	typ := typeByName(pkg, name, meta)
+	if typ == nil {
+		return 0, false
+	}
+	for i := range typ.Fields {
+		if getStringFromPool(meta, typ.Fields[i].Name) == field {
+			return i, true
+		}
+	}
+	return 0, false
+}

--- a/internal/spec/receiver_field.go
+++ b/internal/spec/receiver_field.go
@@ -16,6 +16,7 @@ package spec
 
 import (
 	"github.com/ehabterra/apispec/internal/metadata"
+	"github.com/ehabterra/apispec/internal/typemodel"
 )
 
 // receiverFieldValue resolves `c.field` where `c` is the receiver of the method
@@ -73,16 +74,20 @@ func (b *BasePatternMatcher) receiverFieldValue(arg *metadata.CallArgument, node
 	if recvName == "" {
 		return "", false
 	}
-	// The base must BE the receiver, checked by type. Without this, any
-	// identifier selector entered the walk: an unrelated `other.pattern` inside
-	// a builder method would resolve `pattern` from the builder's constructor
-	// and fabricate a route from a value that has nothing to do with it.
+	// The base must BE the receiver, checked by type IDENTITY — package path
+	// included. Without the check at all, any identifier selector entered the
+	// walk: an unrelated `other.pattern` inside a builder method would resolve
+	// `pattern` from the builder's constructor and fabricate a route from a
+	// value that has nothing to do with it. Without the PACKAGE, `one.Combo`
+	// and `two.Combo` are both "Combo" — the bare-name collision that put a
+	// migration's throwaway struct into a real schema in #457, which is not a
+	// mistake worth repeating here.
 	//
-	// By type rather than by name, because the receiver's variable name is not
+	// By type rather than by variable name, because the receiver's name is not
 	// recorded — CalleeRecvVarName is the receiver expression at the CALL site
 	// and is empty for a chained call, so comparing names would decline every
-	// case this rung exists for. The base's own type is recorded, and it is the
-	// fact that matters.
+	// case this rung exists for. The base's own type is recorded, fully
+	// qualified, and the invocation records the receiver's package and type.
 	//
 	// Two limits this leaves, both measured rather than assumed:
 	//
@@ -96,7 +101,7 @@ func (b *BasePatternMatcher) receiverFieldValue(arg *metadata.CallArgument, node
 	//     registration for the pair, not two — so the value resolved here is
 	//     the first chain's, and the others were already lost upstream. That
 	//     collapse is #465, not something this rung can see.
-	if bareTypeName(arg.X.GetType()) != recvName {
+	if !receiverTypeMatches(arg.X.GetType(), recvPkg, recvName) {
 		return "", false
 	}
 	for e, hops := inv.ChainParent, 0; e != nil && hops < maxChainHops; e, hops = e.ChainParent, hops+1 {
@@ -224,4 +229,21 @@ func structFieldIndex(meta *metadata.Metadata, pkg, name, field string) (int, bo
 		}
 	}
 	return 0, false
+}
+
+// receiverTypeMatches reports whether baseType is the same named type as the
+// receiver (recvPkg, recvName), comparing package path as well as name.
+//
+// An unqualified baseType never matches: it cannot be shown to be the
+// receiver's type, and resolving from the wrong builder is worse than resolving
+// nothing (golden rule #7).
+func receiverTypeMatches(baseType, recvPkg, recvName string) bool {
+	if baseType == "" || recvPkg == "" || recvName == "" {
+		return false
+	}
+	core := typemodel.Parse(baseType).Core()
+	if core == nil || core.Pkg == "" {
+		return false
+	}
+	return core.Pkg == recvPkg && core.Name == recvName
 }

--- a/internal/spec/receiver_field_test.go
+++ b/internal/spec/receiver_field_test.go
@@ -165,3 +165,37 @@ func TestReceiverFieldValueGuards(t *testing.T) {
 		}
 	}
 }
+
+// An empty constructor argument is a RESOLVED value, not an unresolved one:
+// ConstantValue("") returns ("", true), and the caller must honour that rather
+// than testing the string, or a builder constructed with "" would emit a
+// {placeholder} for a path it had actually resolved (review of #464).
+func TestLiteralFieldElementKeepsEmptyValue(t *testing.T) {
+	meta := comboMeta()
+	lit := metadata.NewCallArgument(meta)
+	lit.Kind = meta.StringPool.Get(metadata.KindCompositeLit)
+
+	kv := metadata.NewCallArgument(meta)
+	kv.Kind = meta.StringPool.Get(metadata.KindKeyValue)
+	key := metadata.NewCallArgument(meta)
+	key.Kind = meta.StringPool.Get(metadata.KindIdent)
+	key.Name = meta.StringPool.Get("pattern")
+	val := metadata.NewCallArgument(meta)
+	val.Kind = meta.StringPool.Get(metadata.KindLiteral)
+	val.Value = meta.StringPool.Get(`""`)
+	kv.X, kv.Fun = key, val
+	lit.Args = []*metadata.CallArgument{kv}
+
+	elt, ok := literalFieldElement(meta, lit, "pattern", "example.com/app", "Combo")
+	if !ok || elt == nil {
+		t.Fatal("an empty value must still be found")
+	}
+	cp := NewContextProvider(meta)
+	v, resolved := cp.ConstantValue(elt)
+	if !resolved {
+		t.Error("an empty string literal is resolved, so the ladder must not treat it as a failure")
+	}
+	if v != "" {
+		t.Errorf("value = %q, want the empty string", v)
+	}
+}

--- a/internal/spec/receiver_field_test.go
+++ b/internal/spec/receiver_field_test.go
@@ -1,0 +1,167 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// comboMeta describes a builder type whose second field carries the path, which
+// is what a positional constructor literal has to be matched against.
+func comboMeta() *metadata.Metadata {
+	sp := metadata.NewStringPool()
+	return &metadata.Metadata{
+		StringPool: sp,
+		Packages: map[string]*metadata.Package{
+			"example.com/app": {
+				Name: sp.Get("app"),
+				// In FILE types: TypeInPackage indexes pkg.Files[*].Types and
+				// never the package-level map, so this mirrors what generation
+				// actually produces.
+				Files: map[string]*metadata.File{
+					"app.go": {
+						Types: map[string]*metadata.Type{
+							"Combo": {
+								Name: sp.Get("Combo"),
+								Fields: []metadata.Field{
+									{Name: sp.Get("r"), Type: sp.Get("*example.com/app.Router")},
+									{Name: sp.Get("pattern"), Type: sp.Get("string")},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestStructFieldIndex(t *testing.T) {
+	meta := comboMeta()
+	for _, tc := range []struct {
+		field string
+		want  int
+		ok    bool
+	}{
+		{"r", 0, true},
+		{"pattern", 1, true},
+		{"absent", 0, false},
+	} {
+		got, ok := structFieldIndex(meta, "example.com/app", "Combo", tc.field)
+		if ok != tc.ok || (ok && got != tc.want) {
+			t.Errorf("structFieldIndex(%q) = (%d, %v), want (%d, %v)", tc.field, got, ok, tc.want, tc.ok)
+		}
+	}
+	if _, ok := structFieldIndex(meta, "example.com/app", "Missing", "pattern"); ok {
+		t.Error("an unknown type must not resolve a field index")
+	}
+	if _, ok := structFieldIndex(nil, "example.com/app", "Combo", "pattern"); ok {
+		t.Error("nil metadata must not resolve a field index")
+	}
+}
+
+// A constructor almost always writes its literal POSITIONALLY
+// (`&Combo{r, pattern}`), so the element is found by matching the index against
+// the struct's declared field order — the fact that makes the builder shape
+// resolvable at all (issue #461).
+func TestLiteralFieldElementPositional(t *testing.T) {
+	meta := comboMeta()
+	lit := metadata.NewCallArgument(meta)
+	lit.Kind = meta.StringPool.Get(metadata.KindCompositeLit)
+	first := metadata.NewCallArgument(meta)
+	first.Kind = meta.StringPool.Get(metadata.KindIdent)
+	first.Name = meta.StringPool.Get("r")
+	second := metadata.NewCallArgument(meta)
+	second.Kind = meta.StringPool.Get(metadata.KindIdent)
+	second.Name = meta.StringPool.Get("pattern")
+	lit.Args = []*metadata.CallArgument{first, second}
+
+	got, ok := literalFieldElement(meta, lit, "pattern", "example.com/app", "Combo")
+	if !ok || got == nil {
+		t.Fatalf("positional element for %q not found", "pattern")
+	}
+	if got.GetName() != "pattern" {
+		t.Errorf("resolved element is %q, want the second element", got.GetName())
+	}
+
+	// A field the struct does not declare cannot be positioned.
+	if _, ok := literalFieldElement(meta, lit, "absent", "example.com/app", "Combo"); ok {
+		t.Error("a field the struct does not declare must not resolve")
+	}
+}
+
+// A keyed literal (`&Combo{r: r, pattern: pattern}`) is matched by key, and a
+// field ABSENT from the keys is the zero value — which is not a path, so it is
+// reported unresolved rather than as the empty string.
+func TestLiteralFieldElementKeyed(t *testing.T) {
+	meta := comboMeta()
+	lit := metadata.NewCallArgument(meta)
+	lit.Kind = meta.StringPool.Get(metadata.KindCompositeLit)
+
+	kv := metadata.NewCallArgument(meta)
+	kv.Kind = meta.StringPool.Get(metadata.KindKeyValue)
+	key := metadata.NewCallArgument(meta)
+	key.Kind = meta.StringPool.Get(metadata.KindIdent)
+	key.Name = meta.StringPool.Get("pattern")
+	val := metadata.NewCallArgument(meta)
+	val.Kind = meta.StringPool.Get(metadata.KindLiteral)
+	val.Value = meta.StringPool.Get(`"/items"`)
+	kv.X, kv.Fun = key, val
+	lit.Args = []*metadata.CallArgument{kv}
+
+	got, ok := literalFieldElement(meta, lit, "pattern", "example.com/app", "Combo")
+	if !ok || got == nil {
+		t.Fatal("keyed element not found")
+	}
+	if got.GetValue() != `"/items"` {
+		t.Errorf("resolved value %q, want %q", got.GetValue(), `"/items"`)
+	}
+
+	if _, ok := literalFieldElement(meta, lit, "r", "example.com/app", "Combo"); ok {
+		t.Error("a field absent from a KEYED literal is the zero value, which is not a path")
+	}
+}
+
+// The rung declines anything that is not a field read off an identifier, before
+// it walks any chain.
+func TestReceiverFieldValueGuards(t *testing.T) {
+	meta := comboMeta()
+	b := NewBasePatternMatcher(&APISpecConfig{}, NewContextProvider(meta))
+
+	notSelector := metadata.NewCallArgument(meta)
+	notSelector.Kind = meta.StringPool.Get(metadata.KindIdent)
+	notSelector.Name = meta.StringPool.Get("p")
+
+	sel := metadata.NewCallArgument(meta)
+	sel.Kind = meta.StringPool.Get(metadata.KindSelector)
+	base := metadata.NewCallArgument(meta)
+	base.Kind = meta.StringPool.Get(metadata.KindIdent)
+	base.Name = meta.StringPool.Get("c")
+	field := metadata.NewCallArgument(meta)
+	field.Name = meta.StringPool.Get("pattern")
+	sel.X, sel.Sel = base, field
+
+	for name, arg := range map[string]*metadata.CallArgument{
+		"nil argument":   nil,
+		"not a selector": notSelector,
+		"selector":       sel, // with a nil node
+	} {
+		if v, ok := b.receiverFieldValue(arg, nil); ok {
+			t.Errorf("%s: resolved %q with no tracker node", name, v)
+		}
+	}
+}

--- a/internal/spec/receiver_field_test.go
+++ b/internal/spec/receiver_field_test.go
@@ -199,3 +199,34 @@ func TestLiteralFieldElementKeepsEmptyValue(t *testing.T) {
 		t.Errorf("value = %q, want the empty string", v)
 	}
 }
+
+// Two packages with a `Combo` builder is ordinary, and comparing bare names
+// would make `two.Combo`'s field resolve from `one.Combo`'s constructor — a
+// route stated confidently from the wrong value. That is the bare-name
+// collision #457 was about; the check carries the package path (review of
+// #464).
+func TestReceiverTypeMatchesRequiresPackageIdentity(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		baseType string
+		recvPkg  string
+		recvName string
+		want     bool
+	}{
+		{"same package and name", "*example.com/one.Combo", "example.com/one", "Combo", true},
+		{"pointer-free base", "example.com/one.Combo", "example.com/one", "Combo", true},
+		{"same name, DIFFERENT package", "*example.com/two.Combo", "example.com/one", "Combo", false},
+		{"same package, different name", "*example.com/one.Router", "example.com/one", "Combo", false},
+		// A base with no package cannot be shown to be the receiver's type.
+		{"unqualified base", "*Combo", "example.com/one", "Combo", false},
+		{"empty base", "", "example.com/one", "Combo", false},
+		{"no receiver package", "*example.com/one.Combo", "", "Combo", false},
+		// A path-suffix coincidence must not pass either.
+		{"package suffix collision", "*evil.com/example.com/one.Combo", "example.com/one", "Combo", false},
+	} {
+		if got := receiverTypeMatches(tc.baseType, tc.recvPkg, tc.recvName); got != tc.want {
+			t.Errorf("%s: receiverTypeMatches(%q, %q, %q) = %v, want %v",
+				tc.name, tc.baseType, tc.recvPkg, tc.recvName, got, tc.want)
+		}
+	}
+}

--- a/testdata/chained_wrapper/main.go
+++ b/testdata/chained_wrapper/main.go
@@ -3,10 +3,17 @@
 // returned value, so by the time the framework call runs, the path is a field
 // read rather than a literal.
 //
-// Wrapper derivation already declines this shape — `--verbose` reports it as
-// "incomplete, not applied" — but the framework call inside the wrapper was
-// then matched on its own and documented at `/{pattern}` (issue #428). The two
-// decisions now agree: the registration is reported and left out.
+// Wrapper derivation declines this shape — `--verbose` reports it as
+// "incomplete, not applied" — and the framework call inside the wrapper was
+// then matched on its own and documented at `/{pattern}` (issue #428), then
+// reported and left out.
+//
+// It now RESOLVES: the chain leads back to the call that built the receiver,
+// whose returned literal stores the constructor's parameter, and the argument
+// bound to that parameter is recorded — so `/items` is derived from facts
+// rather than guessed (issue #461). The keyed literal here (`&Combo{r: r,
+// pattern: pattern}`) is the counterpart to receiver_field_path's positional
+// one; both spellings must resolve.
 //
 // The ordinary method on the SAME router must still resolve, which is what
 // separates "this wiring style is not supported" from "this router is not".


### PR DESCRIPTION
Closes #461 — the resolution half. #463 fixed the fabrication; this recovers the
paths it left as placeholders.

## The shape

A builder gives the path once, to a constructor, and each verb reads it back off
the receiver:

```go
r.Combo("/items").Get(list).Post(create)

func (r *Router) Combo(pattern string) *Combo { return &Combo{r, pattern} }
func (c *Combo) Get(h http.HandlerFunc) *Combo { c.r.get(c.pattern, h); return c }
```

The registration itself has no path to read. gitea has 60 routes of this shape.

## The resolution

The chain is walked back to the call that **built** the receiver, and the field
is read out of the composite literal that call returns. Three details the
tracker data settled, none of which I would have got right by reasoning:

* **The walk is a loop.** A chained verb links to the *previous verb*, not the
  constructor, and a verb returns its receiver rather than a literal — so hop 0
  is skipped and hop 1 finds `Router.Combo`. A single hop recovers only `.Get`.
* **The literal carries no type of its own** (`type=""` in the trace), so field
  order comes from the **receiver's** type, which the invocation edge records as
  `*Combo`. Had the constructor built something else, the receiver would not
  have that type — so this is evidence, not assumption.
* **Positional literals are the common spelling.** `&Combo{r, pattern}` names no
  fields, so the element is matched by index against the struct's declared field
  order. `structFieldValue` deliberately refuses positional literals, which is
  exactly why this shape resolved nothing before.

Nothing is matched by name: a candidate qualifies only by returning a literal of
the receiver's type declaring that field, the value must resolve to a constant
or to the argument bound to the parameter the literal stores, and the rung is
**last** in the ladder — asked only after every other rung fails.

## Measured on gitea

| | #463 floor | + this |
|---|---|---|
| paths | 899 | **932** (+33 endpoints) |
| unresolved `{pattern}` paths | 60 | **45** |
| schemas | 242 | 242 |

15 collapsed placeholders became 48 distinct real routes — `/-/admin/auths/new`,
`/-/admin/users/new`, `/admin/hooks/{id}`, `/notifications/threads/{id}`.
**111 fixture specs byte-identical**, with one intended flip below.

## An inverted change detector

`testdata/chained_wrapper` existed to pin this gap **unfixed**: it asserted
`/items` must not be documented because "documenting /items would be a guess",
and that both chained calls be reported as unresolved paths. Neither holds now,
because every step is a fact metadata records — chain link → the constructor's
returned literal → the argument bound to that parameter. The test and the
fixture's own doc comment now describe the resolved behaviour and say why it is
derivation rather than a guess.

That fixture also turns out to cover the **keyed** literal
(`&Combo{r: r, pattern: pattern}`), the counterpart to
`receiver_field_path`'s **positional** one — so both branches of
`literalFieldElement` are exercised by real fixtures.

## What still does not resolve

45 `{pattern}` paths remain on gitea: shapes this rung does not reach (a path on
a package-level struct value, for one — related to #455). They stay honest
placeholders rather than fabrications, which is #463's floor.

## Note

Unit tests pin the rules directly, and record something worth knowing:
`TypeInPackage` indexes `pkg.Files[*].Types` and never the package-level `Types`
map, so hand-built metadata must put types in a file. My first version of those
tests failed for exactly that reason.

Suite, `make lint` and the ratchet (96.1%, floor 96) pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Builder-style method chains now recover route paths from their originating constructors, including chained GET and POST operations.

- **Bug Fixes**
  - Routes previously shown as unresolved placeholders can now be correctly documented when their path is stored on the builder receiver.
  - Resolution supports keyed and positional values, including empty paths, while safely retaining placeholders when values cannot be determined.

- **Documentation**
  - Added an unreleased changelog entry describing receiver-based path resolution and its matching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->