### PR TITLE
test: pin the assignment-matching limit CodeRabbit found

### DIFF
--- a/generator/testdata_variable_path_test.go
+++ b/generator/testdata_variable_path_test.go
@@ -46,16 +46,33 @@ func TestTestdata_VariablePath(t *testing.T) {
 		}
 	}
 
-	// Nothing may be documented under a variable's name or type: those are the
-	// two wrong answers this replaces.
+	// Nothing may be documented under a variable's TYPE: that is the wrong
+	// answer this replaces.
 	for path := range out.Paths {
-		if strings.Contains(path, "{") {
-			t.Errorf("path %q keeps a placeholder — every variable here resolves", path)
-		}
 		if path == "/string" || strings.HasPrefix(path, "/string/") {
 			t.Errorf("path %q is the variable's TYPE, not its value", path)
 		}
 	}
+
+	// CHANGE DETECTOR, not an endorsement (issue #436): assignments are matched
+	// by NAME, so a shadowed binding and a write after the registration each
+	// look like two disagreeing values and keep a placeholder. Both paths ARE
+	// knowable. Asserted at today's conservative behaviour — approximate rather
+	// than wrong — so this fails, and gets updated, when #436 lands.
+	t.Run("a shadowed binding and a later write are not read yet", func(t *testing.T) {
+		for _, notYet := range []string{"/outer/a", "/inner/b", "/first/c"} {
+			if _, ok := out.Paths[notYet]; ok {
+				t.Errorf("%s now resolves — assignments are matched per binding; "+
+					"assert it properly here and close #436", notYet)
+			}
+		}
+		for _, stillApprox := range []string{"/{shadowed}/a", "/{shadowed}/b", "/{later}/c"} {
+			if _, ok := out.Paths[stillApprox]; !ok {
+				t.Errorf("%s is gone — the route must stay documented (approximately) "+
+					"while its prefix is unreadable; have %v", stillApprox, mapPathKeys(out.Paths))
+			}
+		}
+	})
 
 	// The two that cannot be read are reported rather than guessed at: one
 	// assigned in two branches, one assigned from a call.

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -258,9 +258,15 @@ func (b *BasePatternMatcher) variableValue(arg *metadata.CallArgument, node Trac
 // fast path resolved to "/two" with no sign that "/one" existed.
 //
 // The enclosing function's scope records them all, so it answers when it knows
-// the variable; the edge map remains the fallback. An assignment written AFTER
-// the registration counts too, since a loop can make it the live value — that
-// can only make the path unreadable, never wrong.
+// the variable; the edge map remains the fallback.
+//
+// KNOWN LIMIT (issue #436): the scope is keyed by NAME, so this also collects
+// assignments that belong to a different binding of it (an inner block's
+// `prefix := …`) or that cannot reach this call (a write below it). Both read as
+// disagreement, so a knowable path keeps its placeholder. That is the safe
+// direction — approximate, never wrong — and it stays until metadata records
+// which binding an assignment writes to; a write below the call cannot simply be
+// filtered out either, since a loop can carry it back.
 func pathVarAssignments(cp ContextProvider, edge *metadata.CallGraphEdge, name string) []metadata.Assignment {
 	if impl, ok := cp.(*ContextProviderImpl); ok {
 		if am := callerAssignmentMap(impl, edge, name); len(am[name]) > 0 {

--- a/testdata/variable_path/main.go
+++ b/testdata/variable_path/main.go
@@ -85,5 +85,23 @@ func main() {
 	built := buildPath()
 	mux.HandleFunc("GET "+built, fromCall)
 
+	// CHANGE DETECTOR (issue #436): these two ARE knowable, and are not read
+	// today, because assignments are matched by name alone. The inner block
+	// re-declares `shadowed`, and `later` is written after its registration —
+	// so each registration sees two disagreeing values and keeps a placeholder.
+	// Documented approximately rather than wrongly, which is why it is a
+	// precision gap and not a correctness one.
+	shadowed := "/outer"
+	mux.HandleFunc("GET "+shadowed+"/a", list)
+	{
+		shadowed := "/inner"
+		mux.HandleFunc("GET "+shadowed+"/b", list)
+	}
+
+	later := "/first"
+	mux.HandleFunc("GET "+later+"/c", list)
+	later = "/second"
+	_ = later
+
 	http.ListenAndServe(":8080", mux)
 }


### PR DESCRIPTION
Verified both shapes it named. Assignments are collected by NAME, so a shadowed binding (`prefix := "/outer"` and an inner block's `prefix := "/inner"`) and a write below the registration (`p = "/second"` after it) each read as two disagreeing values, and a knowable path keeps its placeholder:

    /{shadowed}/a   should be /outer/a
    /{shadowed}/b   should be /inner/b
    /{later}/c      should be /first/c

Precision, not correctness: the failure mode is an approximate path with a flagged synthesized parameter, never a wrong one.

Only half of it is implementable today. Reachability can use recorded facts — Assignment.Position plus Function.Blocks/blockIndex.dominates, since a plain source-order filter would break `for { p = "/x"; register(p) }`. The lexical half cannot: Assignment.Scope is exported/unexported, not a scope, and the assignment token is not recorded, so `:=` and `=` are indistinguishable. Filed as #436 with both halves rather than approximated with block ranges, which would trade this false negative for a false positive.

The three shapes join testdata/variable_path with change-detector assertions, and the limit is recorded on pathVarAssignments where the rule lives.