### PR TITLE
fix(spec): give response calls their own instance budget

### DIFF
--- a/cmd/apispec/main.go
+++ b/cmd/apispec/main.go
@@ -155,6 +155,7 @@ type CLIConfig struct {
 	MaxNestedArgsDepth           int
 	MaxRecursionDepth            int
 	MaxInstancesPerKey           int
+	MaxResponseInstancesPerKey   int
 	MaxNodesPerRoute             int
 	ShowVersion                  bool
 	OutputFlagSet                bool
@@ -287,7 +288,9 @@ func parseFlags(args []string) (*CLIConfig, error) {
 	fs.IntVar(&config.MaxRecursionDepth, "max-recursion-depth", engine.DefaultMaxRecursionDepth, "Maximum recursion depth to prevent infinite loops")
 	fs.IntVar(&config.MaxRecursionDepth, "mrd", engine.DefaultMaxRecursionDepth, "Shorthand for --max-recursion-depth")
 	fs.IntVar(&config.MaxInstancesPerKey, "max-instances-per-key", engine.DefaultMaxInstancesPerKey,
-		"Maximum copies of one callee within an instance scope (raise it when a group closure holds more routes than the default budget covers)")
+		"Maximum copies of one callee within an instance scope — the bound on call diamonds")
+	fs.IntVar(&config.MaxResponseInstancesPerKey, "max-response-instances-per-key", engine.DefaultMaxResponseInstancesPerKey,
+		"Maximum copies of a call a response pattern is looking for, within an instance scope. Higher than the general bound: these are the calls a route's body is resolved from, and a shared responder needs one copy per route that reaches it")
 	fs.IntVar(&config.MaxNodesPerRoute, "max-nodes-per-route", engine.DefaultMaxNodesPerRoute,
 		"Maximum tree nodes expanded below one route registration, bounding a route's detail without starving the others")
 
@@ -391,6 +394,7 @@ func runGeneration(config *CLIConfig) (*spec.OpenAPISpec, *engine.Engine, error)
 		MaxNestedArgsDepth:           config.MaxNestedArgsDepth,
 		MaxRecursionDepth:            config.MaxRecursionDepth,
 		MaxInstancesPerKey:           config.MaxInstancesPerKey,
+		MaxResponseInstancesPerKey:   config.MaxResponseInstancesPerKey,
 		MaxNodesPerRoute:             config.MaxNodesPerRoute,
 		IncludeFiles:                 config.IncludeFiles,
 		IncludePackages:              config.IncludePackages,

--- a/cmd/apispecui/analysis_test.go
+++ b/cmd/apispecui/analysis_test.go
@@ -155,14 +155,27 @@ func TestTrackerLimitsResolved(t *testing.T) {
 		t.Errorf("raising the per-route budget changed the discovery budget to %d", perRoute.MaxNodesPerTree)
 	}
 
+	// The instance caps are independent too: a project bounding call diamonds
+	// harder must not also cut the calls its response bodies are resolved from
+	// (issue #224).
+	perResponse := TrackerLimits{MaxInstancesPerKey: 25}.resolved()
+	if perResponse.MaxInstancesPerKey != 25 {
+		t.Errorf("max instances per key = %d, want the requested 25", perResponse.MaxInstancesPerKey)
+	}
+	if perResponse.MaxResponseInstancesPerKey != defaults.MaxResponseInstancesPerKey {
+		t.Errorf("lowering the general instance cap changed the response cap to %d",
+			perResponse.MaxResponseInstancesPerKey)
+	}
+
 	all := TrackerLimits{
-		MaxNodesPerTree:    1,
-		MaxNodesPerRoute:   7,
-		MaxChildrenPerNode: 2,
-		MaxArgsPerFunction: 3,
-		MaxNestedArgsDepth: 4,
-		MaxRecursionDepth:  5,
-		MaxInstancesPerKey: 6,
+		MaxNodesPerTree:            1,
+		MaxNodesPerRoute:           7,
+		MaxChildrenPerNode:         2,
+		MaxArgsPerFunction:         3,
+		MaxNestedArgsDepth:         4,
+		MaxRecursionDepth:          5,
+		MaxInstancesPerKey:         6,
+		MaxResponseInstancesPerKey: 8,
 	}
 	if got := all.resolved(); got != all {
 		t.Errorf("fully specified limits were altered: %+v, want %+v", got, all)

--- a/cmd/apispecui/main.go
+++ b/cmd/apispecui/main.go
@@ -216,26 +216,28 @@ type GenerateRequest struct {
 // Zero means "use the engine default", so a client that knows nothing about
 // limits sends nothing and gets today's behaviour.
 type TrackerLimits struct {
-	MaxNodesPerTree    int `json:"maxNodesPerTree,omitempty"`
-	MaxNodesPerRoute   int `json:"maxNodesPerRoute,omitempty"`
-	MaxChildrenPerNode int `json:"maxChildrenPerNode,omitempty"`
-	MaxArgsPerFunction int `json:"maxArgsPerFunction,omitempty"`
-	MaxNestedArgsDepth int `json:"maxNestedArgsDepth,omitempty"`
-	MaxRecursionDepth  int `json:"maxRecursionDepth,omitempty"`
-	MaxInstancesPerKey int `json:"maxInstancesPerKey,omitempty"`
+	MaxNodesPerTree            int `json:"maxNodesPerTree,omitempty"`
+	MaxNodesPerRoute           int `json:"maxNodesPerRoute,omitempty"`
+	MaxChildrenPerNode         int `json:"maxChildrenPerNode,omitempty"`
+	MaxArgsPerFunction         int `json:"maxArgsPerFunction,omitempty"`
+	MaxNestedArgsDepth         int `json:"maxNestedArgsDepth,omitempty"`
+	MaxRecursionDepth          int `json:"maxRecursionDepth,omitempty"`
+	MaxInstancesPerKey         int `json:"maxInstancesPerKey,omitempty"`
+	MaxResponseInstancesPerKey int `json:"maxResponseInstancesPerKey,omitempty"`
 }
 
 // defaultTrackerLimits is what the engine uses when the request says nothing. The
 // UI shows these so a user can see what they are changing.
 func defaultTrackerLimits() TrackerLimits {
 	return TrackerLimits{
-		MaxNodesPerTree:    engine.DefaultMaxNodesPerTree,
-		MaxNodesPerRoute:   engine.DefaultMaxNodesPerRoute,
-		MaxChildrenPerNode: engine.DefaultMaxChildrenPerNode,
-		MaxArgsPerFunction: engine.DefaultMaxArgsPerFunction,
-		MaxNestedArgsDepth: engine.DefaultMaxNestedArgsDepth,
-		MaxRecursionDepth:  engine.DefaultMaxRecursionDepth,
-		MaxInstancesPerKey: engine.DefaultMaxInstancesPerKey,
+		MaxNodesPerTree:            engine.DefaultMaxNodesPerTree,
+		MaxNodesPerRoute:           engine.DefaultMaxNodesPerRoute,
+		MaxChildrenPerNode:         engine.DefaultMaxChildrenPerNode,
+		MaxArgsPerFunction:         engine.DefaultMaxArgsPerFunction,
+		MaxNestedArgsDepth:         engine.DefaultMaxNestedArgsDepth,
+		MaxRecursionDepth:          engine.DefaultMaxRecursionDepth,
+		MaxInstancesPerKey:         engine.DefaultMaxInstancesPerKey,
+		MaxResponseInstancesPerKey: engine.DefaultMaxResponseInstancesPerKey,
 	}
 }
 
@@ -262,6 +264,9 @@ func (l TrackerLimits) resolved() TrackerLimits {
 	}
 	if l.MaxInstancesPerKey <= 0 {
 		l.MaxInstancesPerKey = d.MaxInstancesPerKey
+	}
+	if l.MaxResponseInstancesPerKey <= 0 {
+		l.MaxResponseInstancesPerKey = d.MaxResponseInstancesPerKey
 	}
 	return l
 }
@@ -937,6 +942,7 @@ func (s *UIServer) handleGenerate(w http.ResponseWriter, r *http.Request) {
 		MaxNestedArgsDepth:           limits.MaxNestedArgsDepth,
 		MaxRecursionDepth:            limits.MaxRecursionDepth,
 		MaxInstancesPerKey:           limits.MaxInstancesPerKey,
+		MaxResponseInstancesPerKey:   limits.MaxResponseInstancesPerKey,
 		SkipCGOPackages:              true,
 		AnalyzeFrameworkDependencies: true,
 		AutoIncludeFrameworkPackages: true,

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -99,6 +99,8 @@ const (
 	// DefaultMaxInstancesPerKey mirrors the lazy tree's own default, so the
 	// engine reports one number rather than two that can drift.
 	DefaultMaxInstancesPerKey = intspec.DefaultMaxInstancesPerKey
+	// DefaultMaxResponseInstancesPerKey mirrors the lazy tree's own default.
+	DefaultMaxResponseInstancesPerKey = intspec.DefaultMaxResponseInstancesPerKey
 	// DefaultMaxNodesPerRoute mirrors the lazy tree's own default.
 	DefaultMaxNodesPerRoute = intspec.DefaultMaxNodesPerRoute
 	DefaultMetadataFile     = "metadata.yaml"
@@ -137,6 +139,10 @@ type EngineConfig struct {
 	// MaxInstancesPerKey bounds copies of one callee within an instance scope.
 	// Zero uses DefaultMaxInstancesPerKey.
 	MaxInstancesPerKey int
+
+	// MaxResponseInstancesPerKey is the same bound for the calls a response
+	// pattern is looking for. Zero uses DefaultMaxResponseInstancesPerKey.
+	MaxResponseInstancesPerKey int
 	// MaxNodesPerRoute bounds the nodes expanded below ONE route registration,
 	// so a deep handler cannot consume the allowance the undiscovered routes
 	// still need. Zero uses DefaultMaxNodesPerRoute. Lazy tracker only: the
@@ -866,13 +872,14 @@ func (e *Engine) GenerateOpenAPI() (*spec.OpenAPISpec, error) {
 
 	// Construct the tracker tree
 	limits := metadata.TrackerLimits{
-		MaxNodesPerTree:    e.config.MaxNodesPerTree,
-		MaxChildrenPerNode: e.config.MaxChildrenPerNode,
-		MaxArgsPerFunction: e.config.MaxArgsPerFunction,
-		MaxNestedArgsDepth: e.config.MaxNestedArgsDepth,
-		MaxRecursionDepth:  e.config.MaxRecursionDepth,
-		MaxInstancesPerKey: e.config.MaxInstancesPerKey,
-		MaxNodesPerRoute:   e.config.MaxNodesPerRoute,
+		MaxNodesPerTree:            e.config.MaxNodesPerTree,
+		MaxChildrenPerNode:         e.config.MaxChildrenPerNode,
+		MaxArgsPerFunction:         e.config.MaxArgsPerFunction,
+		MaxNestedArgsDepth:         e.config.MaxNestedArgsDepth,
+		MaxRecursionDepth:          e.config.MaxRecursionDepth,
+		MaxInstancesPerKey:         e.config.MaxInstancesPerKey,
+		MaxResponseInstancesPerKey: e.config.MaxResponseInstancesPerKey,
+		MaxNodesPerRoute:           e.config.MaxNodesPerRoute,
 	}
 	if err := e.ctx().Err(); err != nil {
 		return nil, err
@@ -882,7 +889,8 @@ func (e *Engine) GenerateOpenAPI() (*spec.OpenAPISpec, error) {
 		intspec.WithHandlerInterfaceMethods(apispecConfig.Framework.HandlerInterfaceMethods),
 		intspec.WithEntrypoints(apispecConfig.Framework.EntrypointPatterns,
 			intspec.RouteRegistrationMatcher(apispecConfig, meta), NewVerboseLogger(e.config.Verbose)),
-		intspec.WithTerminalRouteMatcher(intspec.TerminalRouteMatcher(apispecConfig, meta)))
+		intspec.WithTerminalRouteMatcher(intspec.TerminalRouteMatcher(apispecConfig, meta)),
+		intspec.WithResponseCallMatcher(intspec.ResponseCallMatcher(apispecConfig, meta)))
 	e.reportPhase("tracker tree ready", time.Since(tTree))
 	if err := e.ctx().Err(); err != nil {
 		return nil, err

--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -1845,6 +1845,11 @@ type TrackerLimits struct {
 	// off. Zero means that default.
 	MaxInstancesPerKey int
 
+	// MaxResponseInstancesPerKey is the same bound for the calls a response
+	// pattern is looking for — see the lazy tree's
+	// DefaultMaxResponseInstancesPerKey.
+	MaxResponseInstancesPerKey int
+
 	// MaxNodesPerRoute bounds the nodes materialised BELOW one route
 	// registration, so a single deep handler cannot consume the allowance the
 	// rest of the routes still need. MaxNodesPerTree then bounds only the

--- a/internal/spec/entrypoint_roots.go
+++ b/internal/spec/entrypoint_roots.go
@@ -327,9 +327,15 @@ type ExpansionStats struct {
 	// from the failure case, where a scope spanning several routes means one
 	// route's expansion is consuming another's budget.
 	InstanceTruncations int
-	InstanceLimit       int
-	InstanceFirstScope  string
-	InstanceFirstKey    string
+
+	// InstanceLimit is the budget that actually fired on the FIRST truncation,
+	// not whichever one is configured: a response call is bounded by
+	// MaxResponseInstancesPerKey and everything else by MaxInstancesPerKey, so
+	// reporting a fixed one would send a reader to the flag that would not have
+	// helped. Zero when nothing was truncated.
+	InstanceLimit      int
+	InstanceFirstScope string
+	InstanceFirstKey   string
 
 	// RouteTruncations counts route subtrees cut short by their OWN budget, and
 	// RouteFirstTruncated names the first. This shortfall is local: the route is

--- a/internal/spec/entrypoint_roots.go
+++ b/internal/spec/entrypoint_roots.go
@@ -15,6 +15,7 @@
 package spec
 
 import (
+	"regexp"
 	"sort"
 
 	"github.com/ehabterra/apispec/internal/metadata"
@@ -186,6 +187,55 @@ func RouteRegistrationMatcher(cfg *APISpecConfig, meta *metadata.Metadata) func(
 // new place — a limit applied to a group where it was meant to apply to a route.
 func TerminalRouteMatcher(cfg *APISpecConfig, meta *metadata.Metadata) func(*metadata.CallGraphEdge) bool {
 	return registrationMatcher(cfg, meta, false)
+}
+
+// ResponseCallMatcher matches the calls a response pattern is looking for.
+//
+// Used by the tracker to spare those calls from the per-key instance cap
+// (issue #224): they are what the document is made of, and the cap cannot tell
+// the copy that carries a route's response type from the diamond it exists to
+// bound.
+//
+// Matched on the call NAME alone, deliberately wider than the pattern that will
+// eventually run. The receiver scope is what makes an extractor pattern
+// precise, but here a false positive costs a few extra node copies while a
+// false negative costs a response body — and the node the receiver would be
+// read from is the one being decided about. The route and wiring budgets still
+// bound what this lets through.
+func ResponseCallMatcher(cfg *APISpecConfig, meta *metadata.Metadata) func(*metadata.CallGraphEdge) bool {
+	never := func(*metadata.CallGraphEdge) bool { return false }
+	if cfg == nil || meta == nil {
+		return never
+	}
+	res := make([]*regexp.Regexp, 0, len(cfg.Framework.ResponsePatterns))
+	for _, p := range cfg.Framework.ResponsePatterns {
+		if p.CallRegex == "" {
+			continue
+		}
+		re, err := regexp.Compile(p.CallRegex)
+		if err != nil {
+			continue // an unusable pattern spares nothing, as it matches nothing
+		}
+		res = append(res, re)
+	}
+	if len(res) == 0 {
+		return never
+	}
+	return func(edge *metadata.CallGraphEdge) bool {
+		if edge == nil {
+			return false
+		}
+		name := getString(meta, edge.Callee.Name)
+		if name == "" {
+			return false
+		}
+		for _, re := range res {
+			if re.MatchString(name) {
+				return true
+			}
+		}
+		return false
+	}
 }
 
 func registrationMatcher(cfg *APISpecConfig, meta *metadata.Metadata, includeMounts bool) func(*metadata.CallGraphEdge) bool {

--- a/internal/spec/lazytree.go
+++ b/internal/spec/lazytree.go
@@ -193,6 +193,11 @@ type LazyTree struct {
 	// groups) must not, or every route inside a group shares one allowance —
 	// see TerminalRouteMatcher.
 	terminalRouteMatch func(*metadata.CallGraphEdge) bool
+
+	// responseCallMatch marks the calls a response pattern is looking for, so
+	// the instance cap can spare them (see GetChildren). Nil leaves the cap
+	// applying to everything, which is what it did before issue #224.
+	responseCallMatch func(*metadata.CallGraphEdge) bool
 	// routeReach is routeMatch's transitive closure — the functions whose
 	// expansion leads to a route registration. Used to ORDER a node's callee
 	// children so the budget is spent on routing code first (issue #264); never
@@ -422,13 +427,13 @@ func (t *LazyTree) noteInstanceTruncation(scope, key string) {
 		t.instanceWarned = true
 		fmt.Fprintf(os.Stderr,
 			"Warning: MaxInstancesPerKey limit (%d) reached, dropping repeated call copies (first: key %s in scope %s)\n",
-			t.instanceBudget(), key, scopeLabel(scope))
+			t.instanceBudget(), key, scope)
 	}
 }
 
-// scopeLabel renders an instance scope for a human. The empty scope is the
+// scopeLabelText renders an instance scope for a human. The empty scope is the
 // wiring level — above any argument node — and "" would read as missing data.
-func scopeLabel(scope string) string {
+func scopeLabelText(scope string) string {
 	if scope == "" {
 		return "<router wiring>"
 	}
@@ -890,6 +895,14 @@ func WithEntrypoints(patterns []EntrypointPattern, routeMatch func(*metadata.Cal
 // MaxNodesPerTree, as it was before.
 func WithTerminalRouteMatcher(match func(*metadata.CallGraphEdge) bool) LazyTreeOption {
 	return func(t *LazyTree) { t.terminalRouteMatch = match }
+}
+
+// WithResponseCallMatcher supplies the predicate that marks a call as one a
+// response pattern is looking for. Those calls are what the document is FOR, so
+// the instance cap spares them (issue #224); everything else is bounded as
+// before.
+func WithResponseCallMatcher(match func(*metadata.CallGraphEdge) bool) LazyTreeOption {
+	return func(t *LazyTree) { t.responseCallMatch = match }
 }
 
 // SetEdgeMatcher supplies the predicate deciding whether an edge is one some
@@ -1470,12 +1483,16 @@ func (n *LazyNode) GetChildren() []TrackerNodeInterface {
 			// of the nodes on a real service.
 			continue
 		}
-		if scopeCounts[spec.keyID] >= n.tree.instanceBudget() {
+		budget := n.tree.instanceBudget()
+		if n.tree.isResponseCall(spec) {
+			budget = n.tree.responseInstanceBudget()
+		}
+		if scopeCounts[spec.keyID] >= budget {
 			// Diamond inside this scope: stop materializing further copies.
 			// Reusing an existing instance instead would make the tree cyclic
 			// (consumers of a memoized subtree could reach themselves), so the
 			// bound is a skip — the role the eager per-ID recursion cap plays.
-			n.tree.noteInstanceTruncation(n.tree.keyString(scope), spec.key)
+			n.tree.noteInstanceTruncation(n.tree.scopeLabel(scope, childScope), spec.key)
 			continue
 		}
 		child := n.tree.newNode()
@@ -1915,4 +1932,68 @@ func (t *LazyTree) implementerKeys(pkg, recv, method string) []string {
 		}
 	}
 	return out
+}
+
+// isResponseCall reports whether a child is a call a response pattern is
+// looking for.
+func (t *LazyTree) isResponseCall(spec childSpec) bool {
+	return t.responseCallMatch != nil && spec.edge != nil && t.responseCallMatch(spec.edge)
+}
+
+// responseInstanceBudget is the cap in force for a call a response pattern is
+// looking for: its own number, not the general one.
+func (t *LazyTree) responseInstanceBudget() int {
+	if t.limits.MaxResponseInstancesPerKey > 0 {
+		return t.limits.MaxResponseInstancesPerKey
+	}
+	return DefaultMaxResponseInstancesPerKey
+}
+
+// DefaultMaxResponseInstancesPerKey bounds copies of a call a RESPONSE pattern
+// is looking for, separately from the general cap above.
+//
+// One number was doing two jobs (issue #224). The general cap exists to bound
+// call diamonds, where every extra copy buys nothing, and it cannot tell such a
+// diamond from the one path that carries a route's response type: both are
+// copies of the same callee key inside one scope. So on a service whose
+// handlers reach a shared `respond(w, code, v)` helper along many paths, the
+// copies that resolved a body were simply the ones that arrived after the
+// budget ran out — 363 of 503 operations lost their 2xx body at a cap of 10 —
+// and the only remedy was raising the number until it happened to be enough.
+// That is what "no project can know it is safe" means: what pushed a route over
+// the line was how many OTHER routes shared its helper.
+//
+// Splitting the two makes the general number stop deciding. Measured on that
+// service, every one of its 433 bodies is documented at a general cap of 5, 10
+// or 25, where a cap of 10 previously documented 70.
+//
+// 100, and NOT unbounded. Exempting these calls from the cap entirely recovered
+// the same bodies and then took gitea's mapping stage from two minutes to over
+// thirty: a response call reached along millions of paths is still a diamond,
+// and the per-route node budget is far too loose to be the only bound (golden
+// rule #6). A second bounded budget keeps both properties.
+//
+// The two numbers are independent on purpose. Because bodies no longer depend
+// on the general cap, that one can be LOWERED to bound diamonds harder: gitea
+// documents 940 paths in 1m40 at a general cap of 25, against 930 in 2m05 at
+// the uniform 100 it used to run — ten more paths for twenty per cent less
+// time, because the work saved on diamonds is spent finding routes instead.
+const DefaultMaxResponseInstancesPerKey = 100
+
+// scopeLabel renders an instance scope for the truncation report: which
+// argument subtree ran out, and under which route it was reached.
+//
+// The route is worth the extra words. The argument key alone cannot separate a
+// diamond the cap is bounding correctly from a route being starved, and reading
+// that report is how the shape behind #224 was finally identified — the scopes
+// that ran out were business-logic argument nodes deep inside ONE route, not
+// the group closure the issue first blamed.
+func (t *LazyTree) scopeLabel(scope, route int32) string {
+	arg := scopeLabelText(t.keyString(scope))
+	if route > 0 && int(route) < len(t.routeScopeKeys) {
+		if key := t.routeScopeKeys[route]; key != "" {
+			return arg + " under route " + key
+		}
+	}
+	return arg
 }

--- a/internal/spec/lazytree.go
+++ b/internal/spec/lazytree.go
@@ -104,6 +104,7 @@ type LazyTree struct {
 	// is exactly the distinction the number alone cannot make.
 	instanceTruncations int
 	instanceFirstScope  string
+	instanceFirstLimit  int
 	instanceFirstKey    string
 	instanceWarned      bool
 
@@ -417,17 +418,27 @@ func (t *LazyTree) instanceBudget() int {
 // a handler scope that runs out is the cap doing its job on a deep diamond, while
 // a scope spanning several routes means one route's expansion is consuming
 // another's budget.
-func (t *LazyTree) noteInstanceTruncation(scope, key string) {
+// The budget is passed in rather than re-read, because two of them can fire:
+// a response call is bounded by MaxResponseInstancesPerKey and everything else
+// by MaxInstancesPerKey, so recomputing here would report a drop at a response
+// budget of 2 as a 100-copy cap. A report that names the wrong number is worse
+// than a quiet one — it sends the reader to the flag that would not have helped.
+func (t *LazyTree) noteInstanceTruncation(scope, key string, budget int) {
 	t.instanceTruncations++
 	if t.instanceFirstKey == "" {
 		t.instanceFirstScope = scope
 		t.instanceFirstKey = key
+		t.instanceFirstLimit = budget
 	}
 	if !t.instanceWarned {
 		t.instanceWarned = true
+		name := "MaxInstancesPerKey"
+		if budget == t.responseInstanceBudget() && budget != t.instanceBudget() {
+			name = "MaxResponseInstancesPerKey"
+		}
 		fmt.Fprintf(os.Stderr,
-			"Warning: MaxInstancesPerKey limit (%d) reached, dropping repeated call copies (first: key %s in scope %s)\n",
-			t.instanceBudget(), key, scope)
+			"Warning: %s limit (%d) reached, dropping repeated call copies (first: key %s in scope %s)\n",
+			name, budget, key, scope)
 	}
 }
 
@@ -1004,7 +1015,7 @@ func (t *LazyTree) ExpansionStats() ExpansionStats {
 		Limit:               t.limits.MaxNodesPerTree,
 		Truncated:           t.truncated,
 		InstanceTruncations: t.instanceTruncations,
-		InstanceLimit:       t.instanceBudget(),
+		InstanceLimit:       t.instanceFirstLimit,
 		InstanceFirstScope:  t.instanceFirstScope,
 		InstanceFirstKey:    t.instanceFirstKey,
 		RouteTruncations:    t.routeTruncations,
@@ -1492,7 +1503,7 @@ func (n *LazyNode) GetChildren() []TrackerNodeInterface {
 			// Reusing an existing instance instead would make the tree cyclic
 			// (consumers of a memoized subtree could reach themselves), so the
 			// bound is a skip — the role the eager per-ID recursion cap plays.
-			n.tree.noteInstanceTruncation(n.tree.scopeLabel(scope, childScope), spec.key)
+			n.tree.noteInstanceTruncation(n.tree.scopeLabel(scope, childScope), spec.key, budget)
 			continue
 		}
 		child := n.tree.newNode()

--- a/internal/spec/lazytree_budget_test.go
+++ b/internal/spec/lazytree_budget_test.go
@@ -131,6 +131,60 @@ func TestInstanceBudgetCapsTraversal(t *testing.T) {
 	}
 }
 
+// TestResponseCallsHaveTheirOwnBudget is the fix for #224 at unit level: the
+// calls a response pattern is looking for are what the document is made of, so
+// the GENERAL cap must not be what decides how many of them exist.
+//
+// The same six callers and the same shared helper as above, and the same
+// general budget of three — but now the helper is a call a response pattern
+// matches, so it is counted against its own number instead. Before, the fourth
+// caller's copy was dropped, and on a real service that was 363 of 503
+// operations losing their 2xx body at a general cap of 10 while the same run at
+// 100 had all of them.
+func TestResponseCallsHaveTheirOwnBudget(t *testing.T) {
+	const callers = 6
+	limits := metadata.TrackerLimits{
+		MaxNodesPerTree:    10000,
+		MaxChildrenPerNode: 100,
+		MaxInstancesPerKey: 3,
+	}
+	always := func(*metadata.CallGraphEdge) bool { return true }
+
+	// The response budget applies, not the general one.
+	spared := NewLazyTree(sharedHelperGraph(callers), limits, WithResponseCallMatcher(always))
+	if got := countKey(spared.GetRoots(), "shared"); got != callers {
+		t.Errorf("a response call admitted %d copies under a general budget of 3, want all %d — "+
+			"the general cap must not decide whether a route has a body", got, callers)
+	}
+
+	// And it is a BUDGET, not an exemption. This is the property the measurement
+	// bought: exempting these calls outright recovered the same bodies and took
+	// gitea's mapping stage from two minutes to over thirty, because a response
+	// call reached along millions of paths is still a diamond.
+	own := limits
+	own.MaxResponseInstancesPerKey = 2
+	capped := NewLazyTree(sharedHelperGraph(callers), own, WithResponseCallMatcher(always))
+	if got := countKey(capped.GetRoots(), "shared"); got != 2 {
+		t.Errorf("a response call admitted %d copies under a response budget of 2, want 2 — "+
+			"these calls are bounded by their own number, not unbounded", got)
+	}
+
+	// Nothing else changes: a call no response pattern is looking for is still
+	// bounded by the general cap, which is the diamond it exists for.
+	bounded := NewLazyTree(sharedHelperGraph(callers), limits,
+		WithResponseCallMatcher(func(*metadata.CallGraphEdge) bool { return false }))
+	if got := countKey(bounded.GetRoots(), "shared"); got != 3 {
+		t.Errorf("a non-response call admitted %d copies under a general budget of 3, want 3", got)
+	}
+
+	// No matcher at all is the pre-#224 behaviour, so a tree built without the
+	// option cannot accidentally become unbounded.
+	none := NewLazyTree(sharedHelperGraph(callers), limits)
+	if got := countKey(none.GetRoots(), "shared"); got != 3 {
+		t.Errorf("with no matcher the general cap admitted %d copies, want 3", got)
+	}
+}
+
 // TestNewNodeSlabHandsOutStablePointers pins the property the slab must keep: a
 // node's address never moves, and no later carve writes over a node already
 // handed out. Nodes reference their parent, so a slab that grew in place
@@ -260,10 +314,31 @@ func TestInstanceTruncationIsRecordedAndNamed(t *testing.T) {
 }
 
 func TestScopeLabelRendersTheWiringLevel(t *testing.T) {
-	if got := scopeLabel(""); got != "<router wiring>" {
-		t.Errorf("scopeLabel(\"\") = %q — an empty scope is the wiring level, not missing data", got)
+	if got := scopeLabelText(""); got != "<router wiring>" {
+		t.Errorf("scopeLabelText(\"\") = %q — an empty scope is the wiring level, not missing data", got)
 	}
-	if got := scopeLabel("pkg.handler"); got != "pkg.handler" {
-		t.Errorf("scopeLabel(%q) = %q, want it unchanged", "pkg.handler", got)
+	if got := scopeLabelText("pkg.handler"); got != "pkg.handler" {
+		t.Errorf("scopeLabelText(%q) = %q, want it unchanged", "pkg.handler", got)
+	}
+}
+
+// The report names the ROUTE as well as the argument subtree, because the
+// argument key alone cannot separate a diamond the cap is bounding correctly
+// from a route being starved (issue #224).
+func TestScopeLabelNamesTheRoute(t *testing.T) {
+	tree := &LazyTree{routeScopeKeys: []string{"", "chi.Router.Get@router.go:903"}}
+	tree.internKey("pkg.handler")
+	scope := tree.internKey("pkg.handler")
+
+	if got := tree.scopeLabel(scope, 1); got != "pkg.handler under route chi.Router.Get@router.go:903" {
+		t.Errorf("scopeLabel with a route = %q", got)
+	}
+	// The wiring walk has no route to name.
+	if got := tree.scopeLabel(scope, 0); got != "pkg.handler" {
+		t.Errorf("scopeLabel at wiring level = %q, want the argument subtree alone", got)
+	}
+	// A route id past the end names nothing rather than panicking.
+	if got := tree.scopeLabel(scope, 99); got != "pkg.handler" {
+		t.Errorf("scopeLabel with an unknown route = %q", got)
 	}
 }

--- a/internal/spec/lazytree_budget_test.go
+++ b/internal/spec/lazytree_budget_test.go
@@ -294,8 +294,8 @@ func TestBudgetCountsKeysWhileStatsReportWork(t *testing.T) {
 func TestInstanceTruncationIsRecordedAndNamed(t *testing.T) {
 	tree := &LazyTree{limits: metadata.TrackerLimits{MaxInstancesPerKey: 3}}
 
-	tree.noteInstanceTruncation("pkg.handler", "pkg.helper@a.go:1:1")
-	tree.noteInstanceTruncation("pkg.other", "pkg.helper@a.go:2:1")
+	tree.noteInstanceTruncation("pkg.handler", "pkg.helper@a.go:1:1", 3)
+	tree.noteInstanceTruncation("pkg.other", "pkg.helper@a.go:2:1", 3)
 
 	if tree.instanceTruncations != 2 {
 		t.Errorf("counted %d truncations, want 2", tree.instanceTruncations)
@@ -311,6 +311,32 @@ func TestInstanceTruncationIsRecordedAndNamed(t *testing.T) {
 	// ExpansionStats' propagation of these is asserted end to end by
 	// TestGroupClosureInstanceCapIsReported, which has a real tree; calling it
 	// here would only exercise relation-building.
+}
+
+// The number in the report has to be the budget that actually fired. Two can:
+// a response call is bounded by MaxResponseInstancesPerKey and everything else
+// by MaxInstancesPerKey, so a fixed choice would report a drop at a response
+// budget of 2 as a 100-copy cap — sending the reader to the flag that would not
+// have helped (issue #224).
+func TestInstanceTruncationReportsTheBudgetThatFired(t *testing.T) {
+	tree := &LazyTree{limits: metadata.TrackerLimits{
+		MaxInstancesPerKey:         3,
+		MaxResponseInstancesPerKey: 40,
+	}}
+
+	tree.noteInstanceTruncation("pkg.handler", "pkg.responder@a.go:1:1", 40)
+	if tree.instanceFirstLimit != 40 {
+		t.Errorf("reported limit %d, want the response budget 40 that refused the copy",
+			tree.instanceFirstLimit)
+	}
+
+	// The FIRST one is what is kept, so a later drop at the other budget does
+	// not overwrite the number the report will print.
+	tree.noteInstanceTruncation("pkg.other", "pkg.helper@a.go:9:1", 3)
+	if tree.instanceFirstLimit != 40 {
+		t.Errorf("reported limit became %d after a later drop at a different budget, want the first one",
+			tree.instanceFirstLimit)
+	}
 }
 
 func TestScopeLabelRendersTheWiringLevel(t *testing.T) {


### PR DESCRIPTION
Addresses #224.

## One number was doing two jobs

The instance cap bounds call diamonds, where every extra copy of a callee buys nothing. It cannot tell such a diamond from the one path that carries a route's response type — both are copies of the same callee key inside one scope.

So on a service whose handlers reach a shared `respond(w, code, v)` helper along many paths, the copies that resolved a body were simply the ones that arrived after the budget ran out: **363 of 503 operations lost their 2xx body at a cap of 10**. What pushed a route over the line was how many *other* routes shared its helper — which is exactly what "no project can know it is safe" means.

Response-pattern calls now count against their own budget. On that service, all **433 bodies are documented at a general cap of 5, 10 or 25**, where 10 previously documented 70.

## Two directions measured and rejected

Both are written into the code comments so they aren't tried again.

**The issue's own direction — scope the cap per route — is a no-op.** I implemented it and measured:

| general cap | today (arg scope) | per-route scope |
|---|---|---|
| 10 | 70 bodies | 70 |
| 15 | 287 | 287 |
| 25 | 424 | 424 |
| 40–100 | 433 | 433 |

Identical at every cap, and identical on three other projects. Instrumenting *which* scopes exhaust the cap showed them to be business-logic diamonds deep inside **one** route, not argument nodes spanning routes. Rescoping only the response calls per route was actively worse (62 bodies vs 70).

**Exempting response calls outright is not shippable.** It recovered every body and ran *faster* on the starving service — then took gitea's mapping stage from 2 minutes to **over 30** before I killed it. A response call reached along millions of paths is still a diamond, and the per-route node budget is far too loose to be the only bound (golden rule #6). Hence a second *bounded* budget rather than an exemption — and `TestResponseCallsHaveTheirOwnBudget` pins that distinction directly.

## Defaults unchanged: this ships with zero drift

Both budgets default to 100 — the number everything already used — so **118 of 118 fixtures are byte-identical**.

What it buys is that the two concerns now move independently:

- a project whose shared responder outgrows the budget raises **one** flag, without paying that raise on every diamond in its codebase;
- the general cap can be **lowered** to bound diamonds harder without costing bodies.

## Recommendation, measured but not taken here

Dropping the general default from 100 to 25 looks strictly better on everything I can measure, but it moves a shipped default that was itself raised to 100 for a measured reason, so it is left as your call — it is a one-constant change:

| | general 100 (this PR) | general 25 |
|---|---|---|
| gitea | 930 paths, 2m05 | **940 paths, 1m40** |
| 374-route service | 433 bodies | 433 bodies |
| 280-path, 785-file, 2 smaller | baseline | byte-identical |

Ten more paths for twenty per cent less time, because work saved on diamonds is spent finding routes instead.

## Also

The truncation report now names the **route** as well as the argument subtree. Reading that report is how the shape behind this issue was finally identified, and the argument key alone cannot separate a diamond being bounded correctly from a route being starved.

Wired through the engine, the CLI (`--max-response-instances-per-key`) and the apispecui limits. `TestTrackerLimitsResolved` gained the property the change rests on: lowering the general cap must not drag the response cap down with it.

Suite, `make lint`, coverage ratchet (96.0%) pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a separate configurable limit for response-related instances in the command-line and UI settings.
  * Response-related calls now use their dedicated limit, while other calls continue using the general instance limit.
  * Added a default response-instance limit of 100.
  * Instance-limit reports now identify the route and budget that caused expansion to stop.

* **Tests**
  * Added coverage for independent response and general limits, including default, capped, and reporting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->