### PR TITLE
fix(spec): resolve a generic adapter's response type from its instantiation

### DIFF
--- a/generator/testdata_generic_handler_adapter_test.go
+++ b/generator/testdata_generic_handler_adapter_test.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/spec"
+)
+
+// A generic handler adapter — `HandleJSON[Req, Res any](fn) http.HandlerFunc` —
+// is the shape several Go HTTP toolkits ship and many projects hand-roll once
+// and reuse everywhere. Its response type is a TYPE PARAMETER, and the
+// parameter's own name used to reach the schema mapper: every operation built
+// through the adapter `$ref`ed one component named `..._Res`, described as
+// "unresolved type", so endpoints with entirely different response types all
+// claimed the same schema (issue #367).
+//
+// That is worse than documenting nothing. A consumer generating clients from
+// the document gets one wrong Go type for all of them, with nothing saying so.
+func TestTestdata_GenericHandlerAdapter(t *testing.T) {
+	out := loadTestdata(t, "generic_handler_adapter", spec.DefaultHTTPConfig())
+	noDanglingRefs(t, out)
+
+	// Each operation documents ITS OWN instantiation. Two of these go through
+	// the same adapter, which is the point: the binding is per registration.
+	cases := []struct {
+		path, method, want string
+	}{
+		{"/users", "POST", "User"},        // HandleJSON[CreateUserRequest, User]
+		{"/users", "GET", "ListResponse"}, // HandleJSONResponse[ListResponse]
+		{"/health", "GET", "Health"},      // HandleJSONResponse[Health]
+	}
+	for _, tc := range cases {
+		item, ok := out.Paths[tc.path]
+		if !ok {
+			t.Errorf("%s missing; have %v", tc.path, mapPathKeys(out.Paths))
+			continue
+		}
+		op := opFor(item, tc.method)
+		if op == nil {
+			t.Errorf("%s %s missing", tc.method, tc.path)
+			continue
+		}
+		resp, ok := op.Responses["200"]
+		if !ok {
+			t.Errorf("%s %s: no 200; have %v", tc.method, tc.path, sortedStatusKeys(op))
+			continue
+		}
+		ref := ""
+		for _, mt := range resp.Content {
+			if mt.Schema != nil {
+				ref = mt.Schema.Ref
+			}
+		}
+		if !strings.HasSuffix(ref, "_"+tc.want) {
+			t.Errorf("%s %s 200 schema = %q, want the instantiated %s — the response type is the "+
+				"adapter's type PARAMETER, resolved from this registration's instantiation",
+				tc.method, tc.path, ref, tc.want)
+		}
+	}
+
+	// The request side, which already worked, must keep working: the fix reads
+	// the same bindings.
+	if post := opFor(out.Paths["/users"], "POST"); post != nil && post.RequestBody != nil {
+		ref := ""
+		for _, mt := range post.RequestBody.Content {
+			if mt.Schema != nil {
+				ref = mt.Schema.Ref
+			}
+		}
+		if !strings.HasSuffix(ref, "_CreateUserRequest") {
+			t.Errorf("POST /users request body = %q, want CreateUserRequest", ref)
+		}
+	}
+
+	// No component may be named after a type parameter. This is the assertion
+	// that fails loudest on the unfixed code, and it is phrased on the SHAPE
+	// rather than on the one name, so an adapter spelled `[In, Out]` is caught
+	// too.
+	if out.Components != nil {
+		for name := range out.Components.Schemas {
+			for _, param := range []string{"_Res", "_Req", "_In", "_Out", "_T"} {
+				if strings.HasSuffix(name, param) {
+					t.Errorf("component %q is named after a type parameter — it describes nothing, "+
+						"and every operation through the adapter would reference it", name)
+				}
+			}
+		}
+		// And the real types are present, since the whole point is that they
+		// reach the document.
+		for _, want := range []string{"User", "ListResponse", "Health", "CreateUserRequest"} {
+			found := false
+			for name := range out.Components.Schemas {
+				if strings.HasSuffix(name, "_"+want) {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("%s is not in components; the instantiated type never reached the document", want)
+			}
+		}
+	}
+}

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -2568,6 +2568,15 @@ func (r *ResponsePatternMatcherImpl) resolveArgType(arg *metadata.CallArgument, 
 		}
 	}
 
