### PR TITLE
fix(spec): resolve a handler passed through a wrapper parameter

### DIFF
--- a/generator/testdata_handler_through_wrapper_test.go
+++ b/generator/testdata_handler_through_wrapper_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/spec"
+)
+
+// A handler that reaches the registration through a wrapper parameter must be
+// attributed to the concrete function, not to the rendering of the parameter —
+// which is its TYPE, `net/http.HandlerFunc`, and identifies nothing (#466).
+//
+// The fixture alternates the two hops on purpose: `Get(http.HandlerFunc(h3))`
+// is a conversion of a parameter, so resolving once and peeling once is not
+// enough — peeling the conversion exposes `h3`, which must then be resolved
+// again to reach `createItem`. A single pass leaves the type in place, which is
+// what this test would catch.
+func TestTestdata_HandlerThroughWrapper(t *testing.T) {
+	out := loadTestdata(t, "handler_through_wrapper", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+
+	item, ok := out.Paths["/conv"]
+	if !ok {
+		t.Fatalf("/conv missing; have %v", mapPathKeys(out.Paths))
+	}
+	op := firstOperation(&item)
+	if op == nil {
+		t.Fatal("/conv has no operation")
+	}
+	if !strings.HasSuffix(op.OperationID, "createItem") {
+		t.Errorf("operationId = %q, want the concrete handler (…createItem)", op.OperationID)
+	}
+	// The tell of the unresolved case: the handler rendered as its type.
+	if strings.Contains(op.OperationID, "HandlerFunc") {
+		t.Errorf("operationId = %q — the handler was rendered as its type, not resolved", op.OperationID)
+	}
+}

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -973,9 +973,7 @@ func (r *RoutePatternMatcherImpl) extractRouteDetails(node TrackerNodeInterface,
 		// This is #463's rule ("never render an argument") applied to the other
 		// argument of a registration: rendering a path yields a Go symbol,
 		// rendering a handler yields a type.
-		if resolved, _ := resolveArgThroughParams(handlerArg, node); resolved != nil {
-			handlerArg = handlerArgValue(resolved)
-		}
+		handlerArg = resolveHandlerArg(handlerArg, node)
 		routeInfo.Handler = r.contextProvider.GetArgumentInfo(handlerArg)
 		routeInfo.Function = r.contextProvider.GetArgumentInfo(handlerArg)
 
@@ -990,6 +988,44 @@ func (r *RoutePatternMatcherImpl) extractRouteDetails(node TrackerNodeInterface,
 	}
 
 	return found
+}
+
+// resolveHandlerArg follows a handler argument to the concrete function, through
+// any number of parameter hops and wrapper layers, in either order.
+//
+// The two steps feed each other, which is why one pass of each is not enough:
+// resolving a parameter can expose a wrapper CALL (`ParamArgMap["h"] =
+// withLogging(h2)`), and unwrapping that call exposes another parameter (`h2`)
+// that still has to be resolved — one pass stops at the wrapper and documents
+// the middleware as the handler. resolveArgThroughParams only accepts idents,
+// so it cannot make that second hop itself.
+//
+// The node travels with the argument: resolveArgThroughParams returns the frame
+// where the value resolved, and resolving the next hop from the original node
+// would read a binding belonging to a frame this value never passed through.
+//
+// Bounded by the same budget as the unwrap peel, and it stops as soon as a pass
+// changes nothing, so a handler named directly costs one failed lookup.
+func resolveHandlerArg(arg *metadata.CallArgument, node TrackerNodeInterface) *metadata.CallArgument {
+	cur, curNode := arg, node
+	for i := 0; i < maxHandlerUnwraps && cur != nil; i++ {
+		next := cur
+		if resolved, resolvedNode := resolveArgThroughParams(next, curNode); resolved != nil {
+			next = resolved
+			if resolvedNode != nil {
+				curNode = resolvedNode
+			}
+		}
+		next = handlerArgValue(next)
+		if next == nil || next == cur {
+			break
+		}
+		cur = next
+	}
+	if cur == nil {
+		return arg
+	}
+	return cur
 }
 
 // isValidHTTPMethod checks if a string is a valid HTTP method

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -957,6 +957,25 @@ func (r *RoutePatternMatcherImpl) extractRouteDetails(node TrackerNodeInterface,
 
 	if hi, ok := r.handlerArgIndex(edge); ok {
 		handlerArg := handlerArgValue(edge.Args[hi])
+		// A handler that reached the registration through a wrapper parameter is
+		// a PARAMETER here, and rendering a parameter yields its TYPE
+		// ("net/http.HandlerFunc"), which identifies no function. Everything
+		// about the operation hangs off this one value — its responses, request
+		// body, doc-comment summary and operationId — so a wrapper's routes were
+		// documented at the right path with no body at all, while the same
+		// handlers registered directly resolved fully (issue #466).
+		//
+		// The binding is recorded: the enclosing function's invocation carries
+		// ParamArgMap["h"] = listItems. resolveArgThroughParams already walks
+		// exactly that, hop by hop, and returns the argument unchanged when
+		// there is nothing to follow — so a handler named directly is untouched.
+		//
+		// This is #463's rule ("never render an argument") applied to the other
+		// argument of a registration: rendering a path yields a Go symbol,
+		// rendering a handler yields a type.
+		if resolved, _ := resolveArgThroughParams(handlerArg, node); resolved != nil {
+			handlerArg = handlerArgValue(resolved)
+		}
 		routeInfo.Handler = r.contextProvider.GetArgumentInfo(handlerArg)
 		routeInfo.Function = r.contextProvider.GetArgumentInfo(handlerArg)
 

--- a/testdata/handler_through_wrapper/go.mod
+++ b/testdata/handler_through_wrapper/go.mod
@@ -1,0 +1,3 @@
+module handlerwrap
+
+go 1.26

--- a/testdata/handler_through_wrapper/main.go
+++ b/testdata/handler_through_wrapper/main.go
@@ -1,0 +1,55 @@
+// Package main exercises a handler that reaches the registration through a
+// wrapper PARAMETER and a conversion.
+//
+// The registration's handler argument is `h`, a parameter, and rendering a
+// parameter yields its TYPE — so the route was attributed to
+// `net/http.HandlerFunc`, which identifies no function and costs the operation
+// its responses, request body, summary and a usable operationId (issue #466).
+//
+// The two steps feed each other, which is why one pass of each is not enough:
+// resolving the parameter can expose a conversion or wrapper CALL, and peeling
+// that exposes another parameter that still has to be resolved. Here
+// `Get(http.HandlerFunc(h3))` peels to `h3`, which is `registerConv`'s
+// parameter, bound to `createItem` at the call in main.
+//
+// Only one builder chain: a registration shared by several chains collapses
+// into one route before any of this is asked (issue #465), which would make a
+// second chain here silently untested.
+package main
+
+import "net/http"
+
+// Router is a house router.
+type Router struct{ mux *http.ServeMux }
+
+// Combo carries the path so several verbs can be registered from it.
+type Combo struct {
+	r       *Router
+	pattern string
+}
+
+func (r *Router) Combo(pattern string) *Combo { return &Combo{r, pattern} }
+
+// Get takes the handler as a parameter: at the framework call the handler is
+// `h`, not the function that was passed.
+func (c *Combo) Get(h http.HandlerFunc) *Combo {
+	c.r.mux.HandleFunc("GET "+c.pattern, h)
+	return c
+}
+
+// createItem is the concrete handler the operation must be attributed to.
+func createItem(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusCreated)
+}
+
+// registerConv takes the handler as ITS parameter and converts it, so the
+// resolution has to alternate: parameter -> conversion -> parameter.
+func registerConv(rt *Router, h3 http.HandlerFunc) {
+	rt.Combo("/conv").Get(http.HandlerFunc(h3))
+}
+
+func main() {
+	rt := &Router{mux: http.NewServeMux()}
+	registerConv(rt, createItem)
+	_ = http.ListenAndServe(":8080", rt.mux)
+}


### PR DESCRIPTION
Addresses the **attribution** half of #466. The response half is not fixed —
see the end, and note the issue as I filed it overstated what this would
deliver.

## The bug

A handler that reaches the registration through a wrapper parameter is a
PARAMETER at the call site, and rendering a parameter yields its **type**:

```go
func (c *Combo) Get(h http.HandlerFunc) *Combo {
	c.r.mux.HandleFunc("GET "+c.pattern, h)   // routeInfo.Function = "net/http.HandlerFunc"
	return c
}
```

That identifies no function, and everything about the operation hangs off it —
responses, request body, doc-comment summary, operationId. It is #463's rule
applied to the registration's *other* argument: rendering a path yields a Go
symbol, rendering a handler yields a type.

## The fix: alternate both hops

The binding is recorded (`ParamArgMap["h"] = listItems`) and
`resolveArgThroughParams` already walks it. But resolving once and peeling once
is **not enough**, because the two steps feed each other: resolving a parameter
can expose a conversion or wrapper call, and peeling that exposes another
parameter that still has to be resolved. `resolveArgThroughParams` accepts only
idents, so it cannot make that second hop itself.

Measured on an isolated conversion shape — `Get(http.HandlerFunc(h3))` inside a
function taking `h3` as its own parameter:

| build | operationId |
|---|---|
| main | `convwrap.net/http.HandlerFunc` (the type) |
| resolve once, peel once | `convwrap.net/http.HandlerFunc` — **unchanged** |
| alternating loop | **`convwrap.createItem`** |

My first pass did not merely miss the nested case; it did nothing at all for
this one. The loop also carries the node the value resolved at, since resolving
the next hop from the original node would read a binding belonging to a frame
the value never passed through.

## Measured

| | result |
|---|---|
| `chained_wrapper`, `receiver_field_path` | real handlers (`…listItems`, `…createItem`) instead of the `getItems`/`postItems` ids #459 had to synthesise, because both routes resolved to the same unusable symbol |
| 111 other fixture specs | **byte-identical** |
| gitea, echo-realworld, go-clean-echo, a 280-path service | **identical** |

A correctness fix with **no measured effect on the real projects I have** —
worth saying plainly rather than implying a win it did not produce.

`testdata/handler_through_wrapper` pins the alternating shape and fails on both
earlier builds with `handlerwrap.net/http.HandlerFunc`. It holds **one** builder
chain deliberately: a registration shared by several chains collapses into one
route (#465), and my first attempt at the fixture had two, so the second route
was silently untested.

## What this does NOT fix

* **Responses.** `/items` still documents `default: Default response (no
  response found)` rather than the `200 []Item` and `201` its handlers write.
  Attribution and tree **expansion** are different: a direct registration makes
  an argument child keyed by `listItems`, whose expansion pulls in the
  `Encode`/`WriteHeader` calls responses are read from, while the wrapper's
  argument child is keyed by the parameter and expands to nothing —
  `listItems` is never *called* anywhere, only passed. I tried substituting the
  bound argument in `buildPlan` and it cannot work there: plans are memoized per
  content identity and built **before** the node is attached, so `n.parent` is
  nil (traced: `parent=false`). The binding has to be applied at
  materialisation, which touches the expansion hot path and the instance caps.
  #466 stays open with that recorded.
* **A middleware wrapper**, `withLogging(h2)`, resolves to the *wrapper* rather
  than the wrapped handler, because `handlerArgValue` declines to peel it — a
  gap in `wrappedHandler`/`middlewareShaped`, separate from this loop.

Suite, `make lint` and the ratchet (96.1%, floor 96) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GGyBc4ucpCvWbpyP8rpqa5
