### PR TITLE
feat(spec): read what a route constraint states about a path parameter

### DIFF
--- a/generator/testdata_fiber_constraints_test.go
+++ b/generator/testdata_fiber_constraints_test.go
@@ -31,21 +31,24 @@ import (
 // a legal OpenAPI path template and matches no request a client can make, so the
 // operation was keyed under a path that could never be routed.
 //
-// The parameter SCHEMAS are deliberately not asserted beyond `type: string`:
-// turning `<int>` into `type: integer` is the second half of #357 and is not
-// done here. Honest-over-wrong (golden rule #7) — an unrecognised constraint
-// strips cleanly and leaves the general type rather than guessing one.
+// The constraint also STATES something about the value, and that half is now
+// read: `<int>` is `type: integer`, `<guid>` is a uuid-formatted string, and
+// `<min(1);max(500)>` carries its bounds. An unrecognised constraint still
+// strips cleanly and leaves the general type rather than guessing one
+// (golden rule #7).
 func TestTestdata_FiberConstraints(t *testing.T) {
 	out := loadTestdata(t, "fiber_constraints", spec.DefaultFiberConfig())
 	noDanglingRefs(t, out)
 	noNullSchemas(t, out)
 
 	want := []string{
-		"/items/{id}",   // <int>
-		"/users/{uid}",  // <guid>
-		"/events/{day}", // <datetime(2006-01-02)> — parens hold arbitrary text
-		"/pages/{n}",    // <min(1);max(500)> — a ';'-chained list
-		"/plain/{name}", // unconstrained, must be untouched
+		"/items/{id}",    // <int>
+		"/users/{uid}",   // <guid>
+		"/events/{day}",  // <datetime(2006-01-02)> — parens hold arbitrary text
+		"/pages/{n}",     // <min(1);max(500)> — a ';'-chained list
+		"/plain/{name}",  // unconstrained, must be untouched
+		"/unread/{code}", // <int>, and NOT read in the handler
+		"/odd/{x}",       // a constraint the table does not know
 	}
 	for _, p := range want {
 		if _, ok := out.Paths[p]; !ok {
@@ -82,5 +85,67 @@ func TestTestdata_FiberConstraints(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("/items/{id}: no `id` path parameter; have %+v", op.Parameters)
+	}
+
+	// What each constraint states about the value.
+	type schemaWant struct {
+		typ, format string
+		min, max    float64
+	}
+	cases := map[string]schemaWant{
+		"/items/{id}":    {typ: "integer"},                   // <int>
+		"/users/{uid}":   {typ: "string", format: "uuid"},    // <guid>
+		"/pages/{n}":     {typ: "integer", min: 1, max: 500}, // <min(1);max(500)>
+		"/unread/{code}": {typ: "integer"},                   // <int>, unread by the handler
+		"/plain/{name}":  {typ: "string"},                    // unconstrained
+		// The layout in <datetime(2006-01-02)> decides whether the format is
+		// `date` or `date-time`, and reading it is a parse rather than a table
+		// row, so nothing is claimed (golden rule #7).
+		"/events/{day}": {typ: "string"},
+		// An unrecognised constraint states nothing at all.
+		"/odd/{x}": {typ: "string"},
+	}
+	for path, w := range cases {
+		item, ok := out.Paths[path]
+		if !ok {
+			continue // the presence check above already reported it
+		}
+		op := opFor(item, "GET")
+		if op == nil || len(op.Parameters) == 0 {
+			t.Errorf("%s: no parameters", path)
+			continue
+		}
+		p := op.Parameters[0]
+		if p.Schema == nil {
+			t.Errorf("%s: parameter %q has no schema", path, p.Name)
+			continue
+		}
+		if p.Schema.Type != w.typ || p.Schema.Format != w.format {
+			t.Errorf("%s: schema = {type:%q format:%q}, want {type:%q format:%q}",
+				path, p.Schema.Type, p.Schema.Format, w.typ, w.format)
+		}
+		if p.Schema.Minimum != w.min || p.Schema.Maximum != w.max {
+			t.Errorf("%s: bounds = [%v,%v], want [%v,%v]",
+				path, p.Schema.Minimum, p.Schema.Maximum, w.min, w.max)
+		}
+	}
+
+	// A parameter the ROUTE typed is better attested than one a handler happens
+	// to read, so warning that it was "not found in the code" reads as a defect
+	// where there is none. An unrecognised constraint has told us nothing, so
+	// its warning stays.
+	unread := opFor(out.Paths["/unread/{code}"], "GET")
+	if unread != nil && len(unread.Parameters) > 0 {
+		if _, warned := unread.Parameters[0].Extensions["x-warning"]; warned {
+			t.Error("/unread/{code}: the route pattern types this parameter, so it must not be " +
+				"reported as not found in the code")
+		}
+	}
+	odd := opFor(out.Paths["/odd/{x}"], "GET")
+	if odd != nil && len(odd.Parameters) > 0 {
+		if _, warned := odd.Parameters[0].Extensions["x-warning"]; !warned {
+			t.Error("/odd/{x}: an unrecognised constraint states nothing, so the parameter is still " +
+				"only attested by the path")
+		}
 	}
 }

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -2074,15 +2074,12 @@ func (e *Extractor) completeMapKeyPathParams(route *RouteInfo) {
 		return
 	}
 
-	patterns := pathParamPatterns(route.Path)
+	constraints := pathParamConstraints(route.Path)
 	for _, name := range placeholders {
 		if covered[name] {
 			continue
 		}
-		schema := &Schema{Type: "string"}
-		if pat := patterns[name]; pat != "" {
-			schema.Pattern = pat
-		}
+		schema := constraints[name].clone()
 		route.Params = append(route.Params, Parameter{
 			Name:     name,
 			In:       accessor.ParamIn,
@@ -3901,9 +3898,52 @@ func (p *ParamPatternMatcherImpl) ExtractParam(node TrackerNodeInterface, route 
 	// Ensure path parameters are always required
 	if p.pattern.ParamIn == "path" {
 		param.Required = true
+		// What the ROUTER enforces beats what the accessor returns. Every
+		// framework's path accessor hands back a string — `c.Params("id")` is
+		// string even when the route is `:id<int>` — so the accessor's type is a
+		// fact about the API surface, not about the value, and the constraint is
+		// the only statement of what the value may be (issue #357).
+		if route != nil {
+			applyPathConstraint(param, route.Path)
+		}
 	}
 
 	return param
+}
+
+// applyPathConstraint refines a path parameter with what the route pattern
+// states about it. Fields the constraint does not mention are left alone.
+func applyPathConstraint(param *Parameter, rawPath string) {
+	c, ok := pathParamConstraints(rawPath)[param.Name]
+	if !ok || !c.described {
+		return
+	}
+	if param.Schema == nil {
+		param.Schema = c.clone()
+		return
+	}
+	from := c.schema
+	if from.Type != "" {
+		param.Schema.Type = from.Type
+	}
+	if from.Format != "" {
+		param.Schema.Format = from.Format
+	}
+	if from.Pattern != "" {
+		param.Schema.Pattern = from.Pattern
+	}
+	if from.MinLength != 0 {
+		param.Schema.MinLength = from.MinLength
+	}
+	if from.MaxLength != 0 {
+		param.Schema.MaxLength = from.MaxLength
+	}
+	if from.Minimum != 0 {
+		param.Schema.Minimum = from.Minimum
+	}
+	if from.Maximum != 0 {
+		param.Schema.Maximum = from.Maximum
+	}
 }
 
 // resolveTypeOrigin traces the origin of a type through assignments and type parameters

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -628,7 +628,7 @@ func buildPathsFromRoutes(routes []*RouteInfo, handlerMethods ...string) map[str
 		// fresh declaration. The matching {name} in the path is then
 		// considered "covered" by ensureAllPathParams below.
 		operation.Parameters = appendDynamicParamRefs(operation.Parameters, route.DynamicParams)
-		operation.Parameters = ensureAllPathParams(openAPIPath, operation.Parameters, pathParamPatterns(rawPath), catchAllParams)
+		operation.Parameters = ensureAllPathParams(openAPIPath, operation.Parameters, pathParamConstraints(rawPath), catchAllParams)
 
 		// Add responses
 		operation.Responses = buildResponses(route.Response)
@@ -655,7 +655,7 @@ func buildPathsFromRoutes(routes []*RouteInfo, handlerMethods ...string) map[str
 // the parameters slice. openAPIPath is already normalised (regex constraints
 // stripped); patterns carries any `{name:pattern}` constraints recovered from
 // the raw path so synthesized params still surface them as a schema pattern.
-func ensureAllPathParams(openAPIPath string, params []Parameter, patterns map[string]string, catchAll []string) []Parameter {
+func ensureAllPathParams(openAPIPath string, params []Parameter, constraints map[string]pathParamConstraint, catchAll []string) []Parameter {
 	paramMap := make(map[string]bool)
 	for _, p := range params {
 		if p.In == "path" {
@@ -675,22 +675,25 @@ func ensureAllPathParams(openAPIPath string, params []Parameter, patterns map[st
 	for _, match := range matches {
 		name := match[1]
 		if !paramMap[name] {
-			schema := &Schema{Type: "string"}
-			if pat := patterns[name]; pat != "" {
-				schema.Pattern = pat
-			}
+			constraint := constraints[name]
 			param := Parameter{
 				Name:     name,
 				In:       "path",
 				Required: true,
-				Schema:   schema,
+				Schema:   constraint.clone(),
 			}
-			if slices.Contains(catchAll, name) {
+			switch {
+			case slices.Contains(catchAll, name):
 				// A catch-all is not a parameter the handler failed to read —
 				// it is the router matching the rest of the path, so it carries
 				// a description rather than the warning below (issue #403).
 				param.Description = "Matches the remainder of the path."
-			} else {
+			case constraint.described:
+				// The route pattern TYPED this parameter (`:id<int>`), so it is
+				// better attested than one a handler happens to read, and
+				// warning that it was "not found in the code" reads as a defect
+				// where there is none (issue #357).
+			default:
 				param.Extensions = map[string]any{
 					"x-warning": "This parameter is present in the path but not found in the code.",
 				}

--- a/internal/spec/mapper_comprehensive_test.go
+++ b/internal/spec/mapper_comprehensive_test.go
@@ -681,7 +681,11 @@ func TestEnsureAllPathParams_Comprehensive(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := ensureAllPathParams(tt.path, tt.params, tt.patterns, nil)
+			constraints := map[string]pathParamConstraint{}
+			for name, pattern := range tt.patterns {
+				constraints[name] = pathParamConstraint{schema: &Schema{Type: "string", Pattern: pattern}}
+			}
+			result := ensureAllPathParams(tt.path, tt.params, constraints, nil)
 			if len(result) != tt.expected {
 				t.Errorf("Expected %d parameters, got %d", tt.expected, len(result))
 			}

--- a/internal/spec/path_constraints.go
+++ b/internal/spec/path_constraints.go
@@ -1,0 +1,302 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"strconv"
+	"strings"
+)
+
+// constraintRule is what one named route constraint states about a parameter.
+//
+// A rule is DATA, not logic: `argFields` names the schema fields the
+// constraint's own arguments fill, in order, so `range(1,10)` and `minLen(3)`
+// go through the same code as `int`. Adding a router's vocabulary is a table
+// entry (golden rule #5).
+type constraintRule struct {
+	typ       string
+	format    string
+	pattern   string
+	argFields []string
+}
+
+// pathConstraintRules maps a named route constraint to what it states.
+//
+// Not gated on a framework, for the same reason stripAngleConstraints is not:
+// the syntax is unambiguous, so a router that spells `uuid` the way another
+// spells `guid` costs a row rather than a branch. Only fiber writes this form
+// today; both spellings are listed because the vocabulary, not the router, is
+// the thing being described.
+//
+// Absent on purpose: `datetime(layout)`. Its argument is a Go time LAYOUT, and
+// which OpenAPI format it implies depends on what the layout contains — a
+// date-only layout is `date`, one with a clock is `date-time`, and a layout can
+// be neither. That is a parse, not a table row, and guessing one of the two
+// would be wrong for the other (golden rule #7), so the constraint strips and
+// leaves `type: string`.
+var pathConstraintRules = map[string]constraintRule{
+	"int":   {typ: "integer"},
+	"bool":  {typ: "boolean"},
+	"float": {typ: "number"},
+	"alpha": {typ: "string", pattern: "^[A-Za-z]+$"},
+	"guid":  {typ: "string", format: "uuid"},
+	"uuid":  {typ: "string", format: "uuid"},
+
+	"minLen": {typ: "string", argFields: []string{"minLength"}},
+	"maxLen": {typ: "string", argFields: []string{"maxLength"}},
+	// An exact length is both bounds; OpenAPI has no single "length".
+	"len":   {typ: "string", argFields: []string{"minLength", "maxLength"}},
+	"min":   {typ: "integer", argFields: []string{"minimum"}},
+	"max":   {typ: "integer", argFields: []string{"maximum"}},
+	"range": {typ: "integer", argFields: []string{"minimum", "maximum"}},
+	"regex": {typ: "string", argFields: []string{"pattern"}},
+}
+
+// pathParamConstraints returns, for each parameter the RAW path constrains, the
+// schema that constraint states and whether it was understood.
+//
+// The two forms a supported router writes:
+//
+//	/items/{id:[0-9]+}   gorilla/mux, chi — a regex, surfaced as `pattern`
+//	/items/:id<int>      fiber — a named constraint, possibly `;`-chained
+//
+// A parameter with an UNRECOGNISED constraint gets an entry with understood
+// false: the tail is still stripped from the path, but nothing is claimed about
+// the value (golden rule #7).
+func pathParamConstraints(rawPath string) map[string]pathParamConstraint {
+	out := map[string]pathParamConstraint{}
+
+	// The mux/chi regex form. Unchanged behaviour: a pattern, no type — and
+	// `described` stays false, because a regex says what the value looks like
+	// without saying what it IS. Reading a type out of a numeric regex is #345.
+	for name, pattern := range pathParamPatterns(rawPath) {
+		out[name] = pathParamConstraint{schema: &Schema{Type: "string", Pattern: pattern}}
+	}
+
+	for name, spec := range angleConstraints(rawPath) {
+		c := out[name]
+		if c.schema == nil {
+			c.schema = &Schema{Type: "string"}
+		}
+		c.described = applyConstraintSpec(c.schema, spec)
+		out[name] = c
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// pathParamConstraint is what a route pattern states about one parameter.
+//
+// described separates "the router constrained this" from "we understood the
+// constraint". Only the second is evidence about the VALUE, and only the second
+// answers the "not found in the code" warning: a parameter the route pattern
+// types is better attested than one a handler happens to read, while an
+// unrecognised constraint has told us nothing (issue #357).
+type pathParamConstraint struct {
+	schema    *Schema
+	described bool
+}
+
+// clone returns a copy of the constraint's schema, because a parameter schema
+// is written into every operation that has that placeholder and callers must
+// not share one pointer between them.
+func (c pathParamConstraint) clone() *Schema {
+	if c.schema == nil {
+		return &Schema{Type: "string"}
+	}
+	s := *c.schema
+	return &s
+}
+
+// angleConstraints maps a parameter name to the text of its `<...>` tail.
+func angleConstraints(rawPath string) map[string]string {
+	if !strings.ContainsRune(rawPath, '<') {
+		return nil
+	}
+	out := map[string]string{}
+	for i := 0; i < len(rawPath); i++ {
+		if rawPath[i] != '<' {
+			continue
+		}
+		// The name is the identifier immediately before the '<', however the
+		// router spells the placeholder (`:id<int>` or `{id<int>}`).
+		j := i
+		for j > 0 && isParamNameByte(rawPath[j-1]) {
+			j--
+		}
+		name := rawPath[j:i]
+		end := angleTailEnd(rawPath, i)
+		if end < 0 {
+			break // unterminated: nothing reliable to read
+		}
+		if name != "" {
+			out[name] = rawPath[i+1 : end]
+		}
+		i = end
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func isParamNameByte(b byte) bool {
+	return b == '_' || (b >= '0' && b <= '9') || (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}
+
+// angleTailEnd returns the index of the '>' closing the tail opened at start,
+// or -1. Parentheses are tracked because a constraint's argument is arbitrary
+// text — `regex([^>]+)` closes a bracket inside its own argument — which is the
+// same rule stripAngleConstraints applies when removing the tail.
+func angleTailEnd(s string, start int) int {
+	depth := 0
+	for i := start + 1; i < len(s); i++ {
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		case '>':
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// applyConstraintSpec applies a `;`-separated constraint list to schema and
+// reports whether any of it was understood.
+func applyConstraintSpec(schema *Schema, spec string) bool {
+	understood := false
+	for _, part := range splitConstraintList(spec) {
+		name, args := splitConstraintCall(part)
+		rule, ok := pathConstraintRules[name]
+		if !ok {
+			continue
+		}
+		if rule.typ != "" {
+			schema.Type = rule.typ
+		}
+		if rule.format != "" {
+			schema.Format = rule.format
+		}
+		if rule.pattern != "" && schema.Pattern == "" {
+			schema.Pattern = rule.pattern
+		}
+		applyConstraintArgs(schema, rule, args)
+		understood = true
+	}
+	return understood
+}
+
+// applyConstraintArgs fills the schema fields a rule's arguments target. A
+// constraint written with the wrong arity states nothing extra rather than
+// half-filling the schema.
+func applyConstraintArgs(schema *Schema, rule constraintRule, args []string) {
+	if len(rule.argFields) == 0 || len(args) == 0 {
+		return
+	}
+	for i, field := range rule.argFields {
+		// len(n) fills two fields from one argument.
+		arg := args[len(args)-1]
+		if i < len(args) {
+			arg = args[i]
+		}
+		switch field {
+		case "pattern":
+			schema.Pattern = arg
+		case "minLength", "maxLength", "minimum", "maximum":
+			n, err := strconv.ParseFloat(arg, 64)
+			if err != nil {
+				continue
+			}
+			switch field {
+			case "minLength":
+				schema.MinLength = int(n)
+			case "maxLength":
+				schema.MaxLength = int(n)
+			case "minimum":
+				schema.Minimum = n
+			case "maximum":
+				schema.Maximum = n
+			}
+		}
+	}
+}
+
+// splitConstraintList splits on ';' at paren depth zero, so a ';' inside
+// `regex(a;b)` does not split the list.
+func splitConstraintList(spec string) []string {
+	var out []string
+	depth, start := 0, 0
+	for i := 0; i < len(spec); i++ {
+		switch spec[i] {
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		case ';':
+			if depth == 0 {
+				out = append(out, strings.TrimSpace(spec[start:i]))
+				start = i + 1
+			}
+		}
+	}
+	if s := strings.TrimSpace(spec[start:]); s != "" {
+		out = append(out, s)
+	}
+	return out
+}
+
+// splitConstraintCall splits `name(a,b)` into its name and arguments. Arguments
+// are split on ',' at depth zero so a nested call keeps its own.
+func splitConstraintCall(part string) (string, []string) {
+	open := strings.IndexByte(part, '(')
+	if open < 0 || !strings.HasSuffix(part, ")") {
+		return part, nil
+	}
+	name := part[:open]
+	inner := part[open+1 : len(part)-1]
+	if inner == "" {
+		return name, nil
+	}
+	var args []string
+	depth, start := 0, 0
+	for i := 0; i < len(inner); i++ {
+		switch inner[i] {
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				args = append(args, strings.TrimSpace(inner[start:i]))
+				start = i + 1
+			}
+		}
+	}
+	args = append(args, strings.TrimSpace(inner[start:]))
+	return name, args
+}

--- a/internal/spec/path_constraints_test.go
+++ b/internal/spec/path_constraints_test.go
@@ -1,0 +1,107 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import "testing"
+
+func TestPathParamConstraints(t *testing.T) {
+	cases := []struct {
+		name, path, param string
+		typ, format       string
+		pattern           string
+		minLen, maxLen    int
+		min, max          float64
+		described         bool
+	}{
+		{name: "int", path: "/items/:id<int>", param: "id", typ: "integer", described: true},
+		{name: "bool", path: "/f/:on<bool>", param: "on", typ: "boolean", described: true},
+		{name: "float", path: "/f/:x<float>", param: "x", typ: "number", described: true},
+		{name: "guid", path: "/u/:uid<guid>", param: "uid", typ: "string", format: "uuid", described: true},
+		{name: "uuid spelling", path: "/u/:uid<uuid>", param: "uid", typ: "string", format: "uuid", described: true},
+		{name: "alpha", path: "/a/:w<alpha>", param: "w", typ: "string", pattern: "^[A-Za-z]+$", described: true},
+
+		{name: "minLen", path: "/a/:w<minLen(3)>", param: "w", typ: "string", minLen: 3, described: true},
+		{name: "maxLen", path: "/a/:w<maxLen(9)>", param: "w", typ: "string", maxLen: 9, described: true},
+		{name: "len fills both bounds", path: "/a/:w<len(4)>", param: "w", typ: "string", minLen: 4, maxLen: 4, described: true},
+		{name: "range", path: "/p/:n<range(1,10)>", param: "n", typ: "integer", min: 1, max: 10, described: true},
+		{name: "chained", path: "/p/:n<min(1);max(500)>", param: "n", typ: "integer", min: 1, max: 500, described: true},
+		{name: "regex arg", path: "/p/:s<regex([a-z]+)>", param: "s", typ: "string", pattern: "[a-z]+", described: true},
+
+		// A ';' inside the argument does not split the list.
+		{name: "semicolon inside regex", path: "/p/:s<regex(a;b)>", param: "s", typ: "string", pattern: "a;b", described: true},
+
+		// Nothing is claimed: the layout decides date vs date-time, which is a
+		// parse rather than a table row.
+		{name: "datetime states nothing", path: "/e/:d<datetime(2006-01-02)>", param: "d", typ: "string"},
+		{name: "unknown constraint", path: "/o/:x<mystery(7)>", param: "x", typ: "string"},
+		// Wrong arity states nothing extra rather than half-filling the schema.
+		{name: "bad argument", path: "/p/:n<min(abc)>", param: "n", typ: "integer", described: true},
+
+		// The mux/chi regex form keeps today's behaviour: a pattern, and
+		// `described` false, because a regex says what the value looks like
+		// without saying what it is (that is #345).
+		{name: "mux regex", path: "/items/{id:[0-9]+}", param: "id", typ: "string", pattern: "[0-9]+"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := pathParamConstraints(tc.path)[tc.param]
+			if !ok {
+				t.Fatalf("pathParamConstraints(%q) has no entry for %q", tc.path, tc.param)
+			}
+			s := got.clone()
+			if s.Type != tc.typ || s.Format != tc.format || s.Pattern != tc.pattern {
+				t.Errorf("schema = {type:%q format:%q pattern:%q}, want {type:%q format:%q pattern:%q}",
+					s.Type, s.Format, s.Pattern, tc.typ, tc.format, tc.pattern)
+			}
+			if s.MinLength != tc.minLen || s.MaxLength != tc.maxLen {
+				t.Errorf("length bounds = [%d,%d], want [%d,%d]", s.MinLength, s.MaxLength, tc.minLen, tc.maxLen)
+			}
+			if s.Minimum != tc.min || s.Maximum != tc.max {
+				t.Errorf("value bounds = [%v,%v], want [%v,%v]", s.Minimum, s.Maximum, tc.min, tc.max)
+			}
+			if got.described != tc.described {
+				t.Errorf("described = %v, want %v", got.described, tc.described)
+			}
+		})
+	}
+}
+
+// A path with nothing to say produces nothing, and an unterminated tail is not
+// read at all rather than being read to the end of the path.
+func TestPathParamConstraintsEmptyAndUnterminated(t *testing.T) {
+	if got := pathParamConstraints("/plain/{name}"); got != nil {
+		t.Errorf("unconstrained path produced %v", got)
+	}
+	if got := pathParamConstraints("/x/:id<int"); got != nil {
+		t.Errorf("unterminated constraint produced %v — nothing about it is reliable", got)
+	}
+}
+
+// clone must hand back a copy: one constraint feeds every operation that has
+// the placeholder, and a shared pointer would let one operation's later edit
+// rewrite another's parameter.
+func TestPathParamConstraintCloneIsACopy(t *testing.T) {
+	c := pathParamConstraints("/items/:id<int>")["id"]
+	a, b := c.clone(), c.clone()
+	a.Type = "string"
+	if b.Type != "integer" {
+		t.Errorf("clone shares state: b.Type = %q after editing a", b.Type)
+	}
+	var zero pathParamConstraint
+	if s := zero.clone(); s == nil || s.Type != "string" {
+		t.Errorf("the zero constraint must clone to the general type, got %+v", s)
+	}
+}

--- a/testdata/fiber_constraints/main.go
+++ b/testdata/fiber_constraints/main.go
@@ -20,12 +20,19 @@ func main() {
 	app.Get("/pages/:n<min(1);max(500)>", getPage)
 	// An unconstrained parameter alongside, which must be unaffected.
 	app.Get("/plain/:name", getPlain)
+	// Constrained and NOT read in the handler: the route pattern is what
+	// attests it.
+	app.Get("/unread/:code<int>", getUnread)
+	// A constraint nothing in the table understands: strips, states nothing.
+	app.Get("/odd/:x<mystery(7)>", getOdd)
 
 	_ = app.Listen(":8080")
 }
 
-func getItem(c *fiber.Ctx) error  { return c.JSON(Item{ID: c.Params("id")}) }
-func getUser(c *fiber.Ctx) error  { return c.JSON(Item{ID: c.Params("uid")}) }
-func getEvent(c *fiber.Ctx) error { return c.JSON(Item{ID: c.Params("day")}) }
-func getPage(c *fiber.Ctx) error  { return c.JSON(Item{ID: c.Params("n")}) }
-func getPlain(c *fiber.Ctx) error { return c.JSON(Item{ID: c.Params("name")}) }
+func getItem(c *fiber.Ctx) error   { return c.JSON(Item{ID: c.Params("id")}) }
+func getUser(c *fiber.Ctx) error   { return c.JSON(Item{ID: c.Params("uid")}) }
+func getEvent(c *fiber.Ctx) error  { return c.JSON(Item{ID: c.Params("day")}) }
+func getPage(c *fiber.Ctx) error   { return c.JSON(Item{ID: c.Params("n")}) }
+func getPlain(c *fiber.Ctx) error  { return c.JSON(Item{ID: c.Params("name")}) }
+func getUnread(c *fiber.Ctx) error { return c.JSON(Item{}) }
+func getOdd(c *fiber.Ctx) error    { return c.JSON(Item{}) }


### PR DESCRIPTION
Closes #357 (parts 2 and 3). Part 1 — the invalid path template — was already fixed; this PR is the half that reads the constraint instead of discarding it.

## Why the constraint is the only evidence

Every framework's path accessor returns a string. `c.Params("id")` is `string` even when the route is `:id<int>`, so the accessor's type is a fact about the API surface, not about the value. The constraint was stripped from the path and then thrown away, leaving `type: string` for everything.

```
/items/:id<int>            → type: integer
/users/:uid<guid>          → type: string, format: uuid
/pages/:n<min(1);max(500)> → type: integer, minimum: 1, maximum: 500
```

## A table, not a branch

A rule names the type/format/pattern it implies plus **the schema fields its own arguments fill, in order** — which is what lets `int`, `guid`, `minLen(3)` and `range(1,10)` share one code path:

```go
"range": {typ: "integer", argFields: []string{"minimum", "maximum"}},
"len":   {typ: "string",  argFields: []string{"minLength", "maxLength"}},  // one arg, two fields
```

Adding a router's vocabulary is a row (golden rule #5). It isn't gated on a framework for the same reason `stripAngleConstraints` isn't: `<` and `>` are not legal in a URL path, so the form is unambiguous whoever wrote it, and a router spelling `uuid` where another spells `guid` costs a row. `;`-chained constraints apply in order, and a `;` or `,` inside an argument doesn't split the list — `regex(a;b)` keeps its own.

## Two things deliberately say nothing (golden rule #7)

| | why |
|---|---|
| `datetime(layout)` | the argument is a Go time layout; whether it implies `date` or `date-time` depends on what the layout contains. That's a parse, not a table row, and picking one would be wrong for the other. |
| an unrecognised constraint | strips from the path, leaves `type: string`. The router constraining a value is not the same as us understanding the constraint. |

## That distinction answers part 3 too

A parameter the route pattern **types** is better attested than one a handler happens to read, so it no longer carries `x-warning: This parameter is present in the path but not found in the code`. A parameter whose constraint we did **not** understand still does — nothing was learned about it. The fixture asserts both directions.

## Scope held: mux/chi are untouched

The `{name:regex}` form keeps today's behaviour exactly — a `pattern`, no type, warning unchanged — because a regex says what a value *looks like* without saying what it *is*. Reading a type out of a numeric regex is **#345**, which is now one table row plus its own drift measurement.

## Verification

- Fixture A/B: **116 of 117 identical**; the difference is `fiber_constraints`, which gains `integer`, `uuid` and the bounds
- The fixture test was verified to fail on `main`:
  `/items/{id}: schema = {type:"string"}, want {type:"integer"}` … `/unread/{code}: the route pattern types this parameter, so it must not be reported as not found in the code`
- `TestPathParamConstraints` covers each row, the chained and nested-argument cases, wrong arity, an unterminated tail, and that `clone` is a copy (one constraint feeds every operation with that placeholder)

Suite, `make lint`, coverage ratchet (96.0%) pass.