### PR TITLE
fix(spec): a package qualifier is evidence, so a miss must not answer with a twin

### DIFF
--- a/generator/testdata_skipped_package_type_test.go
+++ b/generator/testdata_skipped_package_type_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/spec"
+)
+
+// A package that does not type-check is skipped by the loader — a real and
+// routine state, since a project is often analysed mid-edit — so its types are
+// not recorded. What must NOT then happen is that the lookup falls through to a
+// bare-name scan and fills the component with a same-named type from somewhere
+// else: the component keeps the name of the package that was asked for and gets
+// the fields and doc comment of a different one, with nothing in the output
+// saying so.
+//
+// This was found on a real 280-path service, where one package published five
+// components filled from three others — 58 property and enum keys vanished and
+// 5 descriptions described a different type (issue #447). The fixture makes the
+// trigger explicit: `broken` genuinely fails to compile, and `twin` declares
+// `Row` too.
+func TestTestdata_SkippedPackageType(t *testing.T) {
+	out := loadTestdata(t, "skipped_package_type", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+
+	if !hasPath(out, "/rows") || !hasPath(out, "/sheets") {
+		t.Fatalf("routes missing; have %v — a skipped package must not cost the routes around it",
+			mapPathKeys(out.Paths))
+	}
+
+	var brokenRow, twinRow *spec.Schema
+	for name, schema := range out.Components.Schemas {
+		switch {
+		case strings.HasSuffix(name, "broken_Row"):
+			brokenRow = schema
+		case strings.HasSuffix(name, "twin_Row"):
+			twinRow = schema
+		}
+	}
+
+	if brokenRow == nil {
+		t.Fatalf("no component for broken.Row; have %v", schemaNames(out))
+	}
+	// The tell is twin's field: `sheet` belongs to twin.Row and appears nowhere
+	// in broken.Row, whose fields are cron and enabled.
+	if _, borrowed := brokenRow.Properties["sheet"]; borrowed {
+		t.Errorf("broken.Row was filled from twin.Row (it has twin's `sheet` property) — "+
+			"the package that was asked for does not declare this type, and another package's "+
+			"same-named type is not evidence about it; properties = %v", propertyNames(brokenRow))
+	}
+	if strings.Contains(brokenRow.Description, "shares the NAME") {
+		t.Errorf("broken.Row carries twin.Row's doc comment: %q", brokenRow.Description)
+	}
+
+	// Refusing the substitution must not cost the type that IS declared.
+	if twinRow == nil {
+		t.Fatal("no component for twin.Row")
+	}
+	if _, ok := twinRow.Properties["sheet"]; !ok {
+		t.Errorf("twin.Row lost its own property; properties = %v", propertyNames(twinRow))
+	}
+}
+
+func schemaNames(out *spec.OpenAPISpec) []string {
+	if out.Components == nil {
+		return nil
+	}
+	names := make([]string, 0, len(out.Components.Schemas))
+	for n := range out.Components.Schemas {
+		names = append(names, n)
+	}
+	return names
+}

--- a/generator/testdata_skipped_package_type_test.go
+++ b/generator/testdata_skipped_package_type_test.go
@@ -43,6 +43,11 @@ func TestTestdata_SkippedPackageType(t *testing.T) {
 			mapPathKeys(out.Paths))
 	}
 
