### PR TITLE
fix(spec): keep both credentials when one scope applies two api-key middlewares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   including when another group configures one; and a lookup that is built at
   runtime — or names a source OpenAPI has no apiKey location for, such as a form
   field — keeps the default and is reported on stderr rather than presented as
-  observed. (#370)
+  observed. Two api-key middlewares on one scope stay two credentials: both
+  appear in the operation's requirement (an AND), where collapsing them by
+  middleware identity documented the first and dropped the second. A scheme the
+  user defined themselves is never reshaped; where it contradicts the code, the
+  disagreement is reported. (#370)
 
 - **A path wrapped in a type conversion no longer documents a phantom
   endpoint.** `r.Mount(string(prefix), sub)` rendered as the conversion's

--- a/README.md
+++ b/README.md
@@ -196,8 +196,10 @@ registered under `components.securitySchemes`; explicitly-public routes render
 configuration — echo's `KeyAuthConfig.KeyLookup` and fiber's
 `keyauth.Config.KeyLookup` — so `"query:api_key"` is documented as
 `in: query, name: api_key` rather than the library's default header. Two groups
-configured differently become two schemes; a lookup built at runtime keeps the
-default and says so on stderr.
+configured differently become two schemes, and two key middlewares on one scope
+become two required credentials in the same requirement. A lookup built at
+runtime keeps the default and says so on stderr, as does a scheme you defined
+yourself that the code contradicts — your definition is kept.
 
 ### Not supported (yet)
 

--- a/generator/testdata_auth_keylookup_test.go
+++ b/generator/testdata_auth_keylookup_test.go
@@ -15,6 +15,7 @@
 package generator
 
 import (
+	"sort"
 	"testing"
 
 	intspec "github.com/ehabterra/apispec/internal/spec"
@@ -92,6 +93,27 @@ func TestTestdata_AuthEchoKeyLookup(t *testing.T) {
 		if scheme.Type != "apiKey" || scheme.In != c.in || scheme.Name != c.name {
 			t.Errorf("scheme %s = {type:%s in:%s name:%s}, want {apiKey %s %s}",
 				c.scheme, scheme.Type, scheme.In, scheme.Name, c.in, c.name)
+		}
+	}
+
+	// Two key middlewares on one group: echo runs both, so both credentials are
+	// required and both belong in the SAME requirement object (an AND). Keeping
+	// one shape per scheme documented the first and dropped the second.
+	both := requirementNames(t, out, "/both/items", "GET")
+	sort.Strings(both)
+	want := []string{"apiKeyAuthHeaderXTenantKey", "apiKeyAuthQueryApiKey"}
+	if len(both) != 2 || both[0] != want[0] || both[1] != want[1] {
+		t.Errorf("GET /both/items requires %v, want %v", both, want)
+	}
+	if item, ok := out.Paths["/both/items"]; ok {
+		if op := opFor(item, "GET"); op != nil && op.Security != nil && len(*op.Security) != 1 {
+			t.Errorf("want one requirement object holding both schemes (an AND), got %d: %v",
+				len(*op.Security), *op.Security)
+		}
+	}
+	for _, name := range want {
+		if scheme := schemeOf(t, out, name); scheme.Type != "apiKey" {
+			t.Errorf("scheme %s = %+v, want an apiKey scheme", name, scheme)
 		}
 	}
 

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -81,7 +81,12 @@ type RouteInfo struct {
 	// scheme documented at its library default. The mapper turns these into the
 	// emitted scheme definitions, and splits the name when one project uses
 	// several shapes.
-	SecuritySchemeShapes map[string]apiKeyShape
+	//
+	// A LIST per scheme name, because one scope can apply two api-key
+	// middlewares that read different places (a tenant key beside a user key).
+	// Both credentials are required, so both belong in the requirement; keeping
+	// one shape per name documented the first and silently dropped the second.
+	SecuritySchemeShapes map[string][]apiKeyShape
 
 	// Security holds the per-operation OpenAPI security requirements resolved
 	// from auth middleware detected in scope. Semantics:
@@ -732,7 +737,19 @@ func (e *Extractor) UnresolvedSecurity() []MiddlewareRef {
 	return e.securityUnresolved
 }
 
-// dedupMiddlewareRefs removes duplicate refs by identity, preserving order.
+// dedupMiddlewareRefs removes duplicate refs, preserving order.
+//
+// Keyed by identity AND the site the middleware was constructed at, because the
+// same constructor applied twice is two applications: two api-key middlewares
+// on one scope can read two different places, and both credentials are required
+// (issue #370). Collapsing them by identity alone documented the first and
+// silently dropped the second — and, once the scheme carries a location, that
+// is a confidently wrong answer rather than a vague one.
+//
+// The same argument seen through several tracker paths has one position, so it
+// still collapses to one ref, which is what this exists for. The unresolved
+// diagnostics list dedupes by identity separately (recordUnresolved), so a
+// middleware applied at several sites is still reported once.
 func dedupMiddlewareRefs(refs []MiddlewareRef) []MiddlewareRef {
 	if len(refs) <= 1 {
 		return refs
@@ -741,6 +758,9 @@ func dedupMiddlewareRefs(refs []MiddlewareRef) []MiddlewareRef {
 	out := refs[:0]
 	for _, r := range refs {
 		key := r.String()
+		if r.Position != "" {
+			key += "@" + r.Position
+		}
 		if _, ok := seen[key]; ok {
 			continue
 		}
@@ -789,13 +809,13 @@ func (e *Extractor) applyRouteSecurity(node TrackerNodeInterface, routeInfo *Rou
 	var reqs []SecurityRequirement
 	public := false
 
-	var shapes map[string]apiKeyShape
-	keepShapes := func(found map[string]apiKeyShape) {
-		for name, shape := range found {
+	var shapes map[string][]apiKeyShape
+	keepShapes := func(found map[string][]apiKeyShape) {
+		for name, list := range found {
 			if shapes == nil {
-				shapes = map[string]apiKeyShape{}
+				shapes = map[string][]apiKeyShape{}
 			}
-			shapes[name] = shape
+			shapes[name] = appendUniqueShapes(shapes[name], list...)
 		}
 	}
 

--- a/internal/spec/security.go
+++ b/internal/spec/security.go
@@ -16,6 +16,7 @@ package spec
 
 import (
 	"log"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -328,7 +329,7 @@ func resolveSecurity(refs []MiddlewareRef, mappings []SecurityMapping) (reqs []S
 // A mapping with no LookupField, or one whose lookup is absent or unreadable,
 // contributes no shape and keeps the scheme exactly as declared — the library
 // default, which is right until a project configures otherwise.
-func resolveSecurityWithShapes(refs []MiddlewareRef, mappings []SecurityMapping) (reqs []SecurityRequirement, public bool, unresolved []MiddlewareRef, shapes map[string]apiKeyShape) {
+func resolveSecurityWithShapes(refs []MiddlewareRef, mappings []SecurityMapping) (reqs []SecurityRequirement, public bool, unresolved []MiddlewareRef, shapes map[string][]apiKeyShape) {
 	combined := SecurityRequirement{}
 	var alternatives []SecurityRequirement
 
@@ -355,9 +356,12 @@ func resolveSecurityWithShapes(refs []MiddlewareRef, mappings []SecurityMapping)
 					combined[k] = append([]string{}, v...)
 					if hasShape {
 						if shapes == nil {
-							shapes = map[string]apiKeyShape{}
+							shapes = map[string][]apiKeyShape{}
 						}
-						shapes[k] = shape
+						// Appended, not assigned: two api-key middlewares on one
+						// scope read two different places, and both credentials
+						// are required.
+						shapes[k] = appendUniqueShapes(shapes[k], shape)
 					}
 				}
 			}
@@ -391,6 +395,19 @@ func resolveSecurityWithShapes(refs []MiddlewareRef, mappings []SecurityMapping)
 type apiKeyShape struct {
 	In   string
 	Name string
+}
+
+// appendUniqueShapes adds the shapes not already present, preserving order.
+// Order is first-seen and never reaches the output on its own — the emitted
+// names are derived from the shapes and assigned in sorted order — so this
+// stays a set with a stable rendering.
+func appendUniqueShapes(dst []apiKeyShape, src ...apiKeyShape) []apiKeyShape {
+	for _, shape := range src {
+		if !slices.Contains(dst, shape) {
+			dst = append(dst, shape)
+		}
+	}
+	return dst
 }
 
 // apiKeyShapeOf reads the shape a matched mapping's middleware was configured

--- a/internal/spec/security_lookup.go
+++ b/internal/spec/security_lookup.go
@@ -124,17 +124,20 @@ func reportOverriddenShapes(routes []*RouteInfo, explicit map[string]SecuritySch
 		if route == nil {
 			continue
 		}
-		for name, shape := range route.SecuritySchemeShapes {
+		for name, list := range route.SecuritySchemeShapes {
 			def, written := explicit[name]
 			if !written || reported[name] {
 				continue
 			}
-			if def.In == shape.In && def.Name == shape.Name {
-				continue // agrees; nothing to say
+			for _, shape := range list {
+				if def.In == shape.In && def.Name == shape.Name {
+					continue // this one agrees; nothing to say about it
+				}
+				reported[name] = true
+				names = append(names, name)
+				observed[name] = shape
+				break
 			}
-			reported[name] = true
-			names = append(names, name)
-			observed[name] = shape
 		}
 	}
 	sort.Strings(names) // one line per scheme, in a stable order
@@ -210,18 +213,20 @@ func specializeAPIKeySchemes(routes []*RouteInfo, base, explicit map[string]Secu
 		if route == nil {
 			continue
 		}
-		for name, shape := range route.SecuritySchemeShapes {
+		for name, list := range route.SecuritySchemeShapes {
 			if _, written := explicit[name]; written {
 				continue // the user's own definition governs this scheme
 			}
 			if byScheme[name] == nil {
 				byScheme[name] = map[apiKeyShape]bool{}
 			}
-			byScheme[name][shape] = true
+			for _, shape := range list {
+				byScheme[name][shape] = true
+			}
 		}
 		for _, req := range route.Security {
 			for name := range req {
-				if _, shaped := route.SecuritySchemeShapes[name]; !shaped {
+				if len(route.SecuritySchemeShapes[name]) == 0 {
 					atDefault[name] = true
 				}
 			}
@@ -268,17 +273,34 @@ func specializeAPIKeySchemes(routes []*RouteInfo, base, explicit map[string]Secu
 			continue
 		}
 		for i, req := range route.Security {
+			// Built fresh rather than edited in place: inserting into a map
+			// while ranging over it leaves whether the new keys are visited up
+			// to the runtime, and the derived names are exactly the kind of key
+			// that could be visited again.
+			replacement := make(SecurityRequirement, len(req))
+			changed := false
 			for name, scopes := range req {
-				shape, ok := route.SecuritySchemeShapes[name]
-				if !ok {
+				// One key per shape, all in THIS requirement object: two
+				// api-key middlewares on one scope are two credentials the
+				// server requires together, so they are ANDed rather than one
+				// replacing the other.
+				keys := make([]string, 0, len(route.SecuritySchemeShapes[name]))
+				for _, shape := range route.SecuritySchemeShapes[name] {
+					if key := renames[name][shape]; key != "" {
+						keys = append(keys, key)
+					}
+				}
+				if len(keys) == 0 {
+					replacement[name] = scopes
 					continue
 				}
-				key := renames[name][shape]
-				if key == "" || key == name {
-					continue
+				for _, key := range keys {
+					replacement[key] = append([]string{}, scopes...)
+					changed = changed || key != name
 				}
-				delete(route.Security[i], name)
-				route.Security[i][key] = scopes
+			}
+			if changed {
+				route.Security[i] = replacement
 			}
 		}
 	}

--- a/internal/spec/security_lookup_test.go
+++ b/internal/spec/security_lookup_test.go
@@ -147,7 +147,7 @@ func TestSpecializeAPIKeySchemes(t *testing.T) {
 		return &RouteInfo{
 			Path:                 path,
 			Security:             []SecurityRequirement{{"apiKeyAuth": {}}},
-			SecuritySchemeShapes: map[string]apiKeyShape{"apiKeyAuth": shape},
+			SecuritySchemeShapes: map[string][]apiKeyShape{"apiKeyAuth": {shape}},
 		}
 	}
 	atDefault := func(path string) *RouteInfo {
@@ -243,7 +243,7 @@ func TestSpecializeAPIKeySchemes(t *testing.T) {
 			t.Fatalf("both routes reference %q", schemeNameOf(a))
 		}
 		for _, r := range []*RouteInfo{a, b} {
-			want := r.SecuritySchemeShapes["apiKeyAuth"]
+			want := r.SecuritySchemeShapes["apiKeyAuth"][0]
 			got := defs[schemeNameOf(r)]
 			if got.In != want.In || got.Name != want.Name {
 				t.Errorf("route %s -> %s = {%s %s}, want {%s %s}",
@@ -278,7 +278,7 @@ func TestSpecializeAPIKeySchemes(t *testing.T) {
 				"apiKeyAuth": {},
 				"bearerAuth": {},
 			}},
-			SecuritySchemeShapes: map[string]apiKeyShape{"apiKeyAuth": {In: "query", Name: "api_key"}},
+			SecuritySchemeShapes: map[string][]apiKeyShape{"apiKeyAuth": {{In: "query", Name: "api_key"}}},
 		}
 		other := shaped("/b", apiKeyShape{In: "cookie", Name: "token"})
 		specializeAPIKeySchemes([]*RouteInfo{route, other}, base, nil)
@@ -288,6 +288,36 @@ func TestSpecializeAPIKeySchemes(t *testing.T) {
 		}
 		if _, ok := names["apiKeyAuthQueryApiKey"]; !ok {
 			t.Errorf("the shaped scheme must be renamed, got %v", names)
+		}
+	})
+
+	t.Run("two shapes on one route are ANDed in its requirement", func(t *testing.T) {
+		// Two api-key middlewares on one scope are two credentials the server
+		// requires together, so the requirement names both rather than one
+		// replacing the other (found by probing the shape after review).
+		route := &RouteInfo{
+			Path:     "/both",
+			Security: []SecurityRequirement{{"apiKeyAuth": {}}},
+			SecuritySchemeShapes: map[string][]apiKeyShape{"apiKeyAuth": {
+				{In: "query", Name: "api_key"},
+				{In: "header", Name: "X-Tenant-Key"},
+			}},
+		}
+		defs := specializeAPIKeySchemes([]*RouteInfo{route}, base, nil)
+		if len(route.Security) != 1 {
+			t.Fatalf("want one requirement object (an AND), got %d: %v", len(route.Security), route.Security)
+		}
+		req := route.Security[0]
+		for _, want := range []string{"apiKeyAuthQueryApiKey", "apiKeyAuthHeaderXTenantKey"} {
+			if _, ok := req[want]; !ok {
+				t.Errorf("requirement %v is missing %s", req, want)
+			}
+			if def := defs[want]; def.Type != "apiKey" {
+				t.Errorf("definition for %s = %+v", want, def)
+			}
+		}
+		if _, ok := req["apiKeyAuth"]; ok {
+			t.Errorf("the declared name must be replaced, got %v", req)
 		}
 	})
 
@@ -362,6 +392,22 @@ func TestValidateSecurityLookupFields(t *testing.T) {
 // has no apiKey location for — are the honest fallback this change rests on,
 // and no fixture exercises them (both need code a real project would be odd to
 // write).
+func TestAppendUniqueShapes(t *testing.T) {
+	q := apiKeyShape{In: "query", Name: "api_key"}
+	h := apiKeyShape{In: "header", Name: "X-Key"}
+
+	got := appendUniqueShapes(nil, q, h, q)
+	if len(got) != 2 || got[0] != q || got[1] != h {
+		t.Errorf("got %+v, want [query header] with the repeat dropped", got)
+	}
+	if got := appendUniqueShapes(got, h); len(got) != 2 {
+		t.Errorf("appending a shape already present must change nothing, got %+v", got)
+	}
+	if got := appendUniqueShapes(nil); got != nil {
+		t.Errorf("appending nothing to nothing must stay nil, got %+v", got)
+	}
+}
+
 func TestAPIKeyShapeOf(t *testing.T) {
 	meta := newTestMeta()
 
@@ -466,7 +512,7 @@ func TestReportOverriddenShapesAgreement(t *testing.T) {
 	shape := apiKeyShape{In: "query", Name: "api_key"}
 	route := &RouteInfo{
 		Security:             []SecurityRequirement{{"apiKeyAuth": {}}},
-		SecuritySchemeShapes: map[string]apiKeyShape{"apiKeyAuth": shape},
+		SecuritySchemeShapes: map[string][]apiKeyShape{"apiKeyAuth": {shape}},
 	}
 
 	agrees := map[string]SecurityScheme{"apiKeyAuth": {Type: "apiKey", In: "query", Name: "api_key"}}

--- a/testdata/auth_echo_keylookup/main.go
+++ b/testdata/auth_echo_keylookup/main.go
@@ -40,6 +40,21 @@ func main() {
 	}))
 	c.GET("/me", session)
 
+	// TWO key middlewares on one group, reading different places: echo runs
+	// both, so both credentials are required and both belong in the
+	// requirement. Keeping one shape per scheme documented the first and
+	// dropped the second silently.
+	both := e.Group("/both")
+	both.Use(middleware.KeyAuthWithConfig(middleware.KeyAuthConfig{
+		KeyLookup: "header:X-Tenant-Key",
+		Validator: validate,
+	}))
+	both.Use(middleware.KeyAuthWithConfig(middleware.KeyAuthConfig{
+		KeyLookup: "query:api_key",
+		Validator: validate,
+	}))
+	both.GET("/items", items)
+
 	// Nothing configured: the library default (header:Authorization) is correct.
 	d := e.Group("/default")
 	d.Use(middleware.KeyAuth(validate))


### PR DESCRIPTION
Found by probing the shape after review, and it is this PR's own regression. Two api-key middlewares on one group, reading different places:

    g.Use(middleware.KeyAuthWithConfig(middleware.KeyAuthConfig{KeyLookup: "query:api_key", …}))
    g.Use(middleware.KeyAuthWithConfig(middleware.KeyAuthConfig{KeyLookup: "header:X-Tenant-Key", …}))

documented one `apiKeyAuth` at `query:api_key`, and the tenant key vanished. Before this branch the collapse was merely vague — both middlewares shared the default header scheme — but once the scheme asserts a location it becomes a confidently wrong answer, which is the failure mode #370 exists to remove.

The collapse was a layer below the shapes: dedupMiddlewareRefs keys refs by identity, so two constructions of the same middleware were one ref and the second configuration was never read. It now keys by identity AND construction site. The same argument reached through several tracker paths still has one position and still collapses, which is what the dedup is for; two applications stay two. The unresolved diagnostics dedupe by identity separately, so a middleware applied at several sites is still reported once.

With both configurations visible, a route's shapes became a LIST per scheme name, and the requirement names one scheme per shape in the same requirement object — an AND, which is what echo enforces by running both middlewares.

The rewrite also stopped editing the requirement map while ranging over it: insertion during range leaves visitation up to the runtime, and the derived names are exactly the keys that could be revisited. It builds the replacement and assigns it.

testdata/auth_echo_keylookup gains a /both group, and the structural test asserts both schemes land in one requirement. Drift re-measured after the dedup change, since it is shared: all 105 pre-existing fixtures byte-identical, gitea byte-identical at 894 paths, and coverage back at 96.0%.