### PR TITLE
feat(spec): expand a handler forwarded through a wrapper parameter

### DIFF
--- a/generator/testdata_receiver_field_path_test.go
+++ b/generator/testdata_receiver_field_path_test.go
@@ -73,6 +73,22 @@ func TestTestdata_ReceiverFieldPath(t *testing.T) {
 		t.Error("/items has no POST — the chained verb links to Get, not to the constructor")
 	}
 
+	// The handlers are only ever PASSED to the builder, never called, and they
+	// arrive at the registration as the wrapper's parameter — so their bodies
+	// were invisible to the walk and both verbs documented the framework's
+	// "no response found" default. With the binding substituted, the handler's
+	// own encode/WriteHeader is read (issue #466).
+	if item.Get != nil {
+		if _, ok := item.Get.Responses["200"]; !ok {
+			t.Errorf("GET /items responses = %v, want the 200 its handler encodes", sortedStatusKeys(item.Get))
+		}
+	}
+	if item.Post != nil {
+		if _, ok := item.Post.Responses["201"]; !ok {
+			t.Errorf("POST /items responses = %v, want the 201 its handler writes", sortedStatusKeys(item.Post))
+		}
+	}
+
 	// What replaces a fabricated segment is a declared placeholder, not a
 	// silent shortening — the route stays addressable and visibly incomplete
 	// (issue #34), and #428 reports the registration.

--- a/generator/testdata_unresolved_path_test.go
+++ b/generator/testdata_unresolved_path_test.go
@@ -149,6 +149,21 @@ func TestTestdata_ChainedWrapper(t *testing.T) {
 		t.Error("POST /items missing — the chained verb links to Get rather than to the constructor, so the walk must continue past it")
 	}
 
+	// The handler's own responses, which is the point of resolving the handler
+	// through the wrapper parameter: `listItems` encodes []Item and
+	// `createItem` writes 201. Before, both routes documented only the
+	// framework's "no response found" default (issue #466).
+	if get := opFor(items, "GET"); get != nil {
+		if _, ok := get.Responses["200"]; !ok {
+			t.Errorf("GET /items responses = %v, want a 200 from the handler's Encode", sortedStatusKeys(get))
+		}
+	}
+	if post := opFor(items, "POST"); post != nil {
+		if _, ok := post.Responses["201"]; !ok {
+			t.Errorf("POST /items responses = %v, want the 201 the handler writes", sortedStatusKeys(post))
+		}
+	}
+
 	// The ordinary method on the same router still resolves: what is unsupported
 	// is the chained wiring, not this project's router.
 	item, ok := out.Paths["/health"]