+	// A TYPE PARAMETER is resolved from the instantiation this route registered
+	// (issue #367). Last, because everything above may narrow the type first —
+	// and applied even when nothing did, since the value written by a generic
+	// adapter is a plain ident whose declared type is the parameter itself.
+	if resolved, isParam := resolveTypeParam(bodyType, typeNode, r.metadata()); isParam {
+		bodyType = resolved
+		oneOfTypes = nil // the instantiation is the answer; there is no ambiguity to report
+	}
+
 	// Inferred generic instantiations arrive as the go/types string
 	// (pkg.Envelope[pkg.Product]); fold them into the internal form so they
 	// key to the same clean component as a written Envelope[Product].

--- a/internal/spec/type_params.go
+++ b/internal/spec/type_params.go
@@ -1,0 +1,120 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"github.com/ehabterra/apispec/internal/metadata"
+	"github.com/ehabterra/apispec/internal/typemodel"
+)
+
+// resolveTypeParam substitutes a TYPE PARAMETER with the type bound to it at
+// this instantiation, and reports whether the type was a type parameter at all.
+//
+// A generic handler adapter — `HandleJSON[Req, Res any](fn func(context.Context,
+// Req) (Res, error)) http.HandlerFunc`, the shape several Go HTTP toolkits ship
+// and many projects hand-roll — writes its response by encoding a value whose
+// declared type is the parameter `Res`. The request side already resolved,
+// because `in` is a DECLARED VARIABLE of type Req; `out` is the result of
+// calling a func-typed parameter, and nothing applied the binding to it. The
+// type parameter's own name then reached the schema mapper, which emitted a
+// component named after it: `..._Res`, `type: object`, "unresolved type" — and
+// EVERY operation built through the adapter referenced that one component, so
+// two endpoints with entirely different response types claimed the same schema
+// (issue #367).
+//
+// The binding was never missing. At each registration the node's type-parameter
+// map holds exactly the right instantiation — {Res: pkg.User} under one route,
+// {Res: pkg.ListResponse} under the next — which is also why the operationId
+// could print it. All that was needed was to look.
+//
+// Substitution is structural, through the type model rather than by string
+// surgery (golden rule #2), so a parameter under a constructor comes out whole:
+// `[]Res` becomes `[]pkg.User`, not `pkg.User`.
+func resolveTypeParam(goType string, node TrackerNodeInterface, meta *metadata.Metadata) (string, bool) {
+	if goType == "" || node == nil {
+		return goType, false
+	}
+	ref := typemodel.Parse(goType)
+	core := ref.Core()
+	if core == nil || core.Name == "" {
+		return goType, false
+	}
+
+	bound, ok := node.GetTypeParamMap()[core.Name]
+	if !ok {
+		// Not bound here. It is still a type parameter if the function that
+		// wrote this value declares it as one, and that case must not reach the
+		// mapper either — see unresolvedTypeParamType.
+		if isDeclaredTypeParam(core.Name, node, meta) {
+			return unresolvedTypeParamType, true
+		}
+		return goType, false
+	}
+	if bound == "" || bound == goType {
+		return goType, false
+	}
+
+	boundCore := typemodel.Parse(bound).Core()
+	if boundCore == nil || boundCore.Name == "" {
+		return goType, false
+	}
+	// Clone before mutating: TypeRefs are shared (golden rule #2).
+	out := ref.Clone()
+	outCore := out.Core()
+	outCore.Pkg = boundCore.Pkg
+	outCore.Name = boundCore.Name
+	outCore.Args = boundCore.Args
+	return out.String(), true
+}
+
+// unresolvedTypeParamType is what an unresolved type parameter becomes: the
+// honest general type, which the mapper renders INLINE as `type: object` with
+// no $ref.
+//
+// A shared bogus $ref is strictly worse than an inline unknown, because it does
+// not merely fail to describe the body — it asserts that two operations return
+// the same type when they do not, and a consumer generating clients from that
+// document gets one wrong Go type for both (golden rule #7).
+const unresolvedTypeParamType = "any"
+
+// isDeclaredTypeParam reports whether name is a type parameter declared by the
+// function this node is expanding, or by one of its callers.
+//
+// The chain is walked because the value can be written deeper than the generic
+// function itself: the adapter's `Res` is written inside the closure it returns,
+// whose own record declares no type parameters at all.
+func isDeclaredTypeParam(name string, node TrackerNodeInterface, meta *metadata.Metadata) bool {
+	if name == "" || meta == nil {
+		return false
+	}
+	for cur := node; cur != nil; cur = cur.GetParent() {
+		edge := cur.GetEdge()
+		if edge == nil {
+			continue
+		}
+		for _, call := range []*metadata.Call{&edge.Caller, &edge.Callee} {
+			fn := meta.FunctionInPackage(getString(meta, call.Pkg), getString(meta, call.Name))
+			if fn == nil {
+				continue
+			}
+			for _, tp := range fn.TypeParams {
+				if tp == name {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/internal/spec/type_params.go
+++ b/internal/spec/type_params.go
@@ -40,14 +40,16 @@ import (
 // could print it. All that was needed was to look.
 //
 // Substitution is structural, through the type model rather than by string
-// surgery (golden rule #2), so a parameter under a constructor comes out whole:
-// `[]Res` becomes `[]pkg.User`, not `pkg.User`.
+// surgery (golden rule #2), so constructors survive on BOTH sides: `[]Res`
+// becomes `[]pkg.User` rather than `pkg.User`, and a `Res` bound to `[]User` —
+// the ordinary list endpoint — stays an array rather than collapsing to the
+// element.
 func resolveTypeParam(goType string, node TrackerNodeInterface, meta *metadata.Metadata) (string, bool) {
 	if goType == "" || node == nil {
 		return goType, false
 	}
 	ref := typemodel.Parse(goType)
-	core := ref.Core()
+	core := paramOccurrence(ref)
 	if core == nil || core.Name == "" {
 		return goType, false
 	}
@@ -58,7 +60,7 @@ func resolveTypeParam(goType string, node TrackerNodeInterface, meta *metadata.M
 		// wrote this value declares it as one, and that case must not reach the
 		// mapper either — see unresolvedTypeParamType.
 		if isDeclaredTypeParam(core.Name, node, meta) {
-			return unresolvedTypeParamType, true
+			return substituteCore(ref, typemodel.Parse(unresolvedTypeParamType)), true
 		}
 		return goType, false
 	}
@@ -66,17 +68,48 @@ func resolveTypeParam(goType string, node TrackerNodeInterface, meta *metadata.M
 		return goType, false
 	}
 
-	boundCore := typemodel.Parse(bound).Core()
-	if boundCore == nil || boundCore.Name == "" {
+	boundRef := typemodel.Parse(bound)
+	if c := paramOccurrence(boundRef); c == nil || c.Name == "" {
 		return goType, false
 	}
-	// Clone before mutating: TypeRefs are shared (golden rule #2).
+	return substituteCore(ref, boundRef), true
+}
+
+// paramOccurrence returns the node a type parameter would occupy: the type with
+// its constructors peeled off.
+//
+// typemodel's own Core() stops at a map, and the map case is not exotic — a
+// handler answering `map[string]Res` is one `additionalProperties` away from
+// the same defect, emitting a `$ref` to a component named after the parameter.
+// The VALUE type is followed rather than the key, because a parameter used as a
+// map key cannot reach an OpenAPI schema anyway: property names are strings.
+func paramOccurrence(t *typemodel.TypeRef) *typemodel.TypeRef {
+	for t != nil {
+		switch t.Kind {
+		case typemodel.KindPointer, typemodel.KindSlice, typemodel.KindArray,
+			typemodel.KindChan, typemodel.KindMap:
+			t = t.Elem
+		default:
+			return t
+		}
+	}
+	return nil
+}
+
+// substituteCore replaces the type-parameter node inside ref with the WHOLE
+// bound type, so constructors on both sides survive.
+//
+// Each side can carry its own, and grafting the binding's core alone dropped
+// them: `Res` bound to `[]User` — an ordinary list endpoint — came out as
+// `User`, documenting an object where the handler sends an array, and `[]Res`
+// bound to `[]User` came out as `[]User` rather than `[][]User`. Core() returns
+// a pointer INTO the tree, so overwriting the node it names keeps whatever the
+// occurrence wrapped it in.
+func substituteCore(ref, bound *typemodel.TypeRef) string {
+	// Clone both: TypeRefs are shared, and the graft mutates (golden rule #2).
 	out := ref.Clone()
-	outCore := out.Core()
-	outCore.Pkg = boundCore.Pkg
-	outCore.Name = boundCore.Name
-	outCore.Args = boundCore.Args
-	return out.String(), true
+	*paramOccurrence(out) = *bound.Clone()
+	return out.String()
 }
 
 // unresolvedTypeParamType is what an unresolved type parameter becomes: the

--- a/internal/spec/type_params_test.go
+++ b/internal/spec/type_params_test.go
@@ -1,0 +1,144 @@
+// Copyright 2026 Ehab Terra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"testing"
+
+	"github.com/ehabterra/apispec/internal/metadata"
+)
+
+// typeParamNode is a node whose only interesting property is its bindings.
+type typeParamNode struct {
+	TrackerNodeInterface
+	bindings map[string]string
+	parent   TrackerNodeInterface
+	edge     *metadata.CallGraphEdge
+}
+
+func (n *typeParamNode) GetTypeParamMap() map[string]string { return n.bindings }
+func (n *typeParamNode) GetParent() TrackerNodeInterface    { return n.parent }
+func (n *typeParamNode) GetEdge() *metadata.CallGraphEdge   { return n.edge }
+
+func TestResolveTypeParam(t *testing.T) {
+	node := &typeParamNode{bindings: map[string]string{
+		"Res": "example.com/app.User",
+		"Req": "example.com/app.CreateUserRequest",
+	}}
+
+	cases := []struct {
+		name, in, want string
+		isParam        bool
+	}{
+		// The bare parameter, in both the internal and the go/types spelling.
+		{"bound parameter", "example.com/app-->Res", "example.com/app.User", true},
+		{"bare name", "Res", "example.com/app.User", true},
+		{"the other parameter", "Req", "example.com/app.CreateUserRequest", true},
+
+		// Substitution is structural, so a parameter under a constructor comes
+		// out whole rather than being flattened to its core.
+		{"slice of the parameter", "[]Res", "[]example.com/app.User", true},
+		{"pointer to the parameter", "*Res", "*example.com/app.User", true},
+
+		// Not a type parameter: returned unchanged, and reported as such so the
+		// caller does not discard what it already resolved.
+		{"a real type", "example.com/app.User", "example.com/app.User", false},
+		{"a primitive", "string", "string", false},
+		{"empty", "", "", false},
+		// A name that merely LOOKS like one is not treated as one — only a
+		// binding (or a declaration, see below) makes it a parameter.
+		{"unbound name", "Other", "Other", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, isParam := resolveTypeParam(tc.in, node, nil)
+			if got != tc.want || isParam != tc.isParam {
+				t.Errorf("resolveTypeParam(%q) = (%q, %v), want (%q, %v)",
+					tc.in, got, isParam, tc.want, tc.isParam)
+			}
+		})
+	}
+
+	// A nil node has no bindings to read and must not panic.
+	if got, isParam := resolveTypeParam("Res", nil, nil); got != "Res" || isParam {
+		t.Errorf("with no node: (%q, %v), want (\"Res\", false)", got, isParam)
+	}
+}
+
+// An unresolved type parameter must never reach the mapper as a NAME: a
+// component named after it describes nothing and is shared by every operation
+// the adapter builds, which asserts that unrelated endpoints return the same
+// type. The honest general type maps inline, with no $ref (issue #367,
+// golden rule #7).
+func TestResolveTypeParamFallsBackToTheGeneralType(t *testing.T) {
+	pool := metadata.NewStringPool()
+	meta := &metadata.Metadata{
+		StringPool: pool,
+		Packages: map[string]*metadata.Package{
+			"example.com/app": {Files: map[string]*metadata.File{
+				"f.go": {Functions: map[string]*metadata.Function{
+					"HandleJSON": {TypeParams: []string{"Req", "Res"}},
+				}},
+			}},
+		},
+	}
+	edge := &metadata.CallGraphEdge{
+		Caller: metadata.Call{Meta: meta, Pkg: pool.Get("example.com/app"), Name: pool.Get("HandleJSON")},
+		Callee: metadata.Call{Meta: meta, Pkg: pool.Get("example.com/app"), Name: pool.Get("Encode")},
+	}
+	// No bindings at all: the instantiation could not be recovered.
+	node := &typeParamNode{bindings: map[string]string{}, edge: edge}
+
+	got, isParam := resolveTypeParam("Res", node, meta)
+	if !isParam {
+		t.Fatal("Res is declared as a type parameter of the enclosing function, so it must be " +
+			"recognised as one even with no binding")
+	}
+	if got != unresolvedTypeParamType {
+		t.Errorf("unresolved type parameter = %q, want %q — a $ref to the parameter's name is worse "+
+			"than an inline unknown, because it claims unrelated operations share a type",
+			got, unresolvedTypeParamType)
+	}
+
+	// A name the enclosing function does NOT declare is left alone, so this
+	// fallback cannot swallow a real type whose binding is simply absent.
+	if got, isParam := resolveTypeParam("example.com/app.User", node, meta); isParam || got != "example.com/app.User" {
+		t.Errorf("a declared type came back as (%q, %v), want it untouched", got, isParam)
+	}
+
+	// The declaration is looked up through the chain, because the value is
+	// written inside the closure the generic function returns — whose own
+	// record declares no type parameters.
+	child := &typeParamNode{bindings: map[string]string{}, parent: node}
+	if got, isParam := resolveTypeParam("Res", child, meta); !isParam || got != unresolvedTypeParamType {
+		t.Errorf("from a child node: (%q, %v), want the fallback — the declaration is an ancestor's",
+			got, isParam)
+	}
+}
+
+// The general type must map to an inline schema and never to a $ref, or the
+// fallback above would trade one bogus component for another.
+func TestUnresolvedTypeParamTypeMapsInline(t *testing.T) {
+	schema := mapGoTypeForRoute(map[string]*Schema{}, unresolvedTypeParamType, nil, &APISpecConfig{})
+	if schema == nil {
+		t.Fatal("the fallback type mapped to no schema at all")
+	}
+	if schema.Ref != "" {
+		t.Errorf("the fallback type mapped to a $ref (%q); it must be inline", schema.Ref)
+	}
+	if schema.Type != "object" {
+		t.Errorf("the fallback schema is %+v, want an inline object", schema)
+	}
+}

--- a/internal/spec/type_params_test.go
+++ b/internal/spec/type_params_test.go
@@ -51,6 +51,10 @@ func TestResolveTypeParam(t *testing.T) {
 		// out whole rather than being flattened to its core.
 		{"slice of the parameter", "[]Res", "[]example.com/app.User", true},
 		{"pointer to the parameter", "*Res", "*example.com/app.User", true},
+		// Through a map's VALUE too: typemodel's Core() stops at a map, and a
+		// handler answering map[string]Res is one additionalProperties away
+		// from the same bogus $ref.
+		{"map value", "map[string]Res", "map[string]example.com/app.User", true},
 
 		// Not a type parameter: returned unchanged, and reported as such so the
 		// caller does not discard what it already resolved.
@@ -69,6 +73,24 @@ func TestResolveTypeParam(t *testing.T) {
 					tc.in, got, isParam, tc.want, tc.isParam)
 			}
 		})
+	}
+
+	// The BINDING can carry constructors of its own, which is the ordinary list
+	// endpoint: `func listUsers(ctx) ([]User, error)` binds Res to []User.
+	// Grafting only the binding's core dropped them and documented an object
+	// where the handler sends an array.
+	sliceBound := &typeParamNode{bindings: map[string]string{"Res": "[]example.com/app.User"}}
+	sliceCases := []struct{ in, want string }{
+		{"Res", "[]example.com/app.User"},
+		{"[]Res", "[][]example.com/app.User"}, // both sides' constructors survive
+		{"*Res", "*[]example.com/app.User"},
+	}
+	for _, tc := range sliceCases {
+		got, isParam := resolveTypeParam(tc.in, sliceBound, nil)
+		if got != tc.want || !isParam {
+			t.Errorf("with Res bound to a slice, resolveTypeParam(%q) = (%q, %v), want (%q, true)",
+				tc.in, got, isParam, tc.want)
+		}
 	}
 
 	// A nil node has no bindings to read and must not panic.
@@ -100,6 +122,12 @@ func TestResolveTypeParamFallsBackToTheGeneralType(t *testing.T) {
 	}
 	// No bindings at all: the instantiation could not be recovered.
 	node := &typeParamNode{bindings: map[string]string{}, edge: edge}
+
+	// An unresolved parameter under a constructor keeps it: []Res becomes
+	// []any, an array of unknowns, not a bare object.
+	if got, isParam := resolveTypeParam("[]Res", node, meta); !isParam || got != "[]"+unresolvedTypeParamType {
+		t.Errorf("unresolved []Res = (%q, %v), want an array of the general type", got, isParam)
+	}
 
 	got, isParam := resolveTypeParam("Res", node, meta)
 	if !isParam {

--- a/testdata/generic_handler_adapter/go.mod
+++ b/testdata/generic_handler_adapter/go.mod
@@ -1,0 +1,3 @@
+module github.com/ehabterra/apispec/testdata/generic_handler_adapter
+
+go 1.24.3

--- a/testdata/generic_handler_adapter/main.go
+++ b/testdata/generic_handler_adapter/main.go
@@ -1,0 +1,88 @@
+// Package main exercises a generic handler adapter — the shape several Go HTTP
+// toolkits ship and many projects hand-roll once and reuse everywhere. The
+// response type is a TYPE PARAMETER, resolved from the instantiation at the
+// registration (issue #367).
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+type CreateUserRequest struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+type User struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+type ListResponse struct {
+	Users []User `json:"users"`
+	Total int    `json:"total"`
+}
+
+type Health struct {
+	OK bool `json:"ok"`
+}
+
+// HandleJSON adapts a typed function into an http.HandlerFunc. `in` is a
+// declared variable of type Req, which already resolves; `out` is the RESULT of
+// calling a func-typed parameter, which is the half that did not.
+func HandleJSON[Req any, Res any](fn func(context.Context, Req) (Res, error)) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var in Req
+		if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		out, err := fn(r.Context(), in)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(out)
+	}
+}
+
+// HandleJSONResponse is the response-only variant: one type parameter, no
+// request body.
+func HandleJSONResponse[Res any](fn func(context.Context) (Res, error)) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		out, err := fn(r.Context())
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(out)
+	}
+}
+
+func createUser(_ context.Context, in CreateUserRequest) (User, error) {
+	return User{ID: 1, Name: in.Name}, nil
+}
+
+func listUsers(_ context.Context) (ListResponse, error) {
+	return ListResponse{}, nil
+}
+
+func health(_ context.Context) (Health, error) {
+	return Health{OK: true}, nil
+}
+
+func main() {
+	mux := http.NewServeMux()
+
+	// Two instantiations of the same adapter: each operation must document ITS
+	// OWN response type, not a shared component named after the parameter.
+	mux.Handle("POST /users", HandleJSON(createUser))
+	mux.Handle("GET /users", HandleJSONResponse(listUsers))
+	mux.Handle("GET /health", HandleJSONResponse(health))
+
+	_ = http.ListenAndServe(":8080", mux)
+}


