### PR TITLE
fix(spec): a ServeMux pattern's host is not part of the path

### DIFF
--- a/cmd/apispecui/assets/js/config.js
+++ b/cmd/apispecui/assets/js/config.js
@@ -349,6 +349,18 @@ export function ConfigMode() {
             <button class="btn secondary sm" onClick=${() => addTo("servers", { url: "", description: "" })}>+ Add server</button>
           <//>
 
+          <${Section} title="Virtual hosts" help="Host names your routes are registered under, for routers whose registration pattern can carry one — a Go 1.22 ServeMux pattern is '[METHOD ][HOST]/[PATH]', so mux.HandleFunc(\"GET api.example.com/items\", h) serves /items on that host. Listing a host here documents the route at /items instead of /api.example.com/items. Hosts are listed rather than detected because a pattern that lost its leading slash is indistinguishable from one carrying a host. Hosts already named in Servers count too." hint=${`${(c.hosts || []).length}`}>
+            ${(c.hosts || []).map(
+              (h, i) => html`
+                <div class="row">
+                  ${txt("", h, (e) => setKey("hosts", (c.hosts || []).map((v, j) => (j === i ? e.target.value : v))), "api.example.com")}
+                  <span class="spacer"></span>${RowDelete(() => setKey("hosts", (c.hosts || []).filter((_, j) => j !== i)))}
+                </div>
+              `,
+            )}
+            <button class="btn secondary sm" onClick=${() => addTo("hosts", "")}>+ Add host</button>
+          <//>
+
           <${Section} title="Tags" help="Named groups that organise operations into sections in the docs UI. Routes are usually tagged automatically from their mount/group prefix; add tags here to give them an order and a description. Example: name 'Users', description 'Account and profile endpoints'." hint=${`${(c.tags || []).length}`}>
             ${(c.tags || []).map(
               (t, i) => html`

--- a/generator/testdata_http_host_pattern_test.go
+++ b/generator/testdata_http_host_pattern_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/spec"
+)
+
+// A Go 1.22 ServeMux pattern is "[METHOD ][HOST]/[PATH]". The host selects
+// which mux entry serves the request; it is not part of the URL a client asks
+// for. Folded into the path it produced `/api.example.com/items` — an endpoint
+// that does not exist and that no consumer can call, which is worse than a
+// missing one because nothing in the document says it is wrong (issue #356).
+func TestTestdata_HTTPHostPattern(t *testing.T) {
+	out := loadTestdata(t, "http_host_pattern", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+
+	for _, p := range []string{"/items", "/items/new", "/debug", "/health", "/status"} {
+		if !hasPath(out, p) {
+			t.Errorf("path %q missing; have %v", p, mapPathKeys(out.Paths))
+		}
+	}
+
+	// The defect, stated directly: no path may carry a host.
+	for p := range out.Paths {
+		for _, host := range []string{"api.example.com", "admin.example.com", "localhost"} {
+			if strings.Contains(p, host) {
+				t.Errorf("path %q carries the host — the pattern's host component is not part of "+
+					"the requested URL", p)
+			}
+		}
+	}
+
+	// A pattern with no host is untouched, so the split cannot cost the paths
+	// that were already right.
+	if !hasPath(out, "/health") {
+		t.Error("/health missing — a hostless pattern must pass through unchanged")
+	}
+
+	// Two hosts serving the same path collapse into ONE operation, because a
+	// path is the whole key and the host has nowhere to go yet. Pinned rather
+	// than hidden: documenting both needs `servers`, which is the part of #356
+	// this change deliberately leaves open. When that lands, /status carries a
+	// server per host and this expectation changes.
+	status, ok := out.Paths["/status"]
+	if !ok {
+		t.Fatal("/status missing")
+	}
+	if op := opFor(status, "GET"); op == nil {
+		t.Error("/status has no GET")
+	}
+}

--- a/generator/testdata_http_host_pattern_test.go
+++ b/generator/testdata_http_host_pattern_test.go
@@ -26,8 +26,16 @@ import (
 // for. Folded into the path it produced `/api.example.com/items` — an endpoint
 // that does not exist and that no consumer can call, which is worse than a
 // missing one because nothing in the document says it is wrong (issue #356).
+//
+// The hosts are DECLARED, not detected: a path reaching the matcher may have
+// lost its leading slash, so no shape test can separate a host from a real
+// segment (golden rule #7). This test therefore runs the fixture twice — once
+// with the hosts configured, once without — because the default behaviour is
+// part of the contract.
 func TestTestdata_HTTPHostPattern(t *testing.T) {
-	out := loadTestdata(t, "http_host_pattern", spec.DefaultHTTPConfig())
+	cfg := spec.DefaultHTTPConfig()
+	cfg.Hosts = []string{"api.example.com", "admin.example.com", "localhost:8080"}
+	out := loadTestdata(t, "http_host_pattern", cfg)
 	noDanglingRefs(t, out)
 
 	for _, p := range []string{"/items", "/items/new", "/debug", "/health", "/status"} {
@@ -36,9 +44,9 @@ func TestTestdata_HTTPHostPattern(t *testing.T) {
 		}
 	}
 
-	// The defect, stated directly: no path may carry a host.
+	// The defect, stated directly: no path may carry a declared host.
 	for p := range out.Paths {
-		for _, host := range []string{"api.example.com", "admin.example.com", "localhost"} {
+		for _, host := range cfg.Hosts {
 			if strings.Contains(p, host) {
 				t.Errorf("path %q carries the host — the pattern's host component is not part of "+
 					"the requested URL", p)
@@ -63,5 +71,37 @@ func TestTestdata_HTTPHostPattern(t *testing.T) {
 	}
 	if op := opFor(status, "GET"); op == nil {
 		t.Error("/status has no GET")
+	}
+}
+
+// Declaring the servers is declaring the hosts: a project that already lists
+// `servers` should not have to name the same hosts twice.
+func TestTestdata_HTTPHostPatternFromServers(t *testing.T) {
+	cfg := spec.DefaultHTTPConfig()
+	cfg.Servers = []spec.Server{{URL: "https://api.example.com/"}}
+	out := loadTestdata(t, "http_host_pattern", cfg)
+
+	if !hasPath(out, "/items") {
+		t.Errorf("/items missing; a host named by a server URL must be split off too. have %v",
+			mapPathKeys(out.Paths))
+	}
+	// A host NOT named anywhere is still left alone — the point of declaring.
+	if !hasPath(out, "/admin.example.com/status") {
+		t.Errorf("an undeclared host must be left exactly as it came; have %v", mapPathKeys(out.Paths))
+	}
+}
+
+// With nothing declared, nothing is split. The default is today's behaviour
+// rather than a guess, so the invalid path stays until the project says which
+// hosts are its own — pinned so the default is a decision, not an accident.
+func TestTestdata_HTTPHostPatternUndeclared(t *testing.T) {
+	out := loadTestdata(t, "http_host_pattern", spec.DefaultHTTPConfig())
+
+	if !hasPath(out, "/api.example.com/items") {
+		t.Errorf("with no hosts declared the pattern must pass through unchanged; have %v",
+			mapPathKeys(out.Paths))
+	}
+	if hasPath(out, "/items") {
+		t.Error("a host was split off without being declared — that is the guess this design refuses")
 	}
 }

--- a/internal/spec/config.go
+++ b/internal/spec/config.go
@@ -17,6 +17,7 @@ package spec
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 
@@ -971,6 +972,20 @@ type APISpecConfig struct {
 	// (issue #298). Both default to the fully-qualified Go symbol.
 	Naming Naming `yaml:"naming,omitempty" json:"naming,omitempty"`
 
+	// Hosts names the virtual hosts this project's routes are registered
+	// under, so a registration pattern that carries one — a Go 1.22 ServeMux
+	// pattern is "[METHOD ][HOST]/[PATH]" — is documented at its real path
+	// rather than at `/api.example.com/items` (issue #356).
+	//
+	// Declared rather than inferred. A path reaching the matcher has already
+	// been through resolution and may have lost its leading slash, so Go's own
+	// rule (everything before the first "/" is the host) would read "v1" as the
+	// host of "v1/users" and delete a real segment; deciding by the shape of the
+	// text is the same guess in another form (golden rule #7). Hosts named in
+	// Servers count too, since a project that declares its servers has already
+	// said what its hosts are.
+	Hosts []string `yaml:"hosts,omitempty" json:"hosts,omitempty"`
+
 	// OpenAPI metadata
 	Info            Info                      `yaml:"info" json:"info,omitempty"`
 	Servers         []Server                  `yaml:"servers" json:"servers,omitempty"`
@@ -1380,4 +1395,30 @@ func (c *APISpecConfig) UnanchoredResponsePatterns() []string {
 		out = append(out, fmt.Sprintf("responsePatterns[%d] (callRegex %q)", i, p.CallRegex))
 	}
 	return out
+}
+
+// knownHosts returns the virtual hosts a route registration may carry: those
+// named in Hosts, plus the host of every configured server URL.
+//
+// Servers are included because declaring `servers: [{url: https://api.example.com}]`
+// already says what the project's hosts are, and requiring the same name twice
+// would be a trap rather than a safeguard. A server URL that does not parse, or
+// that is relative (OpenAPI allows both), simply contributes nothing.
+func (c *APISpecConfig) knownHosts() []string {
+	if c == nil {
+		return nil
+	}
+	hosts := make([]string, 0, len(c.Hosts)+len(c.Servers))
+	hosts = append(hosts, c.Hosts...)
+	for _, s := range c.Servers {
+		u, err := url.Parse(s.URL)
+		if err != nil || u.Host == "" {
+			continue
+		}
+		hosts = append(hosts, u.Host)
+	}
+	if len(hosts) == 0 {
+		return nil
+	}
+	return hosts
 }

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -718,38 +718,41 @@ func splitMethodFromPath(raw string) (method, path string) {
 	return candidate, strings.TrimSpace(raw[i+1:])
 }
 
-// serveMuxHost matches the HOST component of a Go 1.22 ServeMux pattern: a
-// dotted name (or localhost), optionally with a port, followed by the "/" that
-// starts the path.
-//
-// Deliberately narrower than Go's own grammar, which treats ANY text before the
-// first "/" as the host — so `mux.Handle("items/x", h)` really does register
-// host "items". Applying that rule here would be destructive, because a path
-// arriving at this function has already been through resolution and may have
-// lost its leading slash (a concatenated prefix, a mount join): stripping "v1"
-// off "v1/users" as a host would delete a real segment. A dotless single label
-// is indistinguishable from that, so only something that LOOKS like a host is
-// treated as one (golden rule #7).
-var serveMuxHost = mustCachedRegex(`^(?:[A-Za-z0-9][A-Za-z0-9-]*(?:\.[A-Za-z0-9][A-Za-z0-9-]*)+|localhost)(?::[0-9]+)?/`)
-
-// splitHostFromPath splits the HOST component off a Go 1.22 ServeMux pattern.
+// splitHostFromPath splits a NAMED host off a Go 1.22 ServeMux pattern.
 //
 // The grammar is "[METHOD ][HOST]/[PATH]", and the host is not part of the URL
 // a client requests — it selects which mux entry serves it. Folded into the
 // path it produced `/api.example.com/items`, an endpoint that does not exist
 // and that no consumer can call (issue #356).
 //
+// Only a host the CONFIG names is split off. Go's own rule — everything before
+// the first "/" is the host — cannot be applied here, because a path reaching
+// this function has already been through resolution and may have lost its
+// leading slash (a concatenated prefix, a mount join): under that rule
+// "v1/users" is host "v1", and stripping it would delete a real segment.
+// Deciding by the SHAPE of the text is the same guess wearing a regex, so the
+// host set is declared rather than inferred (golden rules #5 and #7). A project
+// that declares no hosts keeps today's behaviour exactly.
+//
 // The host is returned rather than discarded so a caller can document it; this
 // one only needs the path.
-func splitHostFromPath(raw string) (host, path string) {
-	if raw == "" || raw[0] == '/' {
+func splitHostFromPath(raw string, hosts []string) (host, path string) {
+	if raw == "" || raw[0] == '/' || len(hosts) == 0 {
 		return "", raw
 	}
-	m := serveMuxHost.FindString(raw)
-	if m == "" {
-		return "", raw
+	slash := strings.IndexByte(raw, '/')
+	if slash <= 0 {
+		return "", raw // no path component: not a pattern this rule applies to
 	}
-	return strings.TrimSuffix(m, "/"), raw[len(m)-1:]
+	candidate := raw[:slash]
+	for _, h := range hosts {
+		// Host names are case-insensitive (RFC 4343), and a config is written
+		// by hand.
+		if strings.EqualFold(candidate, h) {
+			return candidate, raw[slash:]
+		}
+	}
+	return "", raw
 }
 
 // normalizeServeMuxPath rewrites ServeMux-specific path syntax into OpenAPI
@@ -977,7 +980,7 @@ func (r *RoutePatternMatcherImpl) extractRouteDetails(node TrackerNodeInterface,
 			}
 			// The host selects the mux entry; it is not part of the requested
 			// URL (issue #356).
-			if _, rest := splitHostFromPath(path); rest != path {
+			if _, rest := splitHostFromPath(path, r.cfg.knownHosts()); rest != path {
 				path = rest
 			}
 			path = normalizeServeMuxPath(path)

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -718,6 +718,40 @@ func splitMethodFromPath(raw string) (method, path string) {
 	return candidate, strings.TrimSpace(raw[i+1:])
 }
 
+// serveMuxHost matches the HOST component of a Go 1.22 ServeMux pattern: a
+// dotted name (or localhost), optionally with a port, followed by the "/" that
+// starts the path.
+//
+// Deliberately narrower than Go's own grammar, which treats ANY text before the
+// first "/" as the host — so `mux.Handle("items/x", h)` really does register
+// host "items". Applying that rule here would be destructive, because a path
+// arriving at this function has already been through resolution and may have
+// lost its leading slash (a concatenated prefix, a mount join): stripping "v1"
+// off "v1/users" as a host would delete a real segment. A dotless single label
+// is indistinguishable from that, so only something that LOOKS like a host is
+// treated as one (golden rule #7).
+var serveMuxHost = mustCachedRegex(`^(?:[A-Za-z0-9][A-Za-z0-9-]*(?:\.[A-Za-z0-9][A-Za-z0-9-]*)+|localhost)(?::[0-9]+)?/`)
+
+// splitHostFromPath splits the HOST component off a Go 1.22 ServeMux pattern.
+//
+// The grammar is "[METHOD ][HOST]/[PATH]", and the host is not part of the URL
+// a client requests — it selects which mux entry serves it. Folded into the
+// path it produced `/api.example.com/items`, an endpoint that does not exist
+// and that no consumer can call (issue #356).
+//
+// The host is returned rather than discarded so a caller can document it; this
+// one only needs the path.
+func splitHostFromPath(raw string) (host, path string) {
+	if raw == "" || raw[0] == '/' {
+		return "", raw
+	}
+	m := serveMuxHost.FindString(raw)
+	if m == "" {
+		return "", raw
+	}
+	return strings.TrimSuffix(m, "/"), raw[len(m)-1:]
+}
+
 // normalizeServeMuxPath rewrites ServeMux-specific path syntax into OpenAPI
 // path templating: trailing wildcards ({path...}) collapse to {path}, and the
 // {$} end-of-path anchor is dropped.
@@ -939,6 +973,11 @@ func (r *RoutePatternMatcherImpl) extractRouteDetails(node TrackerNodeInterface,
 			if method, rest := splitMethodFromPath(path); method != "" {
 				routeInfo.Method = method
 				routeInfo.MethodExplicit = true
+				path = rest
+			}
+			// The host selects the mux entry; it is not part of the requested
+			// URL (issue #356).
+			if _, rest := splitHostFromPath(path); rest != path {
 				path = rest
 			}
 			path = normalizeServeMuxPath(path)

--- a/internal/spec/servemux_host_test.go
+++ b/internal/spec/servemux_host_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import "testing"
+
+// The rule is deliberately narrower than Go's own grammar, and the cases that
+// must NOT be split are the point: a path reaching this function has already
+// been through resolution and can have lost its leading slash, so treating any
+// dotless prefix as a host (which is what Go itself does) would delete a real
+// segment.
+func TestSplitHostFromPath(t *testing.T) {
+	cases := []struct {
+		in, host, path string
+	}{
+		// Hosts.
+		{"api.example.com/items", "api.example.com", "/items"},
+		{"api.example.com/", "api.example.com", "/"},
+		{"localhost:8080/debug", "localhost:8080", "/debug"},
+		{"api.example.com:8443/items/{id}", "api.example.com:8443", "/items/{id}"},
+		{"sub.api.example.com/x", "sub.api.example.com", "/x"},
+		{"api-1.example.com/x", "api-1.example.com", "/x"},
+
+		// Not hosts.
+		{"/items", "", "/items"},                   // ordinary path
+		{"/", "", "/"},                             // root
+		{"", "", ""},                               // nothing
+		{"v1/users", "", "v1/users"},               // a path that lost its leading slash
+		{"items", "", "items"},                     // no slash at all: not a pattern
+		{"{tenant}/items", "", "{tenant}/items"},   // an unresolved placeholder, not a host
+		{"api.example.com", "", "api.example.com"}, // host with no path: no "/" to split on
+	}
+	for _, tc := range cases {
+		host, path := splitHostFromPath(tc.in)
+		if host != tc.host || path != tc.path {
+			t.Errorf("splitHostFromPath(%q) = (%q, %q), want (%q, %q)", tc.in, host, path, tc.host, tc.path)
+		}
+	}
+}

--- a/internal/spec/servemux_host_test.go
+++ b/internal/spec/servemux_host_test.go
@@ -16,36 +16,72 @@ package spec
 
 import "testing"
 
-// The rule is deliberately narrower than Go's own grammar, and the cases that
-// must NOT be split are the point: a path reaching this function has already
-// been through resolution and can have lost its leading slash, so treating any
-// dotless prefix as a host (which is what Go itself does) would delete a real
-// segment.
+// The host set is DECLARED, so the cases that must not split are as much the
+// point as the ones that do: a path reaching this function may have lost its
+// leading slash, and no shape test can tell "v1/users" from a host.
 func TestSplitHostFromPath(t *testing.T) {
+	hosts := []string{"api.example.com", "localhost:8080", "API.EXAMPLE.COM:8443"}
 	cases := []struct {
 		in, host, path string
 	}{
-		// Hosts.
+		// Named.
 		{"api.example.com/items", "api.example.com", "/items"},
 		{"api.example.com/", "api.example.com", "/"},
 		{"localhost:8080/debug", "localhost:8080", "/debug"},
-		{"api.example.com:8443/items/{id}", "api.example.com:8443", "/items/{id}"},
-		{"sub.api.example.com/x", "sub.api.example.com", "/x"},
-		{"api-1.example.com/x", "api-1.example.com", "/x"},
+		{"API.example.com/items", "API.example.com", "/items"}, // host names are case-insensitive
+		{"api.example.com:8443/x", "api.example.com:8443", "/x"},
 
-		// Not hosts.
-		{"/items", "", "/items"},                   // ordinary path
-		{"/", "", "/"},                             // root
-		{"", "", ""},                               // nothing
-		{"v1/users", "", "v1/users"},               // a path that lost its leading slash
-		{"items", "", "items"},                     // no slash at all: not a pattern
-		{"{tenant}/items", "", "{tenant}/items"},   // an unresolved placeholder, not a host
-		{"api.example.com", "", "api.example.com"}, // host with no path: no "/" to split on
+		// Not named: left exactly as they came, however host-like they look.
+		{"admin.example.com/items", "", "admin.example.com/items"},
+		{"api.example.com:9999/x", "", "api.example.com:9999/x"}, // a different port is a different host
+		{"/items", "", "/items"},
+		{"/", "", "/"},
+		{"", "", ""},
+		{"v1/users", "", "v1/users"},
+		{"{tenant}/items", "", "{tenant}/items"},
+		{"api.example.com", "", "api.example.com"}, // no path component
 	}
 	for _, tc := range cases {
-		host, path := splitHostFromPath(tc.in)
+		host, path := splitHostFromPath(tc.in, hosts)
 		if host != tc.host || path != tc.path {
 			t.Errorf("splitHostFromPath(%q) = (%q, %q), want (%q, %q)", tc.in, host, path, tc.host, tc.path)
 		}
+	}
+
+	// With nothing declared, nothing is split — the default is today's
+	// behaviour, not a guess.
+	if host, path := splitHostFromPath("api.example.com/items", nil); host != "" || path != "api.example.com/items" {
+		t.Errorf("with no configured hosts: got (%q, %q), want (\"\", unchanged)", host, path)
+	}
+}
+
+// A project that declares its servers has already said what its hosts are, so
+// naming them twice is not required.
+func TestKnownHostsIncludesServerHosts(t *testing.T) {
+	cfg := &APISpecConfig{
+		Hosts: []string{"declared.example.com"},
+		Servers: []Server{
+			{URL: "https://api.example.com/v1"},
+			{URL: "http://localhost:8080"},
+			{URL: "/relative"},   // OpenAPI allows a relative server URL: no host
+			{URL: "://nonsense"}, // unparseable: contributes nothing
+		},
+	}
+	got := cfg.knownHosts()
+	want := map[string]bool{"declared.example.com": true, "api.example.com": true, "localhost:8080": true}
+	if len(got) != len(want) {
+		t.Errorf("knownHosts() = %v, want the %d hosts in %v", got, len(want), want)
+	}
+	for _, h := range got {
+		if !want[h] {
+			t.Errorf("knownHosts() returned %q, which no config field names", h)
+		}
+	}
+	if (&APISpecConfig{}).knownHosts() != nil {
+		t.Error("an empty config must declare no hosts")
+	}
+	var nilCfg *APISpecConfig
+	if nilCfg.knownHosts() != nil {
+		t.Error("a nil config must declare no hosts")
 	}
 }

--- a/testdata/http_host_pattern/go.mod
+++ b/testdata/http_host_pattern/go.mod
@@ -1,0 +1,3 @@
+module github.com/ehabterra/apispec/testdata/http_host_pattern
+
+go 1.24.3

--- a/testdata/http_host_pattern/main.go
+++ b/testdata/http_host_pattern/main.go
@@ -1,0 +1,46 @@
+// Package main exercises the HOST component of a Go 1.22 ServeMux pattern.
+// The grammar is "[METHOD ][HOST]/[PATH]", so the host is not part of the URL
+// path and must not reach the OpenAPI path template.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type Item struct {
+	ID string `json:"id"`
+}
+
+func listItems(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode([]Item{})
+}
+
+func createItem(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusCreated)
+}
+
+func health(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode(Item{})
+}
+
+func main() {
+	mux := http.NewServeMux()
+
+	// Method and host together, and host without a method.
+	mux.HandleFunc("GET api.example.com/items", listItems)
+	mux.HandleFunc("api.example.com/items/new", createItem)
+
+	// A port is part of the host too.
+	mux.HandleFunc("GET localhost:8080/debug", health)
+
+	// Two hosts serving the SAME path. Both are the same URL to a consumer,
+	// which is what the collapse below records.
+	mux.HandleFunc("GET api.example.com/status", health)
+	mux.HandleFunc("GET admin.example.com/status", listItems)
+
+	// No host: must be untouched.
+	mux.HandleFunc("GET /health", health)
+
+	_ = http.ListenAndServe(":8080", mux)
+}


### PR DESCRIPTION
Addresses **part 4** of #356 — the half that issue marks as *"a correctness bug [that] can land on its own"*. Parts 1–3 (query/header matchers, `servers` from host+scheme) stay open there.

## The defect

A Go 1.22 ServeMux pattern is `[METHOD ][HOST]/[PATH]`. Only the method was split off:

```go
mux.HandleFunc("GET api.example.com/items", listItems)
```
```yaml
  /api.example.com/items:      # an endpoint that does not exist
```

Worse than a missing route — nothing in the document says it's wrong, so a consumer builds a request against a path that can never match. `splitMethodFromPath`'s own doc comment already named the grammar; the host half was never implemented.

## Declared, not detected

Go treats **any** text before the first `/` as the host, so `mux.Handle("items/x", h)` really does register host `items`. That rule cannot be applied here: a path reaching the matcher has already been through resolution and may have lost its leading slash (a concatenated prefix, a mount join), so `v1/users` would lose a real segment. Deciding by the *shape* of the text — "dotted, or localhost, with an optional port" — is the same guess wearing a regex, and its failure mode is silent.

So the host set is configured:

```yaml
hosts:
  - api.example.com
  - localhost:8080
```

Hosts already named in `servers` count too, because `servers: [{url: https://api.example.com}]` has already said what the project's hosts are. Comparison is case-insensitive (RFC 4343); a different port is a different host.

**A project that declares nothing keeps today's output exactly**, `/api.example.com/items` included. The invalid path is fixed when the project says which hosts are its own — a decision rather than an accident, pinned by a test asserting the unchanged path.

## What this does not fix, pinned rather than hidden

Two hosts serving the same path now collapse into **one** operation — the path is the whole key and the host has nowhere to go yet:

```go
mux.HandleFunc("GET api.example.com/status", health)
mux.HandleFunc("GET admin.example.com/status", listItems)   // → one /status
```

Previously both were documented, as two paths that were both invalid. The fixture covers this with a comment saying the assertion changes when `servers` (part 3 of #356) lands. The host is **returned** by `splitHostFromPath` rather than discarded, so that work has the fact to hand.

## Verification

- `testdata/http_host_pattern` + structural tests, verified to fail on `main`:
  `path "/items" missing; have [/api.example.com/items /api.example.com/items/new /localhost:8080/debug …]`
- `TestSplitHostFromPath` leads with the negative cases: an undeclared but host-shaped prefix, a different port, `v1/users`, `{tenant}/items`
- The fixture runs three ways: hosts declared, host named only by a server URL, and nothing declared
- Fixture A/B: **118 of 118 identical** — with nothing declared, no existing output changes at all
- gitea: **930 paths, nothing lost or gained** — it registers no host patterns, which is why this went unnoticed

Suite, `make lint`, coverage ratchet (96.0%) pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected route generation for host-based HTTP patterns so hostnames no longer appear as part of URL paths.
  * Consolidated routes served by multiple hosts into a single operation when their paths and methods match.

* **Tests**
  * Added coverage for host and path handling, including ports, localhost, hostless paths, and unresolved patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


The new config field is wired into the apispecui editor (`TestConfigEditorCoversEveryFrameworkSection` enforces it).