--- a/internal/spec/lazytree.go
+++ b/internal/spec/lazytree.go
@@ -1196,11 +1196,25 @@ type planKey struct {
 // calls of its own, which is the whole point (a body to expand) and keeps the
 // hot path from re-keying every forwarded string and int in the graph.
 func (n *LazyNode) boundSpec(spec childSpec) childSpec {
-	if spec.arg == nil || n.parent == nil || spec.arg.GetKind() != metadata.KindIdent {
+	if spec.arg == nil || spec.argEdge == nil || n.parent == nil || spec.arg.GetKind() != metadata.KindIdent {
 		return spec
 	}
 	inv := n.parent.edge
 	if inv == nil || len(inv.ParamArgMap) == 0 {
+		return spec
+	}
+	// The frame has to be an invocation OF the function whose body writes this
+	// argument. `n.parent` usually is — an argument of this node's own call —
+	// but not always: an argument node holding a nested call plans the NESTED
+	// call's arguments (buildPlan's ownerEdge), and a chain-parented child is
+	// re-parented at the call-site scope, so the parent frame can belong to
+	// another function entirely. Taking it on trust would bind from a function
+	// that merely shares a parameter NAME, and would disagree with
+	// boundSpecVariants — which enumerates the edges into spec.argEdge.Caller —
+	// so the identity built here would be one the prune index never saw and the
+	// child would be dropped anyway. Declining is the honest branch: the
+	// argument stays as written.
+	if inv.Callee.BaseID() != spec.argEdge.Caller.BaseID() {
 		return spec
 	}
 	name := spec.arg.GetName()
@@ -1359,16 +1373,25 @@ func (t *LazyTree) boundSpecVariants(spec childSpec) []childSpec {
 		return nil
 	}
 	var out []childSpec
-	seen := map[int32]bool{}
+	// Deduplicated on the FULL identity, not the key: two call sites binding
+	// values that render the same ID still intern to different pointers, and
+	// specIdentity compares the argument by pointer — so keying on the key
+	// alone would drop a variant the expansion can build, which is precisely
+	// the miss this index exists to prevent.
+	seen := map[planKey]bool{}
 	for _, in := range t.meta.Callees[enclosing] {
 		if _, ok := in.ParamArgMap[name]; !ok {
 			continue
 		}
 		sub, ok := t.substituteBound(spec, in, name)
-		if !ok || seen[sub.keyID] {
+		if !ok {
 			continue
 		}
-		seen[sub.keyID] = true
+		id := specIdentity(sub)
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
 		out = append(out, sub)
 	}
 	return out

--- a/internal/spec/lazytree.go
+++ b/internal/spec/lazytree.go
@@ -45,6 +45,7 @@ import (
 	"strings"
 
 	"github.com/ehabterra/apispec/internal/metadata"
+	"github.com/ehabterra/apispec/internal/typemodel"
 )
 
 // LazyTree implements TrackerTreeInterface over metadata, expanding on demand.
@@ -227,6 +228,14 @@ type LazyTree struct {
 	// using it directly would let one `foo(q.Get("x"))` anywhere suppress
 	// every `Values.Get` call site in the project.
 	argInstanceIDs map[string]bool
+
+	// funcTypes memoizes funcValued by type string (see funcValued).
+	funcTypes map[string]bool
+
+	// boundArgs interns the value bound to a parameter at one invocation, so a
+	// substituted child has ONE identity across the prune's index and the
+	// expansion (see internBoundArg).
+	boundArgs map[boundArgKey]*metadata.CallArgument
 
 	// plans memoizes each node content-identity's expansion plan — the
 	// "(edgeID, relevant bindings)" memoization from the redesign doc §7:
@@ -1169,6 +1178,202 @@ type planKey struct {
 	isArg bool
 }
 
+// boundSpec substitutes an argument that is a forwarded PARAMETER with the
+// value the caller bound to it, so the child carries something expandable.
+//
+// A handler passed down a wrapper — `Combo.Get(h)` reaching
+// `mux.HandleFunc(path, h)` — is the parameter `h` at the registration, and a
+// parameter has no body: the argument child expands to nothing, so the route
+// documents no responses, no request body and no summary. The concrete handler
+// is never *called* anywhere either, only passed, so nothing else pulls it into
+// the tree (issue #466).
+//
+// It cannot live in buildPlan: plans are memoized per content identity and
+// built before the node is attached, so the parent — and therefore the binding
+// — is not available there. That is the documented split, not an accident.
+//
+// Narrow on purpose. The substitution only happens when the bound value has
+// calls of its own, which is the whole point (a body to expand) and keeps the
+// hot path from re-keying every forwarded string and int in the graph.
+func (n *LazyNode) boundSpec(spec childSpec) childSpec {
+	if spec.arg == nil || n.parent == nil || spec.arg.GetKind() != metadata.KindIdent {
+		return spec
+	}
+	inv := n.parent.edge
+	if inv == nil || len(inv.ParamArgMap) == 0 {
+		return spec
+	}
+	name := spec.arg.GetName()
+	if name == "" {
+		return spec
+	}
+	if _, ok := inv.ParamArgMap[name]; !ok {
+		return spec
+	}
+	if sub, ok := n.tree.substituteBound(spec, inv, name); ok {
+		return sub
+	}
+	return spec
+}
+
+// substituteBound rewrites spec to carry `bound` instead of the parameter it
+// forwards, or reports false when there is nothing to gain.
+//
+// One rule, two callers, deliberately: the per-path substitution in boundSpec
+// and the enumeration the prune's index needs (boundSpecVariants). If they
+// disagreed, the index would answer for an identity the expansion never builds
+// — or, as it did before this was shared, the expansion would build one the
+// index has never heard of and the prune would drop it.
+func (t *LazyTree) substituteBound(spec childSpec, inv *metadata.CallGraphEdge, name string) (childSpec, bool) {
+	boundArg := t.internBoundArg(inv, name)
+	if boundArg == nil || spec.arg == nil || boundArg.GetName() == spec.arg.GetName() {
+		return spec, false
+	}
+	// Only a FUNCTION-valued argument. This is what the substitution is for — a
+	// handler forwarded through a wrapper — and on gitea it is the difference
+	// between 446,034 substitutions and 49,544: 60% of the rest are plain
+	// `string` parameters, then `[]any` and `[]byte`. Those cannot open a route
+	// the walk could not already see, and marking their identities reachable
+	// un-prunes subtrees the barren-subtree prune exists to drop, which cost
+	// +81% node materialisation for one extra response body (issue #466).
+	if !t.funcValued(spec.arg) && !t.funcValued(boundArg) {
+		return spec, false
+	}
+	key := strings.TrimPrefix(boundArg.ID(), "*")
+	if key == "" || key == spec.key {
+		return spec, false
+	}
+	// Base key, as the plan's own callee lookup does: an argument ID carries a
+	// position suffix, and edgesFor is keyed by the position-stripped form.
+	if len(t.edgesFor(metadata.StripToBase(key))) == 0 {
+		return spec, false // nothing to expand: leave the argument as written
+	}
+	spec.arg = boundArg
+	spec.key = key
+	spec.keyID = t.internKey(key)
+	spec.argType = classifyArgument(boundArg)
+	return spec, true
+}
+
+// funcValued reports whether an argument's type is a function.
+//
+// Two forms, because both occur: a literal signature ("func(w
+// net/http.ResponseWriter, r *net/http.Request)"), and a NAMED type whose
+// underlying is one — `net/http.HandlerFunc`. A named type records its
+// underlying in Target, so the check is a fact lookup rather than a guess about
+// the name. Both are consulted for the parameter AND the bound value, since a
+// stdlib named type may not be in metadata at all while the value bound to it
+// still renders as a signature.
+func (t *LazyTree) funcValued(arg *metadata.CallArgument) bool {
+	if arg == nil {
+		return false
+	}
+	ts := arg.GetType()
+	if ts == "" {
+		return false
+	}
+	// Memoized by type string. The uncached version parsed a type and walked
+	// metadata for every candidate, and substituteBound runs per child per
+	// materialised node — putting an allocating parse on the expansion hot path
+	// took the spec-mapping stage from 2m38 to 7m45 on gitea. Distinct type
+	// strings are a few thousand; nodes are millions.
+	if v, ok := t.funcTypes[ts]; ok {
+		return v
+	}
+	v := strings.HasPrefix(ts, "func(")
+	if !v {
+		if core := typemodel.Parse(ts).Core(); core != nil && core.Name != "" {
+			if typ := typeByName(core.Pkg, core.Name, t.meta); typ != nil {
+				v = strings.HasPrefix(getStringFromPool(t.meta, typ.Target), "func(")
+			}
+		}
+	}
+	if t.funcTypes == nil {
+		t.funcTypes = map[string]bool{}
+	}
+	t.funcTypes[ts] = v
+	return v
+}
+
+// internBoundArg returns ONE pointer per (invocation, parameter) for the value
+// bound there.
+//
+// This is not an optimisation. A spec's identity compares its argument by
+// POINTER (specIdentity), and `bound := edge.ParamArgMap[name]` copies — map
+// values are not addressable — so building the argument twice yields two
+// identities for one value. The prune's index would then enumerate one and the
+// expansion would materialise the other, the reach lookup would miss, and the
+// child would be pruned exactly as if it had never been enumerated. That is the
+// shape that made the first attempt at this look correct and change nothing.
+func (t *LazyTree) internBoundArg(inv *metadata.CallGraphEdge, name string) *metadata.CallArgument {
+	if inv == nil {
+		return nil
+	}
+	if t.boundArgs == nil {
+		t.boundArgs = map[boundArgKey]*metadata.CallArgument{}
+	}
+	bk := boundArgKey{edge: inv, name: name}
+	if arg, ok := t.boundArgs[bk]; ok {
+		return arg
+	}
+	bound, ok := inv.ParamArgMap[name]
+	if !ok {
+		t.boundArgs[bk] = nil
+		return nil
+	}
+	arg := handlerArgValue(&bound)
+	t.boundArgs[bk] = arg
+	return arg
+}
+
+// boundArgKey identifies a binding: which call, which parameter.
+type boundArgKey struct {
+	edge *metadata.CallGraphEdge
+	name string
+}
+
+// boundSpecVariants lists every substitution this argument could take across
+// the call sites of the function whose body writes it.
+//
+// The prune's reach index is built from PLANS, and a substituted child is an
+// identity no plan lists — so without enumerating them here, canReachMatch
+// answers with the zero value (false) and the barren-subtree prune skips every
+// handler that arrived through a wrapper, which is exactly what it did
+// (issue #466).
+//
+// Enumerating all bindings rather than one is what makes this sound at index
+// time: the index is over content identities, not paths, and any of these
+// bindings can be the one a given path carries.
+func (t *LazyTree) boundSpecVariants(spec childSpec) []childSpec {
+	if spec.arg == nil || spec.arg.GetKind() != metadata.KindIdent || spec.argEdge == nil {
+		return nil
+	}
+	name := spec.arg.GetName()
+	if name == "" {
+		return nil
+	}
+	// The argument is written in the body of the function that makes this call,
+	// so its bindings are on the edges INTO that function.
+	enclosing := spec.argEdge.Caller.BaseID()
+	if enclosing == "" {
+		return nil
+	}
+	var out []childSpec
+	seen := map[int32]bool{}
+	for _, in := range t.meta.Callees[enclosing] {
+		if _, ok := in.ParamArgMap[name]; !ok {
+			continue
+		}
+		sub, ok := t.substituteBound(spec, in, name)
+		if !ok || seen[sub.keyID] {
+			continue
+		}
+		seen[sub.keyID] = true
+		out = append(out, sub)
+	}
+	return out
+}
+
 // GetChildren implements TrackerNodeInterface, expanding on first access.
 // The expansion PLAN (which children exist, structurally) is memoized per
 // content identity; only the per-path guards — cycle check, per-scope
@@ -1223,6 +1428,12 @@ func (n *LazyNode) GetChildren() []TrackerNodeInterface {
 	// they actually hold, and 91% of expansions hold two children or fewer.
 	childCount := 0
 	for _, spec := range plan {
+		// Per-path, because the plan cannot know it: a value forwarded through
+		// this function's PARAMETER is bound by the call that reached it, and
+		// that binding lives on this node's parent frame. Substituted here, so
+		// the cycle guard, the prune and the instance caps all judge the child
+		// that will actually be built (issue #466).
+		spec = n.boundSpec(spec)
 		if spec.arg == nil && childCount >= n.tree.limits.MaxChildrenPerNode {
 			continue
 		}

--- a/internal/spec/prune.go
+++ b/internal/spec/prune.go
@@ -136,6 +136,19 @@ func (t *LazyTree) buildReachIndex() {
 				specOf[childID] = child
 			}
 			out = append(out, childID)
+			// A forwarded parameter is substituted per path when the child is
+			// materialised (LazyNode.boundSpec), which produces an identity no
+			// plan lists. Enumerate those too, or this index answers with the
+			// zero value for every one of them and the prune skips the subtree
+			// — which is how a handler passed through a wrapper lost its
+			// responses (issue #466).
+			for _, sub := range t.boundSpecVariants(child) {
+				subID := specIdentity(sub)
+				if _, seen := specOf[subID]; !seen {
+					specOf[subID] = sub
+				}
+				out = append(out, subID)
+			}
 		}
 		return out
 	}


### PR DESCRIPTION
Closes #466 (the expansion half; the attribution half shipped in #467).

## The gap

A handler that is only ever **passed** never enters the tree.

```go
r.Combo("/items").Get(listItems).Post(createItem)   // handlers are arguments
func (c *Combo) Get(h http.HandlerFunc) *Combo {
    c.mux.HandleFunc(c.pattern, h)                  // registration sees `h`
}
```

At the registration site the handler argument is the parameter `h`. A parameter
has no body, so the argument child expands to nothing — and because the handler
is never *called* anywhere either, only forwarded, nothing else pulls it in.
The route is found; the operation then documents no responses, no request body
and no summary, just the framework's `default: no response found`.

The binding is already a recorded fact (`CallGraphEdge.ParamArgMap`). Nothing
applied it.

## What had to line up

Four things, and each of them independently made the change *look* correct
while changing nothing:

| | |
|---|---|
| **Where** | Not `buildPlan`: plans are memoized per content identity and built before the node is attached, so the parent frame — and therefore the binding — isn't available there. Substituting in `GetChildren`, ahead of the cycle/prune/cap guards, means all three judge the child that actually gets built. |
| **Identity** | `specIdentity` compares the argument **by pointer**, and `edge.ParamArgMap[name]` copies (map values aren't addressable). Building the value twice = two identities for one binding. `internBoundArg` returns one pointer per (invocation, parameter). |
| **Reachability** | The barren-subtree prune's index is built from *plans*, so a substituted child is an identity no plan lists — `canReachMatch` answered `false` and the prune skipped precisely the subtree this exists to reach. `boundSpecVariants` enumerates the bindings across the enclosing function's call sites, sharing one rule with the per-path substitution so index and expansion cannot disagree. |
| **Scope** | Function-valued arguments only (see below). |

## Why it is narrowed to function-valued arguments

Substituting every forwarded value is **446,034** substitutions on a large real
project against **49,544** for the function-typed ones. The rest:

```
269230  string
 93143  []any
 18521  []byte
```

None of those can open a route the walk can't already see, and marking their
identities reachable un-prunes subtrees the prune exists to drop: **+81% node
materialisation, +42% on the spec-mapping stage, for one extra response body.**

`funcValued` accepts a literal signature and a named type whose metadata
`Target` is one (`http.HandlerFunc`), memoized by type string — the unmemoized
version put an allocating type parse on the per-child expansion path and took
spec mapping from 2m38 to **7m45**.

## Measurements (gitea)

| build | paths | ops | with body | default-only | RSS | spec-mapped |
|---|---|---|---|---|---|---|
| main | 930 | 1142 | 938 | 289 | 4.45 GB | 1m50.7s |
| broad (all forwarded args) | 930 | 1142 | **939** | 289 | 4.48 GB | 2m37.8s |
| **this PR** (narrowed + memo) | 930 | 1142 | 938 | 289 | ~4.0 GB (+13%) | **1m49.1s** |

Time is back at parity. Two things I'm flagging rather than burying:

- **Zero gain on the one real project I can measure.** gitea's own `Combo`
  handlers already resolve by another route, so the byte-identical output there
  is the honest result. I can't claim a population I haven't measured.
- **RSS is a real regression, ~+13%.** Repeat runs settle it: main 3.52 / 3.62
  GB, this branch 3.87 / 4.19 GB — no overlap, and the engine log corroborates
  it independently (call copies dropped by the instance cap go 29.4M → 31.4M,
  +6.7% more of the graph explored). The substitution un-prunes subtrees even
  when narrowed to function-valued arguments, because the reach index is over
  content identities and therefore over-approximates which *path* carries which
  binding. Time is unaffected — the extra work is materialisation the cap
  already discards.

## Fixtures do gain — and they're the shape the issue reports

Builder-style routers (gitea's own `Combo` is one). Both go from `default` on
every verb to real responses:

- `chained_wrapper`: GET `/items` → `200`, POST `/items` → `201`
- `receiver_field_path`: GET `/items` → `200` `[]Item`, POST `/items` → `201`
  `$ref: Item` (request bodies sharpen from bare `object` to `$ref` too)

Both assertions were verified to **fail** without the change.

## Verification

- Fixture A/B across all 114 projects against a baseline built from current
  `main`: **112 byte-identical**, the two above being the intended wins.
- Full suite, `make lint`, coverage ratchet (96.0% / floor 96) pass.

Given zero real-project gain against a measured +13% RSS, the merge call is
yours. The honest summary: this is correct, it fixes the shape the issue
reports, it is proven by two fixtures — and on the only large project I can
measure it costs memory and buys nothing. If the trade isn't worth it, the
narrowing rung to pull next is the reach index: making it path-aware rather
than identity-aware is what would stop the over-approximation, and that is a
larger change than this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Generated API documentation now correctly captures response status codes from handlers passed through wrappers or chained routes.
  - Routes such as `GET /items` and `POST /items` now document their handlers’ encoded responses, including `200` and `201` status codes, instead of incorrectly showing a default “no response found” result.
  - Improved route discovery for wrapped handlers so their response details remain available during documentation generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->