### PR DESCRIPTION
Closes #367.

## The defect

A generic handler adapter — `HandleJSON[Req, Res any](fn) http.HandlerFunc`, the shape several Go HTTP toolkits ship and many projects hand-roll once and reuse everywhere — writes its response by encoding a value whose declared type is the type **parameter**. That parameter's own name reached the schema mapper:

```yaml
  /users:
    post:   { responses: { "200": { schema: { $ref: ..._Res }}}}   # should be User
    get:    { responses: { "200": { schema: { $ref: ..._Res }}}}   # should be ListResponse
  /health:
    get:    { responses: { "200": { schema: { $ref: ..._Res }}}}   # should be Health
components:
  schemas:
    ..._Res: { type: object, description: 'External or unresolved type: ...-->Res' }
```

Every operation built through the adapter referenced **one** component describing nothing, and the real types never reached the document. That is worse than documenting nothing — a consumer generating clients gets one wrong Go type for all of them, with nothing saying so.

## The root cause was narrower than the issue assumed

The issue proposed tracing the return type of a func-valued parameter at the instantiation. That work isn't needed. Instrumenting the resolution showed the binding was never missing:

```
bodyType="pkg-->Res"  arg=ident "out"  isGeneric=false  tpm=map[Res:pkg.User]
bodyType="pkg-->Res"  arg=ident "out"  isGeneric=false  tpm=map[Res:pkg.ListResponse]
bodyType="pkg-->Res"  arg=ident "out"  isGeneric=false  tpm=map[Res:pkg.Health]
```