+	if out.Components == nil {
+		// Fataling here rather than ranging a nil pointer: a panic would replace
+		// the diagnostic this test exists to print.
+		t.Fatal("no components at all — expected one for broken.Row and one for twin.Row")
+	}
 	var brokenRow, twinRow *spec.Schema
 	for name, schema := range out.Components.Schemas {
 		switch {

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -1599,32 +1599,86 @@ func findTypesInMetadata(meta *metadata.Metadata, typeName string) map[string]*m
 	return metaTypes
 }
 
-// typeByName looks a type up in metadata by its parsed core: first in the
-// named package, then across all packages. Metadata keys a type by its bare
-// declared name (tspec.Name.Name — a generic declaration is stored as "Page",
-// its parameters in Type.TypeParams), so callers pass the structured core
-// name (typemodel.Parse(...).Core().Name), never a bracketed form.
+// typeByName looks a type up in metadata by its parsed core. Metadata keys a
+// type by its bare declared name (tspec.Name.Name — a generic declaration is
+// stored as "Page", its parameters in Type.TypeParams), so callers pass the
+// structured core name (typemodel.Parse(...).Core().Name), never a bracketed
+// form.
+//
+// The rule is that a package qualifier is EVIDENCE, and evidence is not
+// discarded on a miss. It used to be: when the qualified lookup found nothing,
+// this scanned every package in sorted order and returned the first type with
+// a matching bare name. Sorting made the answer deterministic, which is what
+// the old comment was about, but not right — the component kept the name of the
+// package that was asked for and got the fields and doc comment of a different
+// one, with nothing in the output saying so. On a real 280-path service one
+// package published five components filled from three other packages: 58
+// property and enum keys vanished and 5 descriptions described a different type
+// (issue #447).
+//
+// So: the named package answers, or the qualifier is resolved as a package NAME
+// (the same unique-fit rule canonicalPackageQualifier uses, because a type
+// recovered by rendering an argument carries the package's name rather than its
+// path — golden rule #3), or nothing. Only a caller with NO qualifier falls back
+// to the bare name, and then only when it is unambiguous: with two packages
+// declaring it there is nothing to choose between them, and a wrong type is
+// worse than an unresolved one (golden rule #7).
 func typeByName(pkgName, typeName string, meta *metadata.Metadata) *metadata.Type {
-	if meta == nil {
+	if meta == nil || typeName == "" {
 		return nil
 	}
 
-	if pkgName != "" && typeName != "" {
+	if pkgName != "" {
 		if typ := meta.TypeInPackage(pkgName, typeName); typ != nil {
 			return typ
 		}
+		if strings.Contains(pkgName, "/") {
+			return nil // an import path that does not declare it: asked and answered
+		}
+		return uniqueTypeInNamedPackage(pkgName, typeName, meta)
 	}
 
-	// Fallback: the bare type name may exist in several packages. Iterate in a
-	// stable (cached) sorted order so the chosen type is deterministic across
-	// runs — otherwise map iteration would pick a different package's type and
-	// flip the schema between runs.
+	return uniqueTypeByBareName(typeName, meta)
+}
+
+// uniqueTypeInNamedPackage resolves a qualifier that is a package NAME
+// ("scheduling") rather than an import path, by finding the one package that
+// both fits the name and declares the type. Two candidates mean the qualifier
+// does not identify a package, so nothing is returned.
+func uniqueTypeInNamedPackage(pkgName, typeName string, meta *metadata.Metadata) *metadata.Type {
+	var found *metadata.Type
 	for _, pkg := range meta.SortedPackageNames() {
-		if typ := meta.TypeInPackage(pkg, typeName); typ != nil {
-			return typ
+		if !packageDeclares(meta, pkg, pkgName) {
+			continue
 		}
+		typ := meta.TypeInPackage(pkg, typeName)
+		if typ == nil {
+			continue
+		}
+		if found != nil {
+			return nil
+		}
+		found = typ
 	}
-	return nil
+	return found
+}
+
+// uniqueTypeByBareName resolves an UNQUALIFIED name, which is the one case
+// where the bare name is all the evidence there is. Sorted so a second
+// declaration is found rather than raced past (golden rule #1).
+func uniqueTypeByBareName(typeName string, meta *metadata.Metadata) *metadata.Type {
+	var found *metadata.Type
+	for _, pkg := range meta.SortedPackageNames() {
+		typ := meta.TypeInPackage(pkg, typeName)
+		if typ == nil {
+			continue
+		}
+		if found != nil {
+			return nil
+		}
+		found = typ
+	}
+	return found
 }
 
 // normalizeGenericInstanceName rewrites a generic instantiation rendered in

--- a/internal/spec/type_lookup_test.go
+++ b/internal/spec/type_lookup_test.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// lookupMeta builds metadata where `agent` is present but does NOT declare the
+// type, while other packages do — the state a package left in when its types
+// were not recorded (issue #447).
+func lookupMeta() *metadata.Metadata {
+	pool := metadata.NewStringPool()
+	field := func(name, typ string) metadata.Field {
+		return metadata.Field{Name: pool.Get(name), Type: pool.Get(typ)}
+	}
+	// TypeInPackage reads a package's types out of its FILES, so that is where
+	// a faithful fixture has to put them.
+	pkg := func(types map[string]*metadata.Type) *metadata.Package {
+		return &metadata.Package{Files: map[string]*metadata.File{"f.go": {Types: types}}}
+	}
+	return &metadata.Metadata{
+		StringPool: pool,
+		Packages: map[string]*metadata.Package{
+			// Present, no types: the package whose load produced nothing.
+			"example.com/m/internal/agent": pkg(map[string]*metadata.Type{}),
+			"example.com/m/internal/scheduling": pkg(map[string]*metadata.Type{
+				"ConfigRow": {Fields: []metadata.Field{field("cron", "string")}},
+			}),
+			"example.com/m/internal/worksheet": pkg(map[string]*metadata.Type{
+				"Spec":  {Fields: []metadata.Field{field("cells", "int")}},
+				"Sheet": {Fields: []metadata.Field{field("rows", "int")}},
+			}),
+			"example.com/m/internal/assets": pkg(map[string]*metadata.Type{
+				"Spec": {Fields: []metadata.Field{field("bytes", "int")}},
+			}),
+		},
+	}
+}
+
+// A type asked for BY PACKAGE that the package does not declare must not be
+// answered with another package's same-named type.
+//
+// The component keeps the name of the package that was asked for and gets the
+// fields and doc comment of a different one, and nothing in the output says
+// so. On a real 280-path service that published five components under one
+// package whose contents came from three other packages: 58 property/enum keys
+// vanished and 5 descriptions described a different type (issue #447).
+func TestTypeByNameRefusesAnotherPackagesType(t *testing.T) {
+	meta := lookupMeta()
+
+	if got := typeByName("example.com/m/internal/agent", "ConfigRow", meta); got != nil {
+		t.Errorf("agent.ConfigRow resolved to %v — agent does not declare it, and scheduling's "+
+			"same-named type is a different type", got.Fields)
+	}
+	// Unambiguous elsewhere is still not evidence about THIS package.
+	if got := typeByName("example.com/m/internal/agent", "Sheet", meta); got != nil {
+		t.Errorf("agent.Sheet resolved to %v — the name being unique elsewhere says nothing "+
+			"about the package that was asked for", got.Fields)
+	}
+	// The package that does declare it still resolves.
+	if got := typeByName("example.com/m/internal/scheduling", "ConfigRow", meta); got == nil {
+		t.Error("scheduling.ConfigRow did not resolve; refusing a substitution must not cost the real lookup")
+	}
+}
+
+// A qualifier that is a package NAME rather than an import path still has to
+// resolve — metadata's own strings carry the full path, but a type recovered
+// by rendering an argument carries the package's name (golden rule #3). The
+// rule is the one canonicalPackageQualifier uses: exactly one package that
+// both fits the name and declares the type.
+func TestTypeByNameResolvesAPackageNameQualifier(t *testing.T) {
+	meta := lookupMeta()
+
+	got := typeByName("scheduling", "ConfigRow", meta)
+	if got == nil {
+		t.Fatal("scheduling.ConfigRow (name qualifier) did not resolve")
+	}
+	if len(got.Fields) != 1 {
+		t.Errorf("resolved the wrong type: fields = %v", got.Fields)
+	}
+	// Ambiguous: two packages declare Spec, and neither is named by the
+	// qualifier, so there is nothing to choose between them.
+	if got := typeByName("agent", "Spec", meta); got != nil {
+		t.Errorf("agent.Spec resolved to %v — no package named agent declares Spec", got.Fields)
+	}
+}
+
+// With no qualifier at all the bare name is the only evidence there is, so it
+// answers only when the name is unambiguous. Two packages declaring `Spec`
+// used to resolve to whichever sorted first, which is deterministic but not
+// right.
+func TestTypeByNameBareNameMustBeUnambiguous(t *testing.T) {
+	meta := lookupMeta()
+
+	if got := typeByName("", "ConfigRow", meta); got == nil {
+		t.Error("a bare name declared in exactly one package must still resolve")
+	}
+	if got := typeByName("", "Spec", meta); got != nil {
+		t.Errorf("bare Spec resolved to %v — it is declared in two packages, so the answer is a "+
+			"coin flip dressed up as determinism", got.Fields)
+	}
+}

--- a/testdata/skipped_package_type/broken/broken.go
+++ b/testdata/skipped_package_type/broken/broken.go
@@ -1,0 +1,13 @@
+package broken
+
+// Row is the type the route actually returns. This package does not COMPILE —
+// the reference below is undefined — so the loader reports errors for it and
+// apispec skips it, exactly as it skips a package that is mid-edit. Its types
+// are therefore not recorded, which is the state that made a real service fill
+// five components from other packages (issue #447).
+type Row struct {
+	Cron    string `json:"cron"`
+	Enabled bool   `json:"enabled"`
+}
+
+var _ = thisSymbolDoesNotExist

--- a/testdata/skipped_package_type/go.mod
+++ b/testdata/skipped_package_type/go.mod
@@ -1,0 +1,3 @@
+module github.com/ehabterra/apispec/testdata/skipped_package_type
+
+go 1.24.3

--- a/testdata/skipped_package_type/main.go
+++ b/testdata/skipped_package_type/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/ehabterra/apispec/testdata/skipped_package_type/broken"
+	"github.com/ehabterra/apispec/testdata/skipped_package_type/twin"
+)
+
+func listRows(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode(broken.Row{})
+}
+
+// The twin package has to be reachable, or it would not be loaded at all.
+func listSheets(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode(twin.Row{})
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /rows", listRows)
+	mux.HandleFunc("GET /sheets", listSheets)
+	_ = http.ListenAndServe(":8080", mux)
+}

--- a/testdata/skipped_package_type/twin/twin.go
+++ b/testdata/skipped_package_type/twin/twin.go
@@ -1,0 +1,7 @@
+package twin
+
+// Row shares the NAME and nothing else. It is a different type, in a package
+// the route never mentions.
+type Row struct {
+	Sheet string `json:"sheet"`
+}


### PR DESCRIPTION
Closes #447.

## The defect

`typeByName` looked a type up in its named package and, on a miss, **scanned every package and returned the first type with a matching bare name**:

```go
for _, pkg := range meta.SortedPackageNames() {
    if typ := meta.TypeInPackage(pkg, typeName); typ != nil {
        return typ
    }
}
```

The sort made the answer deterministic — which is all its comment claimed — but not right. The component keeps the name of the package that was asked for and gets the fields and doc comment of a **different** one, and nothing in the output says so. On a real 280-path service, one package published five components filled from three others: **58 property and enum keys vanished and 5 descriptions described a different type**.

## The trigger, reproduced

The issue was filed without a reproduction because two probe fixtures didn't trigger it — in both, the qualified lookup succeeded. It turns out the trigger is ordinary and already visible in the log: **a package that does not type-check is skipped by the loader**, so its types are never recorded and every lookup into it misses. Analysing a project mid-edit is enough.

`testdata/skipped_package_type` makes that explicit — `broken` genuinely fails to compile, `twin` declares `Row` too — and the engine says so on the way past:

```
[engine]   .../skipped_package_type/broken does not type-check: broken/broken.go:13:9: undefined: thisSymbolDoesNotExist
```

On `main` the route's `broken.Row` then comes out as:

```yaml
    ..._broken_Row:
      description: |-
        Row shares the NAME and nothing else. It is a different type, in a package
        the route never mentions.
      properties:
        sheet: {type: string}       # twin.Row's field; broken.Row has cron and enabled
```

So the cause the issue wanted understood is answered: the load failure **is** already reported. What must not happen is quietly filling the hole with another package's type.

## The rule

A qualifier is evidence, and a miss does not discard it:

| input | behaviour |
|---|---|
| import path that declares the type | resolves (unchanged) |
| import path that does **not** declare it | **nothing** — asked and answered |
| package *name* qualifier (`scheduling.ConfigRow`) | the unique-fit rule `canonicalPackageQualifier` already uses — exactly one package that both fits the name and declares the type. A type recovered by rendering an argument carries the package's name rather than its path (golden rule #3), so this path is load-bearing. |
| no qualifier at all | bare name, **only if exactly one** package declares it. With two there is nothing to choose between them; an unresolved type beats a wrong one (golden rule #7). |

## Measurements

Large real project (930 paths):

- **no component lost**, one **gained** — a named integer type now resolves to its own declaration and is `$ref`'d instead of being inlined as a bare `enum: [0, 1]`
- two silent guesses became honest `External or unresolved type` labels, one of them an unqualified `Config` that the scan had been answering with whichever package sorted first

All **116 fixtures byte-identical**.

## Guards, both verified to fail without the change

- `TestTestdata_SkippedPackageType` — the end-to-end shape (fails on `main` with *"broken.Row was filled from twin.Row (it has twin's `sheet` property)"*)
- `internal/spec/type_lookup_test.go` — the three branches of the rule at unit level, which is what the issue asked for as a minimum

Suite, `make lint`, coverage ratchet (96.0%, floor 96) pass.

> Note on the fixture: `testdata/skipped_package_type/broken` is **deliberately uncompilable** — that is the condition under test. Nothing in CI builds fixture modules (`compare-spec.sh` builds only `./cmd/apispec`), and the file says so at the top.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected type resolution so components use definitions from the requested package.
  - Prevented similarly named types from other packages from supplying incorrect fields or documentation.
  - Ambiguous unqualified type names are no longer resolved unpredictably.
  - Preserved access to valid routes and ensured correctly defined package types remain intact.

- **Tests**
  - Added regression coverage for package-aware type resolution and skipped packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->