The node's type-parameter map already holds the right instantiation at each registration, **distinct per route** — which is also why the `operationId` could print it. Nothing looked.

The existing generic branch is gated on `arg.IsGenericType`, and the encoded value is a plain ident whose *declared type* is the parameter, so the flag is false and the branch never fired. The request side resolved only because `in` is a declared variable of type `Req` — the asymmetry the issue noticed, explained.

`resolveTypeParam` looks the binding up by the type's own name, structurally through the type model rather than string surgery (golden rule #2), so a parameter under a constructor comes out whole: `[]Res` → `[]pkg.User`.

## Result

```
POST /users   200 -> $ref .../User
GET  /users   200 -> $ref .../ListResponse
GET  /health  200 -> $ref .../Health
```

All three of the issue's items: per-instantiation `$ref`s, the real types in `components`, and the response-only `HandleJSONResponse[Res]` variant (which also keeps its 200 rather than landing under `default`).

## Item 2: the safety net

An unresolved type parameter now becomes the honest general type, which maps **inline with no `$ref`**, rather than a component named after the parameter (golden rule #7). A shared bogus `$ref` is strictly worse than an inline unknown, because it asserts unrelated operations return the same type.

Being straight about this one: I built two probe shapes to trigger that path and **both resolve correctly**, behaving identically on the baseline. So it is a safety net, not a live path — and it is covered by unit tests that construct the state directly rather than by a contrived fixture.

## Measurements

| | result |
|---|---|
| fixture A/B (119 projects) | **118 identical**, the difference being the new fixture |
| 3 real projects (280 / 374 / 19 paths) | **byte-identical** |
| gitea | **byte-identical** — 930 paths, 1142 ops, 243 schemas |

`TestTestdata_GenericHandlerAdapter` was verified to fail on unfixed code with all four symptoms: the three wrong `$ref`s, the bogus component, and the three missing types. The component assertion is phrased on the *shape* (`_Res`, `_Req`, `_In`, `_Out`, `_T`) so an adapter spelled `[In, Out]` is caught too.

Suite, `make lint`, coverage ratchet (96.0%) pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected generated API documentation for generic handlers so each operation displays its concrete response schema.
  - Response references now resolve to the appropriate instantiated types, such as user, list, and health responses, instead of shared generic placeholders.
  - Generic request body documentation continues to reference the correct request type.
  - Unresolved generic types now fall back to inline schemas rather than invalid or dangling references